### PR TITLE
fix: remove missing entry files from tsup config

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,38 +17,6 @@ export default defineConfig([
     outDir: 'dist',
     outExtension: () => ({ js: '.js' }),
   },
-  // Execution Node entry point (HTTP server)
-  {
-    entry: ['src/entries/execution-entry.ts'],
-    format: ['esm'],
-    target: 'node18',
-    sourcemap: true,
-    splitting: false,
-    minify: false,
-    bundle: true,
-    platform: 'node',
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
-    outDir: 'dist',
-    outExtension: () => ({ js: '.js' }),
-  },
-  // Communication Node entry point (Feishu bot)
-  {
-    entry: ['src/entries/communication-entry.ts'],
-    format: ['esm'],
-    target: 'node18',
-    sourcemap: true,
-    splitting: false,
-    minify: false,
-    bundle: true,
-    platform: 'node',
-    banner: {
-      js: '#!/usr/bin/env node',
-    },
-    outDir: 'dist',
-    outExtension: () => ({ js: '.js' }),
-  },
   // Feishu MCP server (stdio)
   {
     entry: ['src/mcp/feishu-mcp-server.ts'],


### PR DESCRIPTION
## Problem

Build fails with error:
```
Cannot find src/entries/execution-entry.ts
```

## Root Cause

- `execution-entry.ts` and `communication-entry.ts` were removed in commit `c472e38`
- `tsup.config.ts` was not updated to reflect this change
- Build configuration still references non-existent entry points

## Solution

Remove the non-existent entry points from `tsup.config.ts`:
- `src/entries/execution-entry.ts`
- `src/entries/communication-entry.ts`

## Impact

- Fixes Docker build failure
- Restores ability to deploy via `docker-compose build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)