### PR TITLE
feat: Refactor schedule system to file-based configuration (issue #79)

### DIFF
--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: schedule
+description: 定时任务创建专家 - 交互式创建和管理定时任务
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, create_schedule, list_schedules, delete_schedule, toggle_schedule]
+---
+
+# Schedule Agent
+
+你是定时任务创建专家。帮助用户创建、修改和管理定时任务。
+
+## 单一职责
+
+- ✅ 帮助用户创建定时任务
+- ✅ 帮助用户查看现有任务
+- ✅ 帮助用户修改/删除任务
+- ❌ DO NOT 执行其他无关任务
+
+## 上下文变量
+
+When invoked, you will receive context in the system message:
+
+- **Chat ID**: The Feishu chat ID (from "**Chat ID:** xxx" in the message)
+- **Message ID**: The message ID (from "**Message ID:** xxx" in the message)
+- **Sender Open ID**: The sender's open ID (from "**Sender Open ID:** xxx", if available)
+
+**IMPORTANT**: 使用 chatId 作为任务的 scope，确保任务只在正确的聊天中执行。
+
+## 工作流程
+
+### 创建任务
+
+1. 收集任务信息：
+   - 任务名称（简短描述）
+   - 执行时间（cron 格式或自然语言）
+   - 任务内容（要执行的 prompt）
+
+2. 使用 `create_schedule` 工具创建任务：
+   - name: 任务名称
+   - cron: cron 表达式
+   - prompt: 任务内容
+   - chatId: 从上下文获取
+
+3. 确认创建成功，展示任务详情
+
+### 查看任务
+
+使用 `list_schedules` 工具列出当前聊天的所有任务。
+
+### 删除任务
+
+使用 `delete_schedule` 工具删除指定任务。
+
+### 启用/禁用任务
+
+使用 `toggle_schedule` 工具切换任务状态。
+
+## Cron 格式说明
+
+```
+minute hour day month weekday
+```
+
+示例：
+- `"0 9 * * *"` - 每天 9:00
+- `"30 14 * * 5"` - 每周五 14:30
+- `"0 10 1 * *"` - 每月1日 10:00
+- `"*/15 * * * *"` - 每15分钟
+
+## 任务文件格式
+
+任务会保存为 Markdown 文件：
+
+```markdown
+---
+name: 每日报告
+cron: "0 9 * * *"
+enabled: true
+chatId: oc_xxx
+---
+
+每天早上 9 点，扫描昨日工作进度并发送报告。
+```
+
+## 交互示例
+
+### 创建任务
+
+用户: "帮我创建一个每天早上9点的提醒"
+
+Agent:
+1. 确认任务名称："每日提醒"
+2. 确认时间：每天 9:00 → `"0 9 * * *"`
+3. 询问任务内容："提醒我做什么？"
+4. 收集完整信息后调用 create_schedule
+
+### 查看任务
+
+用户: "我有哪些定时任务？"
+
+Agent: 调用 list_schedules 并格式化展示结果
+
+## 重要行为
+
+1. **友好交互**: 逐步收集信息，不要一次性问太多
+2. **确认时间**: 对自然语言时间描述转换为 cron 格式时确认
+3. **展示结果**: 创建/修改后展示任务详情
+4. **使用 chatId**: 确保使用正确的 chatId scope
+
+## DO NOT
+
+- ❌ 在没有确认的情况下创建任务
+- ❌ 修改其他聊天的任务
+- ❌ 执行与定时任务无关的操作

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -11,7 +11,13 @@ import { Config } from '../config/index.js';
 import { Pilot } from '../agents/pilot.js';
 import { createLogger } from '../utils/logger.js';
 import { parseGlobalArgs, getExecNodeConfig, type ExecNodeConfig } from '../utils/cli-args.js';
-import { ScheduleManager, Scheduler, setScheduleManager, setScheduler } from '../schedule/index.js';
+import {
+  ScheduleManager,
+  Scheduler,
+  ScheduleFileWatcher,
+  setScheduleManager,
+  setScheduler,
+} from '../schedule/index.js';
 
 const logger = createLogger('ExecRunner');
 
@@ -124,8 +130,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
   // Initialize Schedule Manager and Scheduler
   const workspaceDir = Config.getWorkspaceDir();
