### PR TITLE
docs: add Claude CLI installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,31 @@ A multi-platform AI agent bot that bridges messaging platforms (Feishu/Lark) wit
 
 - **Node.js** >= 18.0.0 (>= 20.0.0 recommended for development)
 - **npm** or **yarn** or **pnpm**
+- **Claude CLI** (for Claude Agent SDK functionality)
 
 > **Note**: Some transitive dependencies require Node.js >= 20. If you encounter issues with `npm install`, use Node.js 20+ or run `npm install --production=false`.
 
+### Install Claude CLI
+
+Claude Agent SDK requires the Claude CLI to be installed on your system. Install it with one of the following methods:
+
+```bash
+# Using npm (recommended)
+npm install -g @anthropic-ai/claude-code
+
+# Or using the official installer
+curl -fsSL https://claude.ai/install.sh | sh
+```
+
+After installation, verify:
+
+```bash
+claude --version
+```
+
 ## Quick Start
 
-### 1. Install
+### 1. Install Dependencies
 
 ```bash
 git clone <repo-url>
@@ -57,7 +76,15 @@ The project includes an `.npmrc` file that ensures devDependencies are installed
 npm install --production=false
 ```
 
-### 2. Configure
+### 2. Install Claude CLI (Required)
+
+Make sure Claude CLI is installed (see [Requirements](#requirements) for installation instructions). Without it, you'll encounter errors like:
+
+```
+Error: Claude Code process exited with code 1
+```
+
+### 3. Configure
 
 Copy the example configuration file and customize it:
 
@@ -88,7 +115,7 @@ agent:
 
 For full configuration options (logging, MCP servers, etc.), see `disclaude.config.example.yaml`.
 
-### 3. Run
+### 4. Run
 
 ```bash
 # Development with auto-reload


### PR DESCRIPTION
## Summary

- Add Claude CLI to Requirements section with installation instructions
- Add new Quick Start step for Claude CLI installation
- Reorder Quick Start steps (now 4 steps instead of 3)

## Problem

Developers would encounter `Error: Claude Code process exited with code 1` when running CLI mode without Claude CLI installed. The README did not mention this requirement.

## Solution

Updated README.md to clearly document Claude CLI as a required dependency, with installation instructions and verification steps.

## Changes

### Requirements Section
- Added Claude CLI as a required dependency
- Added installation instructions (npm and curl methods)
- Added verification command

### Quick Start Section
- New step 2: Install Claude CLI (Required)
- Reordered: Configure → Step 3, Run → Step 4

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)