### PR TITLE
refactor: remove unused isCliMode option from Pilot

### DIFF
--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -114,12 +114,6 @@ describe('AgentFactory', () => {
       expect(Config.getAgentConfig).toHaveBeenCalled();
     });
 
-    it('should create Pilot with CLI mode', () => {
-      const pilot = AgentFactory.createPilot(mockCallbacks, {}, true);
-
-      expect(pilot).toBeInstanceOf(Pilot);
-    });
-
     it('should allow overriding config options', () => {
       const pilot = AgentFactory.createPilot(mockCallbacks, {
         apiKey: 'custom-key',

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -141,7 +141,6 @@ export class AgentFactory {
    *
    * @param callbacks - Platform-specific callbacks for Pilot
    * @param options - Optional configuration overrides
-   * @param isCliMode - Whether running in CLI mode (default: false)
    * @returns Configured Pilot instance
    *
    * @example
@@ -155,14 +154,12 @@ export class AgentFactory {
    */
   static createPilot(
     callbacks: PilotCallbacks,
-    options: AgentCreateOptions = {},
-    isCliMode = false
+    options: AgentCreateOptions = {}
   ): Pilot {
     const baseConfig = this.getBaseConfig(options);
     const config: PilotConfig = {
       ...baseConfig,
       callbacks,
-      isCliMode,
     };
 
     return new Pilot(config);

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -86,11 +86,6 @@ export interface PilotConfig extends BaseAgentConfig {
    * Callback functions for platform-specific operations.
    */
   callbacks: PilotCallbacks;
-  /**
-   * Whether running in CLI mode (vs Feishu bot mode).
-   * CLI mode doesn't need Feishu MCP servers.
-   */
-  isCliMode?: boolean;
 }
 
 /**
@@ -111,7 +106,6 @@ interface MessageData {
  */
 export class Pilot extends BaseAgent {
   private readonly callbacks: PilotCallbacks;
-  private readonly isCliMode: boolean;
 
   // Per-chatId Query instances
   private queries = new Map<string, Query>();
@@ -124,7 +118,6 @@ export class Pilot extends BaseAgent {
     super(config);
 
     this.callbacks = config.callbacks;
-    this.isCliMode = config.isCliMode ?? false;
   }
 
   protected getAgentName(): string {
@@ -266,12 +259,9 @@ export class Pilot extends BaseAgent {
    */
   private startAgentLoop(chatId: string): void {
     // Add MCP servers
-    const mcpServers: Record<string, unknown> = {};
-
-    // Only add Feishu MCP server if NOT in CLI mode
-    if (!this.isCliMode) {
-      mcpServers['feishu-context'] = createFeishuSdkMcpServer();
-    }
+    const mcpServers: Record<string, unknown> = {
+      'feishu-context': createFeishuSdkMcpServer(),
+    };
 
     // Merge configured external MCP servers from config file
     const configuredMcpServers = Config.getMcpServersConfig();


### PR DESCRIPTION
## Summary

- Remove `isCliMode` option from `PilotConfig` interface and `Pilot` class
- Always add Feishu MCP server in `startAgentLoop` (no longer conditionally based on CLI mode)
- Remove `isCliMode` parameter from `AgentFactory.createPilot`
- Remove corresponding test case for CLI mode Pilot creation

## Context

Fixes #215

The `isCliMode` option was used to distinguish between CLI mode and Feishu bot mode. However, this distinction is no longer needed:
- The `executeOnce` method is still used by the scheduler for scheduled task execution
- All Pilot instances should include the Feishu MCP server since even scheduled tasks are sent to Feishu chats

## Test plan

- [x] Run `src/agents/pilot.test.ts` - 20 tests passed
- [x] Run `src/agents/factory.test.ts` - 10 tests passed
- [x] Run `src/schedule/scheduler.test.ts` - 16 tests passed (verifies executeOnce still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)