### PR TITLE
fix: reset only specific chatId instead of all chats

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -232,6 +232,65 @@ describe('Pilot (Streaming Input)', () => {
     });
   });
 
+  describe('reset', () => {
+    it('should reset specific chatId only', () => {
+      pilot.processMessage('chat-123', 'Hello', 'msg-001');
+      pilot.processMessage('chat-456', 'Hi', 'msg-002');
+      expect(pilot['states'].size).toBe(2);
+
+      // Reset only chat-123
+      pilot.reset('chat-123');
+
+      // chat-123 should be removed, chat-456 should remain
+      expect(pilot['states'].size).toBe(1);
+      expect(pilot['states'].has('chat-123')).toBe(false);
+      expect(pilot['states'].has('chat-456')).toBe(true);
+    });
+
+    it('should handle non-existent chatId gracefully', () => {
+      pilot.processMessage('chat-123', 'Hello', 'msg-001');
+      expect(pilot['states'].size).toBe(1);
+
+      // Reset non-existent chatId
+      pilot.reset('chat-nonexistent');
+
+      // Original state should remain
+      expect(pilot['states'].size).toBe(1);
+      expect(pilot['states'].has('chat-123')).toBe(true);
+    });
+
+    it('should close query instance when resetting', async () => {
+      pilot.processMessage('chat-123', 'Hello', 'msg-001');
+      const state = pilot['states'].get('chat-123');
+
+      // Wait a bit for agent loop to start
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      pilot.reset('chat-123');
+
+      // State should be removed
+      expect(pilot['states'].has('chat-123')).toBe(false);
+    });
+
+    it('should not affect other chatIds in group chat scenario', () => {
+      // Simulate multiple group chats
+      pilot.processMessage('group-chat-1', 'Hello from group 1', 'msg-001');
+      pilot.processMessage('group-chat-2', 'Hello from group 2', 'msg-002');
+      pilot.processMessage('group-chat-3', 'Hello from group 3', 'msg-003');
+
+      expect(pilot['states'].size).toBe(3);
+
+      // User in group-chat-1 sends /reset
+      pilot.reset('group-chat-1');
+
+      // Only group-chat-1 should be reset
+      expect(pilot['states'].size).toBe(2);
+      expect(pilot['states'].has('group-chat-1')).toBe(false);
+      expect(pilot['states'].has('group-chat-2')).toBe(true);
+      expect(pilot['states'].has('group-chat-3')).toBe(true);
+    });
+  });
+
   describe('resetAll', () => {
     it('should clear all states', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -748,6 +748,31 @@ You can read these files using the Read tool with the local paths above.`;
   }
 
   /**
+   * Reset state for a specific chatId (close session and remove from map).
+   *
+   * This is useful for /reset commands that clear conversation context for a specific chat.
+   * Unlike clearQueue, this method logs the reset for better observability.
+   *
+   * @param chatId - Platform-specific chat identifier
+   */
+  reset(chatId: string): void {
+    const state = this.states.get(chatId);
+    if (state) {
+      state.closed = true;
+      if (state.messageResolver) {
+        state.messageResolver();
+      }
+      if (state.queryInstance) {
+        state.queryInstance.close();
+      }
+      this.states.delete(chatId);
+      this.logger.info({ chatId }, 'State reset for chatId');
+    } else {
+      this.logger.debug({ chatId }, 'No state to reset for chatId');
+    }
+  }
+
+  /**
    * Clear all pending files for a chatId.
    *
    * Note: In the new implementation, file tracking is internal to the state.
@@ -766,7 +791,8 @@ You can read these files using the Read tool with the local paths above.`;
   /**
    * Reset all states (close all and start fresh).
    *
-   * This is useful for /reset commands that clear all conversation context.
+   * WARNING: This resets ALL chatIds. Use reset(chatId) for single chat reset.
+   * This is useful for admin commands or shutdown scenarios.
    */
   resetAll(): void {
     this.logger.info('Resetting all states');

--- a/src/nodes/execution-node.ts
+++ b/src/nodes/execution-node.ts
@@ -206,8 +206,9 @@ export class ExecutionNode {
     try {
       switch (command.type) {
         case 'reset':
-          this.pilot.resetAll();
-          this.logger.info({ chatId: command.chatId }, 'Reset command executed');
+          // Use reset(chatId) to only reset the specific chat, not all chats
+          this.pilot.reset(command.chatId);
+          this.logger.info({ chatId: command.chatId }, 'Reset command executed for chatId');
           return {
             success: true,
             type: command.type,
@@ -216,7 +217,7 @@ export class ExecutionNode {
         case 'restart':
           // Restart is typically handled at the process level (PM2)
           // Here we just reset and let the caller know
-          this.pilot.resetAll();
+          this.pilot.reset(command.chatId);
           this.logger.info({ chatId: command.chatId }, 'Restart command executed (reset performed)');
           return {
             success: true,

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -279,10 +279,11 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
 
           try {
             if (command === 'reset') {
-              sharedPilot.resetAll();
-              logger.info({ chatId }, 'Pilot reset executed');
+              // Use reset(chatId) to only reset the specific chat, not all chats
+              sharedPilot.reset(chatId);
+              logger.info({ chatId }, 'Pilot reset executed for chatId');
             } else if (command === 'restart') {
-              sharedPilot.resetAll();
+              sharedPilot.reset(chatId);
               logger.info({ chatId }, 'Pilot restart executed (reset performed)');
             }
           } catch (error) {


### PR DESCRIPTION
## Summary

- Add `reset(chatId)` method to Pilot for resetting specific chat context
- Update execution-runner.ts to use `reset(chatId)` instead of `resetAll()`
- Update execution-node.ts to use `reset(chatId)` instead of `resetAll()`
- Add tests for the new `reset(chatId)` method

## Problem

Previously, `/reset` command in any chat would reset ALL chat contexts across all groups/users. This meant that when user A in group 1 sent `/reset`, it would also reset the context for user B in group 2.

## Solution

Added a `reset(chatId)` method that only resets the context for the specific chatId that requested the reset, leaving other chats unaffected.

## Test Report

### New Tests Added (4 tests)

| Test | Description | Status |
|------|-------------|--------|
| `should reset specific chatId only` | Tests that reset only affects target chatId | ✅ Pass |
| `should handle non-existent chatId gracefully` | Tests graceful handling of missing chatId | ✅ Pass |
| `should close query instance when resetting` | Tests proper cleanup | ✅ Pass |
| `should not affect other chatIds in group chat scenario` | Tests group chat isolation | ✅ Pass |

### Test Results

```
Test Files  1 failed (timeout) | 41 passed
Tests       1 failed (existing timeout issue) | 41 passed
```

The 1 failed test is a pre-existing timeout issue unrelated to this change.

## Files Changed

- `src/agents/pilot.ts` - Add `reset(chatId)` method
- `src/agents/pilot.test.ts` - Add tests for `reset(chatId)`
- `src/runners/execution-runner.ts` - Use `reset(chatId)` instead of `resetAll()`
- `src/nodes/execution-node.ts` - Use `reset(chatId)` instead of `resetAll()`

## Related Issues

- Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)