### PR TITLE
fix: Filter out stdio MCP servers to prevent transport conflicts

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -193,9 +193,21 @@ export class Pilot extends BaseAgent {
 
     // CLI mode doesn't need Feishu MCP server
     // Merge configured external MCP servers from config file
+    // Note: stdio-based MCP servers cannot be shared across multiple Agent instances.
+    // These servers are filtered out to prevent transport conflicts.
+    // See: https://github.com/hs3180/disclaude/issues/71
+    const STDIO_MCP_BLACKLIST = ['playwright'] as const;
     const configuredMcpServers = Config.getMcpServersConfig();
     if (configuredMcpServers) {
       for (const [name, config] of Object.entries(configuredMcpServers)) {
+        if (STDIO_MCP_BLACKLIST.includes(name as typeof STDIO_MCP_BLACKLIST[number])) {
+          this.logger.warn(
+            { mcpServer: name },
+            'Skipping stdio MCP server that cannot be shared across Agent instances. ' +
+            'See https://github.com/hs3180/disclaude/issues/71 for details.'
+          );
+          continue;
+        }
         mcpServers[name] = {
           type: 'stdio',
           command: config.command,
@@ -561,9 +573,21 @@ ${msg.text}`;
     }
 
     // Merge configured external MCP servers from config file
+    // Note: stdio-based MCP servers cannot be shared across multiple Agent instances.
+    // These servers are filtered out to prevent transport conflicts.
+    // See: https://github.com/hs3180/disclaude/issues/71
+    const STDIO_MCP_BLACKLIST = ['playwright'] as const;
     const configuredMcpServers = Config.getMcpServersConfig();
     if (configuredMcpServers) {
       for (const [name, config] of Object.entries(configuredMcpServers)) {
+        if (STDIO_MCP_BLACKLIST.includes(name as typeof STDIO_MCP_BLACKLIST[number])) {
+          this.logger.warn(
+            { mcpServer: name },
+            'Skipping stdio MCP server that cannot be shared across Agent instances. ' +
+            'See https://github.com/hs3180/disclaude/issues/71 for details.'
+          );
+          continue;
+        }
         mcpServers[name] = {
           type: 'stdio',
           command: config.command,


### PR DESCRIPTION
## Summary

Fixes #71

**Problem**: Stdio-based MCP servers (like playwright) cannot be shared across multiple Agent instances. When multiple chatIds try to use the same stdio MCP server concurrently, it causes transport connection conflicts.

**Error**:
```
Error: Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.
```

## Solution

Add a blacklist to filter out stdio MCP servers that cannot be shared.

**Currently filtered**:
- `playwright`: Uses stdio transport, cannot be shared

## Changes

- Add `STDIO_MCP_BLACKLIST` constant in `pilot.ts`
- Filter blacklisted MCP servers when loading from config
- Log warning when a server is skipped

## Testing

- [x] Build passes
- [ ] Deploy and verify no transport conflicts
- [ ] Verify warning is logged when playwright is in config

## Notes

This is a **temporary fix**. The long-term solution is to use HTTP/WebSocket transport for MCP servers that need to be shared across Agent instances (see Issue #72).

Related: #41 (concurrent MCP transport conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)