### PR TITLE
refactor: remove redundant methods clearQueue and resetAll

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -134,22 +134,6 @@ describe('Pilot (Streaming Input)', () => {
     });
   });
 
-  describe('clearQueue', () => {
-    it('should clear query', () => {
-      pilot.processMessage('chat-123', 'Hello', 'msg-001');
-      expect(pilot['queries'].has('chat-123')).toBe(true);
-
-      pilot.clearQueue('chat-123');
-
-      expect(pilot['queries'].has('chat-123')).toBe(false);
-    });
-
-    it('should handle clearing non-existent query', () => {
-      // Should not throw
-      pilot.clearQueue('chat-nonexistent');
-    });
-  });
-
   describe('reset', () => {
     it('should reset specific chatId only', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
@@ -204,18 +188,6 @@ describe('Pilot (Streaming Input)', () => {
       expect(pilot['queries'].has('group-chat-1')).toBe(false);
       expect(pilot['queries'].has('group-chat-2')).toBe(true);
       expect(pilot['queries'].has('group-chat-3')).toBe(true);
-    });
-  });
-
-  describe('resetAll', () => {
-    it('should clear all queries', () => {
-      pilot.processMessage('chat-123', 'Hello', 'msg-001');
-      pilot.processMessage('chat-456', 'Hi', 'msg-002');
-      expect(pilot['queries'].size).toBe(2);
-
-      pilot.resetAll();
-
-      expect(pilot['queries'].size).toBe(0);
     });
   });
 

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -317,7 +317,7 @@ export class Pilot extends BaseAgent {
    * Process the SDK iterator for a chatId.
    *
    * IMPORTANT: This method preserves conversation context by NOT deleting the Query/Channel
-   * when the iterator ends unexpectedly. Only explicit close (reset/clearQueue)
+   * when the iterator ends unexpectedly. Only explicit close (reset)
    * removes the Query and Channel from the maps.
    *
    * If the iterator ends without explicit close, we attempt to restart the agent loop
@@ -355,7 +355,7 @@ export class Pilot extends BaseAgent {
       }
     }
 
-    // Check if this was an explicit close (reset/clearQueue removed the Query)
+    // Check if this was an explicit close (reset removed the Query)
     // If Query is still in the map, it means the iterator ended unexpectedly
     const wasExplicitClose = !this.queries.has(chatId);
 
@@ -486,32 +486,6 @@ You can read these files using the Read tool with the local paths above.`;
   }
 
   /**
-   * Clear all state for a chatId (close session and remove from map).
-   *
-   * IMPORTANT: Deletes Query and Channel from map BEFORE closing, so processIterator
-   * can distinguish explicit close from unexpected iterator end.
-   *
-   * @param chatId - Platform-specific chat identifier
-   */
-  clearQueue(chatId: string): void {
-    // Close channel first to stop generator
-    const channel = this.channels.get(chatId);
-    if (channel) {
-      this.channels.delete(chatId);
-      channel.close();
-    }
-
-    const query = this.queries.get(chatId);
-    if (query) {
-      // Delete from map FIRST, so processIterator knows this is an explicit close
-      this.queries.delete(chatId);
-      query.close();
-    }
-    this.threadRoots.delete(chatId);
-    this.logger.debug({ chatId }, 'State cleared');
-  }
-
-  /**
    * Reset state for a specific chatId (close session and remove from map).
    *
    * This is useful for /reset commands that clear conversation context for a specific chat.
@@ -539,33 +513,6 @@ You can read these files using the Read tool with the local paths above.`;
     } else {
       this.logger.debug({ chatId }, 'No state to reset for chatId');
     }
-  }
-
-  /**
-   * Reset all states (close all and start fresh).
-   *
-   * WARNING: This resets ALL chatIds. Use reset(chatId) for single chat reset.
-   */
-  resetAll(): void {
-    this.logger.info('Resetting all states');
-
-    // Close all channels first
-    const channelsToClose = Array.from(this.channels.values());
-    this.channels.clear();
-    for (const channel of channelsToClose) {
-      channel.close();
-    }
-
-    // Clear map FIRST, then close all queries
-    const queriesToClose = Array.from(this.queries.values());
-    this.queries.clear();
-    this.threadRoots.clear();
-
-    for (const query of queriesToClose) {
-      query.close();
-    }
-
-    this.logger.info('All states reset');
   }
 
   /**

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -22,7 +22,7 @@ const createMockPilot = (): Pilot => {
   return {
     executeOnce: vi.fn().mockResolvedValue(undefined),
     processMessage: vi.fn().mockResolvedValue(undefined),
-    resetAll: vi.fn(),
+    reset: vi.fn(),
   } as unknown as Pilot;
 };
 


### PR DESCRIPTION
## Summary

- Remove `clearQueue()` method (duplicate of `reset()`)
- Remove `resetAll()` method (only used in tests)
- Update comments that referenced these methods
- Update tests to remove tests for deleted methods
- Update scheduler.test.ts mock to use `reset` instead of `resetAll`

## Changes

| File | Change |
|------|--------|
| `src/agents/pilot.ts` | Removed `clearQueue()` and `resetAll()` methods |
| `src/agents/pilot.test.ts` | Removed tests for `clearQueue` and `resetAll` |
| `src/schedule/scheduler.test.ts` | Updated mock to use `reset` |

## Code Reduction

- **-84 lines** of redundant code removed
- `clearQueue()` was functionally identical to `reset()` 
- `resetAll()` was only used in tests, not in production code

## Test Report

```
 Test Files  44 passed (44)
      Tests  809 passed (809)
   Duration  7.08s
```

✅ All tests passing

Closes #189
Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)