### PR TITLE
fix: Add missing blocking field in ScheduleFileWatcher.parseFile()

### DIFF
--- a/src/schedule/schedule-file-watcher.ts
+++ b/src/schedule/schedule-file-watcher.ts
@@ -226,6 +226,7 @@ export class ScheduleFileWatcher {
         chatId: frontmatter['chatId'] as string,
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
+        blocking: (frontmatter['blocking'] as boolean) ?? true,
         createdBy: frontmatter['createdBy'] as string | undefined,
         createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
         sourceFile: filePath,
@@ -268,6 +269,7 @@ export class ScheduleFileWatcher {
           frontmatter[key] = value.replace(/^["']|["']$/g, '');
           break;
         case 'enabled':
+        case 'blocking':
           frontmatter[key] = value === 'true';
           break;
       }


### PR DESCRIPTION
## Summary
- Fixes #200 
- Add missing `blocking` field parsing in `ScheduleFileWatcher.parseFile()`

## Problem

The `ScheduleFileWatcher.parseFile()` method was missing the `blocking` field parsing, causing the blocking mechanism to fail after schedule file changes. This led to multiple task instances running in parallel when only one should be allowed.

## Root Cause

When a schedule file changes:
1. Task completes → `markExecuted()` updates `lastExecutedAt`
2. `ScheduleFileWatcher` detects file change → calls `parseFile()`
3. New parsed task object **has no `blocking` field** (value is `undefined`)
4. `executeTask()` check: `task.blocking && this.runningTasks.has(task.id)` → `undefined && ...` → `false`
5. **Blocking mechanism fails**

## Changes

| File | Change |
|------|--------|
| `src/schedule/schedule-file-watcher.ts:271-273` | Add `blocking` case to `parseFrontmatter()` switch statement |
| `src/schedule/schedule-file-watcher.ts:229` | Add `blocking` field to return object in `parseFile()` |

## Test Results

✅ All 35 schedule tests pass:
- `src/schedule/scheduler.test.ts` (16 tests)
- `src/schedule/schedule-manager.test.ts` (19 tests)

## Co-Authored-By

Claude Opus 4.6 <noreply@anthropic.com>