### PR TITLE
feat: 添加节点间文件传输支持 (close #94)

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -37,6 +37,7 @@ import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { createTaskSkillSdkMcpServer } from '../mcp/task-skill-mcp.js';
 import { createScheduleSdkMcpServer } from '../schedule/index.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
+import type { FileReference } from '../types/file-reference.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -109,6 +110,8 @@ interface QueuedMessage {
   text: string;
   messageId: string;
   senderOpenId?: string;
+  /** File attachments (if any) */
+  attachments?: FileReference[];
 }
 
 /**
@@ -312,14 +315,16 @@ export class Pilot extends BaseAgent {
    * @param text - User's message text
    * @param messageId - Unique message identifier
    * @param senderOpenId - Optional sender's open_id for @ mentions
+   * @param attachments - Optional file attachments
    */
   processMessage(
     chatId: string,
     text: string,
     messageId: string,
-    senderOpenId?: string
+    senderOpenId?: string,
+    attachments?: FileReference[]
   ): void {
-    this.logger.debug({ chatId, messageId, textLength: text.length }, 'Processing message');
+    this.logger.debug({ chatId, messageId, textLength: text.length, hasAttachments: !!attachments }, 'Processing message');
 
     // Get or create state for this chatId (handles health check and restart)
     const state = this.getOrCreateState(chatId);
@@ -333,7 +338,7 @@ export class Pilot extends BaseAgent {
     this.logger.debug({ chatId, messageId }, 'Set current thread root for replies');
 
     // Push message to the queue
-    state.messageQueue.push({ text, messageId, senderOpenId });
+    state.messageQueue.push({ text, messageId, senderOpenId, attachments });
 
     // Log health status for debugging
     if (state.closed || !state.started) {
@@ -433,12 +438,12 @@ export class Pilot extends BaseAgent {
 ---
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
-**Sender Open ID:** ${msg.senderOpenId}`
+**Sender Open ID:** ${msg.senderOpenId}${this.buildAttachmentsInfo(msg.attachments)}`
         : `
 
 ---
 **Chat ID:** ${chatId}
-**Message ID:** ${msg.messageId}`;
+**Message ID:** ${msg.messageId}${this.buildAttachmentsInfo(msg.attachments)}`;
 
       return `${msg.text}${contextInfo}`;
     }
@@ -473,7 +478,7 @@ When using send_file_to_feishu or send_user_feedback, use:
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
 
 --- User Message ---
-${msg.text}`;
+${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     }
 
     return `You are responding in a Feishu chat.
@@ -486,7 +491,35 @@ When using send_file_to_feishu or send_user_feedback, use:
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
 
 --- User Message ---
-${msg.text}`;
+${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
+  }
+
+  /**
+   * Build attachments info string for the message content.
+   */
+  private buildAttachmentsInfo(attachments?: FileReference[]): string {
+    if (!attachments || attachments.length === 0) {
+      return '';
+    }
+
+    const attachmentList = attachments
+      .map((att, index) => {
+        const sizeInfo = att.size ? ` (${(att.size / 1024).toFixed(1)} KB)` : '';
+        return `${index + 1}. **${att.fileName}**${sizeInfo}
+   - File ID: \`${att.id}\`
+   - Local path: \`${att.storageKey}\`
+   - MIME type: ${att.mimeType || 'unknown'}`;
+      })
+      .join('\n');
+
+    return `
+
+--- Attachments ---
+The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
+
+${attachmentList}
+
+You can read these files using the Read tool with the local paths above.`;
   }
 
   /**

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -12,7 +12,6 @@
  *   (future)       ──│    (Channel Multiplexer)    │    (via WebSocket)
  *                    │                             │
  *                    └─────────────────────────────┘
- * ```
  */
 
 import { WebSocketServer, WebSocket } from 'ws';
@@ -24,6 +23,9 @@ import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from 
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
 import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
+import type { FileReference } from '../types/file-reference.js';
+import { FileStorageService, type FileStorageConfig } from '../services/file-storage-service.js';
+import { createFileTransferAPIHandler } from '../services/file-transfer-api.js';
 
 const logger = createLogger('CommunicationNode');
 
@@ -47,6 +49,8 @@ export interface CommunicationNodeConfig {
   restAuthToken?: string;
   /** Custom channels to register */
   channels?: IChannel[];
+  /** File storage configuration */
+  fileStorage?: FileStorageConfig;
 }
 
 /**
@@ -74,10 +78,17 @@ export class CommunicationNode extends EventEmitter {
   // Channel routing: chatId -> channelId
   private chatToChannel: Map<string, string> = new Map();
 
+  // File storage service
+  private fileStorageService?: FileStorageService;
+  private fileStorageConfig?: FileStorageConfig;
+
   constructor(config: CommunicationNodeConfig) {
     super();
     this.port = config.port;
     this.host = config.host || '0.0.0.0';
+
+    // Store file storage config for later initialization
+    this.fileStorageConfig = config.fileStorage;
 
     // Register custom channels if provided
     if (config.channels) {
@@ -137,7 +148,7 @@ export class CommunicationNode extends EventEmitter {
     });
 
     // Set up control handler
-    channel.onControl(async (command: ControlCommand) => {
+    channel.onControl((command: ControlCommand) => {
       return this.handleControlCommand(command);
     });
 
@@ -161,20 +172,43 @@ export class CommunicationNode extends EventEmitter {
   /**
    * Start WebSocket server for Execution Node connections.
    */
-  private startWebSocketServer(): void {
-    // Create HTTP server for health check and WebSocket upgrade
-    this.httpServer = http.createServer((req, res) => {
-      if (req.url === '/health') {
+  private async startWebSocketServer(): Promise<void> {
+    // Initialize file storage service if configured
+    if (this.fileStorageConfig) {
+      this.fileStorageService = new FileStorageService(this.fileStorageConfig);
+      await this.fileStorageService.initialize();
+      logger.info('File storage service initialized');
+    }
+
+    // Create file API handler
+    const fileApiHandler = this.fileStorageService
+      ? createFileTransferAPIHandler({ storageService: this.fileStorageService })
+      : null;
+
+    // Create HTTP server for health check, file API, and WebSocket upgrade
+    this.httpServer = http.createServer(async (req, res) => {
+      const url = req.url || '/';
+
+      // Handle file API requests
+      if (fileApiHandler && url.startsWith('/api/files')) {
+        const handled = await fileApiHandler(req, res);
+        if (handled) {return;}
+      }
+
+      // Health check
+      if (url === '/health') {
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           status: 'ok',
           mode: 'communication',
           channels: Array.from(this.channels.keys()),
+          fileStorage: this.fileStorageService?.getStats(),
         }));
-      } else {
-        res.writeHead(404);
-        res.end();
+        return;
       }
+
+      res.writeHead(404);
+      res.end();
     });
 
     // Create WebSocket server
@@ -194,7 +228,7 @@ export class CommunicationNode extends EventEmitter {
       ws.on('message', (data) => {
         try {
           const message = JSON.parse(data.toString()) as FeedbackMessage;
-          this.handleFeedback(message);
+          void this.handleFeedback(message);
         } catch (error) {
           logger.error({ err: error }, 'Failed to parse feedback');
         }
@@ -228,6 +262,27 @@ export class CommunicationNode extends EventEmitter {
     // Route chat to channel
     this.chatToChannel.set(message.chatId, channelId);
 
+    // Process attachments if present
+    let attachments: FileReference[] | undefined;
+    if (message.attachments && message.attachments.length > 0 && this.fileStorageService) {
+      attachments = [];
+      for (const att of message.attachments) {
+        try {
+          const fileRef = await this.fileStorageService.storeFromLocal(
+            att.filePath,
+            att.fileName,
+            att.mimeType,
+            'user',
+            message.chatId
+          );
+          attachments.push(fileRef);
+          logger.info({ fileId: fileRef.id, fileName: att.fileName }, 'Attachment stored');
+        } catch (error) {
+          logger.error({ err: error, fileName: att.fileName }, 'Failed to store attachment');
+        }
+      }
+    }
+
     // Send prompt to Execution Node
     await this.sendPrompt({
       type: 'prompt',
@@ -236,6 +291,7 @@ export class CommunicationNode extends EventEmitter {
       messageId: message.messageId,
       senderOpenId: message.userId,
       parentId: message.parentId,
+      attachments,
     });
   }
 
@@ -300,7 +356,7 @@ export class CommunicationNode extends EventEmitter {
    * Handle feedback from Execution Node.
    */
   private async handleFeedback(message: FeedbackMessage): Promise<void> {
-    const { chatId, type, text, card, filePath, error, parentId } = message;
+    const { chatId, type, text, card, error, parentId, fileRef } = message;
 
     try {
       switch (type) {
@@ -313,8 +369,14 @@ export class CommunicationNode extends EventEmitter {
           await this.sendCard(chatId, card || {}, undefined, parentId);
           break;
         case 'file':
-          if (filePath) {
-            await this.sendFileToUser(chatId, filePath, parentId);
+          if (fileRef && this.fileStorageService) {
+            const localPath = this.fileStorageService.getLocalPath(fileRef.id);
+            if (localPath) {
+              await this.sendFileToUser(chatId, localPath, parentId);
+            } else {
+              logger.error({ fileId: fileRef.id }, 'File not found in storage');
+              await this.sendMessage(chatId, `❌ 文件未找到: ${fileRef.fileName}`, parentId);
+            }
           }
           break;
         case 'done':
@@ -430,7 +492,7 @@ export class CommunicationNode extends EventEmitter {
     this.running = true;
 
     // Start WebSocket server for Execution Node connections
-    this.startWebSocketServer();
+    await this.startWebSocketServer();
 
     // Start all registered channels
     for (const [channelId, channel] of this.channels) {
@@ -457,9 +519,15 @@ export class CommunicationNode extends EventEmitter {
    * Stop the Communication Node.
    */
   async stop(): Promise<void> {
-    if (!this.running) return;
+    if (!this.running) {return;}
 
     this.running = false;
+
+    // Shutdown file storage service
+    if (this.fileStorageService) {
+      this.fileStorageService.shutdown();
+      this.fileStorageService = undefined;
+    }
 
     // Stop all channels
     for (const [channelId, channel] of this.channels) {

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -22,6 +22,7 @@ import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { setTaskFlowOrchestrator } from '../mcp/task-skill-mcp.js';
 import { TaskTracker } from '../utils/task-tracker.js';
 import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
+import { FileClient } from '../transport/file-client.js';
 
 const logger = createLogger('ExecRunner');
 
@@ -38,7 +39,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const runnerConfig = config || getExecNodeConfig(globalArgs);
 
   // Get comm URL from config
-  const commUrl = runnerConfig.commUrl;
+  const {commUrl} = runnerConfig;
   const reconnectInterval = 3000;
   let ws: WebSocket | undefined;
   let running = true;
@@ -47,12 +48,19 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   logger.info({ commUrl }, 'Starting Execution Node');
 
   console.log('Initializing Execution Node...');
-  console.log(`Mode: Execution (Pilot Agent + WebSocket Client)`);
+  console.log('Mode: Execution (Pilot Agent + WebSocket Client)');
   console.log(`Comm URL: ${commUrl}`);
   console.log();
 
   // Get agent configuration
   const agentConfig = Config.getAgentConfig();
+
+  // Create FileClient for file transfer with Communication Node
+  const commHttpUrl = commUrl.replace(/^ws/, 'http');
+  const fileClient = new FileClient({
+    commNodeUrl: commHttpUrl,
+    downloadDir: path.join(Config.getWorkspaceDir(), 'downloads'),
+  });
 
   // Map to store active feedback context per chatId
   // Includes sendFeedback function and parentId for thread replies
@@ -93,10 +101,33 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       },
       sendFile: async (chatId: string, filePath: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
-        if (ctx) {
-          ctx.sendFeedback({ type: 'file', chatId, filePath, parentId: ctx.parentId });
-        } else {
+        if (!ctx) {
           logger.warn({ chatId }, 'No active feedback channel for sendFile');
+          return;
+        }
+
+        try {
+          // Upload file to Communication Node
+          const fileRef = await fileClient.uploadFile(filePath, chatId);
+
+          // Send fileRef to Communication Node
+          ctx.sendFeedback({
+            type: 'file',
+            chatId,
+            fileRef,
+            fileName: fileRef.fileName,
+            fileSize: fileRef.size,
+            mimeType: fileRef.mimeType,
+            parentId: ctx.parentId,
+          });
+        } catch (error) {
+          logger.error({ err: error, chatId, filePath }, 'Failed to upload file');
+          ctx.sendFeedback({
+            type: 'error',
+            chatId,
+            error: `Failed to send file: ${(error as Error).message}`,
+            parentId: ctx.parentId,
+          });
         }
       },
       onDone: async (chatId: string, parentMessageId?: string) => {
@@ -137,8 +168,23 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
         }
       },
       sendFile: async (chatId: string, filePath: string) => {
-        if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'file', chatId, filePath }));
+        try {
+          // Upload file to Communication Node
+          const fileRef = await fileClient.uploadFile(filePath, chatId);
+
+          // Send fileRef via WebSocket
+          if (ws?.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({
+              type: 'file',
+              chatId,
+              fileRef,
+              fileName: fileRef.fileName,
+              fileSize: fileRef.size,
+              mimeType: fileRef.mimeType,
+            }));
+          }
+        } catch (error) {
+          logger.error({ err: error, chatId, filePath }, 'Failed to upload file for scheduled task');
         }
       },
     },
@@ -255,8 +301,23 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
         // Handle prompt messages
         if (message.type === 'prompt') {
-          const { chatId, prompt, messageId, senderOpenId, parentId } = message;
-          logger.info({ chatId, messageId, promptLength: prompt.length, parentId }, 'Received prompt');
+          const { chatId, prompt, messageId, senderOpenId, parentId, attachments } = message;
+          logger.info({ chatId, messageId, promptLength: prompt.length, parentId, hasAttachments: !!attachments }, 'Received prompt');
+
+          // Download attachments if present
+          if (attachments && attachments.length > 0) {
+            logger.info({ chatId, attachmentCount: attachments.length }, 'Downloading attachments');
+            for (const att of attachments) {
+              try {
+                const localPath = await fileClient.downloadToFile(att);
+                // Update storageKey to local path for Pilot to use
+                att.storageKey = localPath;
+                logger.info({ fileId: att.id, fileName: att.fileName, localPath }, 'Attachment downloaded');
+              } catch (error) {
+                logger.error({ err: error, fileId: att.id, fileName: att.fileName }, 'Failed to download attachment');
+              }
+            }
+          }
 
           // Create send feedback function for this message
           const sendFeedback = (feedback: FeedbackMessage) => {
@@ -270,9 +331,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
           try {
             // Use processMessage for persistent session context
-            // This is non-blocking - it queues the message and returns immediately
             // The 'done' signal will be sent via onDone callback when Agent completes
-            sharedPilot.processMessage(chatId, prompt, messageId, senderOpenId);
+            sharedPilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments);
           } catch (error) {
             const err = error as Error;
             logger.error({ err, chatId }, 'Execution failed');
@@ -326,7 +386,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   connectToCommNode();
 
   // Handle shutdown
-  const shutdown = async () => {
+  const shutdown = () => {
     logger.info('Shutting down Execution Node...');
     console.log('\nShutting down Execution Node...');
 

--- a/src/services/file-storage-service.ts
+++ b/src/services/file-storage-service.ts
@@ -1,0 +1,217 @@
+/**
+ * File Storage Service
+ *
+ * Manages file storage and retrieval for the Communication Node.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import { createFileReference, type FileReference, type StoredFile } from '../types/file-reference.js';
+
+const logger = createLogger('FileStorageService');
+
+/**
+ * File storage service configuration.
+ */
+export interface FileStorageConfig {
+  /** Root directory for file storage */
+  storageDir: string;
+
+  /** Maximum file size (bytes), default 100MB */
+  maxFileSize?: number;
+}
+
+/**
+ * File Storage Service
+ */
+export class FileStorageService {
+  private storageDir: string;
+  private maxFileSize: number;
+
+  /** File storage mapping: id -> StoredFile */
+  private files = new Map<string, StoredFile>();
+
+  constructor(config: FileStorageConfig) {
+    this.storageDir = config.storageDir;
+    this.maxFileSize = config.maxFileSize ?? 100 * 1024 * 1024; // 100MB
+
+    logger.info({
+      storageDir: this.storageDir,
+      maxFileSize: this.maxFileSize,
+    }, 'FileStorageService created');
+  }
+
+  /**
+   * Initialize the storage service.
+   */
+  async initialize(): Promise<void> {
+    await fs.mkdir(this.storageDir, { recursive: true });
+    logger.info({ storageDir: this.storageDir }, 'FileStorageService initialized');
+  }
+
+  /**
+   * Store a file from a local path.
+   */
+  async storeFromLocal(
+    localPath: string,
+    fileName: string,
+    mimeType?: string,
+    source: 'user' | 'agent' = 'user',
+    chatId?: string
+  ): Promise<FileReference> {
+    const stats = await fs.stat(localPath);
+
+    if (stats.size > this.maxFileSize) {
+      throw new Error(`File size exceeds maximum allowed size: ${stats.size} > ${this.maxFileSize}`);
+    }
+
+    const fileRef = createFileReference(fileName, source, {
+      mimeType,
+      size: stats.size,
+      chatId,
+    });
+
+    const fileDir = path.join(this.storageDir, fileRef.id);
+    await fs.mkdir(fileDir, { recursive: true });
+
+    const storedPath = path.join(fileDir, fileName);
+    await fs.copyFile(localPath, storedPath);
+
+    fileRef.storageKey = storedPath;
+    this.files.set(fileRef.id, { ref: fileRef, localPath: storedPath });
+
+    logger.info({
+      fileId: fileRef.id,
+      fileName,
+      size: stats.size,
+      source,
+    }, 'File stored from local path');
+
+    return fileRef;
+  }
+
+  /**
+   * Store a file from base64 content.
+   */
+  async storeFromBase64(
+    content: string,
+    fileName: string,
+    mimeType?: string,
+    source: 'user' | 'agent' = 'agent',
+    chatId?: string
+  ): Promise<FileReference> {
+    const buffer = Buffer.from(content, 'base64');
+
+    if (buffer.length > this.maxFileSize) {
+      throw new Error(`File size exceeds maximum allowed size: ${buffer.length} > ${this.maxFileSize}`);
+    }
+
+    const fileRef = createFileReference(fileName, source, {
+      mimeType,
+      size: buffer.length,
+      chatId,
+    });
+
+    const fileDir = path.join(this.storageDir, fileRef.id);
+    await fs.mkdir(fileDir, { recursive: true });
+
+    const storedPath = path.join(fileDir, fileName);
+    await fs.writeFile(storedPath, buffer);
+
+    fileRef.storageKey = storedPath;
+    this.files.set(fileRef.id, { ref: fileRef, localPath: storedPath });
+
+    logger.info({
+      fileId: fileRef.id,
+      fileName,
+      size: buffer.length,
+      source,
+    }, 'File stored from base64');
+
+    return fileRef;
+  }
+
+  /**
+   * Get a file by ID.
+   */
+  get(fileId: string): StoredFile | undefined {
+    return this.files.get(fileId);
+  }
+
+  /**
+   * Get file content as base64.
+   */
+  async getContent(fileId: string): Promise<string> {
+    const stored = this.files.get(fileId);
+    if (!stored) {
+      throw new Error(`File not found: ${fileId}`);
+    }
+
+    const buffer = await fs.readFile(stored.localPath);
+    return buffer.toString('base64');
+  }
+
+  /**
+   * Get file local path.
+   */
+  getLocalPath(fileId: string): string | undefined {
+    const stored = this.files.get(fileId);
+    return stored?.localPath;
+  }
+
+  /**
+   * Delete a file.
+   */
+  async delete(fileId: string): Promise<boolean> {
+    const stored = this.files.get(fileId);
+    if (!stored) {
+      return false;
+    }
+
+    try {
+      const fileDir = path.dirname(stored.localPath);
+      await fs.rm(fileDir, { recursive: true, force: true });
+      this.files.delete(fileId);
+
+      logger.info({ fileId }, 'File deleted');
+      return true;
+    } catch (error) {
+      logger.error({ err: error, fileId }, 'Failed to delete file');
+      return false;
+    }
+  }
+
+  /**
+   * Check if a file exists.
+   */
+  has(fileId: string): boolean {
+    return this.files.has(fileId);
+  }
+
+  /**
+   * Get storage statistics.
+   */
+  getStats(): {
+    totalFiles: number;
+    totalSize: number;
+  } {
+    let totalSize = 0;
+
+    for (const stored of this.files.values()) {
+      totalSize += stored.ref.size ?? 0;
+    }
+
+    return {
+      totalFiles: this.files.size,
+      totalSize,
+    };
+  }
+
+  /**
+   * Shutdown the storage service.
+   */
+  shutdown(): void {
+    logger.info('FileStorageService shutdown');
+  }
+}

--- a/src/services/file-transfer-api.ts
+++ b/src/services/file-transfer-api.ts
@@ -1,0 +1,218 @@
+/**
+ * File Transfer API Handler
+ *
+ * Provides HTTP API for file transfer between Communication Node and Execution Node.
+ * Uses Node.js built-in http module.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+import { createLogger } from '../utils/logger.js';
+import type { FileStorageService } from './file-storage-service.js';
+import type {
+  FileUploadRequest,
+  FileUploadResponse,
+  FileDownloadResponse,
+} from '../types/file-reference.js';
+
+const logger = createLogger('FileTransferAPI');
+
+/**
+ * File Transfer API configuration.
+ */
+export interface FileTransferAPIConfig {
+  /** File storage service */
+  storageService: FileStorageService;
+
+  /** Maximum request body size (bytes), default 100MB */
+  maxBodySize?: number;
+}
+
+/**
+ * API response structure.
+ */
+interface APIResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+/**
+ * Read JSON body from request.
+ */
+function readJsonBody<T>(req: IncomingMessage, maxSize: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    let size = 0;
+
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxSize) {
+        req.destroy();
+        reject(new Error(`Request body too large: ${size} > ${maxSize}`));
+        return;
+      }
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(body) as T);
+      } catch (error) {
+        reject(new Error(`Invalid JSON: ${(error as Error).message}`));
+      }
+    });
+
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Send JSON response.
+ */
+function sendJson<T>(res: ServerResponse, statusCode: number, response: APIResponse<T>): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(response));
+}
+
+/**
+ * Create file transfer API handler.
+ *
+ * Returns a function that handles HTTP requests for the file API.
+ *
+ * Routes:
+ * - POST /api/files - Upload file
+ * - GET /api/files/:id - Download file
+ * - GET /api/files/:id/info - Get file info
+ * - DELETE /api/files/:id - Delete file
+ * - GET /api/files - Get storage stats
+ */
+export function createFileTransferAPIHandler(config: FileTransferAPIConfig) {
+  const { storageService, maxBodySize = 100 * 1024 * 1024 } = config;
+
+  /**
+   * Handle file API requests.
+   */
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const url = req.url || '/';
+    const method = req.method || 'GET';
+
+    // Parse URL path
+    const [urlPath] = url.split('?');
+    const pathParts = urlPath.split('/').filter(Boolean);
+
+    // Check if this is a file API request
+    if (pathParts[0] !== 'api' || pathParts[1] !== 'files') {
+      return false; // Not a file API request
+    }
+
+    try {
+      // GET /api/files - Get storage stats
+      if (method === 'GET' && pathParts.length === 2) {
+        const stats = storageService.getStats();
+        sendJson(res, 200, { success: true, data: stats });
+        return true;
+      }
+
+      // POST /api/files - Upload file
+      if (method === 'POST' && pathParts.length === 2) {
+        const request = await readJsonBody<FileUploadRequest>(req, maxBodySize);
+        const { fileName, mimeType, content, chatId } = request;
+
+        if (!fileName || !content) {
+          sendJson(res, 400, { success: false, error: 'Missing required fields: fileName, content' });
+          return true;
+        }
+
+        const fileRef = await storageService.storeFromBase64(
+          content,
+          fileName,
+          mimeType,
+          'agent',
+          chatId
+        );
+
+        logger.info({
+          fileId: fileRef.id,
+          fileName,
+          chatId,
+          size: fileRef.size,
+        }, 'File uploaded via API');
+
+        sendJson(res, 200, { success: true, data: { fileRef } as FileUploadResponse });
+        return true;
+      }
+
+      // Routes with file ID
+      const [, , fileId] = pathParts;
+
+      if (!fileId) {
+        sendJson(res, 400, { success: false, error: 'File ID required' });
+        return true;
+      }
+
+      // GET /api/files/:id/info - Get file info
+      if (method === 'GET' && pathParts[3] === 'info') {
+        const stored = storageService.get(fileId);
+        if (!stored) {
+          sendJson(res, 404, { success: false, error: 'File not found' });
+          return true;
+        }
+
+        sendJson(res, 200, { success: true, data: { fileRef: stored.ref } });
+        return true;
+      }
+
+      // GET /api/files/:id - Download file
+      if (method === 'GET' && pathParts.length === 3) {
+        const stored = storageService.get(fileId);
+        if (!stored) {
+          sendJson(res, 404, { success: false, error: 'File not found' });
+          return true;
+        }
+
+        const content = await storageService.getContent(fileId);
+
+        logger.info({
+          fileId,
+          fileName: stored.ref.fileName,
+        }, 'File downloaded via API');
+
+        sendJson(res, 200, {
+          success: true,
+          data: {
+            fileRef: stored.ref,
+            content,
+          } as FileDownloadResponse,
+        });
+        return true;
+      }
+
+      // DELETE /api/files/:id - Delete file
+      if (method === 'DELETE' && pathParts.length === 3) {
+        const deleted = await storageService.delete(fileId);
+
+        if (!deleted) {
+          sendJson(res, 404, { success: false, error: 'File not found' });
+          return true;
+        }
+
+        logger.info({ fileId }, 'File deleted via API');
+
+        sendJson(res, 200, { success: true, data: { deleted: true } });
+        return true;
+      }
+
+      // Unknown route
+      sendJson(res, 404, { success: false, error: 'Not found' });
+      return true;
+
+    } catch (error) {
+      const err = error as Error;
+      logger.error({ err }, 'File API error');
+      sendJson(res, 500, { success: false, error: err.message });
+      return true;
+    }
+  };
+}
+
+export type FileTransferAPIHandler = ReturnType<typeof createFileTransferAPIHandler>;

--- a/src/transport/file-client.ts
+++ b/src/transport/file-client.ts
@@ -1,0 +1,270 @@
+/**
+ * File Client for Execution Node.
+ *
+ * This client allows the Execution Node to interact with the Communication Node's
+ * file transfer API for uploading and downloading files.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import type {
+  FileReference,
+  FileUploadRequest,
+  FileUploadResponse,
+  FileDownloadResponse,
+} from '../types/file-reference.js';
+
+const logger = createLogger('FileClient');
+
+/**
+ * File client configuration.
+ */
+export interface FileClientConfig {
+  /** Communication Node HTTP URL */
+  commNodeUrl: string;
+
+  /** Request timeout (ms), default 30 seconds */
+  timeout?: number;
+
+  /** Download directory for saving downloaded files */
+  downloadDir?: string;
+}
+
+/**
+ * API response structure.
+ */
+interface APIResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+/**
+ * Detect MIME type from file extension.
+ */
+function detectMimeType(filePath: string): string | undefined {
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    '.txt': 'text/plain',
+    '.md': 'text/markdown',
+    '.json': 'application/json',
+    '.pdf': 'application/pdf',
+    '.doc': 'application/msword',
+    '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    '.xls': 'application/vnd.ms-excel',
+    '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    '.ppt': 'application/vnd.ms-powerpoint',
+    '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.webp': 'image/webp',
+    '.zip': 'application/zip',
+    '.tar': 'application/x-tar',
+    '.gz': 'application/gzip',
+    '.mp3': 'audio/mpeg',
+    '.mp4': 'video/mp4',
+    '.webm': 'video/webm',
+    '.csv': 'text/csv',
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.ts': 'application/typescript',
+    '.py': 'text/x-python',
+    '.java': 'text/x-java-source',
+    '.c': 'text/x-c',
+    '.cpp': 'text/x-c++src',
+    '.h': 'text/x-cheader',
+  };
+  return mimeTypes[ext];
+}
+
+/**
+ * File Client for Execution Node.
+ *
+ * Usage:
+ * ```typescript
+ * const fileClient = new FileClient({
+ *   commNodeUrl: 'http://localhost:3001',
+ *   downloadDir: './downloads',
+ * });
+ *
+ * // Upload a file
+ * const fileRef = await fileClient.uploadFile('/path/to/file.pdf', 'chat-123');
+ *
+ * // Download a file
+ * const localPath = await fileClient.downloadToFile(fileRef);
+ * ```
+ */
+export class FileClient {
+  private baseUrl: string;
+  private timeout: number;
+  private downloadDir?: string;
+
+  constructor(config: FileClientConfig) {
+    this.baseUrl = config.commNodeUrl.replace(/\/$/, '');
+    this.timeout = config.timeout ?? 30000;
+    this.downloadDir = config.downloadDir;
+
+    logger.info({
+      baseUrl: this.baseUrl,
+      timeout: this.timeout,
+      downloadDir: this.downloadDir,
+    }, 'FileClient created');
+  }
+
+  /**
+   * Upload a file to Communication Node.
+   *
+   * @param filePath - Local file path to upload
+   * @param chatId - Optional chat ID for context association
+   * @returns FileReference for the uploaded file
+   */
+  async uploadFile(filePath: string, chatId?: string): Promise<FileReference> {
+    const buffer = await fs.readFile(filePath);
+    const fileName = path.basename(filePath);
+    const mimeType = detectMimeType(filePath);
+
+    logger.info({ filePath, fileName, size: buffer.length, chatId }, 'Uploading file');
+
+    const request: FileUploadRequest = {
+      fileName,
+      mimeType: mimeType || 'application/octet-stream',
+      content: buffer.toString('base64'),
+      chatId,
+    };
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/files`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Failed to upload file: ${response.status} ${text}`);
+      }
+
+      const result = (await response.json()) as APIResponse<FileUploadResponse>;
+
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Failed to upload file');
+      }
+
+      logger.info(
+        { fileId: result.data.fileRef.id, fileName },
+        'File uploaded successfully'
+      );
+
+      return result.data.fileRef;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Download a file from Communication Node.
+   *
+   * @param fileRef - File reference to download
+   * @returns File content as Buffer
+   */
+  async downloadFile(fileRef: FileReference): Promise<Buffer> {
+    logger.info({ fileId: fileRef.id, fileName: fileRef.fileName }, 'Downloading file');
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/files/${fileRef.id}`, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Failed to download file: ${response.status} ${text}`);
+      }
+
+      const result = (await response.json()) as APIResponse<FileDownloadResponse>;
+
+      if (!result.success || !result.data) {
+        throw new Error(result.error || 'Failed to download file');
+      }
+
+      logger.info(
+        { fileId: fileRef.id, size: result.data.content.length },
+        'File downloaded'
+      );
+
+      return Buffer.from(result.data.content, 'base64');
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Download a file and save to local path.
+   *
+   * @param fileRef - File reference to download
+   * @param localPath - Optional local path (auto-generated if not provided)
+   * @returns Local path where the file was saved
+   */
+  async downloadToFile(fileRef: FileReference, localPath?: string): Promise<string> {
+    const buffer = await this.downloadFile(fileRef);
+
+    const savePath =
+      localPath ||
+      path.join(this.downloadDir || '/tmp', fileRef.id, fileRef.fileName);
+
+    await fs.mkdir(path.dirname(savePath), { recursive: true });
+    await fs.writeFile(savePath, buffer);
+
+    logger.info({ fileId: fileRef.id, savePath }, 'File saved to local path');
+
+    return savePath;
+  }
+
+  /**
+   * Get file info without downloading content.
+   *
+   * @param fileId - File ID to get info for
+   * @returns File reference or null if not found
+   */
+  async getFileInfo(fileId: string): Promise<FileReference | null> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/files/${fileId}/info`, {
+        method: 'GET',
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          return null;
+        }
+        const text = await response.text();
+        throw new Error(`Failed to get file info: ${response.status} ${text}`);
+      }
+
+      const result = (await response.json()) as APIResponse<{ fileRef: FileReference }>;
+
+      if (!result.success || !result.data) {
+        return null;
+      }
+
+      return result.data.fileRef;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -11,6 +11,7 @@
  *     │  HTTP Server (:3001)                │  HTTP Server (:3002)
  *     │  - POST /callback                   │  - POST /execute
  *     │  - GET /health                      │  - GET /health
+ *     │  - /api/files/* (file transfer)     │
  *     │                                     │
  *     │  ──── POST /execute ────────────►   │
  *     │  { chatId, prompt, ... }            │
@@ -21,3 +22,4 @@
  */
 
 export * from './types.js';
+export * from './file-client.js';

--- a/src/types/file-reference.ts
+++ b/src/types/file-reference.ts
@@ -1,0 +1,133 @@
+/**
+ * File reference types for communication between nodes.
+ *
+ * When Communication Node and Execution Node are deployed separately,
+ * file references (FileReference) are used to pass file identifiers
+ * instead of local file paths.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * File reference - unique identifier for files passed between nodes.
+ *
+ * @example
+ * // When user uploads a file, comm node creates a fileRef
+ * const fileRef: FileReference = {
+ *   id: 'uuid-xxx',
+ *   fileName: 'report.pdf',
+ *   mimeType: 'application/pdf',
+ *   size: 1024000,
+ *   source: 'user',
+ *   storageKey: '/data/files/uuid-xxx/report.pdf',
+ *   createdAt: Date.now(),
+ *   expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+ * };
+ */
+export interface FileReference {
+  /** Unique file identifier (UUID) */
+  id: string;
+
+  /** Original file name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File size (bytes) */
+  size?: number;
+
+  /** File source */
+  source: 'user' | 'agent';
+
+  /**
+   * File storage location (internal use by comm node)
+   * - Local storage: absolute path
+   * - S3 storage: S3 key
+   */
+  storageKey?: string;
+
+  /** Creation timestamp */
+  createdAt: number;
+
+  /** Expiration timestamp (optional, for auto cleanup) */
+  expiresAt?: number;
+
+  /** Associated chatId (optional, for context association) */
+  chatId?: string;
+}
+
+/**
+ * File upload request - exec node uploads file to comm node.
+ */
+export interface FileUploadRequest {
+  /** File name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File content (base64 encoded) */
+  content: string;
+
+  /** Associated chatId (optional) */
+  chatId?: string;
+}
+
+/**
+ * File upload response.
+ */
+export interface FileUploadResponse {
+  /** File reference after successful upload */
+  fileRef: FileReference;
+}
+
+/**
+ * File download response.
+ */
+export interface FileDownloadResponse {
+  /** File reference */
+  fileRef: FileReference;
+
+  /** File content (base64 encoded) */
+  content: string;
+}
+
+/**
+ * File storage info (internal use).
+ */
+export interface StoredFile {
+  /** File reference */
+  ref: FileReference;
+
+  /** Local storage path */
+  localPath: string;
+}
+
+/**
+ * Factory function to create a FileReference.
+ */
+export function createFileReference(
+  fileName: string,
+  source: 'user' | 'agent',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    storageKey?: string;
+    chatId?: string;
+    expiresInMs?: number;
+  }
+): FileReference {
+  const now = Date.now();
+  return {
+    id: uuidv4(),
+    fileName,
+    mimeType: options?.mimeType,
+    size: options?.size,
+    source,
+    storageKey: options?.storageKey,
+    chatId: options?.chatId,
+    createdAt: now,
+    expiresAt: options?.expiresInMs ? now + options.expiresInMs : undefined,
+  };
+}

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -6,6 +6,8 @@
  * - Execution Node sends: FeedbackMessage
  */
 
+import type { FileReference } from './file-reference.js';
+
 /**
  * Message sent from Communication Node to Execution Node when a user sends a prompt.
  */
@@ -17,6 +19,8 @@ export interface PromptMessage {
   senderOpenId?: string;
   /** Parent message ID for thread replies */
   parentId?: string;
+  /** File attachments (if any) */
+  attachments?: FileReference[];
 }
 
 /**
@@ -36,8 +40,21 @@ export interface FeedbackMessage {
   chatId: string;
   text?: string;
   card?: Record<string, unknown>;
-  filePath?: string;
   error?: string;
   /** Parent message ID for thread replies */
   parentId?: string;
+
+  // ===== File transfer fields =====
+
+  /** File reference */
+  fileRef?: FileReference;
+
+  /** File name (redundant field for convenience) */
+  fileName?: string;
+
+  /** File size (bytes) */
+  fileSize?: number;
+
+  /** MIME type */
+  mimeType?: string;
 }


### PR DESCRIPTION
## Summary
- 新增 FileStorageService 统一管理文件存储，支持跨节点文件引用
- 新增 FileTransferAPI 提供 HTTP 文件传输端点 (POST/GET/DELETE /files)
- 新增 FileClient 实现跨节点文件传输，自动上传/下载文件
- 扩展 WebSocket 消息类型 (PromptMessage/FeedbackMessage) 支持文件引用
- 修改 CommunicationNode 和 ExecutionRunner 支持文件在节点间转发

## Test plan
- [ ] 测试接收飞书文件时文件能正确传递到 exec 节点
- [ ] 测试发送文件时 exec 节点的文件能正确传递到 comm 节点
- [ ] 测试多节点架构下文件传输的完整性

🤖 Generated with [Claude Code](https://claude.com/claude-code)