### PR TITLE
feat(agents): add SiteMiner Subagent for Playwright-based site information mining

### DIFF
--- a/skills/site-miner/SKILL.md
+++ b/skills/site-miner/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: site-miner
+description: Site information mining specialist - extracts specific information from a given website using browser automation. Use when user wants to mine/scrape/extract data from a specific website, monitor page content, or verify website functionality.
+allowed-tools: Read, Write, mcp__playwright__*
+---
+
+# Site Miner Agent
+
+You are a professional site information mining Subagent. Your task is to use Playwright browser automation to extract specific information from a given website.
+
+> **Important Distinction**: This is NOT web search (searching across multiple sites). This is site-specific information mining - extracting data from a single specified website.
+
+## Technical Rationale
+
+This Subagent exists to:
+1. **Reduce context noise** - Playwright MCP generates large amounts of context, which can overwhelm the main conversation
+2. **Improve success rate** - Isolated environment allows focused browser automation
+3. **Keep main context clean** - Browser interactions don't pollute Pilot's context
+
+## Use Cases
+
+- Extract specific information from a website (prices, contact info, product details)
+- Monitor website page content changes
+- Collect structured data from web pages
+- Verify website functionality
+
+## Workflow
+
+1. **Navigate**: Use `browser_navigate` to go to the target URL
+2. **Snapshot**: Use `browser_snapshot` to get page structure (recommended over screenshot for efficiency)
+3. **Interact**: Use `browser_click`/`browser_type` if needed (forms, navigation)
+4. **Wait**: Use `browser_wait_for` for dynamic content
+5. **Extract**: Identify and extract target information from snapshot
+6. **Evidence**: Optionally use `browser_take_screenshot` to save proof
+
+## Best Practices
+
+### Page Analysis
+- Prefer `browser_snapshot` over `browser_take_screenshot` - it returns structured accessibility tree
+- Wait for page load complete before extracting
+- Handle dynamic content with appropriate waits
+
+### Data Extraction
+- Return structured JSON when possible
+- Include confidence score for extracted data
+- Note any missing or uncertain information
+
+### Error Handling
+- If page fails to load, retry up to 3 times
+- If element not found, return partial results with confidence score
+- If blocked by anti-bot, report the issue
+
+## Output Format
+
+Return results in this structure:
+
+```json
+{
+  "success": true,
+  "target_url": "https://...",
+  "information_found": {
+    "field1": "value1",
+    "field2": "value2"
+  },
+  "summary": "Brief summary of findings",
+  "evidence_path": "screenshot.png (optional)",
+  "confidence": 0.95,
+  "notes": "Any issues or caveats"
+}
+```
+
+## Edge Cases
+
+### Login Required
+- Report that login is needed
+- Suggest user to manually login then use CDP connection
+
+### Dynamic/SPA Content
+- Use `browser_wait_for` with appropriate selectors
+- May need multiple snapshots to capture all content
+
+### Anti-Bot Detection
+- If detected, report and suggest alternative approach
+- Consider using human-like delays between actions
+
+### Large Pages
+- Focus on specific sections
+- Don't try to extract everything at once
+
+## Examples
+
+### Example 1: Extract Product Price
+
+Input: "Extract iPhone 15 price from amazon.com"
+
+Steps:
+1. Navigate to amazon.com
+2. Search for "iPhone 15"
+3. Snapshot the product listing
+4. Extract price information
+5. Return structured result
+
+### Example 2: Extract GitHub Trending
+
+Input: "Get today's trending repositories from github.com/trending"
+
+Steps:
+1. Navigate to github.com/trending
+2. Snapshot the trending list
+3. Extract repository names, stars, descriptions
+4. Return structured list
+
+## DO NOT
+
+- Do NOT perform web searches across multiple sites
+- Do NOT extract copyrighted content in bulk
+- Do NOT attempt to bypass authentication
+- Do NOT flood requests - use reasonable delays

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -32,5 +32,14 @@ export { Pilot, type PilotCallbacks, type PilotConfig } from './pilot.js';
 export { SessionManager, type PilotSession, type SessionManagerConfig } from './session-manager.js';
 export { ConversationContext, type ConversationContextConfig } from './conversation-context.js';
 
+// Site mining subagent
+export {
+  runSiteMiner,
+  createSiteMiner,
+  isPlaywrightAvailable,
+  type SiteMinerResult,
+  type SiteMinerOptions,
+} from './site-miner.js';
+
 // Factory
 export { AgentFactory, type AgentCreateOptions } from './factory.js';

