### PR TITLE
fix: Bot回复消息使用root_id构成thread (Fixes #96)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -136,6 +136,11 @@ export class FeishuChannel extends EventEmitter implements IChannel {
         // TODO: Pass parentId when Issue #68 is implemented
         await sender.sendFile(message.chatId, message.filePath || '');
         break;
+      case 'done':
+        // Task completion signal - no actual message to send
+        // This is used for REST sync mode and internal signaling
+        logger.debug({ chatId: message.chatId }, 'Task completed (done signal)');
+        break;
       default:
         throw new Error(`Unsupported message type: ${message.type}`);
     }
@@ -287,7 +292,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     if (!message) return;
 
-    const { message_id, chat_id, content, message_type, create_time, parent_id } = message;
+    const { message_id, chat_id, content, message_type, create_time, parent_id, root_id } = message;
 
     if (!message_id || !chat_id || !content || !message_type) {
       logger.warn('Missing required message fields');
@@ -354,6 +359,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
             messageType: 'file',
             timestamp: create_time,
             parentId: parent_id,
+            threadId: root_id,
             attachments: [{
               fileName: latestAttachment.fileName || 'unknown',
               filePath: latestAttachment.localPath || '',
@@ -473,6 +479,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
         messageType: message_type as any,
         timestamp: create_time,
         parentId: parent_id,
+        threadId: root_id,
       });
     }
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -38,8 +38,11 @@ export interface IncomingMessage {
   /** Timestamp when message was created (ms since epoch) */
   timestamp?: number;
 
-  /** Parent message ID for thread replies */
+  /** Parent message ID for thread replies (immediate parent) */
   parentId?: string;
+
+  /** Thread root ID for thread replies (first message in thread) */
+  threadId?: string;
 
   /** Additional metadata from the channel */
   metadata?: Record<string, unknown>;

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -229,6 +229,7 @@ export class CommunicationNode extends EventEmitter {
     this.chatToChannel.set(message.chatId, channelId);
 
     // Send prompt to Execution Node
+    // Use threadId (root_id) for thread replies if available
     await this.sendPrompt({
       type: 'prompt',
       chatId: message.chatId,
@@ -236,6 +237,7 @@ export class CommunicationNode extends EventEmitter {
       messageId: message.messageId,
       senderOpenId: message.userId,
       parentId: message.parentId,
+      threadId: message.threadId,
     });
   }
 
@@ -279,7 +281,7 @@ export class CommunicationNode extends EventEmitter {
     }
 
     this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId }, 'Prompt sent to Execution Node');
+    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId, threadId: message.threadId }, 'Prompt sent to Execution Node');
   }
 
   /**
@@ -300,21 +302,25 @@ export class CommunicationNode extends EventEmitter {
    * Handle feedback from Execution Node.
    */
   private async handleFeedback(message: FeedbackMessage): Promise<void> {
-    const { chatId, type, text, card, filePath, error, parentId } = message;
+    const { chatId, type, text, card, filePath, error, parentId, threadId } = message;
+
+    // For thread replies: prefer threadId (root_id) over parentId
+    // This ensures bot replies join the thread instead of becoming standalone messages
+    const replyToId = threadId || parentId;
 
     try {
       switch (type) {
         case 'text':
           if (text) {
-            await this.sendMessage(chatId, text, parentId);
+            await this.sendMessage(chatId, text, replyToId);
           }
           break;
         case 'card':
-          await this.sendCard(chatId, card || {}, undefined, parentId);
+          await this.sendCard(chatId, card || {}, undefined, replyToId);
           break;
         case 'file':
           if (filePath) {
-            await this.sendFileToUser(chatId, filePath, parentId);
+            await this.sendFileToUser(chatId, filePath, replyToId);
           }
           break;
         case 'done':
@@ -325,14 +331,14 @@ export class CommunicationNode extends EventEmitter {
             if (channelId) {
               const channel = this.channels.get(channelId);
               if (channel) {
-                await channel.sendMessage({ type: 'done', chatId, parentId });
+                await channel.sendMessage({ type: 'done', chatId, parentId: replyToId });
               }
             }
           }
           break;
         case 'error':
           logger.error({ chatId, error }, 'Execution error');
-          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`, parentId);
+          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`, replyToId);
           break;
       }
     } catch (err) {

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -52,10 +52,11 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const agentConfig = Config.getAgentConfig();
 
   // Map to store active feedback context per chatId
-  // Includes sendFeedback function and parentId for thread replies
+  // Includes sendFeedback function, parentId, and threadId for thread replies
   interface FeedbackContext {
     sendFeedback: (feedback: FeedbackMessage) => void;
     parentId?: string;
+    threadId?: string;
   }
   const activeFeedbackChannels = new Map<string, FeedbackContext>();
 
@@ -75,7 +76,14 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'text', chatId, text, parentId: parentMessageId || ctx.parentId });
+          // Use threadId (root_id) for thread replies if available, otherwise parentId
+          ctx.sendFeedback({
+            type: 'text',
+            chatId,
+            text,
+            parentId: parentMessageId || ctx.parentId,
+            threadId: ctx.threadId,
+          });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendMessage');
         }
