### PR TITLE
fix: resolve workspace dir to absolute path and fix env var priority in buildSdkEnv

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -36,7 +36,11 @@ export class Config {
   static readonly CONFIG_SOURCE = fileConfig._source;
 
   // Workspace configuration
-  static readonly WORKSPACE_DIR = fileConfigOnly.workspace?.dir || process.cwd();
+  // Resolve to absolute path to ensure getWorkspaceDir() always returns absolute path
+  private static readonly RAW_WORKSPACE_DIR = fileConfigOnly.workspace?.dir || process.cwd();
+  static readonly WORKSPACE_DIR = path.isAbsolute(Config.RAW_WORKSPACE_DIR)
+    ? Config.RAW_WORKSPACE_DIR
+    : path.resolve(process.cwd(), Config.RAW_WORKSPACE_DIR);
 
   // Feishu/Lark configuration (from config file)
   static readonly FEISHU_APP_ID = fileConfigOnly.feishu?.appId || '';

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -637,11 +637,17 @@ export function buildSdkEnv(
   const nodeBinDir = getNodeBinDir();
   const newPath = `${nodeBinDir}:${process.env.PATH || ''}`;
 
+  // Priority (highest to lowest):
+  // 1. Our forced values (API_KEY, PATH, BASE_URL)
+  // 2. process.env (system environment)
+  // 3. extraEnv (caller-provided defaults)
+  // This ensures system env vars can't be accidentally overridden by extraEnv,
+  // but our critical values always take precedence.
   const env: Record<string, string | undefined> = {
-    ANTHROPIC_API_KEY: apiKey,
-    PATH: newPath,
     ...extraEnv,
     ...(process.env as Record<string, string | undefined>),
+    ANTHROPIC_API_KEY: apiKey,
+    PATH: newPath,
   };
 
   // Set base URL if provided (for GLM or custom endpoints)


### PR DESCRIPTION
## Summary
- Config.WORKSPACE_DIR now resolves relative paths to absolute using cwd
- buildSdkEnv() now correctly prioritizes: forced values > process.env > extraEnv
- This ensures PATH always includes node bin dir for SDK subprocess spawning
- Fixes 2 failing tests in config and sdk modules

## Test plan
- [ ] Run `npm run test` to verify all tests pass
- [ ] Run `npm run build` to verify build succeeds
- [ ] Test with CLI mode: `disclaude --prompt "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)