### PR TITLE
fix: add blocking field to ScheduleFileWatcher.parseFile()

### DIFF
--- a/src/schedule/schedule-file-watcher.ts
+++ b/src/schedule/schedule-file-watcher.ts
@@ -226,6 +226,7 @@ export class ScheduleFileWatcher {
         chatId: frontmatter['chatId'] as string,
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
+        blocking: (frontmatter['blocking'] as boolean) ?? true,
         createdBy: frontmatter['createdBy'] as string | undefined,
         createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
         sourceFile: filePath,
@@ -268,6 +269,7 @@ export class ScheduleFileWatcher {
           frontmatter[key] = value.replace(/^["']|["']$/g, '');
           break;
         case 'enabled':
+        case 'blocking':
           frontmatter[key] = value === 'true';
           break;
       }


### PR DESCRIPTION
## Summary

- Add `blocking` field parsing to `ScheduleFileWatcher.parseFile()` 
- Add `blocking` case to `parseFrontmatter()` switch statement
- Fix issue where blocking mechanism fails after schedule file changes

## Problem

The blocking mechanism for scheduled tasks would fail after a schedule file was modified. When a task completed and the file was updated (e.g., with `lastExecutedAt`), the file watcher would re-parse the file without the `blocking` field.

Since `task.blocking` was `undefined`, the condition `task.blocking && this.runningTasks.has(task.id)` would evaluate to `false`, causing:
- Multiple task instances to run in parallel
- Resource contention
- Feedback channel confusion

## Root Cause

| File | `blocking` field |
|------|-----------------|
| `src/schedule/schedule-file-scanner.ts:195` | ✅ `blocking: (frontmatter['blocking'] as boolean) ?? true` |
| `src/schedule/schedule-file-watcher.ts:222-233` | ❌ **Missing** |

## Solution

Add the missing `blocking` field to `ScheduleFileWatcher.parseFile()` to match `ScheduleFileScanner.parseFile()` behavior.

## Test Report

```
 ✓ Test Files  43 passed (43)
 ✓ Tests       797 passed (797)
 ✓ Duration    6.90s
```

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)