### PR TITLE
fix: register TaskFlowOrchestrator in Execution Node (Issue #111)

### DIFF
--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -18,6 +18,9 @@ import {
   setScheduleManager,
   setScheduler,
 } from '../schedule/index.js';
+import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
+import { setTaskFlowOrchestrator } from '../mcp/task-skill-mcp.js';
+import { TaskTracker } from '../utils/task-tracker.js';
 import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
 
 const logger = createLogger('ExecRunner');
@@ -164,6 +167,39 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   // Register with MCP tools
   setScheduleManager(scheduleManager);
   setScheduler(scheduler);
+
+  // Initialize TaskFlowOrchestrator for task skill dialogue phase
+  // This fixes Issue #111: TaskFlowOrchestrator needs to be registered in Execution Node
+  const taskTracker = new TaskTracker();
+  const taskFlowOrchestrator = new TaskFlowOrchestrator(
+    taskTracker,
+    {
+      sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
+        if (ws?.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'text', chatId, text, parentId: parentMessageId }));
+        } else {
+          logger.warn({ chatId }, 'Cannot send message: WebSocket not connected');
+        }
+      },
+      sendCard: async (chatId: string, card: Record<string, unknown>, _description?: string, parentMessageId?: string) => {
+        if (ws?.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'card', chatId, card, parentId: parentMessageId }));
+        } else {
+          logger.warn({ chatId }, 'Cannot send card: WebSocket not connected');
+        }
+      },
+      sendFile: async (chatId: string, filePath: string) => {
+        if (ws?.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: 'file', chatId, filePath }));
+        } else {
+          logger.warn({ chatId }, 'Cannot send file: WebSocket not connected');
+        }
+      },
+    },
+    logger
+  );
+  setTaskFlowOrchestrator(taskFlowOrchestrator);
+  console.log('✓ TaskFlowOrchestrator registered');
 
   // Start scheduler
   await scheduler.start();


### PR DESCRIPTION
## Summary

- Fixes Issue #111: TaskFlowOrchestrator 未注册导致后台对话阶段无法启动
- 在 Execution Node 启动时初始化并注册 TaskFlowOrchestrator
- 使用 WebSocket-based 回调实现跨进程消息发送

## Root Cause

系统采用分离架构：
- Communication Node: 处理 Feishu channel，在这里注册 orchestrator
- Execution Node: 运行 Pilot Agent，执行 start_dialogue 工具

由于是不同的进程，task-skill-mcp.ts 中的全局变量 orchestratorInstance 在 Execution Node 中从未被设置。

## Solution

在 Execution Node 的 runExecutionNode() 函数中初始化 TaskFlowOrchestrator 并注册。

## Test Plan

- [x] src/mcp/task-skill-mcp.test.ts - 19 tests passed
- [x] src/feishu/task-flow-orchestrator.test.ts - 全部通过
- [x] TypeScript 编译成功

Fixes: #111