### PR TITLE
test(channels): add unit tests for Feishu platform handlers

### DIFF
--- a/src/channels/platforms/feishu/feishu-file-handler.test.ts
+++ b/src/channels/platforms/feishu/feishu-file-handler.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for FeishuFileHandler.
+ *
+ * Tests the file handling functionality for Feishu platform:
+ * - File message processing
+ * - Image message processing
+ * - Upload prompt generation
+ * - Error handling
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuFileHandler, type FileDownloadFunction } from './feishu-file-handler.js';
+import type { IAttachmentManager, FileAttachment } from '../../adapters/types.js';
+
+// Mock logger
+vi.mock('../../../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+}));
+
+describe('FeishuFileHandler', () => {
+  let handler: FeishuFileHandler;
+  let mockAttachmentManager: IAttachmentManager;
+  let mockDownloadFile: FileDownloadFunction;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAttachmentManager = {
+      hasAttachments: vi.fn(),
+      getAttachments: vi.fn().mockReturnValue([]),
+      addAttachment: vi.fn(),
+      clearAttachments: vi.fn(),
+    };
+
+    mockDownloadFile = vi.fn();
+
+    handler = new FeishuFileHandler({
+      attachmentManager: mockAttachmentManager,
+      downloadFile: mockDownloadFile,
+    });
+  });
+
+  describe('handleFileMessage', () => {
+    it('should handle image message correctly', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/test_image.png',
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        JSON.stringify({ image_key: 'img_key_123' }),
+        'msg-456'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe('/tmp/test_image.png');
+      expect(result.fileKey).toBe('img_key_123');
+      expect(mockDownload).toHaveBeenCalledWith(
+        'img_key_123',
+        'image',
+        'image_img_key_123',
+        'msg-456'
+      );
+    });
+
+    it('should handle file message correctly', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/document.pdf',
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'file',
+        JSON.stringify({ file_key: 'file_key_789', file_name: 'document.pdf' }),
+        'msg-456'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe('/tmp/document.pdf');
+      expect(result.fileKey).toBe('file_key_789');
+      expect(mockDownload).toHaveBeenCalledWith(
+        'file_key_789',
+        'file',
+        'document.pdf',
+        'msg-456'
+      );
+    });
+
+    it('should handle media message correctly', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/video.mp4',
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'media',
+        JSON.stringify({ file_key: 'media_key_abc', file_name: 'video.mp4' }),
+        'msg-456'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe('/tmp/video.mp4');
+    });
+
+    it('should return error when no file_key found', async () => {
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        JSON.stringify({ other_field: 'value' }),
+        'msg-456'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No file_key found');
+    });
+
+    it('should return error when download fails', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: false,
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'file',
+        JSON.stringify({ file_key: 'key_123', file_name: 'test.txt' }),
+        'msg-456'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Download failed');
+    });
+
+    it('should handle invalid JSON content', async () => {
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        'not valid json',
+        'msg-456'
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should add attachment to manager on success', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/test.png',
+      });
+
+      await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        JSON.stringify({ image_key: 'img_key' }),
+        'msg-456'
+      );
+
+      const mockAdd = mockAttachmentManager.addAttachment as ReturnType<typeof vi.fn>;
+      expect(mockAdd).toHaveBeenCalled();
+
+      const [chatId, attachment] = mockAdd.mock.calls[0];
+      expect(chatId).toBe('chat-123');
+      expect(attachment.fileKey).toBe('img_key');
+      expect(attachment.messageId).toBe('msg-456');
+    });
+  });
+
+  describe('buildUploadPrompt', () => {
+    it('should generate prompt with basic file info', () => {
+      const attachment: FileAttachment = {
+        fileKey: 'key_123',
+        fileName: 'test.pdf',
+        localPath: '/tmp/test.pdf',
+        fileType: 'file',
+        messageId: 'msg-456',
+        timestamp: Date.now(),
+      };
+
+      const prompt = handler.buildUploadPrompt(attachment);
+
+      expect(prompt).toContain('User uploaded a file');
+      expect(prompt).toContain('file_name: test.pdf');
+      expect(prompt).toContain('file_type: file');
+      expect(prompt).toContain('file_key: key_123');
+      expect(prompt).toContain('local_path: /tmp/test.pdf');
+    });
+
+    it('should include file size when available', () => {
+      const attachment: FileAttachment = {
+        fileKey: 'key_123',
+        fileName: 'large.zip',
+        localPath: '/tmp/large.zip',
+        fileType: 'file',
+        messageId: 'msg-456',
+        timestamp: Date.now(),
+        fileSize: 5 * 1024 * 1024, // 5 MB
+      };
+
+      const prompt = handler.buildUploadPrompt(attachment);
+
+      expect(prompt).toContain('file_size_mb: 5.00');
+    });
+
+    it('should include mime type when available', () => {
+      const attachment: FileAttachment = {
+        fileKey: 'key_123',
+        fileName: 'doc.pdf',
+        localPath: '/tmp/doc.pdf',
+        fileType: 'file',
+        messageId: 'msg-456',
+        timestamp: Date.now(),
+        mimeType: 'application/pdf',
+      };
+
+      const prompt = handler.buildUploadPrompt(attachment);
+
+      expect(prompt).toContain('mime_type: application/pdf');
+    });
+
+    it('should handle image file type', () => {
+      const attachment: FileAttachment = {
+        fileKey: 'img_key',
+        fileName: 'photo.png',
+        localPath: '/tmp/photo.png',
+        fileType: 'image',
+        messageId: 'msg-456',
+        timestamp: Date.now(),
+      };
+
+      const prompt = handler.buildUploadPrompt(attachment);
+
+      expect(prompt).toContain('file_type: image');
+    });
+
+    it('should include instruction text', () => {
+      const attachment: FileAttachment = {
+        fileKey: 'key',
+        fileName: 'test.txt',
+        fileType: 'file',
+        messageId: 'msg',
+        timestamp: Date.now(),
+      };
+
+      const prompt = handler.buildUploadPrompt(attachment);
+
+      expect(prompt).toContain('wait for the user\'s instructions');
+    });
+  });
+});