--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for SiteMiner Subagent.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  runSiteMiner,
+  createSiteMiner,
+  isPlaywrightAvailable,
+  type SiteMinerOptions,
+  type SiteMinerResult,
+} from './site-miner.js';
+import { Config } from '../config/index.js';
+
+// Mock the Config module
+vi.mock('../config/index.js', () => ({
+  Config: {
+    getAgentConfig: vi.fn(() => ({
+      apiKey: 'test-api-key',
+      model: 'test-model',
+      apiBaseUrl: 'https://test.api',
+      provider: 'glm',
+    })),
+    getMcpServersConfig: vi.fn(() => ({
+      playwright: {
+        command: 'npx',
+        args: ['@playwright/mcp@latest'],
+      },
+    })),
+    getWorkspaceDir: vi.fn(() => '/workspace'),
+    getGlobalEnv: vi.fn(() => ({})),
+    getLoggingConfig: vi.fn(() => ({
+      level: 'debug',
+      pretty: false,
+      rotate: false,
+      sdkDebug: false,
+    })),
+  },
+}));
+
+// Mock the SDK query function
+vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: vi.fn(),
+}));
+
+describe('SiteMiner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isPlaywrightAvailable', () => {
+    it('should return true when Playwright MCP is configured', () => {
+      expect(isPlaywrightAvailable()).toBe(true);
+    });
+
+    it('should return false when Playwright MCP is not configured', () => {
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined);
+      expect(isPlaywrightAvailable()).toBe(false);
+    });
+  });
+
+  describe('runSiteMiner', () => {
+    it('should return failure when Playwright is not available', async () => {
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined);
+
+      const result = await runSiteMiner({
+        url: 'https://example.com',
+        task: 'Extract title',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toContain('Playwright MCP not configured');
+      expect(result.confidence).toBe(0);
+    });
+
+    it('should handle successful mining operation', async () => {
+      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          content: JSON.stringify({
+            success: true,
+            target_url: 'https://example.com',
+            information_found: { title: 'Example Domain' },
+            summary: 'Found the title',
+            confidence: 0.95,
+          }),
+        };
+      });
+
+      const result = await runSiteMiner({
+        url: 'https://example.com',
+        task: 'Extract the page title',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.information_found).toEqual({ title: 'Example Domain' });
+      expect(result.confidence).toBe(0.95);
+    });
+
+    it('should handle query error', async () => {
+      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
+      mockQuery.mockImplementation(async function* () {
+        throw new Error('Query failed');
+      });
+
+      const result = await runSiteMiner({
+        url: 'https://example.com',
+        task: 'Extract title',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.summary).toContain('Error');
+    });
+
+    it('should handle malformed JSON response', async () => {
+      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          content: 'This is not valid JSON',
+        };
+      });
+
+      const result = await runSiteMiner({
+        url: 'https://example.com',
+        task: 'Extract title',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.notes).toContain('Could not parse JSON');
+    });
+
+    it('should handle partial JSON response', async () => {
+      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
+      mockQuery.mockImplementation(async function* () {
+        yield {
+          type: 'result',
+          content: 'Here is the result: {"success": true, "information_found": {"title": "Test"}, "confidence": 0.8} and some extra text',
+        };
+      });
+
+      const result = await runSiteMiner({
+        url: 'https://example.com',
+        task: 'Extract title',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.information_found).toEqual({ title: 'Test' });
+    });
+  });
+
+  describe('createSiteMiner', () => {
+    it('should return the runSiteMiner function', () => {
+      const miner = createSiteMiner();
+      expect(miner).toBe(runSiteMiner);
+    });
+  });
+});
+
+describe('SiteMinerResult', () => {
+  it('should have correct structure', () => {
+    const result: SiteMinerResult = {
+      success: true,
+      target_url: 'https://example.com',
+      information_found: { key: 'value' },
+      summary: 'Test summary',
+      confidence: 0.9,
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.target_url).toBe('https://example.com');
+    expect(result.information_found).toEqual({ key: 'value' });
+    expect(result.summary).toBe('Test summary');
+    expect(result.confidence).toBe(0.9);
+  });
+});
+
+describe('SiteMinerOptions', () => {
+  it('should have correct structure', () => {
+    const options: SiteMinerOptions = {
+      url: 'https://example.com',
+      task: 'Extract data',
+      timeout: 30000,
+      takeScreenshot: true,
+    };
+
+    expect(options.url).toBe('https://example.com');
+    expect(options.task).toBe('Extract data');
+    expect(options.timeout).toBe(30000);
+    expect(options.takeScreenshot).toBe(true);
+  });
+});

