### PR TITLE
fix: Bot回复消息使用threadId构成thread

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -136,6 +136,11 @@ export class FeishuChannel extends EventEmitter implements IChannel {
         // TODO: Pass parentId when Issue #68 is implemented
         await sender.sendFile(message.chatId, message.filePath || '');
         break;
+      case 'done':
+        // Task completion signal - no message to send
+        // This is used for REST sync mode to signal completion
+        logger.debug({ chatId: message.chatId }, 'Task completed (done signal received)');
+        break;
       default:
         throw new Error(`Unsupported message type: ${message.type}`);
     }
@@ -287,7 +292,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     if (!message) return;
 
-    const { message_id, chat_id, content, message_type, create_time, parent_id } = message;
+    const { message_id, chat_id, content, message_type, create_time, parent_id, root_id } = message;
 
     if (!message_id || !chat_id || !content || !message_type) {
       logger.warn('Missing required message fields');
@@ -354,6 +359,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
             messageType: 'file',
             timestamp: create_time,
             parentId: parent_id,
+            threadId: root_id || parent_id, // Use root_id for thread aggregation
             attachments: [{
               fileName: latestAttachment.fileName || 'unknown',
               filePath: latestAttachment.localPath || '',
@@ -473,6 +479,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
         messageType: message_type as any,
         timestamp: create_time,
         parentId: parent_id,
+        threadId: root_id || parent_id, // Use root_id for thread aggregation
       });
     }
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -41,6 +41,13 @@ export interface IncomingMessage {
   /** Parent message ID for thread replies */
   parentId?: string;
 
+  /**
+   * Thread ID for thread replies (root message ID of the thread).
+   * Used to aggregate Bot replies into the same thread.
+   * For Feishu, this is the root_id field.
+   */
+  threadId?: string;
+
   /** Additional metadata from the channel */
   metadata?: Record<string, unknown>;
 

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -236,6 +236,7 @@ export class CommunicationNode extends EventEmitter {
       messageId: message.messageId,
       senderOpenId: message.userId,
       parentId: message.parentId,
+      threadId: message.threadId,
     });
   }
 
@@ -279,7 +280,7 @@ export class CommunicationNode extends EventEmitter {
     }
 
     this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId }, 'Prompt sent to Execution Node');
+    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId, threadId: message.threadId }, 'Prompt sent to Execution Node');
   }
 
   /**

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -52,10 +52,11 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const agentConfig = Config.getAgentConfig();
 
   // Map to store active feedback context per chatId
-  // Includes sendFeedback function and parentId for thread replies
+  // Includes sendFeedback function and threadId for thread replies
   interface FeedbackContext {
     sendFeedback: (feedback: FeedbackMessage) => void;
     parentId?: string;
+    threadId?: string;
   }
   const activeFeedbackChannels = new Map<string, FeedbackContext>();
 
@@ -75,7 +76,9 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'text', chatId, text, parentId: parentMessageId || ctx.parentId });
+          // Use threadId (root_id) for thread aggregation, fallback to parentId then to provided parentMessageId
+          const effectiveParentId = parentMessageId || ctx.threadId || ctx.parentId;
+          ctx.sendFeedback({ type: 'text', chatId, text, parentId: effectiveParentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendMessage');
         }
@@ -83,7 +86,9 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'card', chatId, card, text: description, parentId: parentMessageId || ctx.parentId });
+          // Use threadId (root_id) for thread aggregation, fallback to parentId then to provided parentMessageId
+          const effectiveParentId = parentMessageId || ctx.threadId || ctx.parentId;
+          ctx.sendFeedback({ type: 'card', chatId, card, text: description, parentId: effectiveParentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendCard');
         }
@@ -91,7 +96,9 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendFile: async (chatId: string, filePath: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'file', chatId, filePath, parentId: ctx.parentId });
+          // Use threadId (root_id) for thread aggregation, fallback to parentId
+          const effectiveParentId = ctx.threadId || ctx.parentId;
+          ctx.sendFeedback({ type: 'file', chatId, filePath, parentId: effectiveParentId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendFile');
         }
@@ -99,7 +106,9 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       onDone: async (chatId: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'done', chatId, parentId: parentMessageId || ctx.parentId });
+          // Use threadId (root_id) for thread aggregation, fallback to parentId then to provided parentMessageId
+          const effectiveParentId = parentMessageId || ctx.threadId || ctx.parentId;
+          ctx.sendFeedback({ type: 'done', chatId, parentId: effectiveParentId });
           logger.info({ chatId }, 'Task completed, sent done signal');
         } else {
           logger.warn({ chatId }, 'No active feedback channel for onDone');
@@ -219,8 +228,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
         // Handle prompt messages
         if (message.type === 'prompt') {
-          const { chatId, prompt, messageId, senderOpenId, parentId } = message;
-          logger.info({ chatId, messageId, promptLength: prompt.length, parentId }, 'Received prompt');
+          const { chatId, prompt, messageId, senderOpenId, parentId, threadId } = message;
+          logger.info({ chatId, messageId, promptLength: prompt.length, parentId, threadId }, 'Received prompt');
 
           // Create send feedback function for this message
           const sendFeedback = (feedback: FeedbackMessage) => {
@@ -229,8 +238,9 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             }
           };
 
-          // Register feedback channel for this chatId with parentId
-          activeFeedbackChannels.set(chatId, { sendFeedback, parentId });
+          // Register feedback channel for this chatId with threadId and parentId
+          // threadId (root_id) is used for thread aggregation
+          activeFeedbackChannels.set(chatId, { sendFeedback, parentId, threadId });
 
           try {
             // Use processMessage for persistent session context

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -17,6 +17,11 @@ export interface PromptMessage {
   senderOpenId?: string;
   /** Parent message ID for thread replies */
   parentId?: string;
+  /**
+   * Thread ID for thread replies (root message ID of the thread).
+   * Used to aggregate Bot replies into the same thread.
+   */
+  threadId?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #96

Bot在飞书中回复消息时没有正确构成thread。使用root_id作为threadId来聚合Bot回复到同一个话题下。

修改的文件:
- src/channels/types.ts
- src/channels/feishu-channel.ts
- src/types/websocket-messages.ts
- src/nodes/communication-node.ts
- src/runners/execution-runner.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)