### PR TITLE
fix: 定时任务无限递归问题 - Add defense-in-depth protection

### DIFF
--- a/src/schedule/schedule-mcp.ts
+++ b/src/schedule/schedule-mcp.ts
@@ -145,11 +145,13 @@ notifications to the chat when it executes.`,
       // Prevent recursive schedule creation (Issue #102)
       // If we're currently executing a scheduled task, prevent creating new ones
       if (isExecutingInScheduleContext(chatId)) {
-        logger.warn({ chatId, name }, 'Blocked recursive schedule creation');
+        const runningTaskIds = schedulerInstance?.getRunningTaskIds() || [];
+        logger.warn({ chatId, name, runningTaskIds }, 'Blocked recursive schedule creation');
         return toolSuccess(
           '❌ 定时任务执行期间禁止创建新任务。\n\n' +
-          '这是为了防止无限递归导致系统资源耗尽。\n' +
-          '请在手动对话中创建定时任务。'
+          '**原因**: 当前有定时任务正在执行，为防止无限递归导致系统资源耗尽，创建新任务已被阻止。\n\n' +
+          `**当前执行中的任务**: ${runningTaskIds.join(', ')}\n\n` +
+          '**解决方案**: 请在非定时任务的普通对话中创建新的定时任务。'
         );
       }
 

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -158,6 +158,32 @@ export class Scheduler {
   }
 
   /**
+   * Build wrapped prompt with anti-recursion instructions.
+   * Provides defense-in-depth against infinite recursion.
+   *
+   * @param task - Task being executed
+   * @returns Wrapped prompt with explicit anti-recursion instructions
+   */
+  private buildScheduledTaskPrompt(task: ScheduledTask): string {
+    return `⚠️ **Scheduled Task Execution Context**
+
+You are executing a scheduled task named "${task.name}".
+
+**IMPORTANT RULES:**
+1. Do NOT create new scheduled tasks using create_schedule tool
+2. Do NOT modify existing scheduled tasks
+3. Focus on completing the task described below
+4. If you need to run something periodically, report this need to the user instead
+
+The create_schedule tool is blocked during scheduled task execution to prevent infinite recursion.
+
+---
+
+**Task Prompt:**
+${task.prompt}`;
+  }
+
+  /**
    * Execute a scheduled task.
    * Called by cron job when the schedule triggers.
    *
@@ -185,10 +211,13 @@ export class Scheduler {
         `⏰ 定时任务「${task.name}」开始执行...`
       );
 
+      // Build wrapped prompt with anti-recursion instructions
+      const wrappedPrompt = this.buildScheduledTaskPrompt(task);
+
       // Execute task using Pilot's executeOnce method
       await this.pilot.executeOnce(
         task.chatId,
-        task.prompt,
+        wrappedPrompt,
         `${task.id}-${Date.now()}`,
         task.createdBy
       );


### PR DESCRIPTION
## Summary
- 添加 `buildScheduledTaskPrompt()` 方法，在定时任务执行时包装用户 prompt，明确告知 Agent 不要创建新的定时任务
- 改进 `create_schedule` 工具的错误消息，显示当前正在执行的任务 ID 并提供更详细的解决方案

## 问题描述

定时任务在执行时可能创建新的定时任务，导致无限递归和任务数量爆炸式增长 (Closes #102)。

## 防护层级 (Defense-in-Depth)

1. **技术检查**: `isExecutingInScheduleContext()` 阻止 `create_schedule` 工具调用
2. **Prompt 指导**: 明确告知 Agent 不要创建新任务 (本次新增)
3. **任务限制**: 每个 chatId 最多 50 个任务
4. **去重检查**: 每个任务名称每个 chatId 最多 1 个

## Test plan

- [x] 现有单元测试通过 (3 个 pre-existing 失败与此修改无关)
- [x] 构建成功
- [x] Lint 检查通过 (修改的文件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)