--- a/src/channels/platforms/feishu/feishu-message-sender.test.ts
+++ b/src/channels/platforms/feishu/feishu-message-sender.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for FeishuMessageSender.
+ *
+ * Tests the message sending functionality for Feishu platform:
+ * - Text message sending
+ * - Card message sending
+ * - File message sending
+ * - Reaction handling
+ * - Thread reply support
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuMessageSender } from './feishu-message-sender.js';
+import type { Logger } from 'pino';
+
+// Mock lark client
+const mockClient = {
+  im: {
+    message: {
+      create: vi.fn(),
+    },
+    messageReaction: {
+      create: vi.fn(),
+    },
+  },
+};
+
+// Mock logger
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+};
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn(() => mockClient),
+}));
+
+vi.mock('../../../utils/logger.js', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}));
+
+vi.mock('../../../utils/error-handler.js', () => ({
+  handleError: vi.fn(),
+  ErrorCategory: {
+    API: 'api',
+  },
+}));
+
+vi.mock('./card-builders/content-builder.js', () => ({
+  buildTextContent: vi.fn((text) => JSON.stringify({ text })),
+}));
+
+vi.mock('../../../feishu/message-logger.js', () => ({
+  messageLogger: {
+    logOutgoingMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../../../feishu/file-uploader.js', () => ({
+  uploadAndSendFile: vi.fn(),
+}));
+
+describe('FeishuMessageSender', () => {
+  let sender: FeishuMessageSender;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    sender = new FeishuMessageSender({
+      client: mockClient as any,
+      logger: mockLogger as unknown as Logger,
+    });
+  });
+
+  describe('sendText', () => {
+    it('should send text message successfully', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'msg_123' },
+      });
+
+      await sender.sendText('chat_456', 'Hello World');
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: 'chat_456',
+          msg_type: 'text',
+          content: JSON.stringify({ text: 'Hello World' }),
+        },
+      });
+    });
+
+    it('should send text message with thread reply', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'msg_123' },
+      });
+
+      await sender.sendText('chat_456', 'Reply text', 'thread_789');
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: 'chat_456',
+          msg_type: 'text',
+          content: JSON.stringify({ text: 'Reply text' }),
+          parent_id: 'thread_789',
+        },
+      });
+    });
+
+    it('should handle send error gracefully', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('API error'));
+
+      // Should not throw
+      await sender.sendText('chat_456', 'Test message');
+
+      const { handleError } = await import('../../../utils/error-handler.js');
+      expect(handleError).toHaveBeenCalled();
+    });
+
+    it('should log outgoing message with bot message id', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'bot_msg_123' },
+      });
+
+      await sender.sendText('chat_456', 'Test');
+
+      const { messageLogger } = await import('../../../feishu/message-logger.js');
+      expect(messageLogger.logOutgoingMessage).toHaveBeenCalledWith(
+        'bot_msg_123',
+        'chat_456',
+        'Test'
+      );
+    });
+  });
+
+  describe('sendCard', () => {
+    it('should send card message successfully', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'card_msg_123' },
+      });
+
+      const card = { type: 'template', data: { text: 'Card content' } };
+      await sender.sendCard('chat_456', card, 'Test card');
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: 'chat_456',
+          msg_type: 'interactive',
+          content: JSON.stringify(card),
+        },
+      });
+    });
+
+    it('should send card with thread reply', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'card_msg_123' },
+      });
+
+      const card = { type: 'template' };
+      await sender.sendCard('chat_456', card, 'Card', 'thread_789');
+
+      const callData = mockCreate.mock.calls[0][0].data;
+      expect(callData.parent_id).toBe('thread_789');
+    });
+
+    it('should handle card send error gracefully', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('Card API error'));
+
+      // Should not throw
+      await sender.sendCard('chat_456', { type: 'test' }, 'Test');
+
+      const { handleError } = await import('../../../utils/error-handler.js');
+      expect(handleError).toHaveBeenCalled();
+    });
+
+    it('should work without description', async () => {
+      const mockCreate = mockClient.im.message.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { message_id: 'card_msg_123' },
+      });
+
+      await sender.sendCard('chat_456', { type: 'template' });
+
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+
+  describe('sendFile', () => {
+    it('should send file successfully', async () => {
+      const { uploadAndSendFile } = await import('../../../feishu/file-uploader.js');
+      const mockUpload = uploadAndSendFile as ReturnType<typeof vi.fn>;
+      mockUpload.mockResolvedValue(1024);
+
+      await sender.sendFile('chat_456', '/tmp/test.pdf');
+
+      expect(mockUpload).toHaveBeenCalledWith(
+        mockClient,
+        '/tmp/test.pdf',
+        'chat_456',
+        undefined
+      );
+    });
+
+    it('should send file with thread reply', async () => {
+      const { uploadAndSendFile } = await import('../../../feishu/file-uploader.js');
+      const mockUpload = uploadAndSendFile as ReturnType<typeof vi.fn>;
+      mockUpload.mockResolvedValue(2048);
+
+      await sender.sendFile('chat_456', '/tmp/doc.pdf', 'thread_789');
+
+      expect(mockUpload).toHaveBeenCalledWith(
+        mockClient,
+        '/tmp/doc.pdf',
+        'chat_456',
+        'thread_789'
+      );
+    });
+
+    it('should handle file send error gracefully', async () => {
+      const { uploadAndSendFile } = await import('../../../feishu/file-uploader.js');
+      const mockUpload = uploadAndSendFile as ReturnType<typeof vi.fn>;
+      mockUpload.mockRejectedValue(new Error('Upload failed'));
+
+      // Should not throw
+      await sender.sendFile('chat_456', '/tmp/test.pdf');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('should log outgoing file message', async () => {
+      const { uploadAndSendFile } = await import('../../../feishu/file-uploader.js');
+      const mockUpload = uploadAndSendFile as ReturnType<typeof vi.fn>;
+      mockUpload.mockResolvedValue(5120);
+
+      const { messageLogger } = await import('../../../feishu/message-logger.js');
+
+      await sender.sendFile('chat_456', '/path/to/document.pdf');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: 'chat_456',
+          filePath: '/path/to/document.pdf',
+          fileSize: 5120,
+        }),
+        'File sent to user'
+      );
+    });
+  });
+
+  describe('addReaction', () => {
+    it('should add reaction successfully', async () => {
+      const mockCreate = mockClient.im.messageReaction.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({});
+
+      const result = await sender.addReaction('msg_123', 'THUMBSUP');
+
+      expect(result).toBe(true);
+      expect(mockCreate).toHaveBeenCalledWith({
+        path: { message_id: 'msg_123' },
+        data: {
+          reaction_type: { emoji_type: 'THUMBSUP' },
+        },
+      });
+    });
+
+    it('should return false on reaction error', async () => {
+      const mockCreate = mockClient.im.messageReaction.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('Reaction failed'));
+
+      const result = await sender.addReaction('msg_123', 'THUMBSUP');
+
+      expect(result).toBe(false);
+      expect(mockLogger.warn).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements #168: Channel 架构测试覆盖
- 添加 FeishuFileHandler 单元测试 (12 tests)
- 添加 FeishuMessageSender 单元测试 (14 tests)

## Changes

### FeishuFileHandler Tests (12 tests)
- ✅ 图片消息处理
- ✅ 文件消息处理  
- ✅ 媒体消息处理
- ✅ 错误处理（无 file_key、下载失败）
- ✅ Attachment manager 集成
- ✅ 上传提示生成

### FeishuMessageSender Tests (14 tests)
- ✅ 文本消息发送（支持 thread）
- ✅ 卡片消息发送（支持 thread）
- ✅ 文件发送
- ✅ Reaction 处理
- ✅ 所有操作的错误处理

## Test Results

```
 Test Files  45 passed (45)
      Tests  825 passed (825) (+26 new tests)
   Duration  6.90s
```

## Issue Coverage

Closes #168

| Task | Status |
|------|--------|
| 添加 `BaseChannel` 单元测试 | ✅ 已存在 |
| 添加平台适配器测试 | ✅ 已完成（新增） |
| 添加集成测试框架 | ✅ 已存在 |
| 测试覆盖率目标: 核心模块 > 80% | ✅ 通过 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)