### PR TITLE
fix: optimize Docker build by using COPY --chown instead of recursive chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,28 +100,26 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # Install PM2 globally for process management and logging
 RUN npm install -g pm2@latest
 
-# Copy built artifacts from builder and production dependencies from deps
-COPY --from=builder /app/dist ./dist
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./
-
-# Copy PM2 ecosystem configs for Docker (one for each mode)
-COPY --from=builder /app/ecosystem.comm.config.json ./
-COPY --from=builder /app/ecosystem.exec.config.json ./
-
-# Copy skills directory if it exists
-COPY --from=builder /app/skills ./skills
-
 # Create non-root user for running the application
 RUN groupadd -g 1001 disclaude && \
     useradd -r -u 1001 -g disclaude -d /app -s /usr/sbin/nologin -c "Disclaude user" disclaude
 
-# Give disclaude user ownership of /app (needed for SDK config files)
-RUN chown -R disclaude:disclaude /app
-
 # Create directories for runtime with proper permissions
 RUN mkdir -p /app/workspace /app/logs /app/.claude && \
     chown -R disclaude:disclaude /app/workspace /app/logs /app/.claude
+
+# Copy built artifacts from builder and production dependencies from deps
+# Use --chown to set ownership during copy, avoiding slow recursive chown of node_modules
+COPY --from=builder --chown=disclaude:disclaude /app/dist ./dist
+COPY --from=deps --chown=disclaude:disclaude /app/node_modules ./node_modules
+COPY --from=builder --chown=disclaude:disclaude /app/package.json ./
+
+# Copy PM2 ecosystem configs for Docker (one for each mode)
+COPY --from=builder --chown=disclaude:disclaude /app/ecosystem.comm.config.json ./
+COPY --from=builder --chown=disclaude:disclaude /app/ecosystem.exec.config.json ./
+
+# Copy skills directory if it exists
+COPY --from=builder --chown=disclaude:disclaude /app/skills ./skills
 
 # Set environment variables
 ENV NODE_ENV=production

--- a/Dockerfile.exec
+++ b/Dockerfile.exec
@@ -135,28 +135,26 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 # Install PM2 globally for process management and logging
 RUN npm install -g pm2@latest
 
-# Copy built artifacts from builder and production dependencies from deps
-COPY --from=builder /app/dist ./dist
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./
-
-# Copy PM2 ecosystem configs for Docker (one for each mode)
-COPY --from=builder /app/ecosystem.comm.config.json ./
-COPY --from=builder /app/ecosystem.exec.config.json ./
-
-# Copy skills directory if it exists
-COPY --from=builder /app/skills ./skills
-
 # Create non-root user for running the application
 RUN groupadd -g 1001 disclaude && \
     useradd -r -u 1001 -g disclaude -d /app -s /usr/sbin/nologin -c "Disclaude user" disclaude
 
-# Give disclaude user ownership of /app (needed for SDK config files)
-RUN chown -R disclaude:disclaude /app
-
 # Create directories for runtime with proper permissions
 RUN mkdir -p /app/workspace /app/logs /app/.claude && \
     chown -R disclaude:disclaude /app/workspace /app/logs /app/.claude
+
+# Copy built artifacts from builder and production dependencies from deps
+# Use --chown to set ownership during copy, avoiding slow recursive chown of node_modules
+COPY --from=builder --chown=disclaude:disclaude /app/dist ./dist
+COPY --from=deps --chown=disclaude:disclaude /app/node_modules ./node_modules
+COPY --from=builder --chown=disclaude:disclaude /app/package.json ./
+
+# Copy PM2 ecosystem configs for Docker (one for each mode)
+COPY --from=builder --chown=disclaude:disclaude /app/ecosystem.comm.config.json ./
+COPY --from=builder --chown=disclaude:disclaude /app/ecosystem.exec.config.json ./
+
+# Copy skills directory if it exists
+COPY --from=builder --chown=disclaude:disclaude /app/skills ./skills
 
 # Set environment variables
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
Fixes #116 - Docker build was taking minutes due to slow `chown -R disclaude:disclaude /app` command.

## Problem
The `chown -R disclaude:disclaude /app` command was executed after copying `node_modules`, which contains thousands of files. Changing ownership for all these files took several minutes.

## Solution
- Reorder operations: create the non-root user **before** copying files
- Use `COPY --chown=disclaude:disclaude` to set ownership during the copy operation
- Remove the slow recursive `chown -R disclaude:disclaude /app` command

## Benefits
- Files are written with the correct ownership from the start (more efficient)
- Avoids a separate recursive chown operation on thousands of files
- Faster Docker builds

## Test plan
- [x] Build Docker image: `docker build -t disclaude:latest .`
- [x] Verify file ownership in container: `docker run --rm disclaude:latest ls -la /app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)