### PR TITLE
feat: support Feishu Thread replies for message grouping

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -45,16 +45,18 @@ export interface PilotCallbacks {
    * Send a text message to the user.
    * @param chatId - Platform-specific chat identifier
    * @param text - Message content
+   * @param parentMessageId - Optional parent message ID for thread replies
    */
-  sendMessage: (chatId: string, text: string) => Promise<void>;
+  sendMessage: (chatId: string, text: string, parentMessageId?: string) => Promise<void>;
 
   /**
    * Send an interactive card to the user.
    * @param chatId - Platform-specific chat identifier
    * @param card - Card JSON structure
    * @param description - Optional description for logging
+   * @param parentMessageId - Optional parent message ID for thread replies
    */
-  sendCard: (chatId: string, card: Record<string, unknown>, description?: string) => Promise<void>;
+  sendCard: (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => Promise<void>;
 
   /**
    * Send a file to the user.
@@ -123,6 +125,8 @@ interface PerChatIdState {
   lastActivity: number;
   /** Whether the Agent loop has been started */
   started: boolean;
+  /** Current thread root message ID for replies (the latest user message) */
+  currentThreadRootId?: string;
 }
 
 /**
@@ -276,15 +280,16 @@ export class Pilot extends BaseAgent {
               this.logger.error({ err, filePath, chatId }, 'Failed to send file');
               await this.callbacks.sendMessage(
                 chatId,
-                `❌ Failed to send file: ${filePath}`
+                `❌ Failed to send file: ${filePath}`,
+                messageId // Use current message as thread root for CLI mode
               );
             }
           }
         }
 
-        // Send message content to callback
+        // Send message content to callback (with thread support)
         if (parsed.content) {
-          await this.callbacks.sendMessage(chatId, parsed.content);
+          await this.callbacks.sendMessage(chatId, parsed.content, messageId);
         }
       }
 
@@ -293,7 +298,7 @@ export class Pilot extends BaseAgent {
       const err = error as Error;
       this.logger.error({ err, chatId }, 'CLI query error');
 
-      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`);
+      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`, messageId);
       throw err;
     }
   }
@@ -325,6 +330,11 @@ export class Pilot extends BaseAgent {
 
     // Update last activity
     state.lastActivity = Date.now();
+
+    // Set this message as the current thread root for replies
+    // All bot responses will be threaded to this user message
+    state.currentThreadRootId = messageId;
+    this.logger.debug({ chatId, messageId }, 'Set current thread root for replies');
 
     // Push message to the queue
     state.messageQueue.push({ text, messageId, senderOpenId });
@@ -394,6 +404,7 @@ export class Pilot extends BaseAgent {
       closed: false,
       lastActivity: Date.now(),
       started: false,
+      currentThreadRootId: undefined,
     };
 
     this.states.set(chatId, state);
@@ -461,7 +472,9 @@ To notify the user in your FINAL response, use:
 
 ## Tools
 
-When using send_file_to_feishu or send_user_feedback, use Chat ID: \`${chatId}\`
+When using send_file_to_feishu or send_user_feedback, use:
+- Chat ID: \`${chatId}\`
+- parentMessageId: \`${msg.messageId}\` (for thread replies)
 
 --- User Message ---
 ${msg.text}`;
@@ -472,7 +485,9 @@ ${msg.text}`;
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
 
-When using send_file_to_feishu or send_user_feedback, use this Chat ID.
+When using send_file_to_feishu or send_user_feedback, use:
+- Chat ID: \`${chatId}\`
+- parentMessageId: \`${msg.messageId}\` (for thread replies)
 
 --- User Message ---
 ${msg.text}`;
@@ -631,15 +646,16 @@ ${msg.text}`;
               this.logger.error({ err, filePath, chatId }, 'Failed to send file');
               await this.callbacks.sendMessage(
                 chatId,
-                `❌ Failed to send file: ${filePath}`
+                `❌ Failed to send file: ${filePath}`,
+                state.currentThreadRootId
               );
             }
           }
         }
 
-        // Send message content to callback
+        // Send message content to callback (with thread support)
         if (parsed.content) {
-          await this.callbacks.sendMessage(chatId, parsed.content);
+          await this.callbacks.sendMessage(chatId, parsed.content, state.currentThreadRootId);
         }
       }
 
@@ -652,7 +668,7 @@ ${msg.text}`;
       const err = error as Error;
       this.logger.error({ err, chatId }, 'Agent loop error');
 
-      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`);
+      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`, state.currentThreadRootId);
 
       // Mark as restartable instead of deleting - preserve queue for next session
       state.started = false;

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -267,7 +267,7 @@ export class CommunicationNode extends EventEmitter {
   /**
    * Send a text message to Feishu.
    */
-  async sendMessage(chatId: string, text: string): Promise<void> {
+  async sendMessage(chatId: string, text: string, parentMessageId?: string): Promise<void> {
     if (!this.messageSender) {
       this.getClient();
     }
@@ -275,7 +275,7 @@ export class CommunicationNode extends EventEmitter {
     if (!sender) {
       throw new Error('MessageSender not initialized');
     }
-    await sender.sendText(chatId, text);
+    await sender.sendText(chatId, text, parentMessageId);
   }
 
   /**
@@ -284,7 +284,8 @@ export class CommunicationNode extends EventEmitter {
   async sendCard(
     chatId: string,
     card: Record<string, unknown>,
-    description?: string
+    description?: string,
+    parentMessageId?: string
   ): Promise<void> {
     if (!this.messageSender) {
       this.getClient();
@@ -293,7 +294,7 @@ export class CommunicationNode extends EventEmitter {
     if (!sender) {
       throw new Error('MessageSender not initialized');
     }
-    await sender.sendCard(chatId, card, description);
+    await sender.sendCard(chatId, card, description, parentMessageId);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Implement thread reply mechanism to keep bot responses organized under the original user message
- Add `parent_id` support to all Feishu message sending APIs
- Track current thread root ID in Pilot's per-chat state and pass it through callback interfaces
- Update MCP tool schema to include `parentMessageId` parameter

## Changes

- **feishu-context-mcp.ts**: Add `parentMessageId` parameter to `send_user_feedback` tool and `sendMessageToFeishu` helper
- **message-sender.ts**: Add optional `parentId` parameter to `sendText` and `sendCard` methods
- **pilot.ts**: Track `currentThreadRootId` in per-chat state and pass to callbacks
- **task-flow-orchestrator.ts**: Update `MessageCallbacks` interface and pass `parentMessageId`
- **communication-node.ts**: Update `sendMessage` and `sendCard` signatures to accept `parentMessageId`

## Test Plan

- [x] All 805 existing tests pass
- [x] TypeScript compilation succeeds
- [ ] Manual testing with Feishu to verify thread replies work correctly

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)