### PR TITLE
refactor(pilot): extract SessionManager and ConversationContext

### DIFF
--- a/src/agents/conversation-context.test.ts
+++ b/src/agents/conversation-context.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConversationContext } from './conversation-context.js';
+import type pino from 'pino';
+
+describe('ConversationContext', () => {
+  let context: ConversationContext;
+  let mockLogger: pino.Logger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as pino.Logger;
+
+    context = new ConversationContext({ logger: mockLogger });
+  });
+
+  describe('setThreadRoot', () => {
+    it('should set thread root for a chatId', () => {
+      context.setThreadRoot('chat1', 'msg123');
+
+      expect(context.getThreadRoot('chat1')).toBe('msg123');
+    });
+
+    it('should overwrite existing thread root', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      context.setThreadRoot('chat1', 'msg456');
+
+      expect(context.getThreadRoot('chat1')).toBe('msg456');
+    });
+
+    it('should log thread root set', () => {
+      context.setThreadRoot('chat1', 'msg123');
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { chatId: 'chat1', messageId: 'msg123' },
+        'Thread root set'
+      );
+    });
+  });
+
+  describe('getThreadRoot', () => {
+    it('should return undefined when no thread root exists', () => {
+      expect(context.getThreadRoot('chat1')).toBeUndefined();
+    });
+
+    it('should return the thread root when it exists', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      expect(context.getThreadRoot('chat1')).toBe('msg123');
+    });
+  });
+
+  describe('deleteThreadRoot', () => {
+    it('should return false when no thread root exists', () => {
+      expect(context.deleteThreadRoot('chat1')).toBe(false);
+    });
+
+    it('should delete thread root and return true', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      const result = context.deleteThreadRoot('chat1');
+
+      expect(result).toBe(true);
+      expect(context.getThreadRoot('chat1')).toBeUndefined();
+    });
+
+    it('should log thread root deletion', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      context.deleteThreadRoot('chat1');
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { chatId: 'chat1' },
+        'Thread root deleted'
+      );
+    });
+  });
+
+  describe('clearAll', () => {
+    it('should clear all thread roots', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      context.setThreadRoot('chat2', 'msg456');
+
+      context.clearAll();
+
+      expect(context.size()).toBe(0);
+      expect(context.getThreadRoot('chat1')).toBeUndefined();
+      expect(context.getThreadRoot('chat2')).toBeUndefined();
+    });
+
+    it('should log clearing', () => {
+      context.clearAll();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith('All thread roots cleared');
+    });
+  });
+
+  describe('size', () => {
+    it('should return 0 when no thread roots', () => {
+      expect(context.size()).toBe(0);
+    });
+
+    it('should return correct count', () => {
+      context.setThreadRoot('chat1', 'msg123');
+      context.setThreadRoot('chat2', 'msg456');
+      expect(context.size()).toBe(2);
+    });
+  });
+});

