### PR TITLE
fix: bot消息没有quote用户消息 - 使用reply替代create方法

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -65,27 +65,34 @@ async function sendMessageToFeishu(
   parentId?: string
 ): Promise<void> {
   const messageData: {
-    receive_id: string;
+    receive_id_type?: string;
     msg_type: string;
     content: string;
-    parent_id?: string;
   } = {
-    receive_id: chatId,
     msg_type: msgType,
     content,
   };
 
-  // Add parent_id for thread replies if provided
+  // When replying to a message, use reply method to properly quote the user's message
   if (parentId) {
-    messageData.parent_id = parentId;
+    await client.im.message.reply({
+      path: {
+        message_id: parentId,
+      },
+      data: messageData,
+    });
+  } else {
+    // New message: use create method with receive_id
+    await client.im.message.create({
+      params: {
+        receive_id_type: 'chat_id',
+      },
+      data: {
+        receive_id: chatId,
+        ...messageData,
+      },
+    });
   }
-
-  await client.im.message.create({
-    params: {
-      receive_id_type: 'chat_id',
-    },
-    data: messageData,
-  });
 }
 
 /**


### PR DESCRIPTION
## 概要
修复 Bot 回复用户消息时没有引用(quote)用户原始消息的问题。

## 问题描述
Bot 回复用户消息时，没有引用用户的原始消息。通过分析发现，当前代码使用了 `client.im.message.create()` 方法，该方法不支持 `parent_id` 参数来实现消息引用功能。

## 根因分析
- `im.message.create` 方法用于发送新消息，不支持 `parent_id` 或 `quote_message_id` 参数
- 应该使用 `im.message.reply` 方法来实现消息引用/回复功能

## 解决方案
修改 `sendMessageToFeishu` 函数，添加条件逻辑：
- 当有 `parentId` 时：使用 `client.im.message.reply()` 方法
- 当没有 `parentId` 时：使用 `client.im.message.create()` 方法（保持原有行为）

## 测试
- ✅ npm run build 通过

Fixes #177