--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -1,0 +1,346 @@
+/**
+ * SiteMiner - Site information mining Subagent using Playwright browser automation.
+ *
+ * This Subagent isolates Playwright MCP interactions to:
+ * 1. Reduce context noise - Playwright generates large context
+ * 2. Improve success rate - Focused environment for browser automation
+ * 3. Keep main context clean - Browser interactions don't pollute Pilot's context
+ *
+ * Technical Note: Playwright MCP uses stdio communication. To avoid conflicts with
+ * the main agent's stdio, this Subagent runs in a forked context using the SDK's
+ * built-in context isolation mechanism.
+ *
+ * @module agents/site-miner
+ */
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { Config } from '../config/index.js';
+import { createLogger } from '../utils/logger.js';
+import { buildSdkEnv } from '../utils/sdk.js';
+import type { BaseAgentConfig } from './base-agent.js';
+
+const logger = createLogger('SiteMiner');
+
+/**
+ * Result from site mining operation.
+ */
+export interface SiteMinerResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Target URL that was mined */
+  target_url: string;
+  /** Information extracted from the site */
+  information_found: Record<string, unknown>;
+  /** Brief summary of findings */
+  summary: string;
+  /** Path to screenshot evidence (optional) */
+  evidence_path?: string;
+  /** Confidence score (0-1) */
+  confidence: number;
+  /** Any notes or caveats */
+  notes?: string;
+}
+
+/**
+ * Options for site mining operation.
+ */
+export interface SiteMinerOptions {
+  /** Target URL to mine */
+  url: string;
+  /** Task description - what information to extract */
+  task: string;
+  /** Timeout in milliseconds (default: 60000) */
+  timeout?: number;
+  /** Whether to take a screenshot for evidence */
+  takeScreenshot?: boolean;
+}
+
+/**
+ * Check if Playwright MCP is configured.
+ *
+ * @returns true if Playwright MCP server is available
+ */
+export function isPlaywrightAvailable(): boolean {
+  const mcpServers = Config.getMcpServersConfig();
+  return !!(mcpServers?.playwright);
+}
+
+/**
+ * Run the SiteMiner Subagent to extract information from a website.
+ *
+ * This function creates an isolated agent context with Playwright MCP tools
+ * to mine information from the specified website.
+ *
+ * @param options - Mining options including URL and task description
+ * @returns Structured result with extracted information
+ *
+ * @example
+ * ```typescript
+ * const result = await runSiteMiner({
+ *   url: 'https://github.com/trending',
+ *   task: 'Extract the top 5 trending repositories with their names, stars, and descriptions',
+ * });
+ *
+ * console.log(result.information_found);
+ * // [{ name: 'repo/name', stars: '1234', description: '...' }, ...]
+ * ```
+ */
+export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMinerResult> {
+  const { url, task, timeout = 60000, takeScreenshot = false } = options;
+
+  logger.info({ url, task, timeout }, 'Starting site mining operation');
+
+  // Check if Playwright is available
+  if (!isPlaywrightAvailable()) {
+    logger.warn('Playwright MCP not configured');
+    return {
+      success: false,
+      target_url: url,
+      information_found: {},
+      summary: 'Playwright MCP not configured',
+      confidence: 0,
+      notes: 'Add playwright MCP server to disclaude.config.yaml under tools.mcpServers',
+    };
+  }
+
+  // Get agent configuration
+  const agentConfig = Config.getAgentConfig();
+  const loggingConfig = Config.getLoggingConfig();
+
+  // Build MCP servers - only Playwright for this Subagent
+  const mcpServers: Record<string, unknown> = {};
+
+  // Get Playwright MCP config from user's config file
+  const configuredMcpServers = Config.getMcpServersConfig();
+  if (configuredMcpServers?.playwright) {
+    mcpServers.playwright = {
+      type: 'stdio',
+      command: configuredMcpServers.playwright.command,
+      args: configuredMcpServers.playwright.args || [],
+      ...(configuredMcpServers.playwright.env && { env: configuredMcpServers.playwright.env }),
+    };
+  }
+
+  // Build SDK options with forked context for isolation
+  const sdkOptions: Record<string, unknown> = {
+    cwd: Config.getWorkspaceDir(),
+    permissionMode: 'bypassPermissions',
+    settingSources: ['project'],
+    // Only allow Playwright MCP tools + basic file operations for saving evidence
+    allowedTools: [
+      'Read',
+      'Write',
+      'mcp__playwright__browser_navigate',
+      'mcp__playwright__browser_snapshot',
+      'mcp__playwright__browser_click',
+      'mcp__playwright__browser_type',
+      'mcp__playwright__browser_wait_for',
+      'mcp__playwright__browser_take_screenshot',
+      'mcp__playwright__browser_scroll',
+      'mcp__playwright__browser_hover',
+      'mcp__playwright__browser_drag',
+      'mcp__playwright__browser_select',
+      'mcp__playwright__browser_press',
+      'mcp__playwright__browser_file_upload',
+    ],
+    mcpServers,
+    env: buildSdkEnv(
+      agentConfig.apiKey,
+      agentConfig.apiBaseUrl,
+      Config.getGlobalEnv(),
+      loggingConfig.sdkDebug
+    ),
+    model: agentConfig.model,
+    // Fork context to run in isolation - prevents stdio conflicts
+    context: 'fork',
+  };
+
+  // Build the prompt
+  const prompt = buildSiteMinerPrompt(url, task, takeScreenshot);
+
+  logger.debug({ prompt, mcpServers: Object.keys(mcpServers) }, 'Starting isolated query');
+
+  try {
+    // Create abort controller for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+      logger.warn({ url, timeout }, 'Site mining timed out');
+    }, timeout);
+
+    // Run the query in isolated context
+    const queryResult = query({
+      prompt,
+      options: sdkOptions as Parameters<typeof query>[0]['options'],
+      signal: controller.signal,
+    });
+
+    // Collect results
+    let finalContent = '';
+    let resultReceived = false;
+
+    for await (const message of queryResult) {
+      // Parse message type
+      if (message.type === 'result') {
+        resultReceived = true;
+        finalContent = typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content);
+        logger.debug({ contentLength: finalContent.length }, 'Result received');
+      } else if (message.type === 'assistant') {
+        // Intermediate output
+        const content = typeof message.content === 'string'
+          ? message.content
+          : '';
+        if (content) {
+          logger.debug({ contentLength: content.length }, 'Intermediate output');
+        }
+      }
+    }
+
+    clearTimeout(timeoutId);
+
+    if (!resultReceived) {
+      logger.warn('No result received from SiteMiner');
+      return {
+        success: false,
+        target_url: url,
+        information_found: {},
+        summary: 'No result received from mining operation',
+        confidence: 0,
+      };
+    }
+
+    // Parse the result
+    const result = parseSiteMinerResult(finalContent, url);
+    logger.info({ success: result.success, confidence: result.confidence }, 'Site mining completed');
+
+    return result;
+
+  } catch (error) {
+    const err = error as Error;
+    logger.error({ err, url }, 'Site mining failed');
+
+    // Handle timeout
+    if (err.name === 'AbortError') {
+      return {
+        success: false,
+        target_url: url,
+        information_found: {},
+        summary: 'Operation timed out',
+        confidence: 0,
+        notes: `Timeout after ${timeout}ms`,
+      };
+    }
+
+    return {
+      success: false,
+      target_url: url,
+      information_found: {},
+      summary: `Error: ${err.message}`,
+      confidence: 0,
+      notes: err.stack,
+    };
+  }
+}
+
+/**
+ * Build the prompt for the SiteMiner Subagent.
+ */
+function buildSiteMinerPrompt(url: string, task: string, takeScreenshot: boolean): string {
+  return `You are the Site Miner Agent. Your task is to extract information from a specific website.
+
+## Target
+- **URL**: ${url}
+- **Task**: ${task}
+
+## Instructions
+
+1. **Navigate** to the URL using \`browser_navigate\`
+2. **Wait** for the page to load completely
+3. **Snapshot** the page using \`browser_snapshot\` (preferred over screenshot)
+4. **Extract** the requested information
+5. **Return** results in JSON format${takeScreenshot ? '\n6. **Evidence**: Take a screenshot using `browser_take_screenshot` and save it' : ''}
+
+## Output Format
+
+Return ONLY a JSON object in this exact format:
+
+\`\`\`json
+{
+  "success": true,
+  "target_url": "${url}",
+  "information_found": {
+    // Your extracted data here
+  },
+  "summary": "Brief summary of what you found",
+  "confidence": 0.95,
+  "notes": "Any issues or caveats (optional)"
+}
+\`\`\`
+
+## Important Rules
+
+- If the page fails to load, set \`success: false\` and explain in \`notes\`
+- If you can't find all information, extract what you can and lower \`confidence\`
+- Do NOT include any text outside the JSON object
+- Focus on accuracy over completeness
+
+Begin mining now.`;
+}
+
+/**
+ * Parse the SiteMiner result from the agent output.
+ */
+function parseSiteMinerResult(content: string, url: string): SiteMinerResult {
+  // Default result
+  const defaultResult: SiteMinerResult = {
+    success: false,
+    target_url: url,
+    information_found: {},
+    summary: 'Failed to parse result',
+    confidence: 0,
+  };
+
+  try {
+    // Try to extract JSON from the content
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      logger.warn('No JSON found in result');
+      return {
+        ...defaultResult,
+        summary: content.slice(0, 500), // Return first 500 chars as summary
+        notes: 'Could not parse JSON from response',
+      };
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]);
+
+    // Validate required fields
+    return {
+      success: typeof parsed.success === 'boolean' ? parsed.success : false,
+      target_url: parsed.target_url || url,
+      information_found: parsed.information_found || {},
+      summary: parsed.summary || 'No summary provided',
+      evidence_path: parsed.evidence_path,
+      confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0.5,
+      notes: parsed.notes,
+    };
+
+  } catch (error) {
+    logger.error({ error, content: content.slice(0, 200) }, 'Failed to parse SiteMiner result');
+    return {
+      ...defaultResult,
+      summary: content.slice(0, 500),
+      notes: `Parse error: ${(error as Error).message}`,
+    };
+  }
+}
+
+/**
+ * Export a factory function for convenience.
+ */
+export function createSiteMiner(config?: Partial<BaseAgentConfig>): typeof runSiteMiner {
+  // SiteMiner uses global config, but this allows for future customization
+  return runSiteMiner;
+}


