### PR TITLE
feat(logging): add sdkDebug config option for SDK debug logging

### DIFF
--- a/src/agents/base-agent.test.ts
+++ b/src/agents/base-agent.test.ts
@@ -24,6 +24,12 @@ vi.mock('../config/index.js', () => ({
       provider: 'anthropic',
     })),
     getGlobalEnv: vi.fn(() => ({})),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'info',
+      pretty: true,
+      rotate: false,
+      sdkDebug: true,
+    })),
   },
 }));
 

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -150,7 +150,13 @@ export abstract class BaseAgent {
     }
 
     // Set environment
-    sdkOptions.env = buildSdkEnv(this.apiKey, this.apiBaseUrl, Config.getGlobalEnv());
+    const loggingConfig = Config.getLoggingConfig();
+    sdkOptions.env = buildSdkEnv(
+      this.apiKey,
+      this.apiBaseUrl,
+      Config.getGlobalEnv(),
+      loggingConfig.sdkDebug
+    );
 
     // Set model
     if (this.model) {

--- a/src/agents/evaluator.test.ts
+++ b/src/agents/evaluator.test.ts
@@ -26,6 +26,12 @@ vi.mock('../config/index.js', () => ({
       provider: 'anthropic',
     })),
     getGlobalEnv: vi.fn(() => ({})),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'info',
+      pretty: true,
+      rotate: false,
+      sdkDebug: true,
+    })),
   },
 }));
 

--- a/src/agents/executor.test.ts
+++ b/src/agents/executor.test.ts
@@ -26,6 +26,12 @@ vi.mock('../config/index.js', () => ({
       provider: 'anthropic',
     })),
     getGlobalEnv: vi.fn(() => ({})),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'info',
+      pretty: true,
+      rotate: false,
+      sdkDebug: true,
+    })),
   },
 }));
 

--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -30,6 +30,12 @@ vi.mock('../config/index.js', () => ({
     })),
     getGlobalEnv: vi.fn(() => ({})),
     getMcpServersConfig: vi.fn(() => null),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'info',
+      pretty: true,
+      rotate: false,
+      sdkDebug: true,
+    })),
   },
 }));
 

--- a/src/agents/reporter.test.ts
+++ b/src/agents/reporter.test.ts
@@ -25,6 +25,12 @@ vi.mock('../config/index.js', () => ({
       provider: 'anthropic',
     })),
     getGlobalEnv: vi.fn(() => ({})),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'info',
