### PR TITLE
refactor: simplify Pilot State system - remove redundant fields

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -131,14 +131,6 @@ describe('Pilot (Streaming Input)', () => {
       // Should return almost immediately (not wait for SDK)
       expect(elapsed).toBeLessThan(100);
     });
-
-    it('should update lastActivity timestamp', () => {
-      const before = Date.now();
-      pilot.processMessage('chat-123', 'Hello', 'msg-001');
-      const state = pilot['states'].get('chat-123');
-
-      expect(state?.lastActivity).toBeGreaterThanOrEqual(before);
-    });
   });
 
   describe('clearQueue', () => {

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -118,12 +118,10 @@ interface PerChatIdState {
   queryInstance?: Query;
   /** Whether this chatId is closed */
   closed: boolean;
-  /** Last activity timestamp */
-  lastActivity: number;
   /** Whether the Agent loop has been started */
   started: boolean;
-  /** Current thread root message ID for replies (the latest user message) */
-  currentThreadRootId?: string;
+  /** Current message ID being processed (for thread replies) */
+  currentMessageId?: string;
 }
 
 /**
@@ -261,15 +259,8 @@ export class Pilot extends BaseAgent {
     // Get or create state for this chatId (handles health check and restart)
     const state = this.getOrCreateState(chatId);
 
-    // Update last activity
-    state.lastActivity = Date.now();
-
-    // Set this message as the current thread root for replies
-    // All bot responses will be threaded to this user message
-    state.currentThreadRootId = messageId;
-    this.logger.debug({ chatId, messageId }, 'Set current thread root for replies');
-
     // Push message to the queue
+    // The messageId will be used as threadRootId when processing this message
     state.messageQueue.push({ text, messageId, senderOpenId, attachments });
 
     // Log health status for debugging
@@ -334,9 +325,8 @@ export class Pilot extends BaseAgent {
       messageResolver: undefined,
       queryInstance: undefined,
       closed: false,
-      lastActivity: Date.now(),
       started: false,
-      currentThreadRootId: undefined,
+      currentMessageId: undefined,
     };
 
     this.states.set(chatId, state);
@@ -474,6 +464,10 @@ You can read these files using the Read tool with the local paths above.`;
         }
         this.logger.debug({ messageId: msg.messageId }, 'Yielding message to Agent');
 
+        // Track current message ID for thread replies
+        // This is updated for each message processed
+        state.currentMessageId = msg.messageId;
+
         // Build user message with context
         const enhancedContent = this.buildEnhancedContent(chatId, msg);
 
@@ -568,12 +562,10 @@ You can read these files using the Read tool with the local paths above.`;
           break;
         }
 
-        // Update activity timestamp
-        state.lastActivity = Date.now();
-
         // Send message content to callback (with thread support)
+        // Uses currentMessageId which is set by messageGenerator for each message
         if (parsed.content) {
-          await this.callbacks.sendMessage(chatId, parsed.content, state.currentThreadRootId);
+          await this.callbacks.sendMessage(chatId, parsed.content, state.currentMessageId);
         }
 
         // Check for completion - result type means current turn is done
@@ -584,7 +576,7 @@ You can read these files using the Read tool with the local paths above.`;
           this.logger.debug({ chatId, content: parsed.content }, 'Result received, turn complete');
           // Signal completion to communication layer (e.g., REST sync mode)
           if (this.callbacks.onDone) {
-            await this.callbacks.onDone(chatId, state.currentThreadRootId);
+            await this.callbacks.onDone(chatId, state.currentMessageId);
           }
           // Continue the loop - messageGenerator will wait for next user message
         }
@@ -600,11 +592,11 @@ You can read these files using the Read tool with the local paths above.`;
       const err = error as Error;
       this.logger.error({ err, chatId }, 'Agent loop error');
 
-      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`, state.currentThreadRootId);
+      await this.callbacks.sendMessage(chatId, `❌ Session error: ${err.message}`, state.currentMessageId);
 
       // Signal completion even on error
       if (this.callbacks.onDone) {
-        await this.callbacks.onDone(chatId, state.currentThreadRootId);
+        await this.callbacks.onDone(chatId, state.currentMessageId);
       }
 
       // Mark as restartable instead of deleting - preserve queue for next session

--- a/src/task/task-file-watcher.test.ts
+++ b/src/task/task-file-watcher.test.ts
@@ -238,7 +238,7 @@ Test task description.
     it('should process tasks serially', async () => {
       const executionOrder: string[] = [];
 
-      const slowCallback = vi.fn(async (taskPath: string, messageId: string) => {
+      const slowCallback = vi.fn(async (_taskPath: string, messageId: string) => {
         executionOrder.push(`start-${messageId}`);
         await new Promise(resolve => setTimeout(resolve, 100));
         executionOrder.push(`end-${messageId}`);
@@ -276,7 +276,7 @@ Test task description.
     it('should continue processing after task failure', async () => {
       const executionOrder: string[] = [];
 
-      const failingCallback = vi.fn(async (taskPath: string, messageId: string) => {
+      const failingCallback = vi.fn(async (_taskPath: string, messageId: string) => {
         if (messageId === 'msg_fail') {
           throw new Error('Task failed');
         }

--- a/src/task/task-file-watcher.ts
+++ b/src/task/task-file-watcher.ts
@@ -68,8 +68,6 @@ export class TaskFileWatcher {
   private watcher: fs.FSWatcher | null = null;
   /** Resolver for wait promise */
   private waitResolver: (() => void) | null = null;
-  /** Main loop promise for cleanup */
-  private loopPromise: Promise<void> | null = null;
 
   constructor(options: TaskFileWatcherOptions) {
     this.tasksDir = options.tasksDir;
@@ -94,7 +92,7 @@ export class TaskFileWatcher {
     this.running = true;
 
     // Start the main loop (fire and forget, runs in background)
-    this.loopPromise = this.mainLoop();
+    void this.mainLoop();
 
     logger.info(
       { tasksDir: this.tasksDir },
@@ -186,7 +184,7 @@ export class TaskFileWatcher {
         this.watcher = fs.watch(
           this.tasksDir,
           { recursive: true, persistent: false },
-          (eventType, filename) => {
+          (_eventType, filename) => {
             // Check if it's a task.md file
             if (filename && filename.endsWith('task.md')) {
               this.stopWaiting();


### PR DESCRIPTION
## Summary

根据 Issue #161 的要求简化 Pilot State 系统：

### 1. 移除 `lastActivity` - 死代码

此字段只写不读：
- 在 `processMessage`、`getOrCreateState`、`startAgentLoop` 中设置
- 但没有任何地方读取它来做超时清理等操作

### 2. 重构 `currentThreadRootId` → `currentMessageId`

**之前的问题**：
- `currentThreadRootId` 在消息入队时设置
- 会被后续消息覆盖，导致 thread ID 不准确

**重构方案**：
- 改为在 `messageGenerator` 处理每条消息时设置
- 每条消息处理时更新，更准确地跟踪当前处理的消息

### 3. 修复 task-file-watcher 的未使用变量警告

## State 接口变化

**简化前**:
```typescript
interface PerChatIdState {
  messageQueue: QueuedMessage[];
  messageResolver?: () => void;
  queryInstance?: Query;
  closed: boolean;
  lastActivity: number;           // ❌ 移除
  started: boolean;
  currentThreadRootId?: string;   // ❌ 移除
}
```

**简化后**:
```typescript
interface PerChatIdState {
  messageQueue: QueuedMessage[];
  messageResolver?: () => void;
  queryInstance?: Query;
  closed: boolean;
  started: boolean;
  currentMessageId?: string;      // ✅ 新增：每条消息处理时设置
}
```

## Test Report

```
 Test Files  38 passed (38)
      Tests  740 passed (740)
   Duration  6.41s
```

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)