### PR DESCRIPTION
## Summary

Implements Issue #4 - 封装 Playwright 网站信息挖掘 Subagent 到 Pilot

This PR adds a dedicated Subagent for extracting information from specific websites using Playwright browser automation.

## Technical Rationale

Playwright MCP generates large context that can overwhelm the main conversation. This Subagent isolates browser automation to:
1. **Reduce context noise** - Browser interactions don't pollute Pilot's context
2. **Improve success rate** - Focused environment for browser automation
3. **Keep main context clean** - Isolated from browser interaction details

## Changes

### New Files
| File | Description |
|------|-------------|
| `skills/site-miner/SKILL.md` | Skill definition with workflow and output format |
| `src/agents/site-miner.ts` | Subagent implementation with isolated context |
| `src/agents/site-miner.test.ts` | Unit tests (10 tests) |

### Modified Files
| File | Changes |
|------|---------|
| `src/agents/index.ts` | Export SiteMiner module |

## Features

| Feature | Description |
|---------|-------------|
| Site Mining | Extract specific information from a given website |
| Playwright Integration | Uses browser automation for dynamic content |
| Context Isolation | Runs in forked context to prevent stdio conflicts |
| Structured Output | Returns JSON with confidence scores |
| Timeout Support | Configurable timeout with abort handling |

## Usage

```typescript
import { runSiteMiner } from './agents/site-miner.js';

const result = await runSiteMiner({
  url: 'https://github.com/trending',
  task: 'Extract the top 5 trending repositories with their names, stars, and descriptions',
});

console.log(result.information_found);
// [{ name: 'repo/name', stars: '1234', description: '...' }, ...]
```

## Test Results

```
 ✓ src/agents/site-miner.test.ts (10 tests) 10ms

 Test Files  46 passed (46)
      Tests  846 passed (846)
   Duration  6.99s
```

## Implementation Notes

- The Subagent uses `context: 'fork'` for isolation to prevent stdio conflicts with Playwright MCP
- Returns structured JSON with `success`, `information_found`, `summary`, and `confidence` fields
- Handles missing Playwright configuration gracefully with helpful error message

## Related

- Addresses #4 (P0-P1: Skill 文件创建 + Subagent 实现)

🤖 Generated with [Claude Code](https://claude.com/claude-code)