+      pretty: true,
+      rotate: false,
+      sdkDebug: true,
+    })),
   },
 }));
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -62,6 +62,7 @@ export class Config {
   static readonly LOG_FILE = fileConfigOnly.logging?.file;
   static readonly LOG_PRETTY = fileConfigOnly.logging?.pretty ?? true;
   static readonly LOG_ROTATE = fileConfigOnly.logging?.rotate ?? false;
+  static readonly SDK_DEBUG = fileConfigOnly.logging?.sdkDebug ?? true;
 
   // Skills configuration - loaded from package installation directory
   static readonly SKILLS_DIR = Config.getBuiltinSkillsDir();
@@ -282,12 +283,14 @@ export class Config {
     file?: string;
     pretty: boolean;
     rotate: boolean;
+    sdkDebug: boolean;
   } {
     return {
       level: this.LOG_LEVEL,
       file: this.LOG_FILE,
       pretty: this.LOG_PRETTY,
       rotate: this.LOG_ROTATE,
+      sdkDebug: this.SDK_DEBUG,
     };
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -92,6 +92,8 @@ export interface LoggingConfig {
   pretty?: boolean;
   /** Enable log rotation */
   rotate?: boolean;
+  /** Enable SDK debug logging and capture subprocess stderr */
+  sdkDebug?: boolean;
 }
 
 /**

--- a/src/utils/sdk.test.ts
+++ b/src/utils/sdk.test.ts
@@ -315,6 +315,34 @@ describe('buildSdkEnv', () => {
     // process.env should take precedence
     expect(result.HOME).toBe(originalHome);
   });
+
+  it('should enable SDK debug by default', () => {
+    const result = buildSdkEnv('test-key');
+
+    expect(result.DEBUG_CLAUDE_AGENT_SDK).toBe('1');
+  });
+
+  it('should disable SDK debug when sdkDebug is false', () => {
+    const result = buildSdkEnv('test-key', undefined, undefined, false);
+
+    expect(result.DEBUG_CLAUDE_AGENT_SDK).toBeUndefined();
+  });
+
+  it('should respect process.env.DEBUG_CLAUDE_AGENT_SDK when sdkDebug is true', () => {
+    const originalValue = process.env.DEBUG_CLAUDE_AGENT_SDK;
+    process.env.DEBUG_CLAUDE_AGENT_SDK = 'verbose';
+
+    const result = buildSdkEnv('test-key', undefined, undefined, true);
+
+    expect(result.DEBUG_CLAUDE_AGENT_SDK).toBe('verbose');
+
+    // Restore original value
+    if (originalValue === undefined) {
+      delete process.env.DEBUG_CLAUDE_AGENT_SDK;
+    } else {
+      process.env.DEBUG_CLAUDE_AGENT_SDK = originalValue;
+    }
+  });
 });
 
 describe('extractText', () => {

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -376,12 +376,14 @@ export function extractText(message: AgentMessage): string {
  * @param apiKey - API key for authentication
  * @param apiBaseUrl - Optional base URL for API requests (e.g., for GLM)
  * @param extraEnv - Optional extra environment variables to merge
+ * @param sdkDebug - Enable SDK debug logging (default: true)
  * @returns Environment object for SDK options
  */
 export function buildSdkEnv(
   apiKey: string,
   apiBaseUrl?: string,
-  extraEnv?: Record<string, string | undefined>
+  extraEnv?: Record<string, string | undefined>,
+  sdkDebug: boolean = true
 ): Record<string, string | undefined> {
   const nodeBinDir = getNodeBinDir();
   const newPath = `${nodeBinDir}:${process.env.PATH || ''}`;
@@ -399,7 +401,8 @@ export function buildSdkEnv(
     PATH: newPath,
     // Enable SDK debug logging by default for better troubleshooting
     // SDK subprocess errors go to stderr and are critical for debugging
-    DEBUG_CLAUDE_AGENT_SDK: process.env.DEBUG_CLAUDE_AGENT_SDK ?? '1',
+    // Can be disabled via config logging.sdkDebug: false
+    DEBUG_CLAUDE_AGENT_SDK: sdkDebug ? (process.env.DEBUG_CLAUDE_AGENT_SDK ?? '1') : undefined,
   };
 
   // Set base URL if provided (for GLM or custom endpoints)


### PR DESCRIPTION
## Summary

- Add `sdkDebug` option to `LoggingConfig` type in config
- Default to `true` (debug enabled) for better troubleshooting
- Allow disabling via `logging.sdkDebug: false` in config file
- Update `buildSdkEnv` function to accept `sdkDebug` parameter
- Add comprehensive tests for new `sdkDebug` behavior

## Changes

### Configuration
- `src/config/types.ts`: Added `sdkDebug?: boolean` to `LoggingConfig` interface
- `src/config/index.ts`: Added `SDK_DEBUG` static property and updated `getLoggingConfig()` method

### SDK Utilities
- `src/utils/sdk.ts`: Updated `buildSdkEnv()` to accept optional `sdkDebug` parameter (default: `true`)

### Agent
- `src/agents/base-agent.ts`: Updated `createSdkOptions()` to pass `sdkDebug` config to `buildSdkEnv()`

### Tests
- Added 3 new tests for `sdkDebug` behavior in `src/utils/sdk.test.ts`
- Updated mock Config in agent test files to include `getLoggingConfig()`

## Configuration Example

```yaml
logging:
  level: info
  pretty: true
  sdkDebug: false  # Set to false to disable SDK debug logging
```

## Test Results

All 800 tests pass:
- `src/utils/sdk.test.ts`: 25 tests (including 3 new sdkDebug tests)
- `src/config/index.test.ts`: 45 tests
- `src/agents/base-agent.test.ts`: 15 tests
- All other agent tests pass

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)