### PR TITLE
fix: preserve conversation context across multiple turns

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -656,23 +656,26 @@ ${msg.text}`;
           await this.callbacks.sendMessage(chatId, parsed.content, state.currentThreadRootId);
         }
 
-        // Check for completion - result type means query is done
+        // Check for completion - result type means current turn is done
+        // Do NOT break here to preserve conversation context across multiple turns.
+        // The loop continues waiting for the next message from messageGenerator,
+        // keeping the same Query instance alive (fixes issue #120 - context loss).
         if (parsed.type === 'result') {
-          this.logger.debug({ chatId, content: parsed.content }, 'Result received, breaking loop');
-          break;
+          this.logger.debug({ chatId, content: parsed.content }, 'Result received, turn complete');
+          // Signal completion to communication layer (e.g., REST sync mode)
+          if (this.callbacks.onDone) {
+            await this.callbacks.onDone(chatId, state.currentThreadRootId);
+          }
+          // Continue the loop - messageGenerator will wait for next user message
         }
       }
 
-      this.logger.info({ chatId }, 'Agent loop completed normally');
+      // Loop exited normally (state.closed or iterator exhausted)
+      this.logger.info({ chatId, closed: state.closed }, 'Agent loop completed');
 
-      // Signal completion to communication layer (e.g., REST sync mode)
-      if (this.callbacks.onDone) {
-        await this.callbacks.onDone(chatId, state.currentThreadRootId);
-      }
-
-      // Mark as restartable instead of deleting - preserve queue for next session
+      // Mark as restartable - preserve queue for next session
       state.started = false;
-      // Keep closed=false to allow restart on next message
+      // Keep closed as-is (may be true from clearQueue/resetAll, or false for iterator exhaustion)
     } catch (error) {
       const err = error as Error;
       this.logger.error({ err, chatId }, 'Agent loop error');


### PR DESCRIPTION
## Summary
- Fixes #120 - Chat context loss bug
- Modified startAgentLoop to NOT break on result type messages
- The loop now continues waiting for the next message from messageGenerator
- This keeps the same SDK Query instance alive, preserving conversation context

## Problem
The issue was that startAgentLoop would break out of the loop when receiving a result type message. This caused state.started to be set to false, and on the next user message, getOrCreateState would call startAgentLoop again, creating a NEW SDK Query instance and losing the conversation history.

## Solution
- Do NOT break on result type messages
- Call onDone callback after each result to signal turn completion
- Continue the loop, waiting for the next message from messageGenerator
- The same Query instance stays alive, preserving conversation context

The loop still exits properly when:
- state.closed becomes true (e.g., /reset command)
- The iterator is exhausted
- An error occurs

## Test plan
- [ ] Verify multi-turn conversations maintain context
- [ ] Verify /reset command still works correctly
- [ ] Verify error handling still allows recovery