### PR TITLE
feat: add tool fallback strategy for degraded tool scenarios

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -34,6 +34,7 @@ import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { FileReference } from '../types/file-reference.js';
 import { MessageChannel } from './message-channel.js';
+import { TOOL_FALLBACK_GUIDE } from '../config/tool-fallback-guide.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -430,6 +431,10 @@ When using send_file_to_feishu or send_user_feedback, use:
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
 
+---
+
+${TOOL_FALLBACK_GUIDE}
+
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     }
@@ -442,6 +447,10 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 When using send_file_to_feishu or send_user_feedback, use:
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${msg.messageId}\` (for thread replies)
+
+---
+
+${TOOL_FALLBACK_GUIDE}
 
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;

--- a/src/config/tool-fallback-guide.test.ts
+++ b/src/config/tool-fallback-guide.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isToolLimitError,
+  getFallbackSuggestion,
+  formatLimitMessage,
+} from './tool-fallback-guide.js';
+
+describe('tool-fallback-guide', () => {
+  describe('isToolLimitError', () => {
+    it('should detect usage limit errors', () => {
+      expect(isToolLimitError('The search tool has reached its weekly usage limit')).toBe(true);
+      expect(isToolLimitError('Monthly usage limit exceeded')).toBe(true);
+      expect(isToolLimitError('API quota exceeded for this tool')).toBe(true);
+      expect(isToolLimitError('Rate limit reached, please try again later')).toBe(true);
+    });
+
+    it('should not detect non-limit errors', () => {
+      expect(isToolLimitError('Network connection failed')).toBe(false);
+      expect(isToolLimitError('Invalid parameter provided')).toBe(false);
+      expect(isToolLimitError('Authentication error')).toBe(false);
+    });
+
+    it('should detect case-insensitively', () => {
+      expect(isToolLimitError('USAGE LIMIT REACHED')).toBe(true);
+      expect(isToolLimitError('Weekly Limit')).toBe(true);
+    });
+  });
+
+  describe('getFallbackSuggestion', () => {
+    it('should return fallback for WebSearch', () => {
+      const suggestion = getFallbackSuggestion('WebSearch');
+      expect(suggestion).toContain('Playwright');
+      expect(suggestion).toContain('search engine');
+    });
+
+    it('should return fallback for WebFetch', () => {
+      const suggestion = getFallbackSuggestion('WebFetch');
+      expect(suggestion).toContain('browser_navigate');
+      expect(suggestion).toContain('browser_snapshot');
+    });
+
+    it('should return fallback for webReader', () => {
+      const suggestion = getFallbackSuggestion('mcp__web_reader__webReader');
+      expect(suggestion).toContain('browser_navigate');
+    });
+
+    it('should return null for unknown tools', () => {
+      expect(getFallbackSuggestion('UnknownTool')).toBeNull();
+      expect(getFallbackSuggestion('Bash')).toBeNull();
+    });
+  });
+
+  describe('formatLimitMessage', () => {
+    it('should format WebSearch limit message with fallback', () => {
+      const message = formatLimitMessage('WebSearch', 'weekly limit reached');
+      expect(message).toContain('WebSearch');
+      expect(message).toContain('Playwright');
+      expect(message).toContain('weekly limit reached');
+    });
+
+    it('should format unknown tool limit message without fallback', () => {
+      const message = formatLimitMessage('UnknownTool', 'some error');
+      expect(message).toContain('UnknownTool');
+      expect(message).toContain('some error');
+      expect(message).toContain('try to proceed');
+    });
+  });
+});

--- a/src/config/tool-fallback-guide.ts
+++ b/src/config/tool-fallback-guide.ts
@@ -1,0 +1,99 @@
+/**
+ * Tool Fallback Guide - Provides guidance for tool degradation scenarios.
+ *
+ * When certain tools reach usage limits (e.g., WebSearch, webReader),
+ * this guide helps the Agent understand available alternatives.
+ *
+ * @module config/tool-fallback-guide
+ */
+
+/**
+ * Fallback guidance for when primary tools are unavailable.
+ */
+export const TOOL_FALLBACK_GUIDE = `
+## Tool Limitations & Fallback Strategies
+
+When a tool reports that it has reached its usage limit, follow these strategies:
+
+### WebSearch Limitations
+If WebSearch is unavailable (e.g., "weekly/monthly usage limit"):
+1. **Use Playwright browser tools** as alternative:
+   - Navigate to a search engine (Google, Bing, DuckDuckGo)
+   - Perform the search manually using browser_navigate and browser_type
+   - Extract results using browser_snapshot
+2. **Inform the user** about the limitation and the alternative approach
+3. **Example fallback message**: "WebSearch is currently unavailable. I'll use the browser to search for this information instead."
+
+### webReader / WebFetch Limitations
+If webReader or WebFetch is unavailable:
+1. **Use Playwright browser tools**:
+   - Navigate directly to the URL using browser_navigate
+   - Extract content using browser_snapshot
+2. **For simple pages**: browser_snapshot provides the page structure
+3. **For complex pages**: Use browser_click, browser_wait_for as needed
+
+### MCP Tool Limitations
+If any MCP tool is unavailable:
+1. **Check for alternatives** in the available tools list
+2. **Use Bash commands** as a last resort for some operations
+3. **Inform the user** about the limitation
+
+### Error Recovery Template
+When a tool fails due to limits:
+\`\`\`
+⚠️ [Tool Name] is temporarily unavailable (usage limit reached).
+
+I'll use an alternative approach: [describe alternative]
+
+[Proceed with alternative method]
+\`\`\`
+
+### Best Practices
+1. **Always inform the user** when a tool is unavailable
+2. **Provide clear alternatives** rather than failing
+3. **Continue the task** using available tools
+4. **Be transparent** about any limitations in the final response
+`;
+
+/**
+ * Check if an error message indicates a tool usage limit.
+ */
+export function isToolLimitError(errorMessage: string): boolean {
+  const limitPatterns = [
+    /usage limit/i,
+    /weekly.*limit/i,
+    /monthly.*limit/i,
+    /reached.*limit/i,
+    /quota.*exceeded/i,
+    /rate limit/i,
+    /temporarily unavailable/i,
+  ];
+
+  return limitPatterns.some(pattern => pattern.test(errorMessage));
+}
+
+/**
+ * Get fallback tool suggestion for a given tool name.
+ */
+export function getFallbackSuggestion(toolName: string): string | null {
+  const fallbacks: Record<string, string> = {
+    WebSearch: 'Use Playwright browser tools to navigate to a search engine and perform the search manually.',
+    WebFetch: 'Use Playwright browser_navigate to visit the URL and browser_snapshot to extract content.',
+    'mcp__web_reader__webReader': 'Use Playwright browser_navigate to visit the URL and browser_snapshot to extract content.',
+  };
+
+  return fallbacks[toolName] || null;
+}
+
+/**
+ * Format a user-friendly message about tool limitations.
+ */
+export function formatLimitMessage(toolName: string, originalError: string): string {
+  const fallback = getFallbackSuggestion(toolName);
+
+  if (fallback) {
+    return `⚠️ ${toolName} is temporarily unavailable. ${fallback}\n\nOriginal error: ${originalError}`;
+  }
+
+  return `⚠️ ${toolName} is temporarily unavailable: ${originalError}\n\nI'll try to proceed with available tools.`;
+}


### PR DESCRIPTION
## Summary

- Add tool fallback guidance when primary tools reach usage limits
- Provide alternative approaches using Playwright browser tools
- Add utility functions for detecting and formatting limit errors
- Add comprehensive unit tests

## Changes

### New Files
- `src/config/tool-fallback-guide.ts` - Tool fallback guide and utilities
- `src/config/tool-fallback-guide.test.ts` - Unit tests for fallback functions

### Modified Files
- `src/agents/pilot.ts` - Integrate fallback guide into system prompt

## Fallback Strategies

| Primary Tool | Fallback Approach |
|--------------|-------------------|
| WebSearch | Use Playwright browser to navigate to search engines |
| WebFetch/webReader | Use browser_navigate + browser_snapshot |

## Example

When WebSearch is unavailable:
```
⚠️ WebSearch is temporarily unavailable (usage limit reached).

I'll use an alternative approach: Use Playwright browser tools to navigate to a search engine and perform the search manually.

[Proceeds with browser-based search]
```

## Test Results

- All 808 existing tests pass
- 9 new tests added for fallback functionality

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)