-  const scheduleFilePath = path.join(workspaceDir, 'schedules.json');
-  const scheduleManager = new ScheduleManager(scheduleFilePath);
+  const schedulesDir = path.join(workspaceDir, 'schedules');
+  const scheduleManager = new ScheduleManager({ schedulesDir });
   const scheduler = new Scheduler({
     scheduleManager,
     pilot: sharedPilot,
@@ -155,6 +161,26 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     },
   });
 
+  // Initialize file watcher for hot reload
+  let fileWatcher: ScheduleFileWatcher | undefined;
+  const initFileWatcher = () => {
+    fileWatcher = new ScheduleFileWatcher({
+      schedulesDir,
+      onFileAdded: (task) => {
+        logger.info({ taskId: task.id, name: task.name }, 'Schedule file added, adding to scheduler');
+        scheduler.addTask(task);
+      },
+      onFileChanged: (task) => {
+        logger.info({ taskId: task.id, name: task.name }, 'Schedule file changed, updating scheduler');
+        scheduler.addTask(task);
+      },
+      onFileRemoved: (taskId) => {
+        logger.info({ taskId }, 'Schedule file removed, removing from scheduler');
+        scheduler.removeTask(taskId);
+      },
+    });
+  };
+
   // Register with MCP tools
   setScheduleManager(scheduleManager);
   setScheduler(scheduler);
@@ -162,6 +188,11 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   // Start scheduler
   await scheduler.start();
   console.log('✓ Scheduler started');
+
+  // Start file watcher for hot reload
+  initFileWatcher();
+  await fileWatcher?.start();
+  console.log('✓ Schedule file watcher started');
   console.log();
 
   /**
@@ -287,6 +318,12 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     console.log('\nShutting down Execution Node...');
 
     running = false;
+
+    // Stop file watcher
+    fileWatcher?.stop();
+
+    // Stop scheduler
+    scheduler.stop();
 
     // Clear reconnect timer
     if (reconnectTimer) {

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -5,14 +5,19 @@
  * - ScheduleManager: CRUD operations for scheduled tasks
  * - Scheduler: Cron-based task execution
  * - Schedule MCP Tools: LLM-callable tools for schedule management
+ * - ScheduleFileScanner: Scans and parses schedule markdown files
+ * - ScheduleFileWatcher: Hot reload for schedule files
  *
  * @see Issue #3 - Scheduled task feature
+ * @see Issue #79 - Refactor to file-based configuration
  */
 
-export { ScheduleManager, type ScheduledTask, type CreateScheduleOptions } from './schedule-manager.js';
+export { ScheduleManager, type ScheduledTask, type CreateScheduleOptions, type ScheduleManagerOptions } from './schedule-manager.js';
 export { Scheduler, type SchedulerOptions } from './scheduler.js';
 export {
   scheduleSdkMcpServer,
   setScheduleManager,
   setScheduler,
 } from './schedule-mcp.js';
+export { ScheduleFileScanner, type ScheduleFileTask, type ScheduleFileScannerOptions } from './schedule-file-scanner.js';
+export { ScheduleFileWatcher, type OnFileAdded, type OnFileChanged, type OnFileRemoved, type ScheduleFileWatcherOptions } from './schedule-file-watcher.js';

