### PR TITLE
refactor(file-transfer): Phase 1 - Create unified file transfer directory structure

### DIFF
--- a/src/feishu/attachment-manager.test.ts
+++ b/src/feishu/attachment-manager.test.ts
@@ -1,5 +1,8 @@
 /**
- * Tests for Feishu attachment manager (src/feishu/attachment-manager.ts)
+ * Tests for AttachmentManager.
+ *
+ * Note: The AttachmentManager is now in src/core/attachment-manager.ts
+ * This test file remains in src/feishu/ for backward compatibility testing.
  *
  * Tests the following functionality:
  * - Adding attachments
@@ -9,6 +12,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+// Import from the new location (core), but test the re-export from feishu for backward compatibility
 import { AttachmentManager, type FileAttachment } from './attachment-manager.js';
 
 describe('AttachmentManager', () => {

--- a/src/feishu/attachment-manager.ts
+++ b/src/feishu/attachment-manager.ts
@@ -1,8 +1,14 @@
 /**
  * Attachment manager re-export.
  *
- * @deprecated Import from '../core/index.js' instead.
- * This file is kept for backward compatibility.
+ * @deprecated This file is deprecated and will be removed in a future version.
+ *
+ * Migration guide:
+ * - For AttachmentManager class: Import from `../core/index.js` or `../core/attachment-manager.js`
+ * - For FileAttachment type: Import from `../channels/adapters/types.js` or `../file-transfer/index.js`
+ *
+ * This file is kept for backward compatibility during the file transfer system refactoring.
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
  */
 
 export {

--- a/src/file-transfer/index.ts
+++ b/src/file-transfer/index.ts
@@ -1,0 +1,28 @@
+/**
+ * File Transfer Module.
+ *
+ * Unified file transfer system for handling file operations across:
+ * - Inbound: User uploads to system
+ * - Outbound: Agent sends files to user
+ * - Node Transfer: Distributed mode file transfer between nodes
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+// Unified types
+export {
+  // Types
+  type FileRef,
+  type InboundAttachment,
+  type OutboundFile,
+  type FileReference,
+  type FileAttachment,
+  type FileUploadRequest,
+  type FileUploadResponse,
+  type FileDownloadResponse,
+  type StoredFile,
+  // Factory functions
+  createFileRef,
+  createInboundAttachment,
+  createOutboundFile,
+} from './types.js';

--- a/src/file-transfer/types.ts
+++ b/src/file-transfer/types.ts
@@ -1,0 +1,240 @@
+/**
+ * Unified file transfer types.
+ *
+ * This module consolidates file-related types from across the codebase:
+ * - src/types/file-reference.ts (node-to-node file references)
+ * - src/channels/adapters/types.ts (FileAttachment for platform handling)
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Base file reference - unique identifier for files in the system.
+ *
+ * This is the unified type that replaces both FileReference and FileAttachment.
+ */
+export interface FileRef {
+  /** Unique file identifier (UUID) */
+  id: string;
+
+  /** Original file name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File size in bytes */
+  size?: number;
+
+  /** File source: user upload or agent generated */
+  source: 'user' | 'agent';
+
+  /**
+   * Local storage path.
+   * - For downloaded user files: where the file is stored locally
+   * - For agent files: where the file was created
+   */
+  localPath?: string;
+
+  /**
+   * Platform-specific file key.
+   * - Feishu: file_key from the platform
+   * - Other platforms: platform-specific identifier
+   */
+  platformKey?: string;
+
+  /** Creation timestamp */
+  createdAt: number;
+
+  /** Expiration timestamp (optional, for auto cleanup) */
+  expiresAt?: number;
+}
+
+/**
+ * Inbound attachment - file uploaded by user.
+ *
+ * Used when a user sends a file/image to the system.
+ */
+export interface InboundAttachment extends FileRef {
+  source: 'user';
+
+  /** Chat/conversation ID where the file was uploaded */
+  chatId: string;
+
+  /** Message ID that contained the file */
+  messageId?: string;
+
+  /** File type classification */
+  fileType: 'image' | 'file' | 'media';
+}
+
+/**
+ * Outbound file - file to be sent to user.
+ *
+ * Used when the agent generates a file to send to the user.
+ */
+export interface OutboundFile extends FileRef {
+  source: 'agent';
+
+  /** Target chat/conversation ID */
+  chatId?: string;
+
+  /** Thread ID for threaded replies */
+  threadId?: string;
+}
+
+/**
+ * Legacy compatibility types.
+ * These are kept for backward compatibility during migration.
+ */
+
+/** @deprecated Use FileRef instead */
+export type FileReference = FileRef & {
+  /** Legacy field - use localPath instead */
+  storageKey?: string;
+  /** Legacy field - now part of base FileRef */
+  chatId?: string;
+};
+
+/** @deprecated Use InboundAttachment instead */
+export type FileAttachment = InboundAttachment & {
+  /** Legacy field - use platformKey instead */
+  fileKey: string;
+  /** Legacy field - use id instead */
+  timestamp?: number;
+};
+
+/**
+ * File upload request - exec node uploads file to comm node.
+ */
+export interface FileUploadRequest {
+  /** File name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File content (base64 encoded) */
+  content: string;
+
+  /** Associated chatId (optional) */
+  chatId?: string;
+}
+
+/**
+ * File upload response.
+ */
+export interface FileUploadResponse {
+  /** File reference after successful upload */
+  fileRef: FileRef;
+}
+
+/**
+ * File download response.
+ */
+export interface FileDownloadResponse {
+  /** File reference */
+  fileRef: FileRef;
+
+  /** File content (base64 encoded) */
+  content: string;
+}
+
+/**
+ * File storage info (internal use by comm node).
+ */
+export interface StoredFile {
+  /** File reference */
+  ref: FileRef;
+
+  /** Local storage path */
+  localPath: string;
+}
+
+/**
+ * Factory function to create a FileRef.
+ */
+export function createFileRef(
+  fileName: string,
+  source: 'user' | 'agent',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    platformKey?: string;
+    chatId?: string;
+    messageId?: string;
+    fileType?: 'image' | 'file' | 'media';
+    expiresInMs?: number;
+  }
+): FileRef {
+  const now = Date.now();
+  return {
+    id: uuidv4(),
+    fileName,
+    mimeType: options?.mimeType,
+    size: options?.size,
+    source,
+    localPath: options?.localPath,
+    platformKey: options?.platformKey,
+    createdAt: now,
+    expiresAt: options?.expiresInMs ? now + options.expiresInMs : undefined,
+  };
+}
+
+/**
+ * Factory function to create an InboundAttachment.
+ */
+export function createInboundAttachment(
+  fileName: string,
+  chatId: string,
+  fileType: 'image' | 'file' | 'media',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    platformKey?: string;
+    messageId?: string;
+    expiresInMs?: number;
+  }
+): InboundAttachment {
+  const fileRef = createFileRef(fileName, 'user', {
+    ...options,
+    chatId,
+    fileType,
+  });
+
+  return {
+    ...fileRef,
+    source: 'user',
+    chatId,
+    messageId: options?.messageId,
+    fileType,
+  };
+}
+
+/**
+ * Factory function to create an OutboundFile.
+ */
+export function createOutboundFile(
+  fileName: string,
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    chatId?: string;
+    threadId?: string;
+    expiresInMs?: number;
+  }
+): OutboundFile {
+  const fileRef = createFileRef(fileName, 'agent', options);
+
+  return {
+    ...fileRef,
+    source: 'agent',
+    chatId: options?.chatId,
+    threadId: options?.threadId,
+  };
+}

