### PR TITLE
fix: ensure devDependencies are installed correctly

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,14 @@
+# NPM Configuration for Disclaude
+#
+# This file ensures consistent npm behavior across all environments.
+
+# Always install devDependencies (fixes issue where npm skips devDependencies
+# due to engine mismatches in transitive dependencies like pino-roll/thread-stream)
+# See: https://github.com/hs3180/disclaude/issues/21
+production=false
+
+# Use exact versions for reproducible builds
+save-exact=true
+
+# Lockfile format
+lockfile-version=3

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ A multi-platform AI agent bot that bridges messaging platforms (Feishu/Lark) wit
 
 ## Requirements
 
-- **Node.js** >= 18.0.0
+- **Node.js** >= 18.0.0 (>= 20.0.0 recommended for development)
 - **npm** or **yarn** or **pnpm**
+
+> **Note**: Some transitive dependencies require Node.js >= 20. If you encounter issues with `npm install`, use Node.js 20+ or run `npm install --production=false`.
 
 ## Quick Start
 
@@ -47,6 +49,12 @@ A multi-platform AI agent bot that bridges messaging platforms (Feishu/Lark) wit
 git clone <repo-url>
 cd disclaude
 npm install
+```
+
+The project includes an `.npmrc` file that ensures devDependencies are installed correctly. If you still encounter issues, try:
+
+```bash
+npm install --production=false
 ```
 
 ### 2. Configure

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "vitest-tsconfig-paths": "^3.4.1"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
   }
 }


### PR DESCRIPTION
## Summary

- Add `.npmrc` file with `production=false` to ensure devDependencies are always installed
- Update README.md with clearer Node.js version requirements
- Recommend Node.js >= 20 for development due to transitive dependencies
- Add npm >= 9.0.0 to engines field in package.json

## Problem

When running `npm install` with Node.js 18, devDependencies were not being installed correctly. This was caused by transitive dependency `thread-stream@4.0.0` (from `pino-roll`) requiring Node.js >= 20.

## Solution

1. **`.npmrc` file**: Sets `production=false` to always install devDependencies, bypassing the engine mismatch issue
2. **README update**: Documents the recommended Node.js version and provides fallback instructions
3. **package.json**: Adds npm version requirement to engines field

## Testing

- Clone repo fresh
- Run `npm install`
- Verify devDependencies are installed: `ls node_modules/.bin/ | grep tsc`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)