### PR TITLE
fix: return soft errors from MCP tools to avoid SDK crash

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -571,16 +571,6 @@ function toolSuccess(text: string): { content: Array<{ type: 'text'; text: strin
   };
 }
 
-/**
- * Helper to create an error tool result.
- */
-function toolError(errorMessage: string): { content: Array<{ type: 'text'; text: string }>; isError: true } {
-  return {
-    content: [{ type: 'text', text: `❌ Error: ${errorMessage}` }],
-    isError: true,
-  };
-}
-
 // SDK-compatible tools array
 export const feishuSdkTools = [
   tool(

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -86,12 +86,13 @@ async function send_file_to_feishu(args: { filePath: string; chatId: string }) {
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
+    // Return as soft error (no isError flag) to allow agent to continue
+    // Include detailed error info for agent self-correction
     return {
       content: [{
         type: 'text',
-        text: `❌ Failed to send file: ${errorMessage}`,
+        text: `⚠️ Failed to send file: ${errorMessage}\n\nPlease verify:\n- File path is correct and file exists\n- Chat ID is valid\n- Feishu credentials are configured`,
       }],
-      isError: true,
     };
   }
 }

--- a/src/mcp/task-skill-mcp.test.ts
+++ b/src/mcp/task-skill-mcp.test.ts
@@ -74,7 +74,7 @@ describe('Task Skill MCP', () => {
   });
 
   describe('start_dialogue tool handler', () => {
-    it('should return error when orchestrator not registered', async () => {
+    it('should return soft error when orchestrator not registered', async () => {
       const { startDialogueTool } = await import('./task-skill-mcp.js');
 
       const result = await startDialogueTool.handler(
@@ -82,8 +82,10 @@ describe('Task Skill MCP', () => {
         undefined as any
       );
 
-      expect(result.isError).toBe(true);
-      expect(result.content[0].text).toContain('Error');
+      // Should return soft error (no isError flag) to allow agent to continue
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Failed to start dialogue');
+      expect(result.content[0].text).toContain('TaskFlowOrchestrator not registered');
     });
 
     it('should return success when orchestrator is registered', async () => {

--- a/src/mcp/task-skill-mcp.ts
+++ b/src/mcp/task-skill-mcp.ts
@@ -62,16 +62,6 @@ function toolSuccess(text: string): { content: Array<{ type: 'text'; text: strin
 }
 
 /**
- * Helper to create an error tool result.
- */
-function toolError(errorMessage: string): { content: Array<{ type: 'text'; text: string }>; isError: true } {
-  return {
-    content: [{ type: 'text', text: `❌ Error: ${errorMessage}` }],
-    isError: true,
-  };
-}
-
-/**
  * Tool: start_dialogue
  *
  * Starts the Dialogue phase (Evaluator → Executor loop) after Pilot creates Task.md.
@@ -141,7 +131,9 @@ DO NOT call this tool multiple times for the same task.`,
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error({ err: error, chatId }, 'start_dialogue failed');
 
-      return toolError(errorMessage);
+      // Return as soft error (not isError) to allow agent to continue and retry
+      // Include detailed error info for agent self-correction
+      return toolSuccess(`⚠️ Failed to start dialogue: ${errorMessage}\n\nPlease check:\n1. Task.md file exists and is valid\n2. Message ID and Chat ID are correct\n3. System is properly initialized`);
     }
   }
 );


### PR DESCRIPTION
## Summary
- Convert hard errors (`isError: true`) to soft errors in MCP tools
- Allow agent to continue execution and attempt self-correction
- Include detailed error messages with troubleshooting guidance

## Changes
- Remove unused `toolError` helper functions from `feishu-context-mcp.ts` and `task-skill-mcp.ts`
- `send_file_to_feishu`: return soft error with verification hints for file path, chat ID, and credentials
- `start_dialogue`: return soft error with troubleshooting checklist for Task.md validity and system initialization
- Update tests in `task-skill-mcp.test.ts` to match new soft error behavior

## Test plan
- [x] All 805 tests pass
- [x] Updated test expectations for soft error behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)