### PR TITLE
feat: add tool fallback strategy for rate-limited tools

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -29,7 +29,7 @@
  */
 
 import type { SDKUserMessage, Query } from '@anthropic-ai/claude-agent-sdk';
-import { Config } from '../config/index.js';
+import { Config, TOOL_FALLBACK_SYSTEM_PROMPT } from '../config/index.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { FileReference } from '../types/file-reference.js';
@@ -440,6 +440,8 @@ When using send_file_to_feishu or send_user_feedback, use:
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
 
+---
+${TOOL_FALLBACK_SYSTEM_PROMPT}
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     }
@@ -452,7 +454,7 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 When using send_file_to_feishu or send_user_feedback, use:
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
-
+${TOOL_FALLBACK_SYSTEM_PROMPT}
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
   }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,6 +15,7 @@ import type { DisclaudeConfig, ConfigValidationError } from './types.js';
 // Export constants and types
 export * from './constants.js';
 export * from './tool-configuration.js';
+export * from './tool-fallback.js';
 export * from './types.js';
 export * from './loader.js';
 

--- a/src/config/tool-fallback.test.ts
+++ b/src/config/tool-fallback.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TOOL_FALLBACK_CHAINS,
+  isRateLimitError,
+  getFallbackForTool,
+  generateFallbackErrorMessage,
+  getToolsWithFallbacks,
+} from './tool-fallback.js';
+
+describe('tool-fallback', () => {
+  describe('TOOL_FALLBACK_CHAINS', () => {
+    it('should define fallback chains for WebSearch', () => {
+      expect(TOOL_FALLBACK_CHAINS.WebSearch).toBeDefined();
+      expect(TOOL_FALLBACK_CHAINS.WebSearch.fallbacks.length).toBeGreaterThan(0);
+      expect(TOOL_FALLBACK_CHAINS.WebSearch.description).toBe('Web search functionality');
+    });
+
+    it('should define fallback chains for webReader', () => {
+      expect(TOOL_FALLBACK_CHAINS['mcp__web_reader__webReader']).toBeDefined();
+      expect(TOOL_FALLBACK_CHAINS['mcp__web_reader__webReader'].fallbacks.length).toBeGreaterThan(0);
+    });
+
+    it('should define fallback chains for WebFetch', () => {
+      expect(TOOL_FALLBACK_CHAINS.WebFetch).toBeDefined();
+      expect(TOOL_FALLBACK_CHAINS.WebFetch.fallbacks.length).toBeGreaterThan(0);
+    });
+
+    it('should have rate limit patterns for each tool', () => {
+      for (const [toolName, chain] of Object.entries(TOOL_FALLBACK_CHAINS)) {
+        expect(chain.rateLimitPatterns).toBeDefined();
+        expect(chain.rateLimitPatterns.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('isRateLimitError', () => {
+    it('should detect weekly usage limit errors', () => {
+      expect(isRateLimitError('WebSearch', 'The search tool has reached its weekly usage limit')).toBe(true);
+    });
+
+    it('should detect monthly usage limit errors', () => {
+      expect(isRateLimitError('WebSearch', 'Monthly usage limit exceeded')).toBe(true);
+    });
+
+    it('should detect rate limit errors', () => {
+      expect(isRateLimitError('WebFetch', 'Rate limit exceeded, please try again later')).toBe(true);
+    });
+
+    it('should detect quota exceeded errors', () => {
+      expect(isRateLimitError('mcp__web_reader__webReader', 'Quota exceeded for this period')).toBe(true);
+    });
+
+    it('should detect "won\'t be available until" pattern', () => {
+      expect(isRateLimitError('WebSearch', "won't be available until March 8, 2026")).toBe(true);
+    });
+
+    it('should return false for non-rate-limit errors', () => {
+      expect(isRateLimitError('WebSearch', 'Network connection failed')).toBe(false);
+    });
+
+    it('should return false for unknown tools with non-rate-limit errors', () => {
+      expect(isRateLimitError('UnknownTool', 'Some random error')).toBe(false);
+    });
+
+    it('should detect generic rate limit patterns for unknown tools', () => {
+      expect(isRateLimitError('UnknownTool', 'rate limit exceeded')).toBe(true);
+      expect(isRateLimitError('UnknownTool', 'usage limit reached')).toBe(true);
+    });
+  });
+
+  describe('getFallbackForTool', () => {
+    it('should return fallback chain for WebSearch', () => {
+      const chain = getFallbackForTool('WebSearch');
+      expect(chain).toBeDefined();
+      expect(chain?.description).toBe('Web search functionality');
+    });
+
+    it('should return undefined for unknown tools', () => {
+      const chain = getFallbackForTool('NonExistentTool');
+      expect(chain).toBeUndefined();
+    });
+  });
+
+  describe('generateFallbackErrorMessage', () => {
+    it('should generate enhanced error message with fallbacks for WebSearch', () => {
+      const message = generateFallbackErrorMessage(
+        'WebSearch',
+        'The search tool has reached its weekly usage limit'
+      );
+
+      expect(message).toContain('⚠️');
+      expect(message).toContain('WebSearch');
+      expect(message).toContain('weekly usage limit');
+      expect(message).toContain('Alternative approaches');
+      expect(message).toContain('Playwright');
+    });
+
+    it('should include multiple fallback options when available', () => {
+      const message = generateFallbackErrorMessage(
+        'WebFetch',
+        'Rate limit exceeded'
+      );
+
+      expect(message).toContain('Playwright');
+      expect(message).toContain('curl');
+    });
+
+    it('should return message without fallbacks for unknown tools', () => {
+      const message = generateFallbackErrorMessage(
+        'UnknownTool',
+        'Some error occurred'
+      );
+
+      expect(message).toContain('⚠️');
+      expect(message).toContain('UnknownTool');
+      expect(message).toContain('No automatic fallback');
+    });
+  });
+
+  describe('getToolsWithFallbacks', () => {
+    it('should return list of tools with fallback support', () => {
+      const tools = getToolsWithFallbacks();
+
+      expect(tools).toContain('WebSearch');
+      expect(tools).toContain('mcp__web_reader__webReader');
+      expect(tools).toContain('WebFetch');
+      expect(tools.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+});

--- a/src/config/tool-fallback.ts
+++ b/src/config/tool-fallback.ts
@@ -1,0 +1,238 @@
+/**
+ * Tool Fallback Configuration
+ *
+ * Defines fallback strategies when primary tools hit rate limits or become unavailable.
+ * This module provides:
+ * - Fallback chain definitions (primary → secondary → tertiary)
+ * - Rate limit error detection
+ * - User-friendly error messages with fallback suggestions
+ *
+ * @module config/tool-fallback
+ */
+
+/**
+ * Fallback chain configuration for tools that may hit rate limits.
+ *
+ * Each entry maps a primary tool to an ordered list of fallback alternatives.
+ * When the primary tool fails due to rate limits, the agent should try
+ * alternatives in order.
+ */
+export const TOOL_FALLBACK_CHAINS: Record<string, FallbackChain> = {
+  WebSearch: {
+    description: 'Web search functionality',
+    fallbacks: [
+      {
+        tool: 'mcp__playwright__browser_navigate + browser_snapshot',
+        description: 'Use Playwright to navigate to search engine and extract results',
+        instructions: `
+1. Use browser_navigate to go to https://www.google.com or https://www.bing.com
+2. Use browser_snapshot or browser_evaluate to extract search results
+3. Parse the results from the page content`,
+      },
+    ],
+    rateLimitPatterns: [
+      /weekly.*usage.*limit/i,
+      /monthly.*usage.*limit/i,
+      /rate limit/i,
+      /quota exceeded/i,
+      /too many requests/i,
+    ],
+  },
+
+  'mcp__web_reader__webReader': {
+    description: 'Web page content fetching and reading',
+    fallbacks: [
+      {
+        tool: 'mcp__playwright__browser_navigate + browser_snapshot',
+        description: 'Use Playwright to navigate to URL and extract content',
+        instructions: `
+1. Use browser_navigate to go to the target URL
+2. Wait for page load with browser_wait_for
+3. Use browser_snapshot to get page content as markdown
+4. Extract the relevant information`,
+      },
+    ],
+    rateLimitPatterns: [
+      /weekly.*usage.*limit/i,
+      /monthly.*usage.*limit/i,
+      /rate limit/i,
+      /quota exceeded/i,
+      /too many requests/i,
+    ],
+  },
+
+  WebFetch: {
+    description: 'Web content fetching',
+    fallbacks: [
+      {
+        tool: 'mcp__playwright__browser_navigate + browser_snapshot',
+        description: 'Use Playwright browser automation',
+        instructions: `
+1. Navigate to the URL using browser_navigate
+2. Use browser_snapshot to get page content
+3. Extract needed information`,
+      },
+      {
+        tool: 'Bash + curl',
+        description: 'Use curl command for simple HTTP requests',
+        instructions: `
+1. Use: curl -s "URL" | head -n 100
+2. Parse the HTML/text response manually
+Note: This works best for simple pages without JavaScript rendering`,
+      },
+    ],
+    rateLimitPatterns: [
+      /weekly.*usage.*limit/i,
+      /monthly.*usage.*limit/i,
+      /rate limit/i,
+      /quota exceeded/i,
+    ],
+  },
+};
+
+/**
+ * Represents a single fallback alternative for a tool.
+ */
+export interface FallbackOption {
+  /** The tool or combination of tools to use as fallback */
+  tool: string;
+  /** Human-readable description of the fallback */
+  description: string;
+  /** Step-by-step instructions for using the fallback */
+  instructions: string;
+}
+
+/**
+ * Represents a complete fallback chain for a tool.
+ */
+export interface FallbackChain {
+  /** Description of what the primary tool does */
+  description: string;
+  /** Ordered list of fallback alternatives (try in order) */
+  fallbacks: FallbackOption[];
+  /** Regex patterns to detect rate limit errors */
+  rateLimitPatterns: RegExp[];
+}
+
+/**
+ * Generic rate limit patterns that apply to all tools.
+ */
+const GENERIC_RATE_LIMIT_PATTERNS = [
+  /rate limit/i,
+  /usage limit/i,
+  /quota exceeded/i,
+  /too many requests/i,
+  /won't be available until/i,
+];
+
+/**
+ * Check if an error message indicates a rate limit or usage limit.
+ *
+ * @param toolName - Name of the tool that failed
+ * @param errorMessage - Error message from the tool
+ * @returns True if this appears to be a rate limit error
+ */
+export function isRateLimitError(toolName: string, errorMessage: string): boolean {
+  const chain = TOOL_FALLBACK_CHAINS[toolName];
+
+  // Check tool-specific patterns first
+  if (chain) {
+    const toolMatch = chain.rateLimitPatterns.some(pattern => pattern.test(errorMessage));
+    if (toolMatch) {
+      return true;
+    }
+  }
+
+  // Fall back to generic patterns for all tools
+  return GENERIC_RATE_LIMIT_PATTERNS.some(pattern => pattern.test(errorMessage));
+}
+
+/**
+ * Get fallback suggestions for a tool that hit rate limits.
+ *
+ * @param toolName - Name of the tool that failed
+ * @returns Fallback chain if available, undefined otherwise
+ */
+export function getFallbackForTool(toolName: string): FallbackChain | undefined {
+  return TOOL_FALLBACK_CHAINS[toolName];
+}
+
+/**
+ * Generate a user-friendly error message with fallback suggestions.
+ *
+ * @param toolName - Name of the tool that failed
+ * @param originalError - Original error message
+ * @returns Enhanced error message with fallback suggestions
+ */
+export function generateFallbackErrorMessage(
+  toolName: string,
+  originalError: string
+): string {
+  const chain = TOOL_FALLBACK_CHAINS[toolName];
+
+  if (!chain || chain.fallbacks.length === 0) {
+    // No fallback available
+    return `⚠️ ${toolName} is currently unavailable: ${originalError}
+
+No automatic fallback is available for this tool. Please try again later or use an alternative approach.`;
+  }
+
+  // Build message with fallback suggestions
+  const fallbackList = chain.fallbacks
+    .map((f, i) => `${i + 1}. **${f.tool}**: ${f.description}`)
+    .join('\n');
+
+  return `⚠️ ${toolName} is currently unavailable: ${originalError}
+
+**Alternative approaches you can try:**
+${fallbackList}
+
+Please try one of these alternatives to continue your task.`;
+}
+
+/**
+ * Get all tools that have fallback configurations.
+ *
+ * @returns List of tool names with fallback support
+ */
+export function getToolsWithFallbacks(): string[] {
+  return Object.keys(TOOL_FALLBACK_CHAINS);
+}
+
+/**
+ * System prompt section for tool fallback guidelines.
+ * Add this to agent prompts to inform about fallback strategies.
+ */
+export const TOOL_FALLBACK_SYSTEM_PROMPT = `
+## Tool Fallback Guidelines
+
+When a tool fails due to rate limits or usage limits, follow these fallback strategies:
+
+### WebSearch Fallback
+If WebSearch hits rate limits, use Playwright browser automation:
+1. Navigate to a search engine: \`browser_navigate\` to https://www.google.com
+2. Get page content: Use \`browser_snapshot\` to extract search results
+3. Parse results from the page
+
+### Web Content Fallback
+If web content fetching tools (WebFetch, webReader) hit limits:
+1. Use Playwright: \`browser_navigate\` to the URL
+2. Wait for page load: \`browser_wait_for\` if needed
+3. Extract content: \`browser_snapshot\` returns markdown content
+
+### General Fallback Principles
+- **Detect rate limits**: Look for messages like "usage limit", "rate limit", "quota exceeded"
+- **Switch gracefully**: Don't fail the entire task; try alternatives
+- **Inform the user**: Explain what happened and what alternative you're using
+- **Continue the task**: Complete the user's request using available tools
+
+### Example Rate Limit Response Handling
+\`\`\`
+❌ WebSearch: "The search tool has reached its weekly usage limit..."
+
+→ Switching to Playwright browser automation...
+→ Navigating to search engine...
+→ Extracting results...
+✓ Search completed using fallback method
+\`\`\`
+`;

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -7,6 +7,10 @@ import type {
   ContentBlock,
   ParsedSDKMessage,
 } from '../types/agent.js';
+import {
+  isRateLimitError,
+  generateFallbackErrorMessage,
+} from '../config/tool-fallback.js';
 
 /**
  * Get directory containing node executable.
@@ -276,8 +280,41 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
 
       if (message.subtype === 'error_during_execution' && 'errors' in message) {
         const errors = message.errors as string[];
+        const errorMessage = errors.join(', ');
+
+        // Check for rate limit errors and provide fallback suggestions
+        // Detect common tool names from error message patterns
+        let enhancedError = `❌ Error: ${errorMessage}`;
+
+        // Check for WebSearch rate limit
+        if (isRateLimitError('WebSearch', errorMessage) ||
+            errorMessage.toLowerCase().includes('search tool')) {
+          enhancedError = generateFallbackErrorMessage('WebSearch', errorMessage);
+        }
+        // Check for webReader rate limit
+        else if (isRateLimitError('mcp__web_reader__webReader', errorMessage) ||
+                 errorMessage.toLowerCase().includes('webreader') ||
+                 errorMessage.toLowerCase().includes('web reader')) {
+          enhancedError = generateFallbackErrorMessage('mcp__web_reader__webReader', errorMessage);
+        }
+        // Check for WebFetch rate limit
+        else if (isRateLimitError('WebFetch', errorMessage) ||
+                 errorMessage.toLowerCase().includes('fetch') ||
+                 errorMessage.toLowerCase().includes('webfetch')) {
+          enhancedError = generateFallbackErrorMessage('WebFetch', errorMessage);
+        }
+        // Generic rate limit check
+        else if (isRateLimitError('', errorMessage)) {
+          enhancedError = `⚠️ A tool rate limit was encountered: ${errorMessage}
+
+**Suggested alternatives:**
+- Try using Playwright browser automation (browser_navigate, browser_snapshot) instead
+- Use Bash with curl for simple HTTP requests
+- Wait for the rate limit to reset and try again later`;
+        }
+
         result.type = 'error';
-        result.content = `❌ Error: ${errors.join(', ')}`;
+        result.content = enhancedError;
         return result;
       }
 


### PR DESCRIPTION
## Summary
- Adds tool fallback strategy system for when tools hit rate limits (Fixes #188)
- When WebSearch, webReader, or WebFetch hit rate limits, the agent now has guidance on fallback strategies
- Primarily uses Playwright browser automation as a fallback alternative

## Changes

### New Files
- `src/config/tool-fallback.ts`: New module with fallback chain configuration
  - Defines fallback chains for WebSearch, webReader, and WebFetch
  - Provides rate limit error detection
  - Generates user-friendly error messages with fallback suggestions

- `src/config/tool-fallback.test.ts`: Unit tests for fallback detection
  - 18 tests covering rate limit detection and fallback message generation

### Modified Files
- `src/agents/pilot.ts`: Added `TOOL_FALLBACK_SYSTEM_PROMPT` to agent system instructions
  - Informs the agent about fallback strategies when tools hit rate limits
  - Provides specific guidance for WebSearch and web content fallbacks

- `src/utils/sdk.ts`: Enhanced error message parsing
  - Detects rate limit errors in tool execution results
  - Provides fallback suggestions when rate limits are detected

- `src/config/index.ts`: Export the new tool-fallback module

## How It Works

1. **System Prompt Guidance**: The Pilot agent now includes fallback guidelines in its system prompt, informing the AI about what to do when tools hit rate limits.

2. **Error Detection**: When a tool fails with a rate limit error, the error message is enhanced with fallback suggestions.

3. **Fallback Strategies**:
   - **WebSearch** → Use Playwright to navigate to Google/Bing and extract results
   - **webReader** → Use Playwright to navigate to URL and extract content
   - **WebFetch** → Use Playwright or curl as alternatives

## Test Plan
- [x] All 18 unit tests pass
- [x] Build compiles successfully
- [x] Fallback detection works for various rate limit patterns
- [ ] Manual testing with actual rate-limited tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)