### PR TITLE
feat(feishu): add bot-to-bot collaboration support (Issue #91)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -62,6 +62,20 @@ feishu:
     # Default: 60000 (1 minute)
     maxAgeMs: 60000
 
+  # Bot collaboration settings (optional)
+  # Enable multiple bots to work together in the same chat
+  # botCollaboration:
+  #   # Enable bot-to-bot communication
+  #   enabled: true
+  #   # List of allowed bot IDs (open_id format: cli_xxx)
+  #   # Only messages from these bots will be processed
+  #   allowedBotIds:
+  #     - "cli_example_bot_id_1"
+  #     - "cli_example_bot_id_2"
+  #   # Maximum conversation depth to prevent infinite loops
+  #   # Default: 5
+  #   maxDepth: 5
+
 # -----------------------------------------------------------------------------
 # GLM (Zhipu AI) API Configuration
 # -----------------------------------------------------------------------------

--- a/src/channels/feishu-channel.bot-collaboration.test.ts
+++ b/src/channels/feishu-channel.bot-collaboration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for FeishuChannel bot collaboration feature.
+ *
+ * Tests the bot-to-bot collaboration functionality:
+ * - Configuration loading
+ * - Bot message filtering
+ * - Conversation depth tracking
+ * - Loop prevention
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock dependencies before importing FeishuChannel
+vi.mock('../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  })),
+}));
+
+vi.mock('../core/attachment-manager.js', () => ({
+  attachmentManager: {
+    getAttachments: vi.fn(() => []),
+    cleanupOldAttachments: vi.fn(),
+  },
+}));
+
+vi.mock('../feishu/file-downloader.js', () => ({
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('../feishu/message-logger.js', () => ({
+  messageLogger: {
+    init: vi.fn(),
+    isMessageProcessed: vi.fn(() => false),
+    logIncomingMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../feishu/file-handler.js', () => ({
+  FileHandler: vi.fn().mockImplementation(() => ({
+    handleFileMessage: vi.fn(),
+    buildUploadPrompt: vi.fn(),
+  })),
+}));
+
+vi.mock('../feishu/message-sender.js', () => ({
+  MessageSender: vi.fn(),
+}));
+
+vi.mock('../feishu/task-flow-orchestrator.js', () => ({
+  TaskFlowOrchestrator: vi.fn(),
+}));
+
+vi.mock('../utils/task-tracker.js', () => ({
+  TaskTracker: vi.fn(),
+}));
+
+describe('FeishuChannel Bot Collaboration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  describe('Configuration Loading', () => {
+    it('should create channel with default settings when no bot collaboration config', async () => {
+      // Mock config without bot collaboration
+      vi.doMock('../config/index.js', () => ({
+        Config: {
+          FEISHU_APP_ID: 'test_app_id',
+          FEISHU_APP_SECRET: 'test_app_secret',
+          FEISHU_CLI_CHAT_ID: '',
+          getRawConfig: vi.fn(() => ({})),
+        },
+      }));
+
+      const { FeishuChannel } = await import('./feishu-channel.js');
+      const channel = new FeishuChannel();
+
+      // The channel should be created successfully
+      expect(channel).toBeDefined();
+      expect(channel.id).toBe('feishu');
+    });
+
+    it('should create channel with bot collaboration disabled by default', async () => {
+      // Mock config with empty feishu config
+      vi.doMock('../config/index.js', () => ({
+        Config: {
+          FEISHU_APP_ID: 'test_app_id',
+          FEISHU_APP_SECRET: 'test_app_secret',
+          FEISHU_CLI_CHAT_ID: '',
+          getRawConfig: vi.fn(() => ({
+            feishu: {},
+          })),
+        },
+      }));
+
+      const { FeishuChannel } = await import('./feishu-channel.js');
+      const channel = new FeishuChannel();
+
+      expect(channel).toBeDefined();
+    });
+  });
+
+  describe('Bot Message Handling Logic', () => {
+    it('should load allowed bot IDs when configured', async () => {
+      // Mock config with bot collaboration
+      vi.doMock('../config/index.js', () => ({
+        Config: {
+          FEISHU_APP_ID: 'test_app_id',
+          FEISHU_APP_SECRET: 'test_app_secret',
+          FEISHU_CLI_CHAT_ID: '',
+          getRawConfig: vi.fn(() => ({
+            feishu: {
+              botCollaboration: {
+                enabled: true,
+                allowedBotIds: ['cli_allowed_bot_1', 'cli_allowed_bot_2'],
+                maxDepth: 3,
+              },
+            },
+          })),
+        },
+      }));
+
+      const { FeishuChannel } = await import('./feishu-channel.js');
+      const channel = new FeishuChannel();
+
+      // Access internal state through reflection for testing
+      const channelAny = channel as unknown as {
+        allowedBotIds: Set<string>;
+        botCollaborationEnabled: boolean;
+        maxConversationDepth: number;
+      };
+
+      expect(channelAny.botCollaborationEnabled).toBe(true);
+      expect(channelAny.allowedBotIds.has('cli_allowed_bot_1')).toBe(true);
+      expect(channelAny.allowedBotIds.has('cli_allowed_bot_2')).toBe(true);
+      expect(channelAny.allowedBotIds.has('cli_unknown_bot')).toBe(false);
+      expect(channelAny.maxConversationDepth).toBe(3);
+    });
+  });
+
+  describe('Conversation Depth Tracking', () => {
+    it('should initialize conversation depth map', async () => {
+      vi.doMock('../config/index.js', () => ({
+        Config: {
+          FEISHU_APP_ID: 'test_app_id',
+          FEISHU_APP_SECRET: 'test_app_secret',
+          FEISHU_CLI_CHAT_ID: '',
+          getRawConfig: vi.fn(() => ({})),
+        },
+      }));
+
+      const { FeishuChannel } = await import('./feishu-channel.js');
+      const channel = new FeishuChannel();
+
+      const channelAny = channel as unknown as {
+        conversationDepth: Map<string, number>;
+      };
+
+      expect(channelAny.conversationDepth).toBeInstanceOf(Map);
+      expect(channelAny.conversationDepth.size).toBe(0);
+    });
+  });
+});
+
+describe('Bot Collaboration Utilities', () => {
+  describe('Bot ID Extraction', () => {
+    it('should extract open_id from sender object', () => {
+      // Test the extraction logic pattern
+      const extractOpenId = (sender?: { sender_type?: string; sender_id?: unknown }): string | undefined => {
+        if (!sender?.sender_id) {
+          return undefined;
+        }
+        if (typeof sender.sender_id === 'object' && sender.sender_id !== null) {
+          const senderId = sender.sender_id as { open_id?: string };
+          return senderId.open_id;
+        }
+        if (typeof sender.sender_id === 'string') {
+          return sender.sender_id;
+        }
+        return undefined;
+      };
+
+      expect(extractOpenId()).toBeUndefined();
+      expect(extractOpenId({})).toBeUndefined();
+      expect(extractOpenId({ sender_type: 'app' })).toBeUndefined();
+      expect(extractOpenId({ sender_type: 'app', sender_id: { open_id: 'cli_test' } })).toBe('cli_test');
+      expect(extractOpenId({ sender_type: 'app', sender_id: 'cli_string' })).toBe('cli_string');
+    });
+  });
+
+  describe('Loop Prevention Logic', () => {
+    it('should track and limit conversation depth', () => {
+      const conversationDepth = new Map<string, number>();
+      const maxDepth = 3;
+      const chatId = 'test_chat';
+
+      // Simulate bot messages increasing depth
+      const checkAndIncrementDepth = (chatId: string): boolean => {
+        const currentDepth = conversationDepth.get(chatId) ?? 0;
+        if (currentDepth >= maxDepth) {
+          return false; // Max depth reached, should skip
+        }
+        conversationDepth.set(chatId, currentDepth + 1);
+        return true; // OK to process
+      };
+
+      // First message should pass
+      expect(checkAndIncrementDepth(chatId)).toBe(true);
+      expect(conversationDepth.get(chatId)).toBe(1);
+
+      // Second message should pass
+      expect(checkAndIncrementDepth(chatId)).toBe(true);
+      expect(conversationDepth.get(chatId)).toBe(2);
+
+      // Third message should pass
+      expect(checkAndIncrementDepth(chatId)).toBe(true);
+      expect(conversationDepth.get(chatId)).toBe(3);
+
+      // Fourth message should be blocked
+      expect(checkAndIncrementDepth(chatId)).toBe(false);
+      expect(conversationDepth.get(chatId)).toBe(3);
+    });
+
+    it('should reset depth when human user sends message', () => {
+      const conversationDepth = new Map<string, number>();
+      const chatId = 'test_chat';
+
+      // Set some depth
+      conversationDepth.set(chatId, 3);
+
+      // Human user message should reset depth
+      const handleHumanMessage = (chatId: string) => {
+        conversationDepth.delete(chatId);
+      };
+
+      handleHumanMessage(chatId);
+      expect(conversationDepth.has(chatId)).toBe(false);
+    });
+  });
+});

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -44,6 +44,7 @@ export interface FeishuChannelConfig extends ChannelConfig {
  * - File/image handling
  * - Interactive card support
  * - Typing reactions
+ * - Bot-to-bot collaboration (optional)
  */
 export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   private appId: string;
@@ -58,11 +59,27 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
   private readonly MAX_MESSAGE_AGE = DEDUPLICATION.MAX_MESSAGE_AGE;
 
+  // Bot collaboration settings
+  private readonly botCollaborationEnabled: boolean;
+  private readonly allowedBotIds: Set<string>;
+  private readonly maxConversationDepth: number;
+
+  // Track conversation depth per chat to prevent infinite loops
+  // Key: chatId, Value: current depth
+  private conversationDepth: Map<string, number> = new Map();
+
   constructor(config: FeishuChannelConfig = {}) {
     super(config, 'feishu', 'Feishu');
     this.appId = config.appId || Config.FEISHU_APP_ID;
     this.appSecret = config.appSecret || Config.FEISHU_APP_SECRET;
     this.taskTracker = new TaskTracker();
+
+    // Initialize bot collaboration settings from config
+    const rawConfig = Config.getRawConfig();
+    const botCollab = rawConfig.feishu?.botCollaboration;
+    this.botCollaborationEnabled = botCollab?.enabled ?? false;
+    this.allowedBotIds = new Set(botCollab?.allowedBotIds ?? []);
+    this.maxConversationDepth = botCollab?.maxDepth ?? 5;
 
     // Initialize FileHandler
     this.fileHandler = new FileHandler(
@@ -82,7 +99,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       }
     );
 
-    logger.info({ id: this.id }, 'FeishuChannel created');
+    logger.info(
+      {
+        id: this.id,
+        botCollaboration: this.botCollaborationEnabled,
+        allowedBots: this.allowedBotIds.size,
+      },
+      'FeishuChannel created'
+    );
   }
 
   protected async doStart(): Promise<void> {
@@ -273,10 +297,40 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    // Ignore bot messages
+    // Handle bot messages - support bot-to-bot collaboration
     if (sender?.sender_type === 'app') {
-      logger.debug('Skipped bot message');
-      return;
+      const botId = this.extractOpenId(sender);
+
+      // Check if bot collaboration is enabled and this bot is allowed
+      if (!this.botCollaborationEnabled) {
+        logger.debug('Skipped bot message (collaboration disabled)');
+        return;
+      }
+
+      if (!botId || !this.allowedBotIds.has(botId)) {
+        logger.debug({ botId }, 'Skipped bot message (bot not in allowed list)');
+        return;
+      }
+
+      // Check conversation depth to prevent infinite loops
+      const currentDepth = this.conversationDepth.get(chat_id) ?? 0;
+      if (currentDepth >= this.maxConversationDepth) {
+        logger.warn(
+          { chatId: chat_id, depth: currentDepth },
+          'Max conversation depth reached, skipping bot message'
+        );
+        return;
+      }
+
+      // Increment conversation depth
+      this.conversationDepth.set(chat_id, currentDepth + 1);
+      logger.info(
+        { botId, chatId: chat_id, depth: currentDepth + 1 },
+        'Processing message from allowed bot'
+      );
+    } else {
+      // Reset conversation depth when human user sends a message
+      this.conversationDepth.delete(chat_id);
     }
 
     // Check message age

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -63,6 +63,15 @@ export interface FeishuConfig {
     /** Maximum message age in milliseconds */
     maxAgeMs?: number;
   };
+  /** Bot collaboration settings */
+  botCollaboration?: {
+    /** Enable bot-to-bot communication */
+    enabled?: boolean;
+    /** List of allowed bot IDs (open_id format: cli_xxx) */
+    allowedBotIds?: string[];
+    /** Maximum conversation depth to prevent infinite loops */
+    maxDepth?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Issue #91: 支持多机器人群聊协作

This PR adds support for multiple Feishu bots to collaborate in the same group chat, enabling bot-to-bot message passing and interaction.

## Features

| Feature | Description |
|---------|-------------|
| Bot Collaboration | Enable multiple bots to work together in group chats |
| Bot Whitelist | Configure allowed bot IDs (cli_xxx format) |
| Loop Prevention | Track conversation depth to prevent infinite loops |
| Auto Reset | Reset depth when human user sends a message |

## Configuration

Add to `disclaude.config.yaml`:

```yaml
feishu:
  botCollaboration:
    # Enable bot-to-bot communication
    enabled: true
    # List of allowed bot IDs (open_id format: cli_xxx)
    allowedBotIds:
      - "cli_bot_1"
      - "cli_bot_2"
    # Maximum conversation depth to prevent infinite loops
    maxDepth: 5  # default: 5
```

## Changes

### New Files
- `src/channels/feishu-channel.bot-collaboration.test.ts` - Test suite for bot collaboration

### Modified Files
- `src/config/types.ts` - Add `BotCollaborationConfig` interface
- `src/channels/feishu-channel.ts` - Implement bot message handling with depth tracking
- `disclaude.config.example.yaml` - Add configuration example

## How It Works

1. When a bot message is received, check if `botCollaboration.enabled` is true
2. Verify the sender bot ID is in `allowedBotIds` whitelist
3. Track conversation depth per chat to prevent infinite loops
4. When a human user sends a message, reset the conversation depth

## Test Results

```
 ✓ src/channels/feishu-channel.bot-collaboration.test.ts (7 tests)

 Test Files  44 passed (44)
      Tests  806 passed (806)
```

## Closes

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)