### PR TITLE
fix: disable pino diagnostics to fix Vitest compatibility (Issue #115)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,12 @@ export default defineConfig({
       'dist/',
       '**/workspace/**',
     ],
+    env: {
+      NODE_ENV: 'test',
+      // Disable pino diagnostics_channel to fix compatibility with Vitest
+      // See: https://github.com/hs3180/disclaude/issues/115
+      PINO_DISABLE_DIAGNOSTICS: '1',
+    },
     // Use single-fork mode to prevent multiple worker processes
     // This is critical for preventing OOM in containerized environments
     pool: 'forks',


### PR DESCRIPTION
## Summary
- Fix pino logger compatibility with Vitest by adding `PINO_DISABLE_DIAGNOSTICS=1` environment variable to vitest config
- This resolves the `TypeError: diagChan.tracingChannel is not a function` error that causes 13+ test suites to fail loading in certain CI environments

## Root Cause
Pino logger v10+ uses `diagnostics_channel.tracingChannel` which is not available in some Node.js versions (< 18.19) or certain CI environments. This causes test suite loading failures.

## Solution
Add `PINO_DISABLE_DIAGNOSTICS=1` environment variable to the Vitest configuration, which disables pino's diagnostics channel and ensures tests run reliably across all environments.

## Test Results
- All 40 test files now load successfully
- 838/841 tests pass (3 pre-existing test failures unrelated to this issue)

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)