--- a/src/agents/conversation-context.ts
+++ b/src/agents/conversation-context.ts
@@ -1,0 +1,93 @@
+/**
+ * ConversationContext - Manages conversation context for Pilot.
+ *
+ * Extracts context management concerns from Pilot:
+ * - Thread root tracking (for reply chains)
+ * - Message metadata (chatId, messageId, senderOpenId)
+ *
+ * This class provides a clean interface for managing the contextual
+ * information needed for proper message handling and replies.
+ */
+
+import type pino from 'pino';
+
+/**
+ * Message context information.
+ */
+export interface MessageContext {
+  /** Platform-specific chat identifier */
+  chatId: string;
+  /** Unique message identifier */
+  messageId: string;
+  /** Sender's open_id for @ mentions (optional) */
+  senderOpenId?: string;
+}
+
+/**
+ * Configuration for ConversationContext.
+ */
+export interface ConversationContextConfig {
+  /** Logger instance */
+  logger: pino.Logger;
+}
+
+/**
+ * ConversationContext - Manages conversation context state.
+ *
+ * Primary responsibility is tracking thread roots for each chatId,
+ * which enables proper reply threading in platforms like Feishu.
+ */
+export class ConversationContext {
+  private readonly logger: pino.Logger;
+  /** Map of chatId → thread root message ID */
+  private readonly threadRoots = new Map<string, string>();
+
+  constructor(config: ConversationContextConfig) {
+    this.logger = config.logger;
+  }
+
+  /**
+   * Set the thread root for a chatId.
+   * This is the message ID that subsequent replies should reference.
+   */
+  setThreadRoot(chatId: string, messageId: string): void {
+    this.threadRoots.set(chatId, messageId);
+    this.logger.debug({ chatId, messageId }, 'Thread root set');
+  }
+
+  /**
+   * Get the thread root for a chatId.
+   * Returns undefined if no thread root is set.
+   */
+  getThreadRoot(chatId: string): string | undefined {
+    return this.threadRoots.get(chatId);
+  }
+
+  /**
+   * Delete the thread root for a chatId.
+   * Used during session reset.
+   */
+  deleteThreadRoot(chatId: string): boolean {
+    const existed = this.threadRoots.delete(chatId);
+    if (existed) {
+      this.logger.debug({ chatId }, 'Thread root deleted');
+    }
+    return existed;
+  }
+
+  /**
+   * Clear all thread roots.
+   * Used during shutdown.
+   */
+  clearAll(): void {
+    this.threadRoots.clear();
+    this.logger.debug('All thread roots cleared');
+  }
+
+  /**
+   * Get the number of tracked thread roots.
+   */
+  size(): number {
+    return this.threadRoots.size;
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -7,6 +7,8 @@
  * - Executor: Task execution specialist
  * - Reporter: Communication and instruction generation specialist
  * - Pilot: Platform-agnostic direct chat with streaming input
+ * - SessionManager: Pilot session lifecycle management
+ * - ConversationContext: Pilot conversation context tracking
  */
 
 // Base class
@@ -25,6 +27,10 @@ export { Reporter } from './reporter.js';
 
 // Conversational agent
 export { Pilot, type PilotCallbacks, type PilotConfig } from './pilot.js';
+
+// Pilot support classes (extracted from Pilot for separation of concerns)
+export { SessionManager, type PilotSession, type SessionManagerConfig } from './session-manager.js';
+export { ConversationContext, type ConversationContextConfig } from './conversation-context.js';
 
 // Factory
 export { AgentFactory, type AgentCreateOptions } from './factory.js';

--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -92,42 +92,47 @@ describe('Pilot (Streaming Input)', () => {
       expect(pilot['callbacks']).toBe(mockCallbacks);
     });
 
-    it('should initialize queries map', () => {
-      expect(pilot['queries']).toBeInstanceOf(Map);
-      expect(pilot['queries'].size).toBe(0);
+    it('should initialize sessionManager', () => {
+      expect(pilot['sessionManager']).toBeDefined();
+      expect(pilot['sessionManager'].size()).toBe(0);
+    });
+
+    it('should initialize conversationContext', () => {
+      expect(pilot['conversationContext']).toBeDefined();
+      expect(pilot['conversationContext'].size()).toBe(0);
     });
   });
 
   describe('processMessage', () => {
-    it('should create query for new chatId', () => {
+    it('should create session for new chatId', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
 
-      expect(pilot['queries'].has('chat-123')).toBe(true);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(true);
     });
 
-    it('should handle multiple messages for same chatId (same query)', () => {
+    it('should handle multiple messages for same chatId (same session)', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
       pilot.processMessage('chat-123', 'World', 'msg-002');
 
-      // Should reuse the same query
-      expect(pilot['queries'].size).toBe(1);
-      expect(pilot['queries'].has('chat-123')).toBe(true);
+      // Should reuse the same session
+      expect(pilot['sessionManager'].size()).toBe(1);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(true);
     });
 
-    it('should handle different chatIds independently (different queries)', () => {
+    it('should handle different chatIds independently (different sessions)', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
       pilot.processMessage('chat-456', 'Hi', 'msg-002');
 
-      // Should create two separate queries
-      expect(pilot['queries'].size).toBe(2);
-      expect(pilot['queries'].has('chat-123')).toBe(true);
-      expect(pilot['queries'].has('chat-456')).toBe(true);
+      // Should create two separate sessions
+      expect(pilot['sessionManager'].size()).toBe(2);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(true);
+      expect(pilot['sessionManager'].has('chat-456')).toBe(true);
     });
 
     it('should accept optional senderOpenId parameter', () => {
       // Should not throw
       pilot.processMessage('chat-123', 'Hello', 'msg-001', 'user-open-id');
-      expect(pilot['queries'].has('chat-123')).toBe(true);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(true);
     });
 
     it('should be non-blocking (returns immediately)', () => {
@@ -144,38 +149,38 @@ describe('Pilot (Streaming Input)', () => {
     it('should reset specific chatId only', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
       pilot.processMessage('chat-456', 'Hi', 'msg-002');
-      expect(pilot['queries'].size).toBe(2);
+      expect(pilot['sessionManager'].size()).toBe(2);
 
       // Reset only chat-123
       pilot.reset('chat-123');
 
       // chat-123 should be removed, chat-456 should remain
-      expect(pilot['queries'].size).toBe(1);
-      expect(pilot['queries'].has('chat-123')).toBe(false);
-      expect(pilot['queries'].has('chat-456')).toBe(true);
+      expect(pilot['sessionManager'].size()).toBe(1);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(false);
+      expect(pilot['sessionManager'].has('chat-456')).toBe(true);
     });
 
     it('should handle non-existent chatId gracefully', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
-      expect(pilot['queries'].size).toBe(1);
+      expect(pilot['sessionManager'].size()).toBe(1);
 
       // Reset non-existent chatId
       pilot.reset('chat-nonexistent');
 
-      // Original query should remain
-      expect(pilot['queries'].size).toBe(1);
-      expect(pilot['queries'].has('chat-123')).toBe(true);
+      // Original session should remain
+      expect(pilot['sessionManager'].size()).toBe(1);
+      expect(pilot['sessionManager'].has('chat-123')).toBe(true);
     });
 
-    it('should close query instance when resetting', () => {
+    it('should close session when resetting', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
 
       // Reset should work immediately without waiting
-      // The reset method is synchronous and handles query cleanup
+      // The reset method is synchronous and handles session cleanup
       pilot.reset('chat-123');
 
-      // Query should be removed
-      expect(pilot['queries'].has('chat-123')).toBe(false);
+      // Session should be removed
+      expect(pilot['sessionManager'].has('chat-123')).toBe(false);
     });
 
     it('should not affect other chatIds in group chat scenario', () => {
@@ -184,25 +189,25 @@ describe('Pilot (Streaming Input)', () => {
       pilot.processMessage('group-chat-2', 'Hello from group 2', 'msg-002');
       pilot.processMessage('group-chat-3', 'Hello from group 3', 'msg-003');
 
-      expect(pilot['queries'].size).toBe(3);
+      expect(pilot['sessionManager'].size()).toBe(3);
 
       // User in group-chat-1 sends /reset
       pilot.reset('group-chat-1');
 
       // Only group-chat-1 should be reset
-      expect(pilot['queries'].size).toBe(2);
-      expect(pilot['queries'].has('group-chat-1')).toBe(false);
-      expect(pilot['queries'].has('group-chat-2')).toBe(true);
-      expect(pilot['queries'].has('group-chat-3')).toBe(true);
+      expect(pilot['sessionManager'].size()).toBe(2);
+      expect(pilot['sessionManager'].has('group-chat-1')).toBe(false);
+      expect(pilot['sessionManager'].has('group-chat-2')).toBe(true);
+      expect(pilot['sessionManager'].has('group-chat-3')).toBe(true);
     });
   });
 
   describe('getActiveSessionCount', () => {
-    it('should return 0 when no queries', () => {
+    it('should return 0 when no sessions', () => {
       expect(pilot.getActiveSessionCount()).toBe(0);
     });
 
-    it('should return count of active queries', () => {
+    it('should return count of active sessions', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
       pilot.processMessage('chat-456', 'Hi', 'msg-002');
 
@@ -216,22 +221,25 @@ describe('Pilot (Streaming Input)', () => {
 
       await pilot.shutdown();
 
-      expect(pilot['queries'].size).toBe(0);
+      expect(pilot['sessionManager'].size()).toBe(0);
+      expect(pilot['conversationContext'].size()).toBe(0);
     });
   });
 
-  describe('Query Management', () => {
-    it('should create query when processing first message', () => {
+  describe('Session Management', () => {
+    it('should create session when processing first message', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
-      const query = pilot['queries'].get('chat-123');
+      const session = pilot['sessionManager'].get('chat-123');
 
-      expect(query).toBeDefined();
+      expect(session).toBeDefined();
+      expect(session?.query).toBeDefined();
+      expect(session?.channel).toBeDefined();
     });
 
     it('should store thread root for replies', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
 
-      expect(pilot['threadRoots'].get('chat-123')).toBe('msg-001');
+      expect(pilot['conversationContext'].getThreadRoot('chat-123')).toBe('msg-001');
     });
   });
 

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -14,12 +14,19 @@
  * ```
  * User Message → Pilot.processMessage()
  *                    ↓
- *              Get/Create Query for chatId
+ *              SessionManager.getOrCreate()
+ *                    ↓
+ *              ConversationContext.trackThread()
  *                    ↓
  *              Query.streamInput() → SDK processes
  *                    ↓
  *              SDK output → Callbacks → Platform (Feishu/CLI)
  * ```
+ *
+ * Separation of Concerns (refactored from #218):
+ * - SessionManager: Query and Channel lifecycle management
+ * - ConversationContext: Thread root and context tracking
+ * - Pilot: Orchestration, callbacks, and main logic flow
  *
  * Extends BaseAgent to inherit:
  * - SDK configuration building
@@ -34,6 +41,8 @@ import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { FileReference } from '../types/file-reference.js';
 import { MessageChannel } from './message-channel.js';
+import { SessionManager } from './session-manager.js';
+import { ConversationContext } from './conversation-context.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -103,21 +112,26 @@ interface MessageData {
  *
  * Simplified implementation using SDK's streamInput() for message delivery.
  * Each chatId gets its own persistent Query instance.
+ *
+ * Refactored to use:
+ * - SessionManager for Query/Channel lifecycle
+ * - ConversationContext for thread tracking
  */
 export class Pilot extends BaseAgent {
   private readonly callbacks: PilotCallbacks;
 
-  // Per-chatId Query instances
-  private queries = new Map<string, Query>();
-  // Per-chatId message channels
-  private channels = new Map<string, MessageChannel>();
-  // Thread root IDs for replies
-  private threadRoots = new Map<string, string>();
+  // Separated concerns
+  private readonly sessionManager: SessionManager;
+  private readonly conversationContext: ConversationContext;
 
   constructor(config: PilotConfig) {
     super(config);
 
     this.callbacks = config.callbacks;
+
+    // Initialize separated managers
+    this.sessionManager = new SessionManager({ logger: this.logger });
+    this.conversationContext = new ConversationContext({ logger: this.logger });
   }
 
   protected getAgentName(): string {
@@ -224,11 +238,11 @@ export class Pilot extends BaseAgent {
   ): void {
     this.logger.debug({ chatId, messageId, textLength: text.length, hasAttachments: !!attachments }, 'Processing message');
 
-    // Store thread root for replies
-    this.threadRoots.set(chatId, messageId);
+    // Track thread root using ConversationContext
+    this.conversationContext.setThreadRoot(chatId, messageId);
 
-    // Get or create channel for this chatId
-    if (!this.channels.has(chatId)) {
+    // Get or create session using SessionManager
+    if (!this.sessionManager.has(chatId)) {
       this.startAgentLoop(chatId);
     }
 
@@ -246,7 +260,7 @@ export class Pilot extends BaseAgent {
     };
 
     // Push message to channel - generator will yield it to SDK
-    const channel = this.channels.get(chatId);
+    const channel = this.sessionManager.getChannel(chatId);
     if (channel) {
       channel.push(userMessage);
     }
@@ -286,20 +300,20 @@ export class Pilot extends BaseAgent {
 
     // Create message channel for this chatId
     const channel = new MessageChannel();
-    this.channels.set(chatId, channel);
 
     // Create streaming query using channel's generator
     const { query: queryInstance, iterator } = this.createQueryStream(
       channel.generator(),
       sdkOptions
     );
-    this.queries.set(chatId, queryInstance);
+
+    // Create session using SessionManager
+    this.sessionManager.create(chatId, queryInstance, channel);
 
     // Process SDK messages in background
     this.processIterator(chatId, iterator).catch((err) => {
       this.logger.error({ err, chatId }, 'Agent loop error');
-      this.queries.delete(chatId);
-      this.channels.delete(chatId);
+      this.sessionManager.deleteTracking(chatId);
     });
   }
 
@@ -323,14 +337,16 @@ export class Pilot extends BaseAgent {
       for await (const { parsed } of iterator) {
         // Send message content to callback
         if (parsed.content) {
-          await this.callbacks.sendMessage(chatId, parsed.content, this.threadRoots.get(chatId));
+          const threadRoot = this.conversationContext.getThreadRoot(chatId);
+          await this.callbacks.sendMessage(chatId, parsed.content, threadRoot);
         }
 
         // Check for completion
         if (parsed.type === 'result') {
           this.logger.debug({ chatId, content: parsed.content }, 'Result received, turn complete');
           if (this.callbacks.onDone) {
-            await this.callbacks.onDone(chatId, this.threadRoots.get(chatId));
+            const threadRoot = this.conversationContext.getThreadRoot(chatId);
+            await this.callbacks.onDone(chatId, threadRoot);
           }
         }
       }
@@ -338,16 +354,17 @@ export class Pilot extends BaseAgent {
       iteratorError = error as Error;
       this.logger.error({ err: iteratorError, chatId }, 'Iterator error');
 
-      await this.callbacks.sendMessage(chatId, `❌ Session error: ${iteratorError.message}`, this.threadRoots.get(chatId));
+      const threadRoot = this.conversationContext.getThreadRoot(chatId);
+      await this.callbacks.sendMessage(chatId, `❌ Session error: ${iteratorError.message}`, threadRoot);
 
       if (this.callbacks.onDone) {
-        await this.callbacks.onDone(chatId, this.threadRoots.get(chatId));
+        await this.callbacks.onDone(chatId, threadRoot);
       }
     }
 
-    // Check if this was an explicit close (reset removed the Query)
-    // If Query is still in the map, it means the iterator ended unexpectedly
-    const wasExplicitClose = !this.queries.has(chatId);
+    // Check if this was an explicit close (reset removed the session)
+    // If session is still tracked, it means the iterator ended unexpectedly
+    const wasExplicitClose = !this.sessionManager.has(chatId);
 
     if (wasExplicitClose) {
       this.logger.info({ chatId }, 'Agent loop completed (explicit close)');
@@ -355,16 +372,16 @@ export class Pilot extends BaseAgent {
     }
 
     // Iterator ended without explicit close - this is unexpected
-    // Remove the stale Query and Channel, then attempt to restart
-    this.queries.delete(chatId);
-    this.channels.delete(chatId);
+    // Remove the stale session tracking, then attempt to restart
+    this.sessionManager.deleteTracking(chatId);
     this.logger.warn({ chatId, error: iteratorError?.message }, 'Agent loop ended unexpectedly, attempting restart');
 
     // Notify user about the restart
+    const threadRoot = this.conversationContext.getThreadRoot(chatId);
     const restartMessage = iteratorError
       ? `⚠️ 会话遇到错误，正在重新连接... (${iteratorError.message})`
       : '⚠️ 会话意外断开，正在重新连接...';
-    await this.callbacks.sendMessage(chatId, restartMessage, this.threadRoots.get(chatId));
+    await this.callbacks.sendMessage(chatId, restartMessage, threadRoot);
 
     // Restart the agent loop to preserve context for future messages
     this.startAgentLoop(chatId);
@@ -480,25 +497,18 @@ You can read these files using the Read tool with the local paths above.`;
    *
    * This is useful for /reset commands that clear conversation context for a specific chat.
    *
-   * IMPORTANT: Deletes Query and Channel from map BEFORE closing, so processIterator
+   * IMPORTANT: Deletes session from tracking BEFORE closing, so processIterator
    * can distinguish explicit close from unexpected iterator end.
    *
    * @param chatId - Platform-specific chat identifier
    */
   reset(chatId: string): void {
-    // Close channel first to stop generator
-    const channel = this.channels.get(chatId);
-    if (channel) {
-      this.channels.delete(chatId);
-      channel.close();
-    }
+    // Delete session (this closes channel and query)
+    const deleted = this.sessionManager.delete(chatId);
 
-    const query = this.queries.get(chatId);
-    if (query) {
-      // Delete from map FIRST, so processIterator knows this is an explicit close
-      this.queries.delete(chatId);
-      query.close();
-      this.threadRoots.delete(chatId);
+    if (deleted) {
+      // Also clear thread root
+      this.conversationContext.deleteThreadRoot(chatId);
       this.logger.info({ chatId }, 'State reset for chatId');
     } else {
       this.logger.debug({ chatId }, 'No state to reset for chatId');
@@ -509,7 +519,7 @@ You can read these files using the Read tool with the local paths above.`;
    * Get the number of active sessions.
    */
   getActiveSessionCount(): number {
-    return this.queries.size;
+    return this.sessionManager.size();
   }
 
   /**
@@ -519,21 +529,11 @@ You can read these files using the Read tool with the local paths above.`;
     await Promise.resolve(); // No-op to satisfy linter
     this.logger.info('Shutting down Pilot');
 
-    // Close all channels first
-    const channelsToClose = Array.from(this.channels.values());
-    this.channels.clear();
-    for (const channel of channelsToClose) {
-      channel.close();
-    }
+    // Close all sessions via SessionManager
+    this.sessionManager.closeAll();
 
-    // Clear map FIRST, then close all queries
-    const queriesToClose = Array.from(this.queries.values());
-    this.queries.clear();
-    this.threadRoots.clear();
-
-    for (const query of queriesToClose) {
-      query.close();
-    }
+    // Clear all context via ConversationContext
+    this.conversationContext.clearAll();
 
     this.logger.info('Pilot shutdown complete');
   }

--- a/src/agents/session-manager.test.ts
+++ b/src/agents/session-manager.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionManager, type PilotSession } from './session-manager.js';
+import type { Query } from '@anthropic-ai/claude-agent-sdk';
+import { MessageChannel } from './message-channel.js';
+import type pino from 'pino';
+
+// Mock dependencies
+vi.mock('./message-channel.js');
+
+describe('SessionManager', () => {
+  let sessionManager: SessionManager;
+  let mockLogger: pino.Logger;
+  let mockQuery: Query;
+  let mockChannel: MessageChannel;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as pino.Logger;
+
+    mockQuery = {
+      close: vi.fn(),
+    } as unknown as Query;
+
+    mockChannel = {
+      close: vi.fn(),
+      push: vi.fn(),
+      generator: vi.fn(),
+    } as unknown as MessageChannel;
+
+    sessionManager = new SessionManager({ logger: mockLogger });
+  });
+
+  describe('has', () => {
+    it('should return false when no session exists', () => {
+      expect(sessionManager.has('chat1')).toBe(false);
+    });
+
+    it('should return true when session exists', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      expect(sessionManager.has('chat1')).toBe(true);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined when no session exists', () => {
+      expect(sessionManager.get('chat1')).toBeUndefined();
+    });
+
+    it('should return session when it exists', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      const session = sessionManager.get('chat1');
+      expect(session).toBeDefined();
+      expect(session?.query).toBe(mockQuery);
+      expect(session?.channel).toBe(mockChannel);
+      expect(session?.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('getQuery', () => {
+    it('should return undefined when no session exists', () => {
+      expect(sessionManager.getQuery('chat1')).toBeUndefined();
+    });
+
+    it('should return query when session exists', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      expect(sessionManager.getQuery('chat1')).toBe(mockQuery);
+    });
+  });
+
+  describe('getChannel', () => {
+    it('should return undefined when no session exists', () => {
+      expect(sessionManager.getChannel('chat1')).toBeUndefined();
+    });
+
+    it('should return channel when session exists', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      expect(sessionManager.getChannel('chat1')).toBe(mockChannel);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new session', () => {
+      const session = sessionManager.create('chat1', mockQuery, mockChannel);
+
+      expect(session.query).toBe(mockQuery);
+      expect(session.channel).toBe(mockChannel);
+      expect(session.createdAt).toBeInstanceOf(Date);
+      expect(sessionManager.has('chat1')).toBe(true);
+    });
+
+    it('should log session creation', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        { chatId: 'chat1' },
+        'Session created'
+      );
+    });
+
+    it('should overwrite existing session', () => {
+      const mockQuery2 = { close: vi.fn() } as unknown as Query;
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      sessionManager.create('chat1', mockQuery2, mockChannel);
+
+      expect(sessionManager.getQuery('chat1')).toBe(mockQuery2);
+    });
+  });
+
+  describe('delete', () => {
+    it('should return false when no session exists', () => {
+      expect(sessionManager.delete('chat1')).toBe(false);
+    });
+
+    it('should delete session and close resources', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      const result = sessionManager.delete('chat1');
+
+      expect(result).toBe(true);
+      expect(sessionManager.has('chat1')).toBe(false);
+      expect(mockChannel.close).toHaveBeenCalled();
+      expect(mockQuery.close).toHaveBeenCalled();
+    });
+
+    it('should delete from map before closing resources', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+
+      // Check that has() returns false before close() is called
+      let hasDuringClose = true;
+      vi.mocked(mockChannel.close).mockImplementation(() => {
+        hasDuringClose = sessionManager.has('chat1');
+      });
+
+      sessionManager.delete('chat1');
+
+      expect(hasDuringClose).toBe(false);
+    });
+  });
+
+  describe('deleteTracking', () => {
+    it('should return false when no session exists', () => {
+      expect(sessionManager.deleteTracking('chat1')).toBe(false);
+    });
+
+    it('should remove tracking without closing resources', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      const result = sessionManager.deleteTracking('chat1');
+
+      expect(result).toBe(true);
+      expect(sessionManager.has('chat1')).toBe(false);
+      expect(mockChannel.close).not.toHaveBeenCalled();
+      expect(mockQuery.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('closeChannel', () => {
+    it('should return false when no session exists', () => {
+      expect(sessionManager.closeChannel('chat1')).toBe(false);
+    });
+
+    it('should close channel and remove tracking', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      const result = sessionManager.closeChannel('chat1');
+
+      expect(result).toBe(true);
+      expect(sessionManager.has('chat1')).toBe(false);
+      expect(mockChannel.close).toHaveBeenCalled();
+      // Query should NOT be closed
+      expect(mockQuery.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('size', () => {
+    it('should return 0 when no sessions', () => {
+      expect(sessionManager.size()).toBe(0);
+    });
+
+    it('should return correct count', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      sessionManager.create('chat2', mockQuery, mockChannel);
+      expect(sessionManager.size()).toBe(2);
+    });
+  });
+
+  describe('getActiveChatIds', () => {
+    it('should return empty array when no sessions', () => {
+      expect(sessionManager.getActiveChatIds()).toEqual([]);
+    });
+
+    it('should return all active chatIds', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      sessionManager.create('chat2', mockQuery, mockChannel);
+
+      const chatIds = sessionManager.getActiveChatIds();
+      expect(chatIds).toContain('chat1');
+      expect(chatIds).toContain('chat2');
+      expect(chatIds.length).toBe(2);
+    });
+  });
+
+  describe('closeAll', () => {
+    it('should close all sessions', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+      sessionManager.create('chat2', mockQuery, mockChannel);
+
+      sessionManager.closeAll();
+
+      expect(sessionManager.size()).toBe(0);
+      expect(mockChannel.close).toHaveBeenCalledTimes(2);
+      expect(mockQuery.close).toHaveBeenCalledTimes(2);
+    });
+
+    it('should clear map before closing resources', () => {
+      sessionManager.create('chat1', mockQuery, mockChannel);
+
+      let sizeDuringClose = -1;
+      vi.mocked(mockChannel.close).mockImplementation(() => {
+        sizeDuringClose = sessionManager.size();
+      });
+
+      sessionManager.closeAll();
+
+      expect(sizeDuringClose).toBe(0);
+    });
+  });
+});

--- a/src/agents/session-manager.ts
+++ b/src/agents/session-manager.ts
@@ -1,0 +1,194 @@
+/**
+ * SessionManager - Manages Query and MessageChannel lifecycle for Pilot.
+ *
+ * Extracts session management concerns from Pilot to improve separation of concerns:
+ * - Query instance management (agent interaction)
+ * - MessageChannel management (conversation flow)
+ * - Session lifecycle (create, get, delete, reset)
+ *
+ * Architecture:
+ * ```
+ * Pilot → SessionManager → { Query, MessageChannel }
+ *                     ↓
+ *              Per-chatId session tracking
+ * ```
+ */
+
+import type { Query } from '@anthropic-ai/claude-agent-sdk';
+import { MessageChannel } from './message-channel.js';
+import type pino from 'pino';
+
+/**
+ * Represents an active session for a chatId.
+ */
+export interface PilotSession {
+  /** The Query instance for SDK interaction */
+  query: Query;
+  /** The MessageChannel for streaming input */
+  channel: MessageChannel;
+  /** When this session was created */
+  createdAt: Date;
+}
+
+/**
+ * Configuration for SessionManager.
+ */
+export interface SessionManagerConfig {
+  /** Logger instance */
+  logger: pino.Logger;
+}
+
+/**
+ * SessionManager - Manages Pilot session lifecycle.
+ *
+ * Each chatId gets its own session containing a Query and MessageChannel.
+ * This class handles:
+ * - Creating new sessions
+ * - Retrieving existing sessions
+ * - Deleting sessions
+ * - Tracking active session count
+ */
+export class SessionManager {
+  private readonly logger: pino.Logger;
+  private readonly sessions = new Map<string, PilotSession>();
+
+  constructor(config: SessionManagerConfig) {
+    this.logger = config.logger;
+  }
+
+  /**
+   * Check if a session exists for the given chatId.
+   */
+  has(chatId: string): boolean {
+    return this.sessions.has(chatId);
+  }
+
+  /**
+   * Get an existing session for the chatId.
+   * Returns undefined if no session exists.
+   */
+  get(chatId: string): PilotSession | undefined {
+    return this.sessions.get(chatId);
+  }
+
+  /**
+   * Get the Query for a chatId, if it exists.
+   */
+  getQuery(chatId: string): Query | undefined {
+    return this.sessions.get(chatId)?.query;
+  }
+
+  /**
+   * Get the MessageChannel for a chatId, if it exists.
+   */
+  getChannel(chatId: string): MessageChannel | undefined {
+    return this.sessions.get(chatId)?.channel;
+  }
+
+  /**
+   * Create a new session for the chatId.
+   *
+   * @param chatId - The chat identifier
+   * @param query - The Query instance
+   * @param channel - The MessageChannel instance
+   * @returns The created session
+   */
+  create(chatId: string, query: Query, channel: MessageChannel): PilotSession {
+    const session: PilotSession = {
+      query,
+      channel,
+      createdAt: new Date(),
+    };
+
+    this.sessions.set(chatId, session);
+    this.logger.debug({ chatId }, 'Session created');
+
+    return session;
+  }
+
+  /**
+   * Delete a session for the chatId.
+   *
+   * IMPORTANT: This deletes the session from tracking BEFORE closing resources,
+   * so that external observers can distinguish explicit close from unexpected termination.
+   *
+   * @param chatId - The chat identifier
+   * @returns true if session was deleted, false if it didn't exist
+   */
+  delete(chatId: string): boolean {
+    const session = this.sessions.get(chatId);
+    if (!session) {
+      return false;
+    }
+
+    // Remove from map FIRST for explicit close detection
+    this.sessions.delete(chatId);
+
+    // Close resources
+    session.channel.close();
+    session.query.close();
+
+    this.logger.debug({ chatId }, 'Session deleted');
+    return true;
+  }
+
+  /**
+   * Delete session tracking without closing resources.
+   * Used when resources are already closed or will be closed externally.
+   */
+  deleteTracking(chatId: string): boolean {
+    const existed = this.sessions.delete(chatId);
+    if (existed) {
+      this.logger.debug({ chatId }, 'Session tracking removed');
+    }
+    return existed;
+  }
+
+  /**
+   * Close the channel for a session (keeps the Query alive).
+   * Used during reset to stop the message generator.
+   */
+  closeChannel(chatId: string): boolean {
+    const session = this.sessions.get(chatId);
+    if (!session) {
+      return false;
+    }
+
+    this.sessions.delete(chatId);
+    session.channel.close();
+    return true;
+  }
+
+  /**
+   * Get the number of active sessions.
+   */
+  size(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Get all chatIds with active sessions.
+   */
+  getActiveChatIds(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+
+  /**
+   * Close all sessions and clear tracking.
+   * Used during shutdown.
+   */
+  closeAll(): void {
+    // Clear map FIRST
+    const sessions = Array.from(this.sessions.entries());
+    this.sessions.clear();
+
+    // Then close all resources
+    for (const [chatId, session] of sessions) {
+      session.channel.close();
+      session.query.close();
+      this.logger.debug({ chatId }, 'Session closed during shutdown');
+    }
+
+    this.logger.info('All sessions closed');
+  }
+}


### PR DESCRIPTION
## Summary

Separate concerns in Pilot.ts to improve code organization by extracting two new classes:

- **SessionManager**: Manages Query and Channel lifecycle per chatId
- **ConversationContext**: Tracks thread roots for reply handling
- **Pilot**: Now orchestrates using the extracted classes

This addresses issue #218 which pointed out that Pilot was mixing conversation management, agent interaction, external communication, and configuration all in one file.

## Changes

### New Files
- `src/agents/session-manager.ts` - Session lifecycle management
- `src/agents/session-manager.test.ts` - 230 lines of tests
- `src/agents/conversation-context.ts` - Thread root tracking
- `src/agents/conversation-context.test.ts` - 111 lines of tests

### Modified Files
- `src/agents/pilot.ts` - Refactored to use SessionManager and ConversationContext
- `src/agents/pilot.test.ts` - Updated tests to use new internal structure
- `src/agents/index.ts` - Export new classes

## Architecture

Before:
```
Pilot
├── queries: Map<string, Query>
├── channels: Map<string, MessageChannel>
├── threadRoots: Map<string, string>
└── callbacks: PilotCallbacks
```

After:
```
Pilot
├── sessionManager: SessionManager
│   └── sessions: Map<string, PilotSession>
│       ├── query: Query
│       ├── channel: MessageChannel
│       └── createdAt: Date
├── conversationContext: ConversationContext
│   └── threadRoots: Map<string, string>
└── callbacks: PilotCallbacks
```

## Benefits

1. **Clear separation of concerns**: Each class has a single responsibility
2. **Better testability**: SessionManager and ConversationContext can be tested independently
3. **Easier maintenance**: Changes to session management don't affect context tracking
4. **Improved readability**: Pilot.ts is now focused on orchestration

## Test Results

- All 836 tests pass ✅
- Build succeeds ✅

```
 Test Files  45 passed (45)
      Tests  836 passed (836)
```

## Closes

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)