### PR TITLE
feat: add multi-execution node support (Issue #38)

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -109,7 +109,7 @@ export interface OutgoingMessage {
 /**
  * Control command types.
  */
-export type ControlCommandType = 'reset' | 'restart' | 'status';
+export type ControlCommandType = 'reset' | 'restart' | 'status' | 'list-nodes' | 'switch-node';
 
 /**
  * Control command from user to agent.
@@ -123,6 +123,9 @@ export interface ControlCommand {
 
   /** Additional command data */
   data?: Record<string, unknown>;
+
+  /** Target node ID for switch-node command */
+  targetNodeId?: string;
 }
 
 /**

--- a/src/nodes/communication-node.test.ts
+++ b/src/nodes/communication-node.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for CommunicationNode multi-execution node support.
+ *
+ * Issue #38: Multi-execution node support
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocket } from 'ws';
+
+// Mock the dependencies
+vi.mock('../config/index.js', () => ({
+  Config: {
+    FEISHU_APP_ID: undefined,
+    FEISHU_APP_SECRET: undefined,
+    getWorkspaceDir: () => '/tmp/test-workspace',
+    getTransportConfig: () => ({}),
+    getChannelsConfig: () => ({ rest: { enabled: false } }),
+  },
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// We need to import CommunicationNode after mocking
+import { CommunicationNode } from './communication-node.js';
+
+describe('CommunicationNode Multi-Execution Node Support', () => {
+  describe('Without starting server', () => {
+    it('getExecNodes() should return empty array initially', () => {
+      const commNode = new CommunicationNode({
+        port: 3101,
+        host: '127.0.0.1',
+        enableRestChannel: false,
+        appId: undefined,
+        appSecret: undefined,
+      });
+      const nodes = commNode.getExecNodes();
+      expect(nodes).toEqual([]);
+    });
+
+    it('getChatNodeAssignment() should return undefined when no assignment exists', () => {
+      const commNode = new CommunicationNode({
+        port: 3102,
+        host: '127.0.0.1',
+        enableRestChannel: false,
+        appId: undefined,
+        appSecret: undefined,
+      });
+      const assignment = commNode.getChatNodeAssignment('test-chat-1');
+      expect(assignment).toBeUndefined();
+    });
+
+    it('switchChatNode() should return false when target node does not exist', () => {
+      const commNode = new CommunicationNode({
+        port: 3103,
+        host: '127.0.0.1',
+        enableRestChannel: false,
+        appId: undefined,
+        appSecret: undefined,
+      });
+      const result = commNode.switchChatNode('test-chat-1', 'non-existent-node');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Control Commands', () => {
+    let commNode: CommunicationNode;
+
+    beforeEach(() => {
+      commNode = new CommunicationNode({
+        port: 3104,
+        host: '127.0.0.1',
+        enableRestChannel: false,
+        appId: undefined,
+        appSecret: undefined,
+      });
+    });
+
+    it('should handle list-nodes command with no nodes', async () => {
+      const response = await (commNode as any).handleControlCommand({
+        type: 'list-nodes',
+        chatId: 'test-chat-1',
+      });
+
+      expect(response.success).toBe(true);
+      expect(response.message).toContain('暂无连接的执行节点');
+    });
+
+    it('should handle status command', async () => {
+      const response = await (commNode as any).handleControlCommand({
+        type: 'status',
+        chatId: 'test-chat-1',
+      });
+
+      expect(response.success).toBe(true);
+      expect(response.message).toContain('状态');
+      expect(response.message).toContain('未分配');
+    });
+
+    it('should handle switch-node command without targetNodeId', async () => {
+      const response = await (commNode as any).handleControlCommand({
+        type: 'switch-node',
+        chatId: 'test-chat-1',
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('请指定目标节点ID');
+    });
+
+    it('should handle switch-node command with non-existent targetNodeId', async () => {
+      const response = await (commNode as any).handleControlCommand({
+        type: 'switch-node',
+        chatId: 'test-chat-1',
+        targetNodeId: 'non-existent-node',
+      });
+
+      expect(response.success).toBe(false);
+      expect(response.error).toContain('切换失败');
+    });
+  });
+
+  describe('Internal Methods', () => {
+    let commNode: CommunicationNode;
+
+    beforeEach(() => {
+      commNode = new CommunicationNode({
+        port: 3105,
+        host: '127.0.0.1',
+        enableRestChannel: false,
+        appId: undefined,
+        appSecret: undefined,
+      });
+    });
+
+    it('registerExecNode should add node to execNodes map', () => {
+      const mockWs = { readyState: WebSocket.OPEN } as WebSocket;
+      const nodeId = (commNode as any).registerExecNode(
+        mockWs,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node' },
+        '127.0.0.1'
+      );
+
+      expect(nodeId).toBe('test-node-1');
+      const nodes = commNode.getExecNodes();
+      expect(nodes.length).toBe(1);
+      expect(nodes[0].nodeId).toBe('test-node-1');
+      expect(nodes[0].name).toBe('Test Node');
+      expect(nodes[0].status).toBe('connected');
+    });
+
+    it('registerExecNode should replace existing node with same ID', () => {
+      const mockWs1 = { readyState: WebSocket.OPEN, close: vi.fn() } as unknown as WebSocket;
+      const mockWs2 = { readyState: WebSocket.OPEN } as WebSocket;
+
+      (commNode as any).registerExecNode(
+        mockWs1,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node 1' },
+        '127.0.0.1'
+      );
+
+      (commNode as any).registerExecNode(
+        mockWs2,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node 2' },
+        '127.0.0.1'
+      );
+
+      expect((mockWs1 as any).close).toHaveBeenCalled();
+      const nodes = commNode.getExecNodes();
+      expect(nodes.length).toBe(1);
+      expect(nodes[0].name).toBe('Test Node 2');
+    });
+
+    it('unregisterExecNode should remove node', () => {
+      const mockWs = { readyState: WebSocket.OPEN } as WebSocket;
+      (commNode as any).registerExecNode(
+        mockWs,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node' },
+        '127.0.0.1'
+      );
+
+      expect(commNode.getExecNodes().length).toBe(1);
+
+      (commNode as any).unregisterExecNode('test-node-1');
+
+      expect(commNode.getExecNodes().length).toBe(0);
+    });
+
+    it('getFirstAvailableNode should return first connected node', () => {
+      const mockWs = { readyState: WebSocket.OPEN } as WebSocket;
+      (commNode as any).registerExecNode(
+        mockWs,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node' },
+        '127.0.0.1'
+      );
+
+      const node = (commNode as any).getFirstAvailableNode();
+      expect(node).toBeDefined();
+      expect(node.nodeId).toBe('test-node-1');
+    });
+
+    it('getFirstAvailableNode should return undefined when no nodes connected', () => {
+      const node = (commNode as any).getFirstAvailableNode();
+      expect(node).toBeUndefined();
+    });
+
+    it('getExecNodeForChat should assign first available node to chat', () => {
+      const mockWs = { readyState: WebSocket.OPEN } as WebSocket;
+      (commNode as any).registerExecNode(
+        mockWs,
+        { type: 'register', nodeId: 'test-node-1', name: 'Test Node' },
+        '127.0.0.1'
+      );
+
+      const node = (commNode as any).getExecNodeForChat('chat-1');
+      expect(node).toBeDefined();
+      expect(node.nodeId).toBe('test-node-1');
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('test-node-1');
+    });
+
+    it('getExecNodeForChat should return existing assignment if available', () => {
+      const mockWs1 = { readyState: WebSocket.OPEN } as WebSocket;
+      const mockWs2 = { readyState: WebSocket.OPEN } as WebSocket;
+
+      (commNode as any).registerExecNode(
+        mockWs1,
+        { type: 'register', nodeId: 'node-1', name: 'Node 1' },
+        '127.0.0.1'
+      );
+      (commNode as any).registerExecNode(
+        mockWs2,
+        { type: 'register', nodeId: 'node-2', name: 'Node 2' },
+        '127.0.0.1'
+      );
+
+      // First call assigns to node-1
+      (commNode as any).getExecNodeForChat('chat-1');
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('node-1');
+
+      // Second call should return same assignment
+      const node = (commNode as any).getExecNodeForChat('chat-1');
+      expect(node.nodeId).toBe('node-1');
+    });
+
+    it('switchChatNode should change chat assignment', () => {
+      const mockWs1 = { readyState: WebSocket.OPEN } as WebSocket;
+      const mockWs2 = { readyState: WebSocket.OPEN } as WebSocket;
+
+      (commNode as any).registerExecNode(
+        mockWs1,
+        { type: 'register', nodeId: 'node-1', name: 'Node 1' },
+        '127.0.0.1'
+      );
+      (commNode as any).registerExecNode(
+        mockWs2,
+        { type: 'register', nodeId: 'node-2', name: 'Node 2' },
+        '127.0.0.1'
+      );
+
+      // Assign to node-1
+      (commNode as any).getExecNodeForChat('chat-1');
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('node-1');
+
+      // Switch to node-2
+      const result = commNode.switchChatNode('chat-1', 'node-2');
+      expect(result).toBe(true);
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('node-2');
+    });
+
+    it('unregisterExecNode should reassign chats to another node', () => {
+      const mockWs1 = { readyState: WebSocket.OPEN } as WebSocket;
+      const mockWs2 = { readyState: WebSocket.OPEN } as WebSocket;
+
+      (commNode as any).registerExecNode(
+        mockWs1,
+        { type: 'register', nodeId: 'node-1', name: 'Node 1' },
+        '127.0.0.1'
+      );
+      (commNode as any).registerExecNode(
+        mockWs2,
+        { type: 'register', nodeId: 'node-2', name: 'Node 2' },
+        '127.0.0.1'
+      );
+
+      // Assign chat to node-1
+      (commNode as any).getExecNodeForChat('chat-1');
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('node-1');
+
+      // Unregister node-1
+      (commNode as any).unregisterExecNode('node-1');
+
+      // Chat should be reassigned to node-2
+      expect(commNode.getChatNodeAssignment('chat-1')).toBe('node-2');
+    });
+  });
+});

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -22,7 +22,7 @@ import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, OutgoingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
-import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage, ExecNodeInfo } from '../types/websocket-messages.js';
 import type { FileReference } from '../types/file-reference.js';
 import { FileStorageService, type FileStorageConfig } from '../services/file-storage-service.js';
 import { createFileTransferAPIHandler } from '../services/file-transfer-api.js';
@@ -54,12 +54,24 @@ export interface CommunicationNodeConfig {
 }
 
 /**
+ * Internal representation of a connected execution node.
+ */
+interface ConnectedExecNode {
+  ws: WebSocket;
+  nodeId: string;
+  name: string;
+  connectedAt: Date;
+  clientIp?: string;
+}
+
+/**
  * Communication Node - Manages multiple channels and WebSocket communication with Execution Node.
  *
  * Responsibilities:
  * - Manages multiple communication channels (Feishu, REST, etc.)
  * - Runs WebSocket server for Execution Nodes to connect
- * - Forwards prompts from channels to connected Execution Node via WebSocket
+ * - Supports multiple Execution Nodes with chat-level routing
+ * - Forwards prompts from channels to assigned Execution Node via WebSocket
  * - Receives feedback from Execution Node via WebSocket
  * - Routes feedback back to appropriate channels
  */
@@ -69,8 +81,11 @@ export class CommunicationNode extends EventEmitter {
 
   private httpServer?: http.Server;
   private wss?: WebSocketServer;
-  private execWs?: WebSocket;
   private running = false;
+
+  // Multiple execution nodes support (Issue #38)
+  private execNodes: Map<string, ConnectedExecNode> = new Map();
+  private chatToNode: Map<string, string> = new Map(); // chatId -> nodeId
 
   // Registered channels
   private channels: Map<string, IChannel> = new Map();
@@ -127,6 +142,155 @@ export class CommunicationNode extends EventEmitter {
     }
 
     logger.info({ port: this.port, host: this.host }, 'CommunicationNode created');
+  }
+
+  /**
+   * Register an execution node.
+   * If a node with the same ID exists, close the old connection.
+   */
+  private registerExecNode(ws: WebSocket, msg: RegisterMessage, clientIp?: string): string {
+    const { nodeId, name } = msg;
+
+    // Close existing connection with same nodeId if exists
+    const existing = this.execNodes.get(nodeId);
+    if (existing) {
+      logger.warn({ nodeId }, 'Closing existing connection for nodeId');
+      existing.ws.close();
+      this.execNodes.delete(nodeId);
+    }
+
+    // Register the new node
+    this.execNodes.set(nodeId, {
+      ws,
+      nodeId,
+      name: name || `ExecNode-${nodeId.slice(0, 8)}`,
+      connectedAt: new Date(),
+      clientIp,
+    });
+
+    logger.info({ nodeId, name: msg.name, clientIp, totalNodes: this.execNodes.size }, 'Execution Node registered');
+    this.emit('exec:connected', nodeId);
+
+    return nodeId;
+  }
+
+  /**
+   * Unregister an execution node.
+   * Reassign chats that were assigned to this node.
+   */
+  private unregisterExecNode(nodeId: string): void {
+    const node = this.execNodes.get(nodeId);
+    if (!node) {
+      return;
+    }
+
+    this.execNodes.delete(nodeId);
+    logger.info({ nodeId, totalNodes: this.execNodes.size }, 'Execution Node unregistered');
+
+    // Reassign chats that were using this node
+    const chatsToReassign: string[] = [];
+    for (const [chatId, assignedNodeId] of this.chatToNode) {
+      if (assignedNodeId === nodeId) {
+        chatsToReassign.push(chatId);
+      }
+    }
+
+    // Try to reassign to another available node
+    const availableNode = this.getFirstAvailableNode();
+    for (const chatId of chatsToReassign) {
+      if (availableNode) {
+        this.chatToNode.set(chatId, availableNode.nodeId);
+        logger.info({ chatId, oldNode: nodeId, newNode: availableNode.nodeId }, 'Reassigned chat to available node');
+      } else {
+        this.chatToNode.delete(chatId);
+        logger.warn({ chatId, oldNode: nodeId }, 'No available node to reassign chat');
+      }
+    }
+
+    this.emit('exec:disconnected', nodeId);
+  }
+
+  /**
+   * Get the first available execution node.
+   */
+  private getFirstAvailableNode(): ConnectedExecNode | undefined {
+    for (const node of this.execNodes.values()) {
+      if (node.ws.readyState === WebSocket.OPEN) {
+        return node;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get the execution node assigned to a chat, or assign the first available one.
+   */
+  private getExecNodeForChat(chatId: string): ConnectedExecNode | undefined {
+    // Check if chat already has an assigned node
+    const assignedNodeId = this.chatToNode.get(chatId);
+    if (assignedNodeId) {
+      const node = this.execNodes.get(assignedNodeId);
+      if (node && node.ws.readyState === WebSocket.OPEN) {
+        return node;
+      }
+      // Assigned node is not available, fall through to assign new one
+    }
+
+    // Assign first available node
+    const availableNode = this.getFirstAvailableNode();
+    if (availableNode) {
+      this.chatToNode.set(chatId, availableNode.nodeId);
+      logger.debug({ chatId, nodeId: availableNode.nodeId }, 'Assigned chat to execution node');
+    }
+    return availableNode;
+  }
+
+  /**
+   * Switch a chat to a specific execution node.
+   */
+  switchChatNode(chatId: string, targetNodeId: string): boolean {
+    const targetNode = this.execNodes.get(targetNodeId);
+    if (!targetNode || targetNode.ws.readyState !== WebSocket.OPEN) {
+      logger.warn({ chatId, targetNodeId }, 'Target node not available for switch');
+      return false;
+    }
+
+    const previousNodeId = this.chatToNode.get(chatId);
+    this.chatToNode.set(chatId, targetNodeId);
+    logger.info({ chatId, previousNode: previousNodeId, newNode: targetNodeId }, 'Switched chat to new execution node');
+    return true;
+  }
+
+  /**
+   * Get list of all connected execution nodes.
+   */
+  getExecNodes(): ExecNodeInfo[] {
+    const result: ExecNodeInfo[] = [];
+    for (const [nodeId, node] of this.execNodes) {
+      // Count active chats for this node
+      let activeChats = 0;
+      for (const assignedNodeId of this.chatToNode.values()) {
+        if (assignedNodeId === nodeId) {
+          activeChats++;
+        }
+      }
+
+      result.push({
+        nodeId,
+        name: node.name,
+        status: node.ws.readyState === WebSocket.OPEN ? 'connected' : 'disconnected',
+        activeChats,
+        connectedAt: node.connectedAt,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Get the node assignment for a specific chat.
+   */
+  getChatNodeAssignment(chatId: string): string | undefined {
+    return this.chatToNode.get(chatId);
   }
 
   /**
@@ -219,37 +383,53 @@ export class CommunicationNode extends EventEmitter {
 
     this.wss.on('connection', (ws, req) => {
       const clientIp = req.socket.remoteAddress;
-      logger.info({ clientIp }, 'Execution Node connected');
+      let currentNodeId: string | undefined;
 
-      // Store the connection
-      if (this.execWs && this.execWs.readyState === WebSocket.OPEN) {
-        logger.warn('Closing previous Execution Node connection');
-        this.execWs.close();
-      }
-      this.execWs = ws;
+      logger.info({ clientIp }, 'Execution Node connecting...');
 
+      // Handle incoming messages
       ws.on('message', (data) => {
         try {
-          const message = JSON.parse(data.toString()) as FeedbackMessage;
-          void this.handleFeedback(message);
+          const message = JSON.parse(data.toString());
+
+          // Handle registration message
+          if (message.type === 'register') {
+            const regMsg = message as RegisterMessage;
+            currentNodeId = this.registerExecNode(ws, regMsg, clientIp);
+            return;
+          }
+
+          // Handle feedback message
+          const feedbackMsg = message as FeedbackMessage;
+          void this.handleFeedback(feedbackMsg);
         } catch (error) {
-          logger.error({ err: error }, 'Failed to parse feedback');
+          logger.error({ err: error }, 'Failed to parse message');
         }
       });
 
       ws.on('close', () => {
-        logger.info({ clientIp }, 'Execution Node disconnected');
-        if (this.execWs === ws) {
-          this.execWs = undefined;
+        if (currentNodeId) {
+          this.unregisterExecNode(currentNodeId);
         }
-        this.emit('exec:disconnected');
+        this.emit('exec:disconnected', currentNodeId);
       });
 
       ws.on('error', (error) => {
-        logger.error({ err: error }, 'WebSocket error');
+        logger.error({ err: error, nodeId: currentNodeId }, 'WebSocket error');
       });
 
-      this.emit('exec:connected');
+      // Send a prompt to register (backward compatibility for nodes that don't auto-register)
+      // Set a timeout to auto-register if no registration received
+      const registrationTimeout = setTimeout(() => {
+        if (!currentNodeId && ws.readyState === WebSocket.OPEN) {
+          // Auto-register with generated ID for backward compatibility
+          const autoNodeId = `exec-${Date.now()}`;
+          currentNodeId = this.registerExecNode(ws, { type: 'register', nodeId: autoNodeId, name: 'Auto-registered Node' }, clientIp);
+          logger.info({ nodeId: currentNodeId }, 'Auto-registered execution node (backward compatibility)');
+        }
+      }, 1000);
+
+      ws.on('close', () => clearTimeout(registrationTimeout));
     });
 
     // Start server
@@ -311,16 +491,56 @@ export class CommunicationNode extends EventEmitter {
         await this.sendCommand({ type: 'command', command: 'restart', chatId: command.chatId });
         return { success: true, message: '🔄 **正在重启服务...**' };
 
-      case 'status':
+      case 'status': {
         const status = this.running ? 'Running' : 'Stopped';
-        const execConnected = this.execWs?.readyState === WebSocket.OPEN ? 'Connected' : 'Disconnected';
+        const execNodesList = this.getExecNodes();
+        const execStatus = execNodesList.length > 0
+          ? execNodesList.map(n => `${n.name} (${n.status})`).join(', ')
+          : 'None';
         const channelStatus = Array.from(this.channels.entries())
           .map(([_id, ch]) => `${ch.name}: ${ch.status}`)
           .join(', ');
+        const currentNodeId = this.getChatNodeAssignment(command.chatId);
+        const currentNode = execNodesList.find(n => n.nodeId === currentNodeId);
         return {
           success: true,
-          message: `📊 **状态**\n\n状态: ${status}\nExecution Node: ${execConnected}\nChannels: ${channelStatus}`,
+          message: `📊 **状态**\n\n状态: ${status}\n执行节点: ${execStatus}\n当前节点: ${currentNode?.name || '未分配'}\n通道: ${channelStatus}`,
         };
+      }
+
+      case 'list-nodes': {
+        const nodes = this.getExecNodes();
+        if (nodes.length === 0) {
+          return { success: true, message: '📋 **执行节点列表**\n\n暂无连接的执行节点' };
+        }
+        const currentNodeId = this.getChatNodeAssignment(command.chatId);
+        const nodesList = nodes.map(n => {
+          const isCurrent = n.nodeId === currentNodeId ? ' ✓ (当前)' : '';
+          return `- ${n.name} [${n.status}]${isCurrent} (${n.activeChats} 活跃会话)`;
+        }).join('\n');
+        return { success: true, message: `📋 **执行节点列表**\n\n${nodesList}` };
+      }
+
+      case 'switch-node': {
+        const targetNodeId = command.targetNodeId;
+        if (!targetNodeId) {
+          // Show usage hint
+          const nodes = this.getExecNodes();
+          const nodesList = nodes.map(n => `- \`${n.nodeId}\` (${n.name})`).join('\n');
+          return {
+            success: false,
+            error: `请指定目标节点ID。\n\n可用节点:\n${nodesList}`,
+          };
+        }
+
+        const success = this.switchChatNode(command.chatId, targetNodeId);
+        if (success) {
+          const node = this.execNodes.get(targetNodeId);
+          return { success: true, message: `✅ **已切换执行节点**\n\n当前节点: ${node?.name || targetNodeId}` };
+        } else {
+          return { success: false, error: `切换失败，节点 \`${targetNodeId}\` 不可用` };
+        }
+      }
 
       default:
         return { success: false, error: `Unknown command: ${command.type}` };
@@ -331,30 +551,32 @@ export class CommunicationNode extends EventEmitter {
    * Send prompt to Execution Node via WebSocket.
    */
   private async sendPrompt(message: PromptMessage): Promise<void> {
-    logger.debug({ chatId: message.chatId, messageId: message.messageId, wsState: this.execWs?.readyState }, 'sendPrompt called');
+    logger.debug({ chatId: message.chatId, messageId: message.messageId }, 'sendPrompt called');
 
-    if (!this.execWs || this.execWs.readyState !== WebSocket.OPEN) {
-      logger.warn('No Execution Node connected');
+    const execNode = this.getExecNodeForChat(message.chatId);
+    if (!execNode) {
+      logger.warn('No Execution Node available');
       await this.sendMessage(message.chatId, '❌ 没有可用的执行节点');
-      throw new Error('No Execution Node connected');
+      throw new Error('No Execution Node available');
     }
 
-    this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, messageId: message.messageId, threadId: message.threadId }, 'Prompt sent to Execution Node');
+    execNode.ws.send(JSON.stringify(message));
+    logger.info({ chatId: message.chatId, messageId: message.messageId, threadId: message.threadId, nodeId: execNode.nodeId }, 'Prompt sent to Execution Node');
   }
 
   /**
    * Send command to Execution Node via WebSocket.
    */
   private async sendCommand(message: CommandMessage): Promise<void> {
-    if (!this.execWs || this.execWs.readyState !== WebSocket.OPEN) {
-      logger.warn('No Execution Node connected');
+    const execNode = this.getExecNodeForChat(message.chatId);
+    if (!execNode) {
+      logger.warn('No Execution Node available');
       await this.sendMessage(message.chatId, '❌ 没有可用的执行节点');
-      throw new Error('No Execution Node connected');
+      throw new Error('No Execution Node available');
     }
 
-    this.execWs.send(JSON.stringify(message));
-    logger.info({ chatId: message.chatId, command: message.command }, 'Command sent to Execution Node');
+    execNode.ws.send(JSON.stringify(message));
+    logger.info({ chatId: message.chatId, command: message.command, nodeId: execNode.nodeId }, 'Command sent to Execution Node');
   }
 
   /**
@@ -512,7 +734,11 @@ export class CommunicationNode extends EventEmitter {
     for (const [id, channel] of this.channels) {
       console.log(`  - ${channel.name} (${id}): ${channel.status}`);
     }
-    console.log('Waiting for Execution Node to connect...');
+    console.log('Waiting for Execution Nodes to connect...');
+    console.log();
+    console.log('Control commands available:');
+    console.log('  /list-nodes  - List all connected execution nodes');
+    console.log('  /switch-node <nodeId> - Switch to a specific execution node');
   }
 
   /**
@@ -539,11 +765,17 @@ export class CommunicationNode extends EventEmitter {
       }
     }
 
-    // Close WebSocket connection from Execution Node
-    if (this.execWs) {
-      this.execWs.close();
-      this.execWs = undefined;
+    // Close all Execution Node connections
+    for (const [nodeId, node] of this.execNodes) {
+      try {
+        node.ws.close();
+        logger.info({ nodeId }, 'Execution Node connection closed');
+      } catch (error) {
+        logger.error({ err: error, nodeId }, 'Failed to close Execution Node connection');
+      }
     }
+    this.execNodes.clear();
+    this.chatToNode.clear();
 
     // Close WebSocket server
     if (this.wss) {

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -18,7 +18,7 @@ import {
 } from '../schedule/index.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
-import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage } from '../types/websocket-messages.js';
 import { FileClient } from '../transport/file-client.js';
 
 const logger = createLogger('ExecRunner');
@@ -36,17 +36,23 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   const runnerConfig = config || getExecNodeConfig(globalArgs);
 
   // Get comm URL from config
-  const {commUrl} = runnerConfig;
+  const {commUrl, nodeId: configNodeId, nodeName} = runnerConfig;
   const reconnectInterval = 3000;
   let ws: WebSocket | undefined;
   let running = true;
   let reconnectTimer: NodeJS.Timeout | undefined;
 
-  logger.info({ commUrl }, 'Starting Execution Node');
+  // Generate or use configured node ID
+  const nodeId = configNodeId || `exec-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const nodeDisplayName = nodeName || `ExecNode-${nodeId.slice(0, 8)}`;
+
+  logger.info({ commUrl, nodeId, nodeName: nodeDisplayName }, 'Starting Execution Node');
 
   console.log('Initializing Execution Node...');
   console.log('Mode: Execution (Pilot Agent + WebSocket Client)');
   console.log(`Comm URL: ${commUrl}`);
+  console.log(`Node ID: ${nodeId}`);
+  console.log(`Node Name: ${nodeDisplayName}`);
   console.log();
 
   // Create FileClient for file transfer with Communication Node
@@ -309,6 +315,16 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     ws.on('open', () => {
       logger.info('Connected to Communication Node');
       console.log('✓ Connected to Communication Node');
+
+      // Send registration message
+      const registerMsg: RegisterMessage = {
+        type: 'register',
+        nodeId,
+        name: nodeDisplayName,
+      };
+      ws!.send(JSON.stringify(registerMsg));
+      logger.info({ nodeId, name: nodeDisplayName }, 'Sent registration message');
+
       console.log();
     });
 

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -28,8 +28,37 @@ export interface PromptMessage {
  */
 export interface CommandMessage {
   type: 'command';
-  command: 'reset' | 'restart';
+  command: 'reset' | 'restart' | 'list-nodes' | 'switch-node';
   chatId: string;
+  /** Target exec node ID for switch-node command */
+  targetNodeId?: string;
+}
+
+/**
+ * Message sent from Execution Node to Communication Node for registration.
+ */
+export interface RegisterMessage {
+  type: 'register';
+  /** Unique identifier for this exec node */
+  nodeId: string;
+  /** Human-readable name for this exec node */
+  name?: string;
+}
+
+/**
+ * Information about a connected execution node.
+ */
+export interface ExecNodeInfo {
+  /** Unique identifier */
+  nodeId: string;
+  /** Human-readable name */
+  name: string;
+  /** Connection status */
+  status: 'connected' | 'disconnected';
+  /** Number of active chats assigned */
+  activeChats: number;
+  /** Connection time */
+  connectedAt: Date;
 }
 
 /**

--- a/src/utils/cli-args.ts
+++ b/src/utils/cli-args.ts
@@ -53,6 +53,10 @@ export interface ExecNodeConfig {
   commUrl: string;
   /** Authentication token */
   authToken?: string;
+  /** Unique identifier for this execution node (auto-generated if not provided) */
+  nodeId?: string;
+  /** Human-readable name for this execution node */
+  nodeName?: string;
 }
 
 /**
@@ -144,5 +148,7 @@ export function getExecNodeConfig(globalArgs: GlobalArgs): ExecNodeConfig {
   return {
     commUrl: globalArgs.commUrl,
     authToken: globalArgs.authToken,
+    nodeId: process.env.EXEC_NODE_ID,
+    nodeName: process.env.EXEC_NODE_NAME,
   };
 }


### PR DESCRIPTION
## Summary

- Implements Issue #38: 多执行节点支持
- CommunicationNode 现在支持多个 Execution Node 连接
- 添加 chatId → execNodeId 路由，自动分配和手动切换
- 添加控制命令：`/list-nodes`, `/switch-node`
- 节点断开时自动重新分配 chat 到其他可用节点

## Changes

### 核心功能

| 功能 | 描述 |
|------|------|
| 多节点连接 | CommunicationNode 支持同时连接多个 Execution Node |
| 自动路由 | 每个 chat 自动分配到第一个可用节点 |
| 手动切换 | 通过 `/switch-node <nodeId>` 切换到指定节点 |
| 节点列表 | 通过 `/list-nodes` 查看所有连接的执行节点 |
| 故障转移 | 节点断开时自动将 chat 重新分配到其他可用节点 |
| 向后兼容 | 未注册的节点自动分配 ID（兼容旧版本） |

### 新增类型

- `RegisterMessage`: Execution Node 注册消息
- `ExecNodeInfo`: Execution Node 信息结构
- 扩展 `ControlCommandType`: 添加 `list-nodes`, `switch-node`

### 环境变量

- `EXEC_NODE_ID`: 自定义节点标识符
- `EXEC_NODE_NAME`: 人类可读的节点名称

## Usage

### 启动 Execution Node 并指定 ID

```bash
EXEC_NODE_ID=node-1 EXEC_NODE_NAME="Node 1" npm start -- --mode exec
```

### 控制命令

```
/list-nodes              # 列出所有执行节点
/switch-node <nodeId>    # 切换当前会话到指定节点
```

## Test Results

```
 ✓ src/nodes/communication-node.test.ts (16 tests) 4ms

 Test Files  44 passed (44)
      Tests  815 passed (815)
```

## Closes

Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)