### PR TITLE
fix: 定时任务无法正常执行 - fallback to default channel (Issue #109)

### DIFF
--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -74,6 +74,9 @@ export class CommunicationNode extends EventEmitter {
   // Channel routing: chatId -> channelId
   private chatToChannel: Map<string, string> = new Map();
 
+  // Default channel ID for scheduled tasks and other async operations (Issue #109)
+  private defaultChannelId: string = 'feishu';
+
   constructor(config: CommunicationNodeConfig) {
     super();
     this.port = config.port;
@@ -156,6 +159,31 @@ export class CommunicationNode extends EventEmitter {
    */
   getChannels(): IChannel[] {
     return Array.from(this.channels.values());
+  }
+
+  /**
+   * Get channel for a chatId, falling back to default channel if not found.
+   * This enables scheduled tasks to send messages without an active session.
+   * (Issue #109)
+   */
+  private getChannelForChat(chatId: string): { channel: IChannel; channelId: string } | null {
+    // First, try to find the mapped channel
+    const channelId = this.chatToChannel.get(chatId);
+    if (channelId) {
+      const channel = this.channels.get(channelId);
+      if (channel) {
+        return { channel, channelId };
+      }
+    }
+
+    // Fallback to default channel (for scheduled tasks, etc.)
+    const defaultChannel = this.channels.get(this.defaultChannelId);
+    if (defaultChannel) {
+      logger.debug({ chatId, defaultChannelId: this.defaultChannelId }, 'Using default channel for chat');
+      return { channel: defaultChannel, channelId: this.defaultChannelId };
+    }
+
+    return null;
   }
 
   /**
@@ -342,20 +370,16 @@ export class CommunicationNode extends EventEmitter {
 
   /**
    * Send a text message to the appropriate channel.
+   * Falls back to default channel if no mapping found (for scheduled tasks).
    */
   async sendMessage(chatId: string, text: string, parentMessageId?: string): Promise<void> {
-    const channelId = this.chatToChannel.get(chatId);
-    if (!channelId) {
-      logger.warn({ chatId }, 'No channel found for chat');
+    const result = this.getChannelForChat(chatId);
+    if (!result) {
+      logger.warn({ chatId }, 'No channel found for chat (including default)');
       return;
     }
 
-    const channel = this.channels.get(channelId);
-    if (!channel) {
-      logger.warn({ chatId, channelId }, 'Channel not found');
-      return;
-    }
-
+    const { channel } = result;
     await channel.sendMessage({
       chatId,
       type: 'text',
@@ -366,6 +390,7 @@ export class CommunicationNode extends EventEmitter {
 
   /**
    * Send an interactive card to the appropriate channel.
+   * Falls back to default channel if no mapping found (for scheduled tasks).
    */
   async sendCard(
     chatId: string,
@@ -373,18 +398,13 @@ export class CommunicationNode extends EventEmitter {
     description?: string,
     parentMessageId?: string
   ): Promise<void> {
-    const channelId = this.chatToChannel.get(chatId);
-    if (!channelId) {
-      logger.warn({ chatId }, 'No channel found for chat');
+    const result = this.getChannelForChat(chatId);
+    if (!result) {
+      logger.warn({ chatId }, 'No channel found for chat (including default)');
       return;
     }
 
-    const channel = this.channels.get(channelId);
-    if (!channel) {
-      logger.warn({ chatId, channelId }, 'Channel not found');
-      return;
-    }
-
+    const { channel } = result;
     await channel.sendMessage({
       chatId,
       type: 'card',
@@ -396,20 +416,16 @@ export class CommunicationNode extends EventEmitter {
 
   /**
    * Send a file to the appropriate channel.
+   * Falls back to default channel if no mapping found (for scheduled tasks).
    */
   async sendFileToUser(chatId: string, filePath: string, _parentId?: string): Promise<void> {
-    const channelId = this.chatToChannel.get(chatId);
-    if (!channelId) {
-      logger.warn({ chatId }, 'No channel found for chat');
+    const result = this.getChannelForChat(chatId);
+    if (!result) {
+      logger.warn({ chatId }, 'No channel found for chat (including default)');
       return;
     }
 
-    const channel = this.channels.get(channelId);
-    if (!channel) {
-      logger.warn({ chatId, channelId }, 'Channel not found');
-      return;
-    }
-
+    const { channel } = result;
     // TODO: Pass parentId when Issue #68 is implemented
     await channel.sendMessage({
       chatId,


### PR DESCRIPTION
## Summary

修复定时任务无法正常执行的 bug。当定时任务触发时，CommunicationNode 的 chatToChannel 映射为空，导致无法找到对应的 channel 来发送消息。

## Problem

- 定时任务由 exec 节点的 Scheduler 触发
- 需要通过 comm 节点发送消息到飞书
- 但 chatToChannel 映射只在收到用户消息时被填充
- 定时任务触发时没有活跃的用户会话，所以映射为空
- 结果：No channel found for chat 警告，消息无法发送

## Solution

1. 添加 defaultChannelId 属性，默认指向 feishu channel
2. 添加 getChannelForChat() 私有方法，当找不到 chatId 映射时回退到默认 channel
3. 修改 sendMessage()、sendCard()、sendFileToUser() 使用这个回退逻辑

## Changes

- src/nodes/communication-node.ts: 添加默认 channel 回退逻辑

## Test Plan

1. 创建一个定时任务（如 */1 * * * *）
2. 启动 comm 和 exec 节点
3. 等待定时任务触发
4. 验证飞书群收到定时任务通知消息
5. 验证日志不再出现 No channel found for chat 警告

Fixes #109