--- a/src/schedule/schedule-file-scanner.ts
+++ b/src/schedule/schedule-file-scanner.ts
@@ -1,0 +1,290 @@
+/**
+ * Schedule File Scanner - Scans and parses schedule markdown files.
+ *
+ * Scans the schedules/ directory for .md files with YAML frontmatter.
+ * Each file represents a scheduled task with metadata and prompt.
+ *
+ * ## File Format
+ *
+ * ```markdown
+ * ---
+ * name: Daily Report
+ * cron: "0 9 * * *"
+ * enabled: true
+ * chatId: oc_xxx
+ * createdBy: ou_xxx
+ * ---
+ *
+ * Task prompt content here...
+ * ```
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import type { ScheduledTask } from './schedule-manager.js';
+
+const logger = createLogger('ScheduleFileScanner');
+
+/**
+ * Schedule file with additional metadata.
+ */
+export interface ScheduleFileTask extends ScheduledTask {
+  /** Source file path */
+  sourceFile: string;
+  /** File modification time */
+  fileMtime: Date;
+}
+
+/**
+ * ScheduleFileScanner options.
+ */
+export interface ScheduleFileScannerOptions {
+  /** Directory to scan for schedule files */
+  schedulesDir: string;
+}
+
+/**
+ * Parse YAML frontmatter from schedule content.
+ *
+ * Extracts:
+ * - name (required)
+ * - cron (required)
+ * - enabled (optional, default: true)
+ * - chatId (required)
+ * - createdBy (optional)
+ * - createdAt (optional)
+ *
+ * @param content - Raw schedule file content
+ * @returns Parsed frontmatter and content start position
+ */
+function parseScheduleFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>;
+  contentStart: number;
+} {
+  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
+  const match = content.match(frontmatterRegex);
+
+  if (!match) {
+    return { frontmatter: {}, contentStart: 0 };
+  }
+
+  const [, frontmatterText] = match;
+  const frontmatter: Record<string, unknown> = {};
+
+  // Parse key-value pairs
+  const lines = frontmatterText.split('\n');
+  for (const line of lines) {
+    const colonIndex = line.indexOf(':');
+    if (colonIndex === -1) { continue; }
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+
+    switch (key) {
+      case 'name':
+      case 'cron':
+      case 'chatId':
+      case 'createdBy':
+      case 'createdAt':
+        // Remove quotes if present
+        frontmatter[key] = value.replace(/^["']|["']$/g, '');
+        break;
+      case 'enabled':
+        frontmatter[key] = value === 'true';
+        break;
+    }
+  }
+
+  return {
+    frontmatter,
+    contentStart: match[0].length
+  };
+}
+
+/**
+ * Generate a slug from task name for file naming.
+ */
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-') // Keep alphanumeric and Chinese
+    .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
+}
+
+/**
+ * Generate task ID from file name.
+ */
+function generateTaskId(fileName: string): string {
+  const baseName = path.basename(fileName, '.md');
+  return `schedule-${baseName}`;
+}
+
+/**
+ * ScheduleFileScanner - Scans and parses schedule markdown files.
+ */
+export class ScheduleFileScanner {
+  private schedulesDir: string;
+
+  constructor(options: ScheduleFileScannerOptions) {
+    this.schedulesDir = options.schedulesDir;
+    logger.info({ schedulesDir: this.schedulesDir }, 'ScheduleFileScanner initialized');
+  }
+
+  /**
+   * Ensure the schedules directory exists.
+   */
+  async ensureDir(): Promise<void> {
+    await fs.mkdir(this.schedulesDir, { recursive: true });
+  }
+
+  /**
+   * Scan all .md files and return parsed tasks.
+   */
+  async scanAll(): Promise<ScheduleFileTask[]> {
+    await this.ensureDir();
+
+    const tasks: ScheduleFileTask[] = [];
+
+    try {
+      const files = await fs.readdir(this.schedulesDir);
+      const mdFiles = files.filter(f => f.endsWith('.md'));
+
+      for (const file of mdFiles) {
+        const filePath = path.join(this.schedulesDir, file);
+        const task = await this.parseFile(filePath);
+        if (task) {
+          tasks.push(task);
+        }
+      }
+
+      logger.info({ count: tasks.length }, 'Scanned schedule files');
+      return tasks;
+
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        logger.debug('Schedules directory does not exist, returning empty');
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Parse a single schedule file.
+   *
+   * @param filePath - Path to the schedule file
+   * @returns Parsed task or null if invalid
+   */
+  async parseFile(filePath: string): Promise<ScheduleFileTask | null> {
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      const stats = await fs.stat(filePath);
+      const { frontmatter, contentStart } = parseScheduleFrontmatter(content);
+
+      // Validate required fields
+      if (!frontmatter['name'] || !frontmatter['cron'] || !frontmatter['chatId']) {
+        logger.warn({ filePath }, 'Schedule file missing required fields (name, cron, chatId)');
+        return null;
+      }
+
+      const prompt = content.slice(contentStart).trim();
+      const fileName = path.basename(filePath);
+
+      const task: ScheduleFileTask = {
+        id: generateTaskId(fileName),
+        name: frontmatter['name'] as string,
+        cron: frontmatter['cron'] as string,
+        chatId: frontmatter['chatId'] as string,
+        prompt,
+        enabled: (frontmatter['enabled'] as boolean) ?? true,
+        createdBy: frontmatter['createdBy'] as string | undefined,
+        createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
+        sourceFile: filePath,
+        fileMtime: stats.mtime,
+      };
+
+      logger.debug({ taskId: task.id, name: task.name }, 'Parsed schedule file');
+      return task;
+
+    } catch (error) {
+      logger.error({ err: error, filePath }, 'Failed to parse schedule file');
+      return null;
+    }
+  }
+
+  /**
+   * Write a task to a markdown file.
+   *
+   * @param task - Task to write
+   * @returns The file path
+   */
+  async writeTask(task: ScheduledTask): Promise<string> {
+    await this.ensureDir();
+
+    const slug = slugify(task.name);
+    const fileName = `${slug}.md`;
+    const filePath = path.join(this.schedulesDir, fileName);
+
+    const frontmatter = [
+      '---',
+      `name: "${task.name}"`,
+      `cron: "${task.cron}"`,
+      `enabled: ${task.enabled}`,
+      `chatId: ${task.chatId}`,
+    ];
+
+    if (task.createdBy) {
+      frontmatter.push(`createdBy: ${task.createdBy}`);
+    }
+    if (task.createdAt) {
+      frontmatter.push(`createdAt: ${task.createdAt}`);
+    }
+
+    frontmatter.push('---', '');
+
+    const content = frontmatter.join('\n') + task.prompt;
+
+    await fs.writeFile(filePath, content, 'utf-8');
+    logger.info({ taskId: task.id, filePath }, 'Wrote schedule file');
+
+    return filePath;
+  }
+
+  /**
+   * Delete a task file by task ID.
+   *
+   * @param taskId - Task ID to delete
+   * @returns true if deleted, false if not found
+   */
+  async deleteTask(taskId: string): Promise<boolean> {
+    // Task ID format: schedule-{slug}
+    if (!taskId.startsWith('schedule-')) {
+      return false;
+    }
+
+    const slug = taskId.slice('schedule-'.length);
+    const filePath = path.join(this.schedulesDir, `${slug}.md`);
+
+    try {
+      await fs.unlink(filePath);
+      logger.info({ taskId, filePath }, 'Deleted schedule file');
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get the file path for a task ID.
+   */
+  getFilePath(taskId: string): string {
+    const slug = taskId.startsWith('schedule-')
+      ? taskId.slice('schedule-'.length)
+      : taskId;
+    return path.join(this.schedulesDir, `${slug}.md`);
+  }
+}

--- a/src/schedule/schedule-file-watcher.ts
+++ b/src/schedule/schedule-file-watcher.ts
@@ -1,0 +1,294 @@
+/**
+ * Schedule File Watcher - Hot reload for schedule files.
+ *
+ * Watches the schedules/ directory for changes and notifies the scheduler.
+ * Supports:
+ * - File added: new task
+ * - File changed: update task
+ * - File removed: delete task
+ *
+ * Uses Node.js native fs.watch with debouncing for reliability.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import type { ScheduleFileTask } from './schedule-file-scanner.js';
+
+const logger = createLogger('ScheduleFileWatcher');
+
+/**
+ * Callback when a file is added.
+ */
+export type OnFileAdded = (task: ScheduleFileTask) => void;
+
+/**
+ * Callback when a file is changed.
+ */
+export type OnFileChanged = (task: ScheduleFileTask) => void;
+
+/**
+ * Callback when a file is removed.
+ */
+export type OnFileRemoved = (taskId: string, filePath: string) => void;
+
+/**
+ * ScheduleFileWatcher options.
+ */
+export interface ScheduleFileWatcherOptions {
+  /** Directory to watch */
+  schedulesDir: string;
+  /** Callback when a file is added */
+  onFileAdded: OnFileAdded;
+  /** Callback when a file is changed */
+  onFileChanged: OnFileChanged;
+  /** Callback when a file is removed */
+  onFileRemoved: OnFileRemoved;
+  /** Debounce interval in ms (default: 100) */
+  debounceMs?: number;
+}
+
+/**
+ * ScheduleFileWatcher - Watches schedule directory for changes.
+ */
+export class ScheduleFileWatcher {
+  private schedulesDir: string;
+  private onFileAdded: OnFileAdded;
+  private onFileChanged: OnFileChanged;
+  private onFileRemoved: OnFileRemoved;
+  private debounceMs: number;
+  private watcher: fs.FSWatcher | null = null;
+  private debounceTimers: Map<string, NodeJS.Timeout> = new Map();
+  private running = false;
+
+  constructor(options: ScheduleFileWatcherOptions) {
+    this.schedulesDir = options.schedulesDir;
+    this.onFileAdded = options.onFileAdded;
+    this.onFileChanged = options.onFileChanged;
+    this.onFileRemoved = options.onFileRemoved;
+    this.debounceMs = options.debounceMs ?? 100;
+  }
+
+  /**
+   * Start watching the schedules directory.
+   */
+  async start(): Promise<void> {
+    if (this.running) {
+      logger.warn('File watcher already running');
+      return;
+    }
+
+    // Ensure directory exists
+    await fs.promises.mkdir(this.schedulesDir, { recursive: true });
+
+    try {
+      this.watcher = fs.watch(
+        this.schedulesDir,
+        { persistent: true, recursive: false },
+        (eventType, filename) => {
+          this.handleFileEvent(eventType, filename);
+        }
+      );
+
+      this.watcher.on('error', (error) => {
+        logger.error({ err: error }, 'File watcher error');
+      });
+
+      this.running = true;
+      logger.info({ schedulesDir: this.schedulesDir }, 'File watcher started');
+
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to start file watcher');
+      throw error;
+    }
+  }
+
+  /**
+   * Stop watching.
+   */
+  stop(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+
+    // Clear all debounce timers
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
+
+    this.running = false;
+    logger.info('File watcher stopped');
+  }
+
+  /**
+   * Check if watcher is running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Handle file system event with debouncing.
+   */
+  private handleFileEvent(eventType: string, filename: string | null): void {
+    if (!filename || !filename.endsWith('.md')) {
+      return;
+    }
+
+    const filePath = path.join(this.schedulesDir, filename);
+    logger.debug({ eventType, filename }, 'File event received');
+
+    // Clear existing timer for this file
+    const existingTimer = this.debounceTimers.get(filePath);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    // Debounce the event
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(filePath);
+      this.processFileEvent(eventType, filePath, filename);
+    }, this.debounceMs);
+
+    this.debounceTimers.set(filePath, timer);
+  }
+
+  /**
+   * Process the file event after debouncing.
+   */
+  private async processFileEvent(eventType: string, filePath: string, filename: string): Promise<void> {
+    const taskId = this.generateTaskId(filename);
+
+    try {
+      if (eventType === 'rename') {
+        // Check if file exists to determine if it was added or removed
+        const exists = await this.fileExists(filePath);
+
+        if (exists) {
+          // File added or renamed to this name
+          const task = await this.parseFile(filePath);
+          if (task) {
+            logger.info({ taskId, filename }, 'Schedule file added');
+            this.onFileAdded(task);
+          }
+        } else {
+          // File removed
+          logger.info({ taskId, filename }, 'Schedule file removed');
+          this.onFileRemoved(taskId, filePath);
+        }
+      } else if (eventType === 'change') {
+        // File modified
+        const task = await this.parseFile(filePath);
+        if (task) {
+          logger.info({ taskId, filename }, 'Schedule file changed');
+          this.onFileChanged(task);
+        }
+      }
+    } catch (error) {
+      logger.error({ err: error, filePath, eventType }, 'Error processing file event');
+    }
+  }
+
+  /**
+   * Check if a file exists.
+   */
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.promises.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Parse a schedule file.
+   */
+  private async parseFile(filePath: string): Promise<ScheduleFileTask | null> {
+    try {
+      const content = await fs.promises.readFile(filePath, 'utf-8');
+      const stats = await fs.promises.stat(filePath);
+
+      const frontmatter = this.parseFrontmatter(content);
+      if (!frontmatter['name'] || !frontmatter['cron'] || !frontmatter['chatId']) {
+        return null;
+      }
+
+      const fileName = path.basename(filePath);
+      const prompt = this.extractContent(content);
+
+      return {
+        id: this.generateTaskId(fileName),
+        name: frontmatter['name'] as string,
+        cron: frontmatter['cron'] as string,
+        chatId: frontmatter['chatId'] as string,
+        prompt,
+        enabled: (frontmatter['enabled'] as boolean) ?? true,
+        createdBy: frontmatter['createdBy'] as string | undefined,
+        createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
+        sourceFile: filePath,
+        fileMtime: stats.mtime,
+      };
+    } catch (error) {
+      logger.error({ err: error, filePath }, 'Failed to parse schedule file');
+      return null;
+    }
+  }
+
+  /**
+   * Parse YAML frontmatter.
+   */
+  private parseFrontmatter(content: string): Record<string, unknown> {
+    const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n/;
+    const match = content.match(frontmatterRegex);
+
+    if (!match) {
+      return {};
+    }
+
+    const [, frontmatterText] = match;
+    const frontmatter: Record<string, unknown> = {};
+
+    const lines = frontmatterText.split('\n');
+    for (const line of lines) {
+      const colonIndex = line.indexOf(':');
+      if (colonIndex === -1) { continue; }
+
+      const key = line.slice(0, colonIndex).trim();
+      const value = line.slice(colonIndex + 1).trim();
+
+      switch (key) {
+        case 'name':
+        case 'cron':
+        case 'chatId':
+        case 'createdBy':
+        case 'createdAt':
+          frontmatter[key] = value.replace(/^["']|["']$/g, '');
+          break;
+        case 'enabled':
+          frontmatter[key] = value === 'true';
+          break;
+      }
+    }
+
+    return frontmatter;
+  }
+
+  /**
+   * Extract content after frontmatter.
+   */
+  private extractContent(content: string): string {
+    const frontmatterRegex = /^---\s*\n[\s\S]*?\n---\s*\n/;
+    return content.replace(frontmatterRegex, '').trim();
+  }
+
+  /**
+   * Generate task ID from file name.
+   */
+  private generateTaskId(fileName: string): string {
+    const baseName = path.basename(fileName, '.md');
+    return `schedule-${baseName}`;
+  }
+}

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -2,18 +2,18 @@
  * Schedule Manager - CRUD operations for scheduled tasks.
  *
  * Manages scheduled tasks that are triggered by cron expressions.
- * Tasks are persisted to JSON file and can be dynamically managed.
+ * Tasks are persisted as markdown files in the schedules/ directory.
  *
  * Features:
  * - CRUD operations for scheduled tasks
- * - JSON file persistence
+ * - File-based persistence (markdown with YAML frontmatter)
  * - Scope by chatId (each chat has its own tasks)
  */
 
-import * as fs from 'fs/promises';
 import * as path from 'path';
 import { createLogger } from '../utils/logger.js';
 import { v4 as uuidv4 } from 'uuid';
+import { ScheduleFileScanner, type ScheduleFileTask } from './schedule-file-scanner.js';
 
 const logger = createLogger('ScheduleManager');
 
@@ -42,14 +42,6 @@ export interface ScheduledTask {
 }
 
 /**
- * Schedule storage structure.
- */
-interface ScheduleStorage {
-  version: string;
-  schedules: ScheduledTask[];
-}
-
-/**
  * Options for creating a new scheduled task.
  */
 export interface CreateScheduleOptions {
@@ -61,11 +53,19 @@ export interface CreateScheduleOptions {
 }
 
 /**
+ * ScheduleManager options.
+ */
+export interface ScheduleManagerOptions {
+  /** Directory for schedule files */
+  schedulesDir: string;
+}
+
+/**
  * ScheduleManager - Manages CRUD operations for scheduled tasks.
  *
  * Usage:
  * ```typescript
- * const manager = new ScheduleManager('./workspace/schedules.json');
+ * const manager = new ScheduleManager({ schedulesDir: './workspace/schedules' });
  *
  * // Create a task
  * const task = await manager.create({
@@ -86,61 +86,49 @@ export interface CreateScheduleOptions {
  * ```
  */
 export class ScheduleManager {
-  private filePath: string;
-  private cache: ScheduleStorage | null = null;
+  private fileScanner: ScheduleFileScanner;
+  private cache: Map<string, ScheduledTask> = new Map();
 
-  constructor(filePath: string) {
-    this.filePath = filePath;
-    logger.info({ filePath }, 'ScheduleManager initialized');
+  constructor(options: ScheduleManagerOptions) {
+    this.fileScanner = new ScheduleFileScanner({ schedulesDir: options.schedulesDir });
+    logger.info({ schedulesDir: options.schedulesDir }, 'ScheduleManager initialized');
   }
 
   /**
-   * Load schedules from JSON file.
+   * Load schedules from files.
    * Uses cache if available.
    */
-  private async load(): Promise<ScheduleStorage> {
-    if (this.cache) {
-      return this.cache;
+  private async load(): Promise<void> {
+    if (this.cache.size > 0) {
+      return;
     }
-
-    try {
-      const content = await fs.readFile(this.filePath, 'utf-8');
-      this.cache = JSON.parse(content) as ScheduleStorage;
-      logger.debug({ count: this.cache.schedules.length }, 'Loaded schedules from file');
-      return this.cache;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        // File doesn't exist, create empty storage
-        this.cache = { version: '1.0.0', schedules: [] };
-        await this.save();
-        logger.info('Created new schedule storage file');
-        return this.cache;
-      }
-      throw error;
-    }
+    await this.reload();
   }
 
   /**
-   * Save schedules to JSON file.
+   * Force reload from files.
    */
-  private async save(): Promise<void> {
-    if (!this.cache) {
-      return;
+  async reload(): Promise<void> {
+    this.cache.clear();
+    const tasks = await this.fileScanner.scanAll();
+    for (const task of tasks) {
+      this.cache.set(task.id, task);
     }
-
-    // Ensure directory exists
-    const dir = path.dirname(this.filePath);
-    await fs.mkdir(dir, { recursive: true });
-
-    await fs.writeFile(this.filePath, JSON.stringify(this.cache, null, 2), 'utf-8');
-    logger.debug({ count: this.cache.schedules.length }, 'Saved schedules to file');
+    logger.debug({ count: this.cache.size }, 'Reloaded schedules from files');
   }
 
   /**
    * Invalidate cache (force reload on next operation).
    */
   invalidateCache(): void {
-    this.cache = null;
+    this.cache.clear();
+  }
+
+  /**
+   * Get the file scanner instance.
+   */
+  getFileScanner(): ScheduleFileScanner {
+    return this.fileScanner;
   }
 
   /**
@@ -150,10 +138,11 @@ export class ScheduleManager {
    * @returns The created task
    */
   async create(options: CreateScheduleOptions): Promise<ScheduledTask> {
-    const storage = await this.load();
+    await this.load();
 
+    const slug = this.generateSlug(options.name);
     const task: ScheduledTask = {
-      id: `schedule-${uuidv4().slice(0, 8)}`,
+      id: `schedule-${slug}`,
       name: options.name,
       cron: options.cron,
       prompt: options.prompt,
@@ -163,11 +152,28 @@ export class ScheduleManager {
       createdAt: new Date().toISOString(),
     };
 
-    storage.schedules.push(task);
-    await this.save();
+    // Write to file
+    await this.fileScanner.writeTask(task);
+
+    // Update cache
+    this.cache.set(task.id, task);
 
     logger.info({ taskId: task.id, name: task.name, chatId: task.chatId }, 'Created scheduled task');
     return task;
+  }
+
+  /**
+   * Generate a slug from task name.
+   */
+  private generateSlug(name: string): string {
+    const baseSlug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+
+    // Add short UUID to ensure uniqueness
+    const shortId = uuidv4().slice(0, 8);
+    return `${baseSlug}-${shortId}`;
   }
 
   /**
@@ -177,8 +183,8 @@ export class ScheduleManager {
    * @returns The task or undefined if not found
    */
   async get(id: string): Promise<ScheduledTask | undefined> {
-    const storage = await this.load();
-    return storage.schedules.find(t => t.id === id);
+    await this.load();
+    return this.cache.get(id);
   }
 
   /**
@@ -188,8 +194,8 @@ export class ScheduleManager {
    * @returns Array of tasks for the chat
    */
   async listByChatId(chatId: string): Promise<ScheduledTask[]> {
-    const storage = await this.load();
-    return storage.schedules.filter(t => t.chatId === chatId);
+    await this.load();
+    return Array.from(this.cache.values()).filter(t => t.chatId === chatId);
   }
 
   /**
@@ -198,8 +204,8 @@ export class ScheduleManager {
    * @returns Array of all enabled tasks
    */
   async listEnabled(): Promise<ScheduledTask[]> {
-    const storage = await this.load();
-    return storage.schedules.filter(t => t.enabled);
+    await this.load();
+    return Array.from(this.cache.values()).filter(t => t.enabled);
   }
 
   /**
@@ -208,8 +214,8 @@ export class ScheduleManager {
    * @returns Array of all tasks
    */
   async listAll(): Promise<ScheduledTask[]> {
-    const storage = await this.load();
-    return storage.schedules;
+    await this.load();
+    return Array.from(this.cache.values());
   }
 
   /**
@@ -220,21 +226,26 @@ export class ScheduleManager {
    * @returns The updated task or undefined if not found
    */
   async update(id: string, updates: Partial<Omit<ScheduledTask, 'id' | 'createdAt'>>): Promise<ScheduledTask | undefined> {
-    const storage = await this.load();
-    const index = storage.schedules.findIndex(t => t.id === id);
+    await this.load();
 
-    if (index === -1) {
+    const task = this.cache.get(id);
+    if (!task) {
       return undefined;
     }
 
-    storage.schedules[index] = {
-      ...storage.schedules[index],
+    const updatedTask: ScheduledTask = {
+      ...task,
       ...updates,
     };
 
-    await this.save();
+    // Write to file
+    await this.fileScanner.writeTask(updatedTask);
+
+    // Update cache
+    this.cache.set(id, updatedTask);
+
     logger.info({ taskId: id, updates }, 'Updated scheduled task');
-    return storage.schedules[index];
+    return updatedTask;
   }
 
   /**
@@ -244,7 +255,7 @@ export class ScheduleManager {
    * @param enabled - New enabled status
    * @returns The updated task or undefined if not found
    */
-  toggle(id: string, enabled: boolean): Promise<ScheduledTask | undefined> {
+  async toggle(id: string, enabled: boolean): Promise<ScheduledTask | undefined> {
     return this.update(id, { enabled });
   }
 
@@ -264,15 +275,21 @@ export class ScheduleManager {
    * @returns true if deleted, false if not found
    */
   async delete(id: string): Promise<boolean> {
-    const storage = await this.load();
-    const index = storage.schedules.findIndex(t => t.id === id);
+    await this.load();
 
-    if (index === -1) {
+    const task = this.cache.get(id);
+    if (!task) {
       return false;
     }
 
-    storage.schedules.splice(index, 1);
-    await this.save();
+    // Delete file
+    const deleted = await this.fileScanner.deleteTask(id);
+    if (!deleted) {
+      return false;
+    }
+
+    // Remove from cache
+    this.cache.delete(id);
 
     logger.info({ taskId: id }, 'Deleted scheduled task');
     return true;


### PR DESCRIPTION
## Summary

- Replace JSON-based schedule storage with Markdown files in `schedules/` directory
- Add `ScheduleFileScanner` to parse `.md` files with YAML frontmatter
- Add `ScheduleFileWatcher` for hot-reload on file changes using `fs.watch`
- Simplify `ScheduleManager` to file-only storage (no JSON dependency)
- Create `schedule` Skill for interactive task creation via `/schedule` command
- Update MCP Tools to use file-based storage

## Task File Format

```markdown
---
name: "Daily Report"
cron: "0 9 * * *"
enabled: true
chatId: "oc_xxx"
---

Generate daily summary...
```

## Breaking Changes

- `schedules.json` no longer supported
- Existing schedules need manual migration to `.md` files

## Files Changed

| File | Action |
|------|--------|
| `src/schedule/schedule-file-scanner.ts` | Create |
| `src/schedule/schedule-file-watcher.ts` | Create |
| `src/schedule/schedule-manager.ts` | Modify |
| `src/schedule/index.ts` | Modify |
| `src/runners/execution-runner.ts` | Modify |
| `skills/schedule/SKILL.md` | Create |

## Test Plan

- [ ] Create task via `/schedule` skill, verify file generation
- [ ] Edit `.md` file directly, verify hot-reload works
- [ ] Delete `.md` file, verify task removed from scheduler
- [ ] Restart service, verify task persistence
- [ ] Run unit tests: `npm test`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)