### PR TITLE
refactor: 简化 threadId 处理逻辑，直接使用 message_id

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -297,12 +297,11 @@ export class FeishuChannel extends EventEmitter implements IChannel {
 
     if (!message) {return;}
 
-    const { message_id, chat_id, content, message_type, create_time, root_id } = message;
+    const { message_id, chat_id, content, message_type, create_time } = message;
 
-    // Bot always replies to the triggering message, forming or continuing a thread
-    // - In thread: use root_id to keep replies in the same thread
-    // - New message: use message_id to start a new thread
-    const threadId = root_id || message_id;
+    // Bot replies to user message by setting parent_id = message_id
+    // Feishu automatically handles thread affiliation
+    const threadId = message_id;
 
     if (!message_id || !chat_id || !content || !message_type) {
       logger.warn('Missing required message fields');

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -38,7 +38,7 @@ export interface IncomingMessage {
   /** Timestamp when message was created (ms since epoch) */
   timestamp?: number;
 
-  /** Thread root message ID for thread replies (from root_id in Feishu) */
+  /** Message ID to reply to (used as parent_id when sending) */
   threadId?: string;
 
   /** Additional metadata from the channel */

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -19,9 +19,6 @@ export interface FeishuMessageEvent {
       name: string;
       tenant_key: string;
     }>;
-    parent_id?: string;
-    root_id?: string;
-    thread_id?: string;
   };
   sender: {
     sender_type?: string;


### PR DESCRIPTION
## Summary

- 简化 `threadId` 处理逻辑，直接使用 `message_id`
- 移除未使用的 `parent_id`、`root_id`、`thread_id` 字段
- 更新注释说明

## 问题分析

根据飞书 API 设计：
- 发送消息时设置 `parent_id`
- 如果 parent 消息在 thread 中，回复会自动进入同一 thread
- 如果 parent 消息是新消息，回复会形成新的 thread

**关键点**: 我们不需要知道消息是否在 thread 中，只需要回复用户的消息即可。

## 修改内容

### 1. feishu-channel.ts
```typescript
// 之前
const threadId = root_id || message_id;

// 之后
const threadId = message_id;
```

### 2. platform.ts
移除未使用的字段：
- `parent_id?: string;`
- `root_id?: string;`
- `thread_id?: string;`

### 3. types.ts
更新注释：`threadId` 用于标识要回复的消息 ID

## 测试报告

### 测试环境
- Node.js: v18+
- 测试框架: Vitest

### 测试结果
```
Test Files  38 passed (38)
Tests       741 passed (741)
Duration    6.40s
```

✅ **所有测试通过**

## 预期效果

1. 代码更简洁，逻辑更清晰
2. 减少不必要的字段处理
3. 行为保持不变（bot 正确回复到对应的消息）

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)