### PR TITLE
fix: MessageSender should use reply() method to quote user messages

### DIFF
--- a/src/feishu/message-sender.ts
+++ b/src/feishu/message-sender.ts
@@ -45,27 +45,36 @@ export class MessageSender {
       // Always use plain text format
       // Use content builder utility for consistent message formatting
       const messageData: {
-        receive_id: string;
         msg_type: string;
         content: string;
-        parent_id?: string;
       } = {
-        receive_id: chatId,
         msg_type: 'text',
         content: buildTextContent(text),
       };
 
-      // Add parent_id for thread replies if provided
-      if (parentId) {
-        messageData.parent_id = parentId;
-      }
+      let response;
 
-      const response = await this.client.im.message.create({
-        params: {
-          receive_id_type: 'chat_id',
-        },
-        data: messageData,
-      });
+      // Use reply() method when parentId is provided to properly quote user messages
+      // This ensures the bot message references the original user message
+      if (parentId) {
+        response = await this.client.im.message.reply({
+          path: {
+            message_id: parentId,
+          },
+          data: messageData,
+        });
+      } else {
+        // Use create() method for new messages (no thread reply)
+        response = await this.client.im.message.create({
+          params: {
+            receive_id_type: 'chat_id',
+          },
+          data: {
+            receive_id: chatId,
+            ...messageData,
+          },
+        });
+      }
 
       // Track outgoing bot message in history
       // Feishu API returns message_id in response.data.message_id
@@ -108,27 +117,36 @@ export class MessageSender {
   ): Promise<void> {
     try {
       const messageData: {
-        receive_id: string;
         msg_type: string;
         content: string;
-        parent_id?: string;
       } = {
-        receive_id: chatId,
         msg_type: 'interactive',
         content: JSON.stringify(card),
       };
 
-      // Add parent_id for thread replies if provided
-      if (parentId) {
-        messageData.parent_id = parentId;
-      }
+      let response;
 
-      const response = await this.client.im.message.create({
-        params: {
-          receive_id_type: 'chat_id',
-        },
-        data: messageData,
-      });
+      // Use reply() method when parentId is provided to properly quote user messages
+      // This ensures the bot message references the original user message
+      if (parentId) {
+        response = await this.client.im.message.reply({
+          path: {
+            message_id: parentId,
+          },
+          data: messageData,
+        });
+      } else {
+        // Use create() method for new messages (no thread reply)
+        response = await this.client.im.message.create({
+          params: {
+            receive_id_type: 'chat_id',
+          },
+          data: {
+            receive_id: chatId,
+            ...messageData,
+          },
+        });
+      }
 
       // Track outgoing bot message in history
       const botMessageId = response?.data?.message_id;


### PR DESCRIPTION
## Summary
- Modify `MessageSender.sendText()` and `MessageSender.sendCard()` to use `client.im.message.reply()` when `parentId` is provided
- This ensures bot messages properly quote/reference the original user message, matching the behavior of MCP tools (fixed in PR #178)

## Problem
When the bot sends messages via `MessageSender` class, it uses `client.im.message.create()` with `parent_id` parameter. This only places the message in the same thread but **does not quote/reference the original user message**.

## Root Cause
PR #178 fixed this issue for MCP tools (`feishu-context-mcp.ts`) by using `client.im.message.reply()` method, but **did not fix the same issue in `MessageSender` class**.

**Current behavior:**
- MCP tool: Uses `reply()` ✅ (correctly quotes user message)
- MessageSender: Uses `create()` + `parent_id` ❌ (only threads, doesn't quote)

## Solution
Use the same pattern as PR #178:
- When `parentId` is provided → use `client.im.message.reply()`
- When `parentId` is not provided → use `client.im.message.create()`

## Test plan
- [ ] Send a message to the bot in a Feishu chat
- [ ] Verify the bot's reply appears in the same thread
- [ ] Verify the bot's message quotes/references the original user message

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)