### PR TITLE
feat: rename task skill to deep-task for clarity

### DIFF
--- a/skills/deep-task/SKILL.md
+++ b/skills/deep-task/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: task
-description: Task initialization specialist for ONE-TIME execution tasks. Creates Task.md specifications for code changes, bug fixes, and feature implementations. NOT for scheduled/recurring tasks - use /schedule skill instead. Keywords: task, feature, fix, implement, refactor.
+name: deep-task
+description: Deep task initialization specialist for ONE-TIME execution tasks with full dialogue workflow (Evaluator → Executor → Reporter). Creates Task.md specifications for code changes, bug fixes, and feature implementations. NOT for scheduled/recurring tasks - use /schedule skill instead. Keywords: task, feature, fix, implement, refactor, deep task.
 allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
 ---
 
-# Task Agent
+# Deep Task Agent
 
-You are a task initialization specialist. Your job is to analyze user requests and create Task.md specification files.
+You are a deep task initialization specialist. Your job is to analyze user requests and create Task.md specification files that will trigger a full dialogue workflow with evaluation and execution phases.
 
 ## When to Use This Skill
 

--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: schedule
-description: Schedule management specialist for RECURRING/SCHEDULED tasks. Use when user wants to create, view, modify, or delete scheduled/cron jobs, timers, reminders, or periodic executions. Triggered by keywords: "schedule", "timer", "cron", "定时任务", "提醒", "定期", "周期", "每天", "每周", "recurring", "periodic". For one-time tasks, use /task skill instead.
+description: Schedule management specialist for RECURRING/SCHEDULED tasks. Use when user wants to create, view, modify, or delete scheduled/cron jobs, timers, reminders, or periodic executions. Triggered by keywords: "schedule", "timer", "cron", "定时任务", "提醒", "定期", "周期", "每天", "每周", "recurring", "periodic". For one-time tasks with full workflow, use /deep-task skill instead.
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep
 ---
 
@@ -18,9 +18,9 @@ Manage schedules with full CRUD operations.
 - Viewing or modifying existing schedules
 
 **❌ DO NOT use this skill for:**
-- One-time code changes → Use `/task` skill instead
-- Bug fixes or feature implementations → Use `/task` skill instead
-- Single execution operations → Use `/task` skill instead
+- One-time code changes → Use `/deep-task` skill instead
+- Bug fixes or feature implementations → Use `/deep-task` skill instead
+- Single execution operations → Use `/deep-task` skill instead
 
 **Keywords that trigger this skill**: "定时任务", "schedule", "cron", "timer", "reminder", "每天", "每周", "定期", "周期性", "recurring", "periodic"
 

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -175,7 +175,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
   /**
    * Get the TaskFlowOrchestrator for this channel.
-   * Used by task skill MCP tools.
+   * Used by deep-task skill MCP tools.
    */
   getTaskFlowOrchestrator(): TaskFlowOrchestrator | undefined {
     return this.taskFlowOrchestrator;

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -248,7 +248,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     });
   };
 
-  // Initialize TaskFlowOrchestrator for task skill dialogue phase
+  // Initialize TaskFlowOrchestrator for deep-task skill dialogue phase
   // Uses file watcher to detect new Task.md files and trigger dialogue
   const taskTracker = new TaskTracker();
   const taskFlowOrchestrator = new TaskFlowOrchestrator(

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -2,13 +2,13 @@
  * Agent module exports.
  *
  * Architecture (Evaluation-Execution):
- * - Pilot: Handles user messages with task skill for Task.md creation
+ * - Pilot: Handles user messages with deep-task skill for Task.md creation
  * - Evaluator: Task completion evaluation
  * - Executor: Executes tasks directly with Reporter for progress updates
  * - DialogueOrchestrator: Manages direct Evaluator-Executor flow
  *
  * Complete Workflow:
- * Flow 1: User request → Pilot (with task skill) → Task.md
+ * Flow 1: User request → Pilot (with deep-task skill) → Task.md
  * Flow 2: Task.md → Evaluator (evaluate) → Executor (execute directly) → ...
  *
  * Evaluation-Execution Flow:

--- a/src/utils/task-tracker.ts
+++ b/src/utils/task-tracker.ts
@@ -108,7 +108,7 @@ export class TaskTracker {
 
   /**
    * Save task processing record to disk (asynchronous).
-   * Note: Task directories are now used for workflow (Pilot → task skill → Task.md → dialogue).
+   * Note: Task directories are now used for workflow (Pilot → deep-task skill → Task.md → dialogue).
    * Deduplication is handled by MessageLogger via MD file parsing.
    *
    * @param messageId - Unique message identifier


### PR DESCRIPTION
## Summary

- Rename `skills/task/` directory to `skills/deep-task/`
- Update skill name from `task` to `deep-task`
- Update all references from `/task` to `/deep-task` throughout the codebase
- Update skill description to clarify the full dialogue workflow

## Context

Fixes #216

The rename better distinguishes this skill from "schedule task" and clarifies its purpose as a one-time execution task with full dialogue workflow (Evaluator → Executor → Reporter).

## Changes

| File | Change |
|------|--------|
| `skills/task/` → `skills/deep-task/` | Directory renamed |
| `skills/deep-task/SKILL.md` | Name changed to `deep-task`, description updated |
| `skills/schedule/SKILL.md` | References updated from `/task` to `/deep-task` |
| `src/task/index.ts` | Comments updated |
| `src/channels/feishu-channel.ts` | Comments updated |
| `src/runners/execution-runner.ts` | Comments updated |
| `src/utils/task-tracker.ts` | Comments updated |

## Key Differences: Deep Task vs Schedule Task

| Deep Task | Schedule Task |
|-----------|---------------|
| One-time execution | Recurring/scheduled execution |
| Full dialogue workflow | Direct scheduled prompts |
| Manual trigger via `/deep-task` | Automatic trigger via cron |

## Test plan

- [x] Run `npm test` - 800 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)