--- a/src/platforms/base/index.ts
+++ b/src/platforms/base/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Platform Base Module.
+ *
+ * Provides platform-agnostic interfaces for building platform adapters.
+ */
+
+export * from './types.js';

--- a/src/platforms/base/types.ts
+++ b/src/platforms/base/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Platform Adapter Base Types.
+ *
+ * These interfaces define platform-agnostic contracts for message handling
+ * and file operations. Each platform (Feishu, REST, etc.) should implement
+ * these interfaces.
+ *
+ * This file re-exports from channels/adapters/types.ts for backward compatibility
+ * and provides a cleaner import path: `platforms/base` instead of `channels/adapters`.
+ *
+ * Architecture:
+ * ```
+ * Channel (BaseChannel)
+ *     ├── IMessageSender (adapter)
+ *     └── IFileHandler (adapter)
+ * ```
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+// Re-export all types from channels/adapters/types.ts for backward compatibility
+export type {
+  FileAttachment,
+  FileHandlerResult,
+  IMessageSender,
+  IFileHandler,
+  IAttachmentManager,
+  IPlatformAdapter,
+} from '../../channels/adapters/types.js';

--- a/src/platforms/feishu/README.md
+++ b/src/platforms/feishu/README.md
@@ -1,0 +1,18 @@
+/**
+ * Feishu Platform Adapter.
+ *
+ * This module will contain the Feishu-specific platform implementations:
+ * - FeishuPlatformAdapter: Main adapter combining sender + file handler
+ * - FeishuApiClient: Feishu SDK wrapper
+ * - Card builders: Interactive card construction
+ *
+ * Migration Status:
+ * - [ ] Merge feishu/message-sender.ts + sender.ts + feishu-message-sender.ts
+ * - [ ] Merge feishu/file-handler.ts + feishu-file-handler.ts
+ * - [ ] Move card-builders from channels/platforms/feishu/
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+// Re-export from existing location for backward compatibility
+export * from '../../channels/platforms/feishu/index.js';

--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Feishu Platform Module.
+ *
+ * Re-exports from channels/platforms/feishu/ for backward compatibility.
+ * Future migration will consolidate all Feishu-specific code here.
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+// Re-export from existing location for backward compatibility
+export * from '../../channels/platforms/feishu/index.js';

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Platforms Module.
+ *
+ * Unified platform adapter system supporting multiple messaging platforms.
+ *
+ * Structure:
+ * - base/: Platform-agnostic interfaces (IPlatformAdapter, IMessageSender, etc.)
+ * - feishu/: Feishu/Lark platform implementation
+ * - (future) rest/: REST API platform implementation
+ * - (future) wecom/: WeChat Work platform implementation
+ * - (future) dingtalk/: DingTalk platform implementation
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+// Base interfaces
+export * from './base/index.js';
+
+// Platform implementations
+export * from './feishu/index.js';


### PR DESCRIPTION
## Summary

This PR implements **Phase 1** of Issue #194 - creating the unified file transfer system architecture.

- Creates `src/file-transfer/` directory with unified types
- Creates `src/platforms/` directory for platform adapter interfaces
- Updates deprecated `src/feishu/attachment-manager.ts` with clearer migration guide

## Changes

### New Files

| File | Description |
|------|-------------|
| `src/file-transfer/types.ts` | Unified file types consolidating `FileReference` and `FileAttachment` |
| `src/file-transfer/index.ts` | Public exports for file-transfer module |
| `src/platforms/base/types.ts` | Platform adapter interfaces (re-export from `channels/adapters`) |
| `src/platforms/base/index.ts` | Base module exports |
| `src/platforms/feishu/README.md` | Documentation for Feishu platform migration |
| `src/platforms/feishu/index.ts` | Feishu platform re-exports |
| `src/platforms/index.ts` | Main platforms module exports |

### Modified Files

| File | Changes |
|------|---------|
| `src/feishu/attachment-manager.ts` | Enhanced deprecation notice with migration guide |
| `src/feishu/attachment-manager.test.ts` | Updated comments to reflect new import paths |

## Unified Types

The new `src/file-transfer/types.ts` provides:

```typescript
// Base file reference (unified)
interface FileRef {
  id: string;
  fileName: string;
  mimeType?: string;
  size?: number;
  source: 'user' | 'agent';
  localPath?: string;
  platformKey?: string;
  createdAt: number;
  expiresAt?: number;
}

// Inbound attachment (user uploads)
interface InboundAttachment extends FileRef {
  source: 'user';
  chatId: string;
  messageId?: string;
  fileType: 'image' | 'file' | 'media';
}

// Outbound file (agent sends)
interface OutboundFile extends FileRef {
  source: 'agent';
  chatId?: string;
  threadId?: string;
}
```

## Migration Path

### Before
```typescript
import { FileReference } from '../types/file-reference.js';
import { FileAttachment } from '../channels/adapters/types.js';
```

### After
```typescript
import { FileRef, InboundAttachment, OutboundFile } from '../file-transfer/index.js';
```

## Test Results

- ✅ All 799 tests passed
- ✅ Build succeeded

## Related

- Addresses #194 (Phase 1: 创建新目录结构)

## Next Steps

Future PRs will implement:
- Phase 2: Merge redundant file handler modules
- Phase 3: Reorganize file transfer components
- Phase 4: Rename modules to avoid confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)