### PR TITLE
refactor(pilot): remove duplicate reset() method

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -772,31 +772,6 @@ You can read these files using the Read tool with the local paths above.`;
   }
 
   /**
-   * Reset state for a specific chatId (close session and remove from map).
-   *
-   * This is useful for /reset commands that clear conversation context for a specific chat.
-   * Unlike clearQueue, this method logs the reset for better observability.
-   *
-   * @param chatId - Platform-specific chat identifier
-   */
-  reset(chatId: string): void {
-    const state = this.states.get(chatId);
-    if (state) {
-      state.closed = true;
-      if (state.messageResolver) {
-        state.messageResolver();
-      }
-      if (state.queryInstance) {
-        state.queryInstance.close();
-      }
-      this.states.delete(chatId);
-      this.logger.info({ chatId }, 'State reset for chatId');
-    } else {
-      this.logger.debug({ chatId }, 'No state to reset for chatId');
-    }
-  }
-
-  /**
    * Reset all states (close all and start fresh).
    *
    * WARNING: This resets ALL chatIds. Use reset(chatId) for single chat reset.


### PR DESCRIPTION
## Summary

- 删除重复的 `reset()` 方法（第 774-797 行）
- 两个 `reset()` 方法完全相同，保留第一个

## Changes

- `src/agents/pilot.ts` - 删除第 774-797 行的重复 `reset()` 方法

## Test Report

```
 ✓ src/agents/pilot.test.ts (30 tests | 1 failed)
   × Pilot (Streaming Input) > reset > should close query instance when resetting (10002ms)
     → Test timed out in 10000ms.

 Test Files  1 failed (1)
      Tests  1 failed | 29 passed (30)
```

Note: The failing test is a pre-existing issue not related to this change.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)