### PR TITLE
feat(docker): add PM2 support for process management and logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,9 @@ services:
     container_name: disclaude-comm
     restart: unless-stopped
 
-    # Command: run Communication Node
-    command: ["node", "dist/cli-entry.js", "start", "--mode", "comm"]
+    # Command: run Communication Node with PM2
+    # PM2 provides process management and logging support
+    command: ["pm2-runtime", "start", "ecosystem.config.docker.cjs", "--", "comm"]
 
     # Network mode: host allows container to access host's CDP endpoint
     network_mode: host
@@ -76,8 +77,9 @@ services:
     container_name: disclaude-exec
     restart: unless-stopped
 
-    # Command: run Execution Node, connect to Communication Node
-    command: ["node", "dist/cli-entry.js", "start", "--mode", "exec", "--comm-url", "ws://localhost:3001"]
+    # Command: run Execution Node with PM2
+    # PM2 provides process management and logging support
+    command: ["pm2-runtime", "start", "ecosystem.config.docker.cjs", "--", "exec"]
 
     # Network mode: host for local connection to comm node
     network_mode: host

--- a/ecosystem.config.docker.cjs
+++ b/ecosystem.config.docker.cjs
@@ -1,0 +1,62 @@
+/**
+ * PM2 Configuration for Docker Environment
+ *
+ * This configuration is specifically designed for running Disclaude
+ * inside Docker containers using PM2 for process management.
+ *
+ * Benefits:
+ * - Centralized logging via `pm2 logs`
+ * - Process monitoring via `pm2 status`
+ * - `/restart` command support in Feishu bot
+ * - Automatic restart on crashes
+ *
+ * Usage in docker-compose.yml:
+ *   command: ["pm2-runtime", "start", "ecosystem.config.docker.cjs", "--", "comm"]
+ *   or
+ *   command: ["pm2-runtime", "start", "ecosystem.config.docker.cjs", "--", "exec"]
+ */
+
+const mode = process.argv[2] || 'comm';
+
+const configs = {
+  comm: {
+    name: 'disclaude-docker',
+    script: 'dist/cli-entry.js',
+    args: 'start --mode comm',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '1G',
+    // PM2 log configuration
+    log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+    error_file: '/app/logs/pm2-error.log',
+    out_file: '/app/logs/pm2-out.log',
+    merge_logs: true,
+    // Environment
+    env: {
+      NODE_ENV: 'production',
+    },
+  },
+  exec: {
+    name: 'disclaude-docker',
+    script: 'dist/cli-entry.js',
+    args: 'start --mode exec --comm-url ws://localhost:3001',
+    instances: 1,
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '2G',
+    // PM2 log configuration
+    log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+    error_file: '/app/logs/pm2-error.log',
+    out_file: '/app/logs/pm2-out.log',
+    merge_logs: true,
+    // Environment
+    env: {
+      NODE_ENV: 'production',
+    },
+  },
+};
+
+module.exports = {
+  apps: [configs[mode] || configs.comm],
+};

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -468,8 +468,15 @@ export class CommunicationNode extends EventEmitter {
         const { exec } = await import('node:child_process');
         const { promisify } = await import('node:util');
         const execAsync = promisify(exec);
-        await execAsync('pm2 restart disclaude-feishu');
-        logger.info('PM2 service restarted successfully');
+
+        // Detect Docker environment and use appropriate PM2 app name
+        // Docker: disclaude-docker (from ecosystem.config.docker.cjs)
+        // Local: disclaude-feishu (from ecosystem.config.cjs)
+        const isDocker = require('fs').existsSync('/.dockerenv');
+        const pm2AppName = isDocker ? 'disclaude-docker' : 'disclaude-feishu';
+
+        await execAsync(`pm2 restart ${pm2AppName}`);
+        logger.info({ pm2AppName, isDocker }, 'PM2 service restarted successfully');
       } catch (error) {
         logger.error({ err: error }, 'Failed to restart PM2 service');
       }


### PR DESCRIPTION
## Summary

- Install PM2 globally in Docker image for process management
- Add `ecosystem.config.docker.cjs` for Docker environment PM2 configuration
- Update `docker-compose.yml` to use `pm2-runtime` for both comm and exec nodes
- Update healthcheck to use PM2 pid command
- Modify `/restart` command to detect Docker environment and use correct PM2 app name

## Issues Resolved

- Closes #28 - Docker 容器内无法访问服务日志
- Closes #27 - Docker 容器中 /restart 指令无效

## Benefits of PM2 in Docker

- **Centralized logging**: Logs accessible via `pm2 logs` command
- **Process monitoring**: Status via `pm2 status`
- **Automatic restart**: On crashes or memory limits
- **/restart command support**: Works in both local and Docker environments

## Changes

### Dockerfile
- Add PM2 global installation
- Update CMD to use `pm2-runtime`
- Update healthcheck to use `pm2 pid`

### docker-compose.yml
- Update command for both comm and exec nodes to use PM2

### ecosystem.config.docker.cjs (new file)
- PM2 configuration for Docker environment
- Supports both comm and exec modes
- Configures log paths to `/app/logs/`

### src/nodes/communication-node.ts
- Detect Docker environment via `/.dockerenv`
- Use appropriate PM2 app name (`disclaude-docker` in Docker, `disclaude-feishu` locally)

## Test Plan

- [ ] Build Docker image: `docker build -t disclaude:test .`
- [ ] Run with docker-compose: `docker compose up -d`
- [ ] Verify logs: `docker compose exec comm pm2 logs`
- [ ] Test /restart command in Feishu

🤖 Generated with [Claude Code](https://claude.com/claude-code)