### PR TITLE
test: fix pilot.test.ts timeout issue

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -184,12 +184,11 @@ describe('Pilot (Streaming Input)', () => {
       expect(pilot['states'].has('chat-123')).toBe(true);
     });
 
-    it('should close query instance when resetting', async () => {
+    it('should close query instance when resetting', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
 
-      // Wait a bit for agent loop to start
-      await new Promise(resolve => setTimeout(resolve, 100));
-
+      // Reset should work immediately without waiting
+      // The reset method is synchronous and handles queryInstance cleanup
       pilot.reset('chat-123');
 
       // State should be removed


### PR DESCRIPTION
## Summary

- 修复单元测试超时问题
- 所有 739 个测试现在全部通过
- 测试执行时间从 13.72s 优化到 3.54s

## Problem

测试 `Pilot (Streaming Input) > reset > should close query instance when resetting` 在使用 `vi.useFakeTimers()` 的情况下使用了真实的 `setTimeout` Promise，导致测试超时（10秒）。

## Solution

移除不必要的异步延迟。`reset()` 方法是同步的，不需要等待 agent loop 启动。

### Before
```typescript
it('should close query instance when resetting', async () => {
  pilot.processMessage('chat-123', 'Hello', 'msg-001');
  // Wait a bit for agent loop to start
  await new Promise(resolve => setTimeout(resolve, 100));  // ❌ 永远不会完成
  pilot.reset('chat-123');
  expect(pilot['states'].has('chat-123')).toBe(false);
});
```

### After
```typescript
it('should close query instance when resetting', () => {  // ✅ 同步测试
  pilot.processMessage('chat-123', 'Hello', 'msg-001');
  pilot.reset('chat-123');  // reset() 是同步方法
  expect(pilot['states'].has('chat-123')).toBe(false);
});
```

## Test Report

```
 Test Files  38 passed (38)
      Tests  739 passed (739)
   Duration  3.54s (之前: 13.72s)
```

## Best Practice

单元测试不应该：
- 依赖真实的延迟/等待
- 执行过于复杂或耗时过长的逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)