### PR TITLE
fix: resolve TypeScript and ESLint static analysis issues

### DIFF
--- a/src/agents/executor.test.ts
+++ b/src/agents/executor.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TaskProgressEvent } from './executor.js';
 
 // Mock SDK
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -218,7 +218,10 @@ export class Executor extends BaseAgent {
       // Use BaseAgent's handleIteratorError for consistent error handling
       const errorResult = this.handleIteratorError(err, 'executeTask');
       // Extract error message from AgentMessage content
-      error = errorResult.content;
+      // errorResult.content may be string or ContentBlock[], extract string representation
+      error = typeof errorResult.content === 'string'
+        ? errorResult.content
+        : JSON.stringify(errorResult.content);
 
       // Create execution.md even on error
       try {
@@ -229,7 +232,7 @@ export class Executor extends BaseAgent {
 
       yield {
         type: 'error',
-        error,
+        error: error ?? 'Unknown error',
       };
 
       return {

--- a/src/agents/reporter.ts
+++ b/src/agents/reporter.ts
@@ -209,7 +209,7 @@ export class Reporter extends BaseAgent {
       chatId: context.chatId,
     });
 
-    if (!prompt) return;
+    if (!prompt) {return;}
 
     try {
       for await (const msg of this.sendFeedback(prompt)) {

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -191,9 +191,9 @@ export class FeishuChannel extends EventEmitter implements IChannel {
     logger.info('FeishuChannel started');
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     if (this._status === 'stopped') {
-      return;
+      return Promise.resolve();
     }
 
     this._status = 'stopping';
@@ -207,6 +207,7 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     this._status = 'stopped';
     logger.info('FeishuChannel stopped');
+    return Promise.resolve();
   }
 
   isHealthy(): boolean {
@@ -287,14 +288,14 @@ export class FeishuChannel extends EventEmitter implements IChannel {
    * Handle incoming message event from WebSocket.
    */
   private async handleMessageReceive(data: FeishuEventData): Promise<void> {
-    if (this._status !== 'running') return;
+    if (this._status !== 'running') {return;}
 
     this.getClient();
 
     const event = (data.event || data) as FeishuMessageEvent;
     const { message, sender } = event;
 
-    if (!message) return;
+    if (!message) {return;}
 
     const { message_id, chat_id, content, message_type, create_time, parent_id, root_id } = message;
 

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -141,7 +141,7 @@ export class RestChannel extends EventEmitter implements IChannel {
     this.controlHandler = handler;
   }
 
-  async sendMessage(message: OutgoingMessage): Promise<void> {
+  sendMessage(message: OutgoingMessage): Promise<void> {
     const messageId = this.chatToMessage.get(message.chatId);
 
     // Handle 'done' type - task completion signal for sync mode
@@ -165,7 +165,7 @@ export class RestChannel extends EventEmitter implements IChannel {
 
         logger.debug({ chatId: message.chatId, messageId }, 'Task completed, sync response resolved');
       }
-      return;
+      return Promise.resolve();
     }
 
     // For sync mode: buffer text responses
@@ -179,12 +179,13 @@ export class RestChannel extends EventEmitter implements IChannel {
     // For streaming mode: this could be extended to use Server-Sent Events
     // Currently we just log the message
     logger.debug({ chatId: message.chatId, type: message.type }, 'Message sent through REST channel');
+    return Promise.resolve();
   }
 
-  async start(): Promise<void> {
+  start(): Promise<void> {
     if (this._status === 'running') {
       logger.warn('RestChannel already running');
-      return;
+      return Promise.resolve();
     }
 
     this._status = 'starting';
@@ -211,9 +212,9 @@ export class RestChannel extends EventEmitter implements IChannel {
     });
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     if (this._status === 'stopped') {
-      return;
+      return Promise.resolve();
     }
 
     this._status = 'stopping';
@@ -351,7 +352,7 @@ export class RestChannel extends EventEmitter implements IChannel {
 
     const chatId = chatRequest.chatId || uuidv4();
     const messageId = uuidv4();
-    const userId = chatRequest.userId;
+    const {userId} = chatRequest;
 
     logger.info({ chatId, messageId, userId, syncMode }, 'Received chat request');
 

--- a/src/cli-entry.test.ts
+++ b/src/cli-entry.test.ts
@@ -47,21 +47,21 @@ describe('CLI Entry Point', () => {
 
     it('should detect comm mode', () => {
       const args = ['start', '--mode', 'comm'];
-      const mode = args[2];
+      const [, , mode] = args;
 
       expect(mode).toBe('comm');
     });
 
     it('should detect exec mode', () => {
       const args = ['start', '--mode', 'exec'];
-      const mode = args[2];
+      const [, , mode] = args;
 
       expect(mode).toBe('exec');
     });
 
     it('should detect missing mode argument', () => {
       const args = ['start'];
-      const mode = args[2];
+      const [, , mode] = args;
 
       expect(mode).toBeUndefined();
     });

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -35,7 +35,7 @@ function showHelp(): void {
   console.log('');
   console.log('═══════════════════════════════════════════════════');
   console.log('  Disclaude - Multi-platform Agent Bot');
-  console.log('  Version: ' + packageJson.version);
+  console.log(`  Version: ${  packageJson.version}`);
   console.log('═══════════════════════════════════════════════════');
   console.log('');
   console.log('Usage:');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -183,10 +183,10 @@ export class Config {
       logger.error({ errors }, 'Configuration validation failed');
       throw new Error(
         `Configuration validation failed:\n\n${messages}\n\n` +
-        `Please update your disclaude.config.yaml file:\n` +
-        `  glm:\n` +
-        `    apiKey: \"your-key\"\n` +
-        `    model: \"glm-5\"`
+        'Please update your disclaude.config.yaml file:\n' +
+        '  glm:\n' +
+        '    apiKey: \"your-key\"\n' +
+        '    model: \"glm-5\"'
       );
     }
   }

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -130,9 +130,9 @@ function getCardValidationError(content: unknown): string {
   const obj = content as Record<string, unknown>;
   const missing: string[] = [];
 
-  if (!('config' in obj)) missing.push('config');
-  if (!('header' in obj)) missing.push('header');
-  if (!('elements' in obj)) missing.push('elements');
+  if (!('config' in obj)) {missing.push('config');}
+  if (!('header' in obj)) {missing.push('header');}
+  if (!('elements' in obj)) {missing.push('elements');}
 
   if (missing.length > 0) {
     return `missing required fields: ${missing.join(', ')}`;
@@ -293,7 +293,7 @@ export async function send_user_feedback(params: {
           return {
             success: false,
             error: `Invalid JSON: ${parseError instanceof Error ? parseError.message : 'Parse failed'}`,
-            message: `❌ Content is not valid JSON. Expected a Feishu card object with: { config, header: { title }, elements: [] }`,
+            message: '❌ Content is not valid JSON. Expected a Feishu card object with: { config, header: { title }, elements: [] }',
           };
         }
       } else {
@@ -308,7 +308,7 @@ export async function send_user_feedback(params: {
         return {
           success: false,
           error: `Invalid content type: expected object or string, got ${actualType}`,
-          message: `❌ Invalid content type. Expected Feishu card object or JSON string.`,
+          message: '❌ Invalid content type. Expected Feishu card object or JSON string.',
         };
       }
     }

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -255,7 +255,7 @@ export class CommunicationNode extends EventEmitter {
   /**
    * Handle message from a channel.
    */
-  private async handleChannelMessage(channelId: string, message: IncomingMessage): Promise<void> {
+  private async handleChannelMessage(_channelId: string, message: IncomingMessage): Promise<void> {
     // Process attachments if present
     let attachments: FileReference[] | undefined;
     if (message.attachments && message.attachments.length > 0 && this.fileStorageService) {

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import WebSocket from 'ws';
 import { Config } from '../config/index.js';
 import { AgentFactory } from '../agents/index.js';
-import type { Pilot } from '../agents/index.js';
 import { createLogger } from '../utils/logger.js';
 import { parseGlobalArgs, getExecNodeConfig, type ExecNodeConfig } from '../utils/cli-args.js';
 import {
@@ -72,21 +71,23 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
    * Uses AgentFactory for consistent configuration (Issue #129).
    */
   const sharedPilot = AgentFactory.createPilot({
-    sendMessage: async (chatId: string, text: string, threadMessageId?: string) => {
+    sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
       const ctx = activeFeedbackChannels.get(chatId);
       if (ctx) {
         ctx.sendFeedback({ type: 'text', chatId, text, threadId: threadMessageId || ctx.threadId });
       } else {
         logger.warn({ chatId }, 'No active feedback channel for sendMessage');
       }
+      return Promise.resolve();
     },
-    sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, threadMessageId?: string) => {
+    sendCard: (chatId: string, card: Record<string, unknown>, description?: string, threadMessageId?: string): Promise<void> => {
       const ctx = activeFeedbackChannels.get(chatId);
       if (ctx) {
         ctx.sendFeedback({ type: 'card', chatId, card, text: description, threadId: threadMessageId || ctx.threadId });
       } else {
         logger.warn({ chatId }, 'No active feedback channel for sendCard');
       }
+      return Promise.resolve();
     },
     sendFile: async (chatId: string, filePath: string) => {
       const ctx = activeFeedbackChannels.get(chatId);
@@ -119,7 +120,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
         });
       }
     },
-    onDone: async (chatId: string, threadMessageId?: string) => {
+    onDone: (chatId: string, threadMessageId?: string): Promise<void> => {
       const ctx = activeFeedbackChannels.get(chatId);
       if (ctx) {
         ctx.sendFeedback({ type: 'done', chatId, threadId: threadMessageId || ctx.threadId });
@@ -127,6 +128,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
       } else {
         logger.warn({ chatId }, 'No active feedback channel for onDone');
       }
+      return Promise.resolve();
     },
   });
 
@@ -138,7 +140,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     scheduleManager,
     pilot: sharedPilot,
     callbacks: {
-      sendMessage: async (chatId: string, text: string) => {
+      sendMessage: (chatId: string, text: string): Promise<void> => {
         const ctx = activeFeedbackChannels.get(chatId);
         if (ctx) {
           ctx.sendFeedback({ type: 'text', chatId, text });
@@ -149,11 +151,13 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
             ws.send(JSON.stringify({ type: 'text', chatId, text }));
           }
         }
+        return Promise.resolve();
       },
-      sendCard: async (chatId: string, card: Record<string, unknown>, description?: string) => {
+      sendCard: (chatId: string, card: Record<string, unknown>, description?: string): Promise<void> => {
         if (ws?.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'card', chatId, card, text: description }));
         }
+        return Promise.resolve();
       },
       sendFile: async (chatId: string, filePath: string) => {
         try {
@@ -204,26 +208,29 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const taskFlowOrchestrator = new TaskFlowOrchestrator(
     taskTracker,
     {
-      sendMessage: async (chatId: string, text: string, threadMessageId?: string) => {
+      sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
         if (ws?.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'text', chatId, text, threadId: threadMessageId }));
         } else {
           logger.warn({ chatId }, 'Cannot send message: WebSocket not connected');
         }
+        return Promise.resolve();
       },
-      sendCard: async (chatId: string, card: Record<string, unknown>, _description?: string, threadMessageId?: string) => {
+      sendCard: (chatId: string, card: Record<string, unknown>, _description?: string, threadMessageId?: string): Promise<void> => {
         if (ws?.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'card', chatId, card, threadId: threadMessageId }));
         } else {
           logger.warn({ chatId }, 'Cannot send card: WebSocket not connected');
         }
+        return Promise.resolve();
       },
-      sendFile: async (chatId: string, filePath: string) => {
+      sendFile: (chatId: string, filePath: string): Promise<void> => {
         if (ws?.readyState === WebSocket.OPEN) {
           ws.send(JSON.stringify({ type: 'file', chatId, filePath }));
         } else {
           logger.warn({ chatId }, 'Cannot send file: WebSocket not connected');
         }
+        return Promise.resolve();
       },
     },
     logger

--- a/src/schedule/schedule-file-scanner.ts
+++ b/src/schedule/schedule-file-scanner.ts
@@ -107,16 +107,6 @@ function parseScheduleFrontmatter(content: string): {
 }
 
 /**
- * Generate a slug from task name for file naming.
- */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-') // Keep alphanumeric and Chinese
-    .replace(/^-+|-+$/g, ''); // Remove leading/trailing dashes
-}
-
-/**
  * Generate task ID from file name.
  */
 function generateTaskId(fileName: string): string {

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -236,7 +236,7 @@ export class ScheduleManager {
    * @param enabled - New enabled status
    * @returns The updated task or undefined if not found
    */
-  async toggle(id: string, enabled: boolean): Promise<ScheduledTask | undefined> {
+  toggle(id: string, enabled: boolean): Promise<ScheduledTask | undefined> {
     return this.update(id, { enabled });
   }
 

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -296,7 +296,7 @@ describe('Scheduler', () => {
       expect(scheduler.getActiveJobs()).toHaveLength(0);
     });
 
-    it('should handle delete and recreate same task ID', async () => {
+    it('should handle delete and recreate same task ID', () => {
       const taskId = 'schedule-same-id';
 
       const task1: ScheduledTask = {

--- a/src/task/task-file-watcher.test.ts
+++ b/src/task/task-file-watcher.test.ts
@@ -228,7 +228,7 @@ Test task description.
       await new Promise(resolve => setTimeout(resolve, 150));
 
       // Modify the file
-      await fs.promises.writeFile(taskFile, taskContent + '\n\nMore content', 'utf-8');
+      await fs.promises.writeFile(taskFile, `${taskContent  }\n\nMore content`, 'utf-8');
 
       // Wait for another poll cycle
       await new Promise(resolve => setTimeout(resolve, 150));

--- a/src/task/task-file-watcher.ts
+++ b/src/task/task-file-watcher.ts
@@ -96,7 +96,7 @@ export class TaskFileWatcher {
    * Schedule the next poll.
    */
   private scheduleNextPoll(): void {
-    if (!this.running) return;
+    if (!this.running) {return;}
 
     this.pollTimer = setTimeout(() => {
       this.poll().catch((error) => {

--- a/src/utils/cli-args.ts
+++ b/src/utils/cli-args.ts
@@ -70,7 +70,7 @@ function parseArgValue(args: string[], flag: string): string | undefined {
  * Parse an integer argument value.
  */
 function parseIntArg(value: string | undefined, defaultValue: number): number {
-  if (!value) return defaultValue;
+  if (!value) {return defaultValue;}
   const parsed = parseInt(value, 10);
   return isNaN(parsed) ? defaultValue : parsed;
 }

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -164,12 +164,12 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
 
       // Check for tool_use blocks in content
       const toolBlocks = apiMessage.content.filter(
-        (block) => block.type === 'tool_use'
+        (block: ContentBlock) => block.type === 'tool_use'
       );
 
       // Check for text blocks
       const textBlocks = apiMessage.content.filter(
-        (block) => block.type === 'text' && 'text' in block
+        (block: ContentBlock) => block.type === 'text' && 'text' in block
       );
 
       // Accumulate all content blocks (tool uses + text)
@@ -199,8 +199,8 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
 
       // Extract all text content
       const textParts = textBlocks
-        .filter((block) => 'text' in block)
-        .map((block) => (block as { text: string }).text);
+        .filter((block: ContentBlock) => 'text' in block)
+        .map((block: ContentBlock) => (block as { text: string }).text);
 
       if (textParts.length > 0) {
         contentParts.push(textParts.join(''));


### PR DESCRIPTION
## Summary

- 修复 TypeScript 类型错误 (10个)
- 修复 ESLint 错误 (37个)
- 所有更改均通过 `npm run type-check` 和 `npm run lint` 验证

## Changes

### TypeScript 类型错误修复
- `src/agents/executor.test.ts`: 添加 `TaskProgressEvent` 类型导入
- `src/agents/executor.ts`: 处理 `string | ContentBlock[]` 类型，添加类型守卫
- `src/utils/sdk.ts`: 为 `block` 参数添加显式 `ContentBlock` 类型注解
- `src/nodes/communication-node.ts`: 未使用的 `channelId` 参数添加下划线前缀

### ESLint require-await 修复
- `src/channels/feishu-channel.ts`: 移除 `stop()` 的 async 关键字，返回 Promise.resolve()
- `src/channels/rest-channel.ts`: 移除 `sendMessage()`, `start()`, `stop()` 的 async 关键字
- `src/runners/execution-runner.ts`: 重构回调函数签名，使用显式 Promise 返回
- `src/schedule/schedule-manager.ts`: 移除 `toggle()` 的 async 关键字
- `src/schedule/scheduler.test.ts`: 移除测试函数的 async 关键字

### ESLint curly/quotes/prefer-template 修复
- 为所有 if 语句添加大括号
- 统一使用单引号
- 使用模板字面量替代字符串拼接

### ESLint prefer-destructuring 修复
- `src/cli-entry.test.ts`: 使用数组解构

### 移除未使用的导入/变量
- `src/runners/execution-runner.ts`: 移除未使用的 `Pilot` 导入
- `src/schedule/schedule-file-scanner.ts`: 移除未使用的 `slugify` 函数

## Test Report

```
Test Files  1 failed | 37 passed (38)
      Tests  1 failed | 738 passed (739)
   Duration  13.68s
```

注：1个测试超时失败是已存在的问题，与本次修复无关。

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)