### PR TITLE
refactor: 抽取共享的 WebSocket 消息类型定义

### DIFF
--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -23,6 +23,7 @@ import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
 
 const logger = createLogger('CommunicationNode');
 
@@ -46,36 +47,6 @@ export interface CommunicationNodeConfig {
   restAuthToken?: string;
   /** Custom channels to register */
   channels?: IChannel[];
-}
-
-/**
- * WebSocket message types.
- */
-interface PromptMessage {
-  type: 'prompt';
-  chatId: string;
-  prompt: string;
-  messageId: string;
-  senderOpenId?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
-}
-
-interface CommandMessage {
-  type: 'command';
-  command: 'reset' | 'restart';
-  chatId: string;
-}
-
-interface FeedbackMessage {
-  type: 'text' | 'card' | 'file' | 'done' | 'error';
-  chatId: string;
-  text?: string;
-  card?: Record<string, unknown>;
-  filePath?: string;
-  error?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
 }
 
 /**

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -18,38 +18,9 @@ import {
   setScheduleManager,
   setScheduler,
 } from '../schedule/index.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
 
 const logger = createLogger('ExecRunner');
-
-/**
- * WebSocket message types.
- */
-interface PromptMessage {
-  type: 'prompt';
-  chatId: string;
-  prompt: string;
-  messageId: string;
-  senderOpenId?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
-}
-
-interface CommandMessage {
-  type: 'command';
-  command: 'reset' | 'restart';
-  chatId: string;
-}
-
-interface FeedbackMessage {
-  type: 'text' | 'card' | 'file' | 'done' | 'error';
-  chatId: string;
-  text?: string;
-  card?: Record<string, unknown>;
-  filePath?: string;
-  error?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
-}
 
 /**
  * Run Execution Node (Pilot Agent with WebSocket client).

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -1,0 +1,43 @@
+/**
+ * WebSocket message types for Communication Node and Execution Node communication.
+ *
+ * These types define the message format exchanged between the two nodes:
+ * - Communication Node sends: PromptMessage, CommandMessage
+ * - Execution Node sends: FeedbackMessage
+ */
+
+/**
+ * Message sent from Communication Node to Execution Node when a user sends a prompt.
+ */
+export interface PromptMessage {
+  type: 'prompt';
+  chatId: string;
+  prompt: string;
+  messageId: string;
+  senderOpenId?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
+}
+
+/**
+ * Message sent from Communication Node to Execution Node for control commands.
+ */
+export interface CommandMessage {
+  type: 'command';
+  command: 'reset' | 'restart';
+  chatId: string;
+}
+
+/**
+ * Message sent from Execution Node to Communication Node for feedback.
+ */
+export interface FeedbackMessage {
+  type: 'text' | 'card' | 'file' | 'done' | 'error';
+  chatId: string;
+  text?: string;
+  card?: Record<string, unknown>;
+  filePath?: string;
+  error?: string;
+  /** Parent message ID for thread replies */
+  parentId?: string;
+}


### PR DESCRIPTION
## Summary

- Extract `PromptMessage`, `CommandMessage`, and `FeedbackMessage` interfaces from `communication-node.ts` and `execution-runner.ts` into a shared `src/types/websocket-messages.ts` file
- Eliminate duplicate type definitions that could lead to maintenance issues and type drift

## Changes

| File | Change |
|------|--------|
| `src/types/websocket-messages.ts` | New file with shared WebSocket message types |
| `src/nodes/communication-node.ts` | Import types from shared location, remove local definitions |
| `src/runners/execution-runner.ts` | Import types from shared location, remove local definitions |

## Benefits

- **Single source of truth**: All WebSocket message types are defined in one place
- **Reduced maintenance cost**: Adding new fields only requires updating one file
- **No sync risk**: Impossible to have inconsistent type definitions between nodes

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)