### PR TITLE
fix(schedule): add missing blocking field to ScheduleFileWatcher.parseFile()

### DIFF
--- a/src/schedule/schedule-file-watcher.ts
+++ b/src/schedule/schedule-file-watcher.ts
@@ -226,6 +226,7 @@ export class ScheduleFileWatcher {
         chatId: frontmatter['chatId'] as string,
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
+        blocking: (frontmatter['blocking'] as boolean) ?? true,
         createdBy: frontmatter['createdBy'] as string | undefined,
         createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
         sourceFile: filePath,
@@ -268,6 +269,7 @@ export class ScheduleFileWatcher {
           frontmatter[key] = value.replace(/^["']|["']$/g, '');
           break;
         case 'enabled':
+        case 'blocking':
           frontmatter[key] = value === 'true';
           break;
       }


### PR DESCRIPTION
## Summary
- Add missing `blocking` field to `ScheduleFileWatcher.parseFile()` method
- Add `blocking` case to `parseFrontmatter()` switch statement for proper parsing

## Problem
The `parseFile()` method in `ScheduleFileWatcher` was missing the `blocking` field, causing the blocking mechanism to fail after schedule file changes.

When a task completed and updated `lastExecutedAt`, the file watcher would re-parse the file, but the resulting task object had no `blocking` field (`undefined`). This caused the blocking check to always evaluate to false, allowing multiple task instances to run in parallel.

## Root Cause
```typescript
// In executeTask():
task.blocking && this.runningTasks.has(task.id)  // undefined && ... → false
```

## Fix
Added the `blocking` field to the returned task object with a default value of `true`, consistent with `ScheduleFileScanner.parseFile()`.

## Test Plan
- [x] All 797 existing tests pass
- [x] Verified the fix matches the implementation in `ScheduleFileScanner.parseFile()`

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)