@@ -83,7 +91,14 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'card', chatId, card, text: description, parentId: parentMessageId || ctx.parentId });
+          ctx.sendFeedback({
+            type: 'card',
+            chatId,
+            card,
+            text: description,
+            parentId: parentMessageId || ctx.parentId,
+            threadId: ctx.threadId,
+          });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendCard');
         }
@@ -91,7 +106,13 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       sendFile: async (chatId: string, filePath: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'file', chatId, filePath, parentId: ctx.parentId });
+          ctx.sendFeedback({
+            type: 'file',
+            chatId,
+            filePath,
+            parentId: ctx.parentId,
+            threadId: ctx.threadId,
+          });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendFile');
         }
@@ -99,7 +120,12 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       onDone: async (chatId: string, parentMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'done', chatId, parentId: parentMessageId || ctx.parentId });
+          ctx.sendFeedback({
+            type: 'done',
+            chatId,
+            parentId: parentMessageId || ctx.parentId,
+            threadId: ctx.threadId,
+          });
           logger.info({ chatId }, 'Task completed, sent done signal');
         } else {
           logger.warn({ chatId }, 'No active feedback channel for onDone');
@@ -219,8 +245,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
         // Handle prompt messages
         if (message.type === 'prompt') {
-          const { chatId, prompt, messageId, senderOpenId, parentId } = message;
-          logger.info({ chatId, messageId, promptLength: prompt.length, parentId }, 'Received prompt');
+          const { chatId, prompt, messageId, senderOpenId, parentId, threadId } = message;
+          logger.info({ chatId, messageId, promptLength: prompt.length, parentId, threadId }, 'Received prompt');
 
           // Create send feedback function for this message
           const sendFeedback = (feedback: FeedbackMessage) => {
@@ -229,8 +255,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             }
           };
 
-          // Register feedback channel for this chatId with parentId
-          activeFeedbackChannels.set(chatId, { sendFeedback, parentId });
+          // Register feedback channel for this chatId with parentId and threadId
+          activeFeedbackChannels.set(chatId, { sendFeedback, parentId, threadId });
 
           try {
             // Use processMessage for persistent session context
@@ -240,8 +266,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
           } catch (error) {
             const err = error as Error;
             logger.error({ err, chatId }, 'Execution failed');
-            sendFeedback({ type: 'error', chatId, error: err.message, parentId });
-            sendFeedback({ type: 'done', chatId, parentId });
+            sendFeedback({ type: 'error', chatId, error: err.message, parentId, threadId });
+            sendFeedback({ type: 'done', chatId, parentId, threadId });
           }
           return;
         }

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -15,8 +15,10 @@ export interface PromptMessage {
   prompt: string;
   messageId: string;
   senderOpenId?: string;
-  /** Parent message ID for thread replies */
+  /** Parent message ID for thread replies (immediate parent) */
   parentId?: string;
+  /** Thread root ID for thread replies (first message in thread) */
+  threadId?: string;
 }
 
 /**
@@ -38,6 +40,8 @@ export interface FeedbackMessage {
   card?: Record<string, unknown>;
   filePath?: string;
   error?: string;
-  /** Parent message ID for thread replies */
+  /** Parent message ID for thread replies (immediate parent) */
   parentId?: string;
+  /** Thread root ID for thread replies (first message in thread) */
+  threadId?: string;
 }


### PR DESCRIPTION
## Summary

- 新增 `threadId` 字段到 `IncomingMessage`、`PromptMessage` 和 `FeedbackMessage` 接口
- `FeishuChannel` 提取 `root_id` 并传递为 `threadId`
- `CommunicationNode` 和 `ExecutionRunner` 传递 `threadId` 用于线程回复
- 回复时优先使用 `threadId` (root_id) 作为 `parentId`，确保 Bot 回复进入线程
- 处理 `'done'` 消息类型，避免 "Unsupported message type: done" 错误

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)