### PR TITLE
feat(sdk): enable SDK debug logging and capture stderr to project logs

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -157,6 +157,17 @@ export abstract class BaseAgent {
       sdkOptions.model = this.model;
     }
 
+    // Enable SDK debug mode and capture stderr to project logs
+    // This helps troubleshoot SDK subprocess errors like rate limits and API errors
+    const sdkDebug = Config.SDK_DEBUG;
+    if (sdkDebug) {
+      sdkOptions.debug = true;
+      sdkOptions.stderr = (data: string) => {
+        // Log SDK stderr output to project logs
+        this.logger.debug({ source: 'SDK stderr' }, data.trim());
+      };
+    }
+
     return sdkOptions;
   }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -62,6 +62,7 @@ export class Config {
   static readonly LOG_FILE = fileConfigOnly.logging?.file;
   static readonly LOG_PRETTY = fileConfigOnly.logging?.pretty ?? true;
   static readonly LOG_ROTATE = fileConfigOnly.logging?.rotate ?? false;
+  static readonly SDK_DEBUG = fileConfigOnly.logging?.sdkDebug ?? true;
 
   // Skills configuration - loaded from package installation directory
   static readonly SKILLS_DIR = Config.getBuiltinSkillsDir();
@@ -282,12 +283,14 @@ export class Config {
     file?: string;
     pretty: boolean;
     rotate: boolean;
+    sdkDebug: boolean;
   } {
     return {
       level: this.LOG_LEVEL,
       file: this.LOG_FILE,
       pretty: this.LOG_PRETTY,
       rotate: this.LOG_ROTATE,
+      sdkDebug: this.SDK_DEBUG,
     };
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -92,6 +92,12 @@ export interface LoggingConfig {
   pretty?: boolean;
   /** Enable log rotation */
   rotate?: boolean;
+  /**
+   * Enable SDK debug mode for Claude Code subprocess.
+   * When true, enables verbose debug logging and captures stderr to project logs.
+   * Debug logs help troubleshoot SDK subprocess errors like rate limits and API errors.
+   */
+  sdkDebug?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `sdkDebug` option to LoggingConfig (default: true) for configurable SDK debug mode
- Add `SDK_DEBUG` static property to Config class
- Update `createSdkOptions()` in BaseAgent to enable SDK debug mode and capture stderr output
- stderr output from SDK subprocess is now logged via the agent's logger at debug level

## Problem

当 SDK 子进程异常退出时（如 `Claude Code process exited with code 1`），我们无法看到子进程内部的具体错误信息，包括：
- GLM/Anthropic API 返回的错误（如速率限制）
- SDK 内部的调试信息
- 子进程的 stderr 输出

## Solution

1. **启用 SDK DEBUG 日志**: 在 `createSdkOptions()` 中添加 `debug: true` 选项
2. **捕获子进程 stderr**: 添加 `stderr` 回调函数，将 SDK 子进程的 stderr 输出捕获到项目日志系统
3. **配置项**: 添加 `logging.sdkDebug` 配置项（默认启用），允许用户控制是否启用 SDK 调试模式

## Configuration

在 `disclaude.config.yaml` 中可以配置：

```yaml
logging:
  sdkDebug: true  # default is true
```

## Testing

- All 797 tests passed
- Build successful

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)