### PR TITLE
feat(exec): use Python base image for exec node (Issue #99)

### DIFF
--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -1,0 +1,176 @@
+# =============================================================================
+# Disclaude Exec Node Dockerfile
+# =============================================================================
+# Python-based image for the Execution Node to enhance data analysis capabilities.
+#
+# This Dockerfile is specifically for the exec node, which needs:
+# - Python runtime for data analysis tasks (pandas, numpy, matplotlib, etc.)
+# - Node.js runtime for the Disclaude TypeScript application
+#
+# Build:
+#   docker build -f Dockerfile.exec -t disclaude:exec .
+#
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1: Dependencies
+# -----------------------------------------------------------------------------
+FROM docker.m.daocloud.io/library/node:18-bookworm-slim AS deps
+WORKDIR /app
+
+# Install build dependencies for native modules
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy package files
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci --omit=dev && \
+    npm cache clean --force
+
+# -----------------------------------------------------------------------------
+# Stage 2: Builder
+# -----------------------------------------------------------------------------
+FROM docker.m.daocloud.io/library/node:18-bookworm-slim AS builder
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy package files
+COPY package.json package-lock.json ./
+
+# Install all dependencies (including devDependencies for building)
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the project
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# Stage 3: Production Image (Python-based)
+# -----------------------------------------------------------------------------
+FROM docker.m.daocloud.io/library/python:3.11-slim AS production
+WORKDIR /app
+
+# Install curl, ca-certificates (needed for NodeSource setup)
+# Install Node.js 18 from NodeSource repository
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs && \
+    node --version && npm --version
+
+# Install runtime dependencies and Playwright library dependencies
+# Note: Browser binaries are NOT installed here - container uses CDP to connect
+# to Chrome running on the host machine
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Curl for downloading Node.js and GitHub CLI (must be first for NodeSource setup)
+    curl \
+    ca-certificates \
+    # Procps for health check (pgrep)
+    procps \
+    # Playwright library dependencies (for @playwright/mcp package)
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    # Build tools for Python packages
+    gcc \
+    g++ \
+    make \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip and install Python data analysis libraries
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir \
+    # Core data science libraries
+    pandas \
+    numpy \
+    scipy \
+    matplotlib \
+    seaborn \
+    # Machine learning libraries
+    scikit-learn \
+    # Data visualization
+    plotly \
+    # Excel/CSV handling
+    openpyxl \
+    xlrd \
+    # Jupyter for interactive analysis
+    jupyter \
+    # HTTP requests
+    requests \
+    # Data validation
+    pydantic
+
+# Install GitHub CLI (gh)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install PM2 globally for process management and logging
+RUN npm install -g pm2@latest
+
+# Copy built artifacts from builder and production dependencies from deps
+COPY --from=builder /app/dist ./dist
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./
+
+# Copy PM2 ecosystem configs for Docker (one for each mode)
+COPY --from=builder /app/ecosystem.comm.config.json ./
+COPY --from=builder /app/ecosystem.exec.config.json ./
+
+# Copy skills directory if it exists
+COPY --from=builder /app/skills ./skills
+
+# Create non-root user for running the application
+RUN groupadd -g 1001 disclaude && \
+    useradd -r -u 1001 -g disclaude -d /app -s /usr/sbin/nologin -c "Disclaude user" disclaude
+
+# Give disclaude user ownership of /app (needed for SDK config files)
+RUN chown -R disclaude:disclaude /app
+
+# Create directories for runtime with proper permissions
+RUN mkdir -p /app/workspace /app/logs /app/.claude && \
+    chown -R disclaude:disclaude /app/workspace /app/logs /app/.claude
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV PYTHONUNBUFFERED=1
+
+# Health check - check if PM2 process is running
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD pm2 pid disclaude-docker > /dev/null 2>&1 || exit 1
+
+# Switch to non-root user
+USER disclaude
+
+# Default command: run with PM2 for process management and logging
+# Logs will be available at:
+#   - /app/logs/disclaude-combined.log (pino application logs)
+#   - ~/.pm2/logs/ (PM2 stdout/stderr logs)
+CMD ["pm2-runtime", "start", "ecosystem.exec.config.json"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: disclaude:latest
+    image: disclaude:comm
     container_name: disclaude-comm
     restart: unless-stopped
 
@@ -73,8 +73,8 @@ services:
   exec:
     build:
       context: .
-      dockerfile: Dockerfile
-    image: disclaude:latest
+      dockerfile: Dockerfile.exec
+    image: disclaude:exec
     container_name: disclaude-exec
     restart: unless-stopped
 


### PR DESCRIPTION
## Summary

- **Add \`Dockerfile.exec\`**: Python 3.11-slim based Docker image for the exec node
- **Pre-install data analysis libraries**: pandas, numpy, scipy, matplotlib, seaborn, scikit-learn, plotly, jupyter
- **Update \`docker-compose.yml\`**: Use \`Dockerfile.exec\` for exec service, separate images for comm and exec

## Motivation

This change addresses issue #99 by enhancing the exec node with Python data analysis capabilities while maintaining the Node.js runtime needed for the TypeScript application.

## Benefits

1. **Powerful data analysis ecosystem** - pandas, numpy, scipy for data manipulation
2. **Machine learning support** - scikit-learn for ML tasks
3. **Better data processing** - openpyxl, xlrd for Excel files
4. **Visualization tools** - matplotlib, seaborn, plotly for charts
5. **Interactive analysis** - Jupyter notebook support

## Technical Details

- Base image: \`python:3.11-slim\`
- Node.js 18 installed via NodeSource repository
- All Disclaude dependencies and functionality preserved
- Image size remains reasonable (~2GB with all Python packages)

## Test plan

- [x] Build Docker image successfully
- [x] Verify Node.js v18.20.8 is available
- [x] Verify Python 3.11.14 is available
- [x] Verify pandas, numpy, matplotlib are installed
- [ ] Deploy exec node with new image
- [ ] Test data analysis task execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)