### PR TITLE
feat: sendFile 支持发送到 Thread 中

### DIFF
--- a/src/feishu/file-uploader.ts
+++ b/src/feishu/file-uploader.ts
@@ -189,12 +189,14 @@ export async function uploadFile(
  * @param client - Lark SDK client
  * @param chatId - Target chat ID
  * @param uploadResult - Upload result from uploadFile()
+ * @param parentId - Optional parent message ID for thread replies
  * @throws Error if sending fails
  */
 export async function sendFileMessage(
   client: lark.Client,
   chatId: string,
-  uploadResult: UploadResult
+  uploadResult: UploadResult,
+  parentId?: string
 ): Promise<void> {
   try {
     // Build message type and content based on file type
@@ -243,19 +245,32 @@ export async function sendFileMessage(
       uploadApiType: uploadResult.apiFileType,
       msgType,
       fileKey: uploadResult.fileKey,
-      fileName: uploadResult.fileName
+      fileName: uploadResult.fileName,
+      parentId,
     }, 'Sending file message to Feishu');
 
     // Send message
+    const messageData: {
+      receive_id: string;
+      msg_type: 'text' | 'post' | 'image' | 'file' | 'audio' | 'media';
+      content: string;
+      parent_id?: string;
+    } = {
+      receive_id: chatId,
+      msg_type: msgType as 'text' | 'post' | 'image' | 'file' | 'audio' | 'media',
+      content,
+    };
+
+    // Add parent_id for thread replies if provided
+    if (parentId) {
+      messageData.parent_id = parentId;
+    }
+
     const response = await client.im.message.create({
       params: {
         receive_id_type: 'chat_id',
       },
-      data: {
-        receive_id: chatId,
-        msg_type: msgType as 'text' | 'post' | 'image' | 'file' | 'audio' | 'media',
-        content,
-      },
+      data: messageData,
     });
 
     logger.info({
@@ -341,19 +356,21 @@ export async function sendFileMessage(
  * @param client - Lark SDK client
  * @param filePath - Local file path
  * @param chatId - Target chat ID
+ * @param parentId - Optional parent message ID for thread replies
  * @returns File size in bytes
  * @throws Error if any step fails
  */
 export async function uploadAndSendFile(
   client: lark.Client,
   filePath: string,
-  chatId: string
+  chatId: string,
+  parentId?: string
 ): Promise<number> {
   // Step 1: Upload file
   const uploadResult = await uploadFile(client, filePath, chatId);
 
   // Step 2: Send message
-  await sendFileMessage(client, chatId, uploadResult);
+  await sendFileMessage(client, chatId, uploadResult, parentId);
 
   return uploadResult.fileSize;
 }

--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -161,11 +161,12 @@ export class MessageSender {
    *
    * @param chatId - Target chat ID
    * @param filePath - Local file path to send
+   * @param parentId - Optional parent message ID for thread replies
    */
-  async sendFile(chatId: string, filePath: string): Promise<void> {
+  async sendFile(chatId: string, filePath: string, parentId?: string): Promise<void> {
     try {
       const { uploadAndSendFile } = await import('./file-uploader.js');
-      const fileSize = await uploadAndSendFile(this.client, filePath, chatId);
+      const fileSize = await uploadAndSendFile(this.client, filePath, chatId, parentId);
 
       // Log file message to persistent MD file
       const fileName = path.basename(filePath);
@@ -176,9 +177,9 @@ export class MessageSender {
         fileContent
       );
 
-      this.logger.info({ chatId, filePath, fileSize }, 'File sent to user');
+      this.logger.info({ chatId, filePath, fileSize, parentId }, 'File sent to user');
     } catch (error) {
-      this.logger.error({ err: error, filePath, chatId }, 'Failed to send file to user');
+      this.logger.error({ err: error, filePath, chatId, parentId }, 'Failed to send file to user');
       // Don't throw - file sending failure shouldn't break the main flow
     }
   }


### PR DESCRIPTION
## Summary

- 为 `sendFile()` 方法添加 `parentId` 参数支持
- 为 `uploadAndSendFile()` 函数添加 `parentId` 参数支持  
- 为 `sendFileMessage()` 函数添加 `parentId` 参数支持
- 当提供 `parentId` 时，在飞书 API 消息数据中包含 `parent_id`
- 更新日志记录以包含 `parentId` 上下文

## Test plan

- [x] Build succeeds (`npm run build`)
- [x] Changes follow same pattern as existing `sendText` and `sendCard` methods
- [x] Backward compatible - `parentId` is optional parameter

## Related

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)