### PR TITLE
fix(schedule): ensure threadId consistency for scheduled task messages

### DIFF
--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -220,36 +220,41 @@ ${task.prompt}`;
     // Mark task as running
     this.runningTasks.add(task.id);
 
+    // Generate a unique execution ID for this task execution
+    // This ID is used as threadId to group all messages in this execution
+    const executionId = `${task.id}-${Date.now()}`;
+
     // Set up feedback channel for Pilot's sendMessage callbacks
     // The sendFeedback will be provided by ExecutionRunner to directly send via WebSocket
     // We don't call callbacks.sendMessage here to avoid recursion
     if (this.setFeedbackChannel) {
-      const messageId = `${task.id}-${Date.now()}`;
       this.setFeedbackChannel(task.chatId, {
         // sendFeedback will be implemented by ExecutionRunner to directly use WebSocket
         sendFeedback: () => {
           // This is a placeholder - ExecutionRunner will replace this with actual implementation
         },
-        threadId: messageId,
+        threadId: executionId,
       });
       logger.debug({ chatId: task.chatId, taskId: task.id }, 'Feedback channel set for scheduled task');
     }
 
     try {
-      // Send start notification
+      // Send start notification with threadId for proper threading
       await this.callbacks.sendMessage(
         task.chatId,
-        `⏰ 定时任务「${task.name}」开始执行...`
+        `⏰ 定时任务「${task.name}」开始执行...`,
+        executionId
       );
 
       // Build wrapped prompt with anti-recursion instructions
       const wrappedPrompt = this.buildScheduledTaskPrompt(task);
 
       // Execute task using Pilot's executeOnce method
+      // Use the same executionId as messageId for consistency
       await this.pilot.executeOnce(
         task.chatId,
         wrappedPrompt,
-        `${task.id}-${Date.now()}`,
+        executionId,
         task.createdBy
       );
 
@@ -262,10 +267,11 @@ ${task.prompt}`;
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error({ err: error, taskId: task.id }, 'Scheduled task failed');
 
-      // Send error notification
+      // Send error notification with threadId for proper threading
       await this.callbacks.sendMessage(
         task.chatId,
-        `❌ 定时任务「${task.name}」执行失败: ${errorMessage}`
+        `❌ 定时任务「${task.name}」执行失败: ${errorMessage}`,
+        executionId
       );
     } finally {
       // Always remove from running tasks


### PR DESCRIPTION
Fixes #184

## Summary
- Generate a unique `executionId` at the start of each scheduled task execution
- Pass `executionId` as `threadId` to all messages sent during task execution:
  - Start notification message
  - Error notification message
  - Pilot.executeOnce() for consistent message grouping
- Use the same `executionId` for `setFeedbackChannel` to ensure all messages in the execution are grouped in a thread

## Problem
Scheduled task messages (start notification, error notification) were not passing `threadId`, causing them to be sent as independent messages rather than grouped in a thread. This made it difficult for users to track the progress and results of scheduled tasks.

## Solution
Modified `src/schedule/scheduler.ts` to:
1. Generate a unique `executionId = ${task.id}-${Date.now()}` at the start of task execution
2. Pass this `executionId` as the `threadId` parameter to all `sendMessage` calls
3. Use the same `executionId` as the `messageId` parameter for `pilot.executeOnce()`

## Testing
All 797 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)