### PR TITLE
fix: Thread replies not working - pass parentId through data flow

### DIFF
--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -47,6 +47,8 @@ interface PromptMessage {
   prompt: string;
   messageId: string;
   senderOpenId?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
 }
 
 interface CommandMessage {
@@ -62,6 +64,8 @@ interface FeedbackMessage {
   card?: Record<string, unknown>;
   filePath?: string;
   error?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
 }
 
 /**
@@ -216,7 +220,7 @@ export class CommunicationNode extends EventEmitter {
     }
 
     this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, messageId: message.messageId }, 'Prompt sent to Execution Node');
+    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId }, 'Prompt sent to Execution Node');
   }
 
   /**
@@ -237,21 +241,21 @@ export class CommunicationNode extends EventEmitter {
    * Handle feedback from Execution Node.
    */
   private async handleFeedback(message: FeedbackMessage): Promise<void> {
-    const { chatId, type, text, card, filePath, error } = message;
+    const { chatId, type, text, card, filePath, error, parentId } = message;
 
     try {
       switch (type) {
         case 'text':
           if (text) {
-            await this.sendMessage(chatId, text);
+            await this.sendMessage(chatId, text, parentId);
           }
           break;
         case 'card':
-          await this.sendCard(chatId, card || {});
+          await this.sendCard(chatId, card || {}, undefined, parentId);
           break;
         case 'file':
           if (filePath) {
-            await this.sendFileToUser(chatId, filePath);
+            await this.sendFileToUser(chatId, filePath, parentId);
           }
           break;
         case 'done':
@@ -259,7 +263,7 @@ export class CommunicationNode extends EventEmitter {
           break;
         case 'error':
           logger.error({ chatId, error }, 'Execution error');
-          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`);
+          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`, parentId);
           break;
       }
     } catch (err) {
@@ -319,8 +323,9 @@ export class CommunicationNode extends EventEmitter {
 
   /**
    * Send a file to Feishu user.
+   * Note: Thread replies for files require Issue #68 implementation.
    */
-  async sendFileToUser(chatId: string, filePath: string): Promise<void> {
+  async sendFileToUser(chatId: string, filePath: string, _parentId?: string): Promise<void> {
     if (!this.messageSender) {
       this.getClient();
     }
@@ -328,6 +333,7 @@ export class CommunicationNode extends EventEmitter {
     if (!sender) {
       throw new Error('MessageSender not initialized');
     }
+    // TODO: Pass parentId to sendFile when Issue #68 is implemented
     await sender.sendFile(chatId, filePath);
   }
 
@@ -373,7 +379,7 @@ export class CommunicationNode extends EventEmitter {
 
     if (!message) return;
 
-    const { message_id, chat_id, content, message_type, create_time } = message;
+    const { message_id, chat_id, content, message_type, create_time, parent_id } = message;
 
     if (!message_id || !chat_id || !content || !message_type) {
       logger.warn('Missing required message fields');
@@ -437,6 +443,7 @@ export class CommunicationNode extends EventEmitter {
           prompt: enhancedPrompt,
           messageId: `${message_id}-file`,
           senderOpenId: this.extractOpenId(sender),
+          parentId: parent_id,
         });
       }
       return;
@@ -538,6 +545,7 @@ export class CommunicationNode extends EventEmitter {
       prompt: text,
       messageId: message_id,
       senderOpenId: this.extractOpenId(sender),
+      parentId: parent_id,
     });
   }
 

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -22,6 +22,8 @@ interface PromptMessage {
   prompt: string;
   messageId: string;
   senderOpenId?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
 }
 
 interface CommandMessage {
@@ -37,6 +39,8 @@ interface FeedbackMessage {
   card?: Record<string, unknown>;
   filePath?: string;
   error?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
 }
 
 /**
@@ -68,9 +72,13 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   // Get agent configuration
   const agentConfig = Config.getAgentConfig();
 
-  // Map to store active sendFeedback functions per chatId
-  // This allows callbacks to route messages to the correct WebSocket context
-  const activeFeedbackChannels = new Map<string, (feedback: FeedbackMessage) => void>();
+  // Map to store active feedback context per chatId
+  // Includes sendFeedback function and parentId for thread replies
+  interface FeedbackContext {
+    sendFeedback: (feedback: FeedbackMessage) => void;
+    parentId?: string;
+  }
+  const activeFeedbackChannels = new Map<string, FeedbackContext>();
 
   /**
    * Create a shared Pilot instance for all messages.
@@ -85,26 +93,26 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     apiBaseUrl: agentConfig.apiBaseUrl,
     isCliMode: false, // Enable persistent sessions for context retention
     callbacks: {
-      sendMessage: async (chatId: string, text: string) => {
-        const sendFeedback = activeFeedbackChannels.get(chatId);
-        if (sendFeedback) {
-          sendFeedback({ type: 'text', chatId, text });
+      sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
+        const ctx = activeFeedbackChannels.get(chatId);
+        if (ctx) {
+          ctx.sendFeedback({ type: 'text', chatId, text, parentId: parentMessageId || ctx.parentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendMessage');
         }
       },
-      sendCard: async (chatId: string, card: Record<string, unknown>, description?: string) => {
-        const sendFeedback = activeFeedbackChannels.get(chatId);
-        if (sendFeedback) {
-          sendFeedback({ type: 'card', chatId, card, text: description });
+      sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => {
+        const ctx = activeFeedbackChannels.get(chatId);
+        if (ctx) {
+          ctx.sendFeedback({ type: 'card', chatId, card, text: description, parentId: parentMessageId || ctx.parentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendCard');
         }
       },
       sendFile: async (chatId: string, filePath: string) => {
-        const sendFeedback = activeFeedbackChannels.get(chatId);
-        if (sendFeedback) {
-          sendFeedback({ type: 'file', chatId, filePath });
+        const ctx = activeFeedbackChannels.get(chatId);
+        if (ctx) {
+          ctx.sendFeedback({ type: 'file', chatId, filePath, parentId: ctx.parentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendFile');
         }
@@ -156,8 +164,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
         // Handle prompt messages
         if (message.type === 'prompt') {
-          const { chatId, prompt, messageId, senderOpenId } = message;
-          logger.info({ chatId, messageId, promptLength: prompt.length }, 'Received prompt');
+          const { chatId, prompt, messageId, senderOpenId, parentId } = message;
+          logger.info({ chatId, messageId, promptLength: prompt.length, parentId }, 'Received prompt');
 
           // Create send feedback function for this message
           const sendFeedback = (feedback: FeedbackMessage) => {
@@ -166,8 +174,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             }
           };
 
-          // Register feedback channel for this chatId
-          activeFeedbackChannels.set(chatId, sendFeedback);
+          // Register feedback channel for this chatId with parentId
+          activeFeedbackChannels.set(chatId, { sendFeedback, parentId });
 
           try {
             // Use processMessage for persistent session context
@@ -177,11 +185,11 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             // Send done signal after processing
             // Note: Since processMessage is non-blocking, we send done immediately
             // The actual response will come through the callbacks asynchronously
-            sendFeedback({ type: 'done', chatId });
+            sendFeedback({ type: 'done', chatId, parentId });
           } catch (error) {
             const err = error as Error;
             logger.error({ err, chatId }, 'Execution failed');
-            sendFeedback({ type: 'error', chatId, error: err.message });
+            sendFeedback({ type: 'error', chatId, error: err.message, parentId });
           }
           return;
         }


### PR DESCRIPTION
## Summary

Fixes #66 - Bot replies were appearing outside of threads instead of within them.

This was caused by `parentId` not being passed through the communication pipeline between Communication Node and Execution Node.

## Root Cause

The data flow had three breakpoints where `parentId` was being lost:

1. **CommunicationNode.handleMessageReceive()** - Extracted only `message_id, chat_id, content` from Feishu message, ignoring `parent_id`
2. **PromptMessage/FeedbackMessage interfaces** - Missing `parentId` field definition
3. **Execution Runner callbacks** - Not receiving/using `parentMessageId` parameter

## Changes

### Communication Node (`communication-node.ts`)
- Extract `parent_id` from Feishu message event
- Add `parentId` field to `PromptMessage` and `FeedbackMessage` interfaces
- Pass `parentId` in `sendPrompt()` calls
- Pass `parentId` to `MessageSender.sendText()` and `sendCard()` in `handleFeedback()`

### Execution Runner (`execution-runner.ts`)
- Add `parentId` field to `PromptMessage` and `FeedbackMessage` interfaces
- Create `FeedbackContext` interface to store both `sendFeedback` function and `parentId`
- Update Pilot callbacks to receive `parentMessageId` and pass it via `FeedbackMessage`
- Extract and store `parentId` when receiving prompt messages

## Data Flow (After Fix)

```
Feishu WebSocket Event (parent_id)
   ↓
CommunicationNode.handleMessageReceive()
   ↓ Extract parent_id
PromptMessage { parentId }
   ↓ WebSocket
Execution Runner
   ↓ Store in FeedbackContext
Pilot callbacks (parentMessageId)
   ↓
FeedbackMessage { parentId }
   ↓ WebSocket
CommunicationNode.handleFeedback()
   ↓
MessageSender.sendText/sendCard(parentId)
   ↓
Feishu API (parent_id in request)
```

## Test Plan

- [ ] Send message in Feishu thread
- [ ] Verify bot reply appears within the thread
- [ ] Test with multiple concurrent threads
- [ ] Verify non-thread messages still work normally

## Notes

- File thread replies (Issue #68) still need separate implementation in `file-uploader.ts`
- The `sendFileToUser` method now accepts `_parentId` parameter for future implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)