### PR TITLE
fix(skill): disambiguate task and schedule skill triggers

### DIFF
--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -1,12 +1,28 @@
 ---
 name: schedule
-description: Schedule management specialist. Use when user wants to create, view, modify, or delete schedules. Triggered by keywords like "schedule", "timer", "cron", "定时任务", "提醒".
+description: Schedule management specialist for RECURRING/SCHEDULED tasks. Use when user wants to create, view, modify, or delete scheduled/cron jobs, timers, reminders, or periodic executions. Triggered by keywords: "schedule", "timer", "cron", "定时任务", "提醒", "定期", "周期", "每天", "每周", "recurring", "periodic". For one-time tasks, use /task skill instead.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
 # Schedule Manager
 
 Manage schedules with full CRUD operations.
+
+## When to Use This Skill
+
+**✅ Use this skill for:**
+- Creating scheduled/recurring tasks
+- Setting up cron jobs
+- Managing timers and reminders
+- Periodic executions (daily, weekly, monthly, etc.)
+- Viewing or modifying existing schedules
+
+**❌ DO NOT use this skill for:**
+- One-time code changes → Use `/task` skill instead
+- Bug fixes or feature implementations → Use `/task` skill instead
+- Single execution operations → Use `/task` skill instead
+
+**Keywords that trigger this skill**: "定时任务", "schedule", "cron", "timer", "reminder", "每天", "每周", "定期", "周期性", "recurring", "periodic"
 
 ## Core Principle
 

--- a/skills/task/SKILL.md
+++ b/skills/task/SKILL.md
@@ -1,12 +1,27 @@
 ---
 name: task
-description: Task initialization specialist - analyzes requests and creates Task.md specifications
+description: Task initialization specialist for ONE-TIME execution tasks. Creates Task.md specifications for code changes, bug fixes, and feature implementations. NOT for scheduled/recurring tasks - use /schedule skill instead. Keywords: task, feature, fix, implement, refactor.
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
 ---
 
 # Task Agent
 
 You are a task initialization specialist. Your job is to analyze user requests and create Task.md specification files.
+
+## When to Use This Skill
+
+**✅ Use this skill for:**
+- One-time code changes (bug fixes, feature implementations)
+- Refactoring tasks
+- Code review tasks
+- Single execution operations
+
+**❌ DO NOT use this skill for:**
+- Scheduled/recurring tasks → Use `/schedule` skill instead
+- Timers or reminders → Use `/schedule` skill instead
+- Periodic executions (daily, weekly, etc.) → Use `/schedule` skill instead
+
+**If user mentions**: "定时任务", "schedule", "cron", "timer", "reminder", "每天", "每周", "定期" → Redirect to `/schedule` skill
 
 ## Single Responsibility
 


### PR DESCRIPTION
## Summary
- Enhanced task skill description to explicitly exclude scheduled/recurring tasks
- Enhanced schedule skill description with more keywords for recurring tasks (定期, 周期, 每天, 每周, recurring, periodic)
- Added "When to Use This Skill" section to both skills with clear examples
- Added explicit redirect guidance when wrong skill is triggered

## Problem
Fixes #191

The task and schedule skills were easily confused when users mention "定时任务" (scheduled task), which could trigger the wrong skill.

## Solution
1. Updated skill descriptions to be more explicit about their scope
2. Added clear "When to Use This Skill" sections with ✅/❌ lists
3. Added more Chinese keywords for schedule detection

## Test Results
All 800 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)