### PR TITLE
fix: Bot回复消息未构成thread，应使用root_id而非parent_id

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -122,22 +122,27 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     switch (message.type) {
       case 'text':
-        await sender.sendText(message.chatId, message.text || '', message.parentId);
+        await sender.sendText(message.chatId, message.text || '', message.threadId);
         break;
       case 'card':
         await sender.sendCard(
           message.chatId,
           message.card || {},
           message.description,
-          message.parentId
+          message.threadId
         );
         break;
       case 'file':
-        // TODO: Pass parentId when Issue #68 is implemented
+        // TODO: Pass threadId when Issue #68 is implemented
         await sender.sendFile(message.chatId, message.filePath || '');
         break;
+      case 'done':
+        // Task completion signal, no actual message to send
+        // This is used for REST sync mode and internal signaling
+        logger.debug({ chatId: message.chatId }, 'Task completed (done signal)');
+        break;
       default:
-        throw new Error(`Unsupported message type: ${message.type}`);
+        throw new Error(`Unsupported message type: ${(message as { type: string }).type}`);
     }
   }
 
@@ -287,7 +292,11 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     if (!message) return;
 
-    const { message_id, chat_id, content, message_type, create_time, parent_id } = message;
+    const { message_id, chat_id, content, message_type, create_time, parent_id, root_id } = message;
+
+    // Use root_id for thread replies (this ensures all replies go to the same thread)
+    // root_id is the thread root message ID, parent_id is the direct parent
+    const threadId = root_id || parent_id;
 
     if (!message_id || !chat_id || !content || !message_type) {
       logger.warn('Missing required message fields');
@@ -353,7 +362,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
             content: uploadPrompt,
             messageType: 'file',
             timestamp: create_time,
-            parentId: parent_id,
+            threadId,
             attachments: [{
               fileName: latestAttachment.fileName || 'unknown',
               filePath: latestAttachment.localPath || '',
@@ -472,7 +481,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
         content: text,
         messageType: message_type as any,
         timestamp: create_time,
-        parentId: parent_id,
+        threadId,
       });
     }
   }

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -53,8 +53,8 @@ interface ChatRequest {
   message: string;
   /** User ID (optional) */
   userId?: string;
-  /** Parent message ID for thread context (optional) */
-  parentId?: string;
+  /** Thread root message ID for thread context (optional) */
+  threadId?: string;
   /** Response mode: 'stream' or 'sync' */
   mode?: 'stream' | 'sync';
 }
@@ -371,7 +371,7 @@ export class RestChannel extends EventEmitter implements IChannel {
           content: chatRequest.message,
           messageType: 'text',
           timestamp: Date.now(),
-          parentId: chatRequest.parentId,
+          threadId: chatRequest.threadId,
         });
       } catch (error) {
         logger.error({ err: error, messageId }, 'Failed to handle message');

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -38,8 +38,8 @@ export interface IncomingMessage {
   /** Timestamp when message was created (ms since epoch) */
   timestamp?: number;
 
-  /** Parent message ID for thread replies */
-  parentId?: string;
+  /** Thread root message ID for thread replies (from root_id in Feishu) */
+  threadId?: string;
 
   /** Additional metadata from the channel */
   metadata?: Record<string, unknown>;
@@ -96,8 +96,8 @@ export interface OutgoingMessage {
   /** Optional description for logging */
   description?: string;
 
-  /** Parent message ID for thread replies */
-  parentId?: string;
+  /** Thread root message ID for thread replies */
+  threadId?: string;
 
   /** Task success status (for type 'done') */
   success?: boolean;

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -290,7 +290,7 @@ export class CommunicationNode extends EventEmitter {
       prompt: message.content,
       messageId: message.messageId,
       senderOpenId: message.userId,
-      parentId: message.parentId,
+      threadId: message.threadId,
       attachments,
     });
   }
@@ -335,7 +335,7 @@ export class CommunicationNode extends EventEmitter {
     }
 
     this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, messageId: message.messageId, parentId: message.parentId }, 'Prompt sent to Execution Node');
