### PR TITLE
fix: change reaction emoji from Keyboard to Eyes

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -39,6 +39,6 @@ export const MESSAGE_LOGGING = {
  * Reaction emoji constants for message feedback
  */
 export const REACTIONS = {
-  /** Emoji to indicate the bot is typing/processing */
-  TYPING: 'Keyboard',
+  /** Emoji to indicate the bot is typing/processing (Eyes = 正在查看/处理中) */
+  TYPING: 'Eyes',
 } as const;


### PR DESCRIPTION
## Summary
- 将表情反应从 `Keyboard` 改为 `Eyes`，因为飞书 API 不支持 `Keyboard` 表情类型

## Problem
飞书 API 返回错误码 231001: `reaction type is invalid` 当使用 `Keyboard` 作为表情类型时。

## Solution
使用飞书支持的 `Eyes` 表情，同样传达"正在查看/处理中"的含义。

## Test Plan
- ✅ 所有 805 个测试通过
- ✅ 构建成功

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)