### PR TITLE
feat: 完善消息日志 - 记录完整的用户与 Bot 消息往来 (#63)

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -182,11 +182,13 @@ export class MessageLogger {
         ? new Date(entry.timestamp).toISOString()
         : entry.timestamp;
 
-    const direction = entry.direction === 'incoming' ? 'Incoming' : 'Outgoing';
+    // Use emoji to distinguish message direction
+    const emoji = entry.direction === 'incoming' ? '📥' : '📤';
+    const direction = entry.direction === 'incoming' ? 'User' : 'Bot';
 
     return `
 
-## [${timestamp}] ${direction} (message_id: ${entry.messageId})
+## [${timestamp}] ${emoji} ${direction} (message_id: ${entry.messageId})
 
 **Sender**: ${entry.senderId}
 **Type**: ${entry.messageType}

--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -13,6 +13,7 @@
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
+import path from 'path';
 import { buildTextContent } from './content-builder.js';
 import { messageLogger } from './message-logger.js';
 import { handleError, ErrorCategory } from '../utils/error-handler.js';
@@ -122,15 +123,25 @@ export class MessageSender {
         messageData.parent_id = parentId;
       }
 
-      await this.client.im.message.create({
+      const response = await this.client.im.message.create({
         params: {
           receive_id_type: 'chat_id',
         },
         data: messageData,
       });
 
+      // Track outgoing bot message in history
+      const botMessageId = response?.data?.message_id;
+      if (botMessageId) {
+        // Log card content to persistent MD file
+        const cardContent = description
+          ? `[Card] ${description}\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
+          : `[Interactive Card]\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
+        await messageLogger.logOutgoingMessage(botMessageId, chatId, cardContent);
+      }
+
       const desc = description ? ` (${description})` : '';
-      this.logger.debug({ chatId, description: desc, parentId }, 'Card sent');
+      this.logger.debug({ chatId, description: desc, parentId, botMessageId }, 'Card sent');
     } catch (error) {
       handleError(error, {
         category: ErrorCategory.API,
@@ -155,6 +166,16 @@ export class MessageSender {
     try {
       const { uploadAndSendFile } = await import('./file-uploader.js');
       const fileSize = await uploadAndSendFile(this.client, filePath, chatId);
+
+      // Log file message to persistent MD file
+      const fileName = path.basename(filePath);
+      const fileContent = `[File] ${fileName}\nPath: ${filePath}`;
+      await messageLogger.logOutgoingMessage(
+        `file_${Date.now()}`, // File messages may not have a message_id
+        chatId,
+        fileContent
+      );
+
       this.logger.info({ chatId, filePath, fileSize }, 'File sent to user');
     } catch (error) {
       this.logger.error({ err: error, filePath, chatId }, 'Failed to send file to user');


### PR DESCRIPTION
## Summary

- 在 `sendCard` 方法中添加 `logOutgoingMessage` 调用，记录卡片消息内容（JSON 格式）
- 在 `sendFile` 方法中添加 `logOutgoingMessage` 调用，记录文件发送信息
- 优化 Markdown 格式，使用 emoji 区分消息方向 (📥 User / 📤 Bot)

## 修改内容

| 文件 | 修改内容 |
|------|---------|
| `src/feishu/message-sender.ts` | 添加 sendCard、sendFile 的日志记录 |
| `src/feishu/message-logger.ts` | 优化格式，添加 emoji 区分消息方向 |

## 测试验证

- [x] 项目构建成功 (`npm run build`)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)