+    logger.info({ chatId: message.chatId, messageId: message.messageId, threadId: message.threadId }, 'Prompt sent to Execution Node');
   }
 
   /**
@@ -356,26 +356,26 @@ export class CommunicationNode extends EventEmitter {
    * Handle feedback from Execution Node.
    */
   private async handleFeedback(message: FeedbackMessage): Promise<void> {
-    const { chatId, type, text, card, error, parentId, fileRef } = message;
+    const { chatId, type, text, card, error, threadId, fileRef } = message;
 
     try {
       switch (type) {
         case 'text':
           if (text) {
-            await this.sendMessage(chatId, text, parentId);
+            await this.sendMessage(chatId, text, threadId);
           }
           break;
         case 'card':
-          await this.sendCard(chatId, card || {}, undefined, parentId);
+          await this.sendCard(chatId, card || {}, undefined, threadId);
           break;
         case 'file':
           if (fileRef && this.fileStorageService) {
             const localPath = this.fileStorageService.getLocalPath(fileRef.id);
             if (localPath) {
-              await this.sendFileToUser(chatId, localPath, parentId);
+              await this.sendFileToUser(chatId, localPath, threadId);
             } else {
               logger.error({ fileId: fileRef.id }, 'File not found in storage');
-              await this.sendMessage(chatId, `❌ 文件未找到: ${fileRef.fileName}`, parentId);
+              await this.sendMessage(chatId, `❌ 文件未找到: ${fileRef.fileName}`, threadId);
             }
           }
           break;
@@ -387,14 +387,14 @@ export class CommunicationNode extends EventEmitter {
             if (channelId) {
               const channel = this.channels.get(channelId);
               if (channel) {
-                await channel.sendMessage({ type: 'done', chatId, parentId });
+                await channel.sendMessage({ type: 'done', chatId, threadId });
               }
             }
           }
           break;
         case 'error':
           logger.error({ chatId, error }, 'Execution error');
-          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`, parentId);
+          await this.sendMessage(chatId, `❌ 执行错误: ${error || 'Unknown error'}`, threadId);
           break;
       }
     } catch (err) {
@@ -405,7 +405,7 @@ export class CommunicationNode extends EventEmitter {
   /**
    * Send a text message to the appropriate channel.
    */
-  async sendMessage(chatId: string, text: string, parentMessageId?: string): Promise<void> {
+  async sendMessage(chatId: string, text: string, threadMessageId?: string): Promise<void> {
     const channelId = this.chatToChannel.get(chatId);
     if (!channelId) {
       logger.warn({ chatId }, 'No channel found for chat');
@@ -422,7 +422,7 @@ export class CommunicationNode extends EventEmitter {
       chatId,
       type: 'text',
       text,
-      parentId: parentMessageId,
+      threadId: threadMessageId,
     });
   }
 
@@ -433,7 +433,7 @@ export class CommunicationNode extends EventEmitter {
     chatId: string,
     card: Record<string, unknown>,
     description?: string,
-    parentMessageId?: string
+    threadMessageId?: string
   ): Promise<void> {
     const channelId = this.chatToChannel.get(chatId);
     if (!channelId) {
@@ -452,14 +452,14 @@ export class CommunicationNode extends EventEmitter {
       type: 'card',
       card,
       description,
-      parentId: parentMessageId,
+      threadId: threadMessageId,
     });
   }
 
   /**
    * Send a file to the appropriate channel.
    */
-  async sendFileToUser(chatId: string, filePath: string, _parentId?: string): Promise<void> {
+  async sendFileToUser(chatId: string, filePath: string, _threadId?: string): Promise<void> {
     const channelId = this.chatToChannel.get(chatId);
     if (!channelId) {
       logger.warn({ chatId }, 'No channel found for chat');
@@ -472,7 +472,7 @@ export class CommunicationNode extends EventEmitter {
       return;
     }
 
-    // TODO: Pass parentId when Issue #68 is implemented
+    // TODO: Pass threadId when Issue #68 is implemented
     await channel.sendMessage({
       chatId,
       type: 'file',

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -63,10 +63,10 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   });
 
   // Map to store active feedback context per chatId
-  // Includes sendFeedback function and parentId for thread replies
+  // Includes sendFeedback function and threadId for thread replies
   interface FeedbackContext {
     sendFeedback: (feedback: FeedbackMessage) => void;
-    parentId?: string;
+    threadId?: string;
   }
   const activeFeedbackChannels = new Map<string, FeedbackContext>();
 
@@ -83,18 +83,18 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     apiBaseUrl: agentConfig.apiBaseUrl,
     isCliMode: false, // Enable persistent sessions for context retention
     callbacks: {
-      sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
+      sendMessage: async (chatId: string, text: string, threadMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'text', chatId, text, parentId: parentMessageId || ctx.parentId });
+          ctx.sendFeedback({ type: 'text', chatId, text, threadId: threadMessageId || ctx.threadId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendMessage');
         }
       },
-      sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => {
+      sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, threadMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'card', chatId, card, text: description, parentId: parentMessageId || ctx.parentId });
+          ctx.sendFeedback({ type: 'card', chatId, card, text: description, threadId: threadMessageId || ctx.threadId });
         } else {
           logger.warn({ chatId }, 'No active feedback channel for sendCard');
         }
@@ -118,7 +118,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             fileName: fileRef.fileName,
             fileSize: fileRef.size,
             mimeType: fileRef.mimeType,
-            parentId: ctx.parentId,
+            threadId: ctx.threadId,
           });
         } catch (error) {
           logger.error({ err: error, chatId, filePath }, 'Failed to upload file');
@@ -126,14 +126,14 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             type: 'error',
             chatId,
             error: `Failed to send file: ${(error as Error).message}`,
-            parentId: ctx.parentId,
+            threadId: ctx.threadId,
           });
         }
       },
-      onDone: async (chatId: string, parentMessageId?: string) => {
+      onDone: async (chatId: string, threadMessageId?: string) => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
-          ctx.sendFeedback({ type: 'done', chatId, parentId: parentMessageId || ctx.parentId });
+          ctx.sendFeedback({ type: 'done', chatId, threadId: threadMessageId || ctx.threadId });
           logger.info({ chatId }, 'Task completed, sent done signal');
         } else {
           logger.warn({ chatId }, 'No active feedback channel for onDone');
@@ -220,16 +220,16 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const taskFlowOrchestrator = new TaskFlowOrchestrator(
     taskTracker,
     {
-      sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
+      sendMessage: async (chatId: string, text: string, threadMessageId?: string) => {
         if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'text', chatId, text, parentId: parentMessageId }));
+          ws.send(JSON.stringify({ type: 'text', chatId, text, threadId: threadMessageId }));
         } else {
           logger.warn({ chatId }, 'Cannot send message: WebSocket not connected');
         }
       },
-      sendCard: async (chatId: string, card: Record<string, unknown>, _description?: string, parentMessageId?: string) => {
+      sendCard: async (chatId: string, card: Record<string, unknown>, _description?: string, threadMessageId?: string) => {
         if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(JSON.stringify({ type: 'card', chatId, card, parentId: parentMessageId }));
+          ws.send(JSON.stringify({ type: 'card', chatId, card, threadId: threadMessageId }));
         } else {
           logger.warn({ chatId }, 'Cannot send card: WebSocket not connected');
         }
@@ -301,8 +301,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
         // Handle prompt messages
         if (message.type === 'prompt') {
-          const { chatId, prompt, messageId, senderOpenId, parentId, attachments } = message;
-          logger.info({ chatId, messageId, promptLength: prompt.length, parentId, hasAttachments: !!attachments }, 'Received prompt');
+          const { chatId, prompt, messageId, senderOpenId, threadId, attachments } = message;
+          logger.info({ chatId, messageId, promptLength: prompt.length, threadId, hasAttachments: !!attachments }, 'Received prompt');
 
           // Download attachments if present
           if (attachments && attachments.length > 0) {
@@ -326,8 +326,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             }
           };
 
-          // Register feedback channel for this chatId with parentId
-          activeFeedbackChannels.set(chatId, { sendFeedback, parentId });
+          // Register feedback channel for this chatId with threadId
+          activeFeedbackChannels.set(chatId, { sendFeedback, threadId });
 
           try {
             // Use processMessage for persistent session context
@@ -336,8 +336,8 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
           } catch (error) {
             const err = error as Error;
             logger.error({ err, chatId }, 'Execution failed');
-            sendFeedback({ type: 'error', chatId, error: err.message, parentId });
-            sendFeedback({ type: 'done', chatId, parentId });
+            sendFeedback({ type: 'error', chatId, error: err.message, threadId });
+            sendFeedback({ type: 'done', chatId, threadId });
           }
           return;
         }

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -17,8 +17,8 @@ export interface PromptMessage {
   prompt: string;
   messageId: string;
   senderOpenId?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
+  /** Thread root message ID for thread replies */
+  threadId?: string;
   /** File attachments (if any) */
   attachments?: FileReference[];
 }
@@ -41,8 +41,8 @@ export interface FeedbackMessage {
   text?: string;
   card?: Record<string, unknown>;
   error?: string;
-  /** Parent message ID for thread replies */
-  parentId?: string;
+  /** Thread root message ID for thread replies */
+  threadId?: string;
 
   // ===== File transfer fields =====
 


### PR DESCRIPTION
## 问题描述

Fixes #96

Bot 在飞书中回复消息时，没有正确构成 thread（话题串），每条回复都是独立消息，没有聚合到同一个话题下。

## 根因分析

飞书的 threading 模型有两个关键字段：
- **`parent_id`**: 直接回复的消息ID
- **`root_id`**: 线程根消息ID（thread的第一条消息）

之前代码只提取和使用了 `parent_id`，忽略了 `root_id`。要让回复进入 thread，必须使用 `root_id` 作为 API 请求中的 `parent_id`。

## 修复方案

1. **统一命名**：将 `parentId` 重命名为 `threadId`，避免 `parentId`/`root_id`/`threadId` 混淆
2. **提取 root_id**：从飞书消息中提取 `root_id` 字段
3. **优先使用 threadId**：Bot 回复时使用 `root_id || parent_id`（优先 root_id）
4. **处理 done 类型**：在 `FeishuChannel.sendMessage()` 中处理 `done` 消息类型

## 修改的文件

- `src/channels/types.ts` - `parentId` -> `threadId` (IncomingMessage, OutgoingMessage)
- `src/types/websocket-messages.ts` - `parentId` -> `threadId` (PromptMessage, FeedbackMessage)
- `src/channels/feishu-channel.ts` - 提取并使用 `root_id`，处理 `done` 类型
- `src/channels/rest-channel.ts` - `parentId` -> `threadId`
- `src/nodes/communication-node.ts` - `parentId` -> `threadId`
- `src/runners/execution-runner.ts` - `parentId` -> `threadId`

## 测试计划

- [ ] 在飞书中发送消息触发 Bot
- [ ] 验证 Bot 的回复出现在同一个 thread 中
- [ ] 验证 REST API 仍然正常工作
- [ ] 验证 `done` 信号不再报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)