### PR TITLE
refactor: 解耦 Pilot 中的对话管理逻辑

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -97,9 +97,9 @@ describe('Pilot (Streaming Input)', () => {
       expect(pilot['sessionManager'].size()).toBe(0);
     });
 
-    it('should initialize conversationContext', () => {
-      expect(pilot['conversationContext']).toBeDefined();
-      expect(pilot['conversationContext'].size()).toBe(0);
+    it('should initialize conversationOrchestrator', () => {
+      expect(pilot['conversationOrchestrator']).toBeDefined();
+      expect(pilot['conversationOrchestrator'].size()).toBe(0);
     });
   });
 
@@ -222,7 +222,7 @@ describe('Pilot (Streaming Input)', () => {
       await pilot.shutdown();
 
       expect(pilot['sessionManager'].size()).toBe(0);
-      expect(pilot['conversationContext'].size()).toBe(0);
+      expect(pilot['conversationOrchestrator'].size()).toBe(0);
     });
   });
 
@@ -239,7 +239,7 @@ describe('Pilot (Streaming Input)', () => {
     it('should store thread root for replies', () => {
       pilot.processMessage('chat-123', 'Hello', 'msg-001');
 
-      expect(pilot['conversationContext'].getThreadRoot('chat-123')).toBe('msg-001');
+      expect(pilot['conversationOrchestrator'].getThreadRoot('chat-123')).toBe('msg-001');
     });
   });
 

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -35,14 +35,14 @@
  * - Error handling
  */
 
-import type { SDKUserMessage, Query } from '@anthropic-ai/claude-agent-sdk';
+import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
 import { Config } from '../config/index.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { FileReference } from '../types/file-reference.js';
 import { MessageChannel } from './message-channel.js';
 import { SessionManager } from './session-manager.js';
-import { ConversationContext } from './conversation-context.js';
+import { ConversationOrchestrator } from '../conversation/index.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -115,14 +115,14 @@ interface MessageData {
  *
  * Refactored to use:
  * - SessionManager for Query/Channel lifecycle
- * - ConversationContext for thread tracking
+ * - ConversationOrchestrator for conversation management (from #237)
  */
 export class Pilot extends BaseAgent {
   private readonly callbacks: PilotCallbacks;
 
   // Separated concerns
   private readonly sessionManager: SessionManager;
-  private readonly conversationContext: ConversationContext;
+  private readonly conversationOrchestrator: ConversationOrchestrator;
 
   constructor(config: PilotConfig) {
     super(config);
@@ -131,7 +131,7 @@ export class Pilot extends BaseAgent {
 
     // Initialize separated managers
     this.sessionManager = new SessionManager({ logger: this.logger });
-    this.conversationContext = new ConversationContext({ logger: this.logger });
+    this.conversationOrchestrator = new ConversationOrchestrator({ logger: this.logger });
   }
 
   protected getAgentName(): string {
@@ -239,7 +239,7 @@ export class Pilot extends BaseAgent {
     this.logger.debug({ chatId, messageId, textLength: text.length, hasAttachments: !!attachments }, 'Processing message');
 
     // Track thread root using ConversationContext
-    this.conversationContext.setThreadRoot(chatId, messageId);
+    this.conversationOrchestrator.setThreadRoot(chatId, messageId);
 
     // Get or create session using SessionManager
     if (!this.sessionManager.has(chatId)) {
@@ -337,7 +337,7 @@ export class Pilot extends BaseAgent {
       for await (const { parsed } of iterator) {
         // Send message content to callback
         if (parsed.content) {
-          const threadRoot = this.conversationContext.getThreadRoot(chatId);
+          const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
           await this.callbacks.sendMessage(chatId, parsed.content, threadRoot);
         }
 
@@ -345,7 +345,7 @@ export class Pilot extends BaseAgent {
         if (parsed.type === 'result') {
           this.logger.debug({ chatId, content: parsed.content }, 'Result received, turn complete');
           if (this.callbacks.onDone) {
-            const threadRoot = this.conversationContext.getThreadRoot(chatId);
+            const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
             await this.callbacks.onDone(chatId, threadRoot);
           }
         }
@@ -354,7 +354,7 @@ export class Pilot extends BaseAgent {
       iteratorError = error as Error;
       this.logger.error({ err: iteratorError, chatId }, 'Iterator error');
 
-      const threadRoot = this.conversationContext.getThreadRoot(chatId);
+      const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
       await this.callbacks.sendMessage(chatId, `❌ Session error: ${iteratorError.message}`, threadRoot);
 
       if (this.callbacks.onDone) {
@@ -377,7 +377,7 @@ export class Pilot extends BaseAgent {
     this.logger.warn({ chatId, error: iteratorError?.message }, 'Agent loop ended unexpectedly, attempting restart');
 
     // Notify user about the restart
-    const threadRoot = this.conversationContext.getThreadRoot(chatId);
+    const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
     const restartMessage = iteratorError
       ? `⚠️ 会话遇到错误，正在重新连接... (${iteratorError.message})`
       : '⚠️ 会话意外断开，正在重新连接...';
@@ -508,7 +508,7 @@ You can read these files using the Read tool with the local paths above.`;
 
     if (deleted) {
       // Also clear thread root
-      this.conversationContext.deleteThreadRoot(chatId);
+      this.conversationOrchestrator.deleteThreadRoot(chatId);
       this.logger.info({ chatId }, 'State reset for chatId');
     } else {
       this.logger.debug({ chatId }, 'No state to reset for chatId');
@@ -533,7 +533,7 @@ You can read these files using the Read tool with the local paths above.`;
     this.sessionManager.closeAll();
 
     // Clear all context via ConversationContext
-    this.conversationContext.clearAll();
+    this.conversationOrchestrator.clearAll();
 
     this.logger.info('Pilot shutdown complete');
   }

--- a/src/conversation/conversation-orchestrator.ts
+++ b/src/conversation/conversation-orchestrator.ts
@@ -1,0 +1,207 @@
+/**
+ * ConversationOrchestrator - High-level conversation management.
+ *
+ * This is the main entry point for the conversation layer, combining:
+ * - SessionManager for lifecycle management
+ * - Message queuing and threading
+ * - Event callbacks for consumer integration
+ *
+ * The orchestrator provides a clean API for:
+ * - Processing incoming messages
+ * - Managing sessions (reset, shutdown)
+ * - Thread tracking
+ *
+ * Architecture:
+ * ```
+ * Pilot (or other Agent)
+ *       ↓
+ * ConversationOrchestrator
+ *       ↓
+ * ConversationSessionManager → Session state
+ *       ↓
+ * Callbacks → Platform-specific operations
+ * ```
+ */
+
+import type pino from 'pino';
+import type { QueuedMessage, SessionCallbacks, ProcessMessageResult, SessionStats } from './types.js';
+import { ConversationSessionManager, type ConversationSessionManagerConfig } from './session-manager.js';
+
+/**
+ * Configuration for ConversationOrchestrator.
+ */
+export interface ConversationOrchestratorConfig {
+  /** Logger instance */
+  logger: pino.Logger;
+  /** Callbacks for session events */
+  callbacks?: SessionCallbacks;
+}
+
+/**
+ * ConversationOrchestrator - Coordinates conversation components.
+ *
+ * This class provides the high-level API for conversation management,
+ * abstracting away the details of session and message handling.
+ */
+export class ConversationOrchestrator {
+  protected readonly logger: pino.Logger;
+  protected readonly sessionManager: ConversationSessionManager;
+  /** Callbacks for session events - can be used by subclasses */
+  protected readonly callbacks?: SessionCallbacks;
+
+  constructor(config: ConversationOrchestratorConfig) {
+    this.logger = config.logger;
+    this.callbacks = config.callbacks;
+
+    // Create session manager
+    const sessionManagerConfig: ConversationSessionManagerConfig = {
+      logger: this.logger,
+    };
+    this.sessionManager = new ConversationSessionManager(sessionManagerConfig);
+  }
+
+  /**
+   * Process an incoming message.
+   *
+   * This method:
+   * 1. Tracks the thread root for the message
+   * 2. Queues the message for processing
+   * 3. Returns immediately (non-blocking)
+   *
+   * @param chatId - Platform-specific chat identifier
+   * @param message - The message to process
+   * @returns Result indicating success/failure
+   */
+  processMessage(chatId: string, message: QueuedMessage): ProcessMessageResult {
+    this.logger.debug(
+      { chatId, messageId: message.messageId, textLength: message.text.length },
+      'Processing message'
+    );
+
+    // Track thread root
+    this.sessionManager.setThreadRoot(chatId, message.messageId);
+
+    // Queue the message
+    const success = this.sessionManager.queueMessage(chatId, message);
+
+    const stats = this.sessionManager.getStats(chatId);
+
+    return {
+      success,
+      queueLength: stats?.queueLength ?? 0,
+      error: success ? undefined : new Error('Session is closed'),
+    };
+  }
+
+  /**
+   * Check if a session exists for the chatId.
+   */
+  hasSession(chatId: string): boolean {
+    return this.sessionManager.has(chatId);
+  }
+
+  /**
+   * Get the thread root for a chatId.
+   */
+  getThreadRoot(chatId: string): string | undefined {
+    return this.sessionManager.getThreadRoot(chatId);
+  }
+
+  /**
+   * Set the thread root for a chatId.
+   */
+  setThreadRoot(chatId: string, messageId: string): void {
+    this.sessionManager.setThreadRoot(chatId, messageId);
+  }
+
+  /**
+   * Delete the thread root for a chatId.
+   * Used during session reset.
+   */
+  deleteThreadRoot(chatId: string): boolean {
+    return this.sessionManager.deleteThreadRoot(chatId);
+  }
+
+  /**
+   * Get session statistics.
+   */
+  getSessionStats(chatId: string): SessionStats | undefined {
+    return this.sessionManager.getStats(chatId);
+  }
+
+  /**
+   * Get the number of active sessions.
+   */
+  getActiveSessionCount(): number {
+    return this.sessionManager.size();
+  }
+
+  /**
+   * Get the number of active sessions (alias for getActiveSessionCount).
+   * Provided for backward compatibility with ConversationContext API.
+   */
+  size(): number {
+    return this.getActiveSessionCount();
+  }
+
+  /**
+   * Get all active chat IDs.
+   */
+  getActiveChatIds(): string[] {
+    return this.sessionManager.getActiveChatIds();
+  }
+
+  /**
+   * Reset state for a specific chatId.
+   *
+   * This clears the session, including thread roots and queued messages.
+   *
+   * @param chatId - Platform-specific chat identifier
+   * @returns true if session was reset, false if it didn't exist
+   */
+  reset(chatId: string): boolean {
+    const deleted = this.sessionManager.delete(chatId);
+    if (deleted) {
+      this.logger.info({ chatId }, 'Session reset for chatId');
+    } else {
+      this.logger.debug({ chatId }, 'No session to reset for chatId');
+    }
+    return deleted;
+  }
+
+  /**
+   * Reset all sessions.
+   */
+  resetAll(): void {
+    this.sessionManager.closeAll();
+    this.logger.info('All sessions reset');
+  }
+
+  /**
+   * Clear all sessions (alias for resetAll).
+   * Provided for backward compatibility with ConversationContext API.
+   */
+  clearAll(): void {
+    this.resetAll();
+  }
+
+  /**
+   * Cleanup resources on shutdown.
+   */
+  async shutdown(): Promise<void> {
+    this.logger.info('Shutting down ConversationOrchestrator');
+
+    // Close all sessions
+    this.sessionManager.closeAll();
+
+    this.logger.info('ConversationOrchestrator shutdown complete');
+  }
+
+  /**
+   * Get the underlying session manager for advanced use cases.
+   * Use with caution - direct manipulation may bypass orchestrator logic.
+   */
+  getSessionManager(): ConversationSessionManager {
+    return this.sessionManager;
+  }
+}

--- a/src/conversation/index.ts
+++ b/src/conversation/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Conversation Management Layer
+ *
+ * This module provides agent-agnostic conversation management components:
+ *
+ * - **ConversationOrchestrator**: High-level API for conversation management
+ * - **ConversationSessionManager**: Session lifecycle management
+ * - **MessageQueue**: Producer-consumer pattern for message streaming
+ * - **Types**: Shared interfaces and types
+ *
+ * ## Architecture
+ *
+ * ```
+ * src/conversation/
+ * ├── index.ts                      # This file - public exports
+ * ├── types.ts                      # Shared interfaces
+ * ├── message-queue.ts              # Queue + Resolver pattern
+ * ├── session-manager.ts            # Session lifecycle management
+ * └── conversation-orchestrator.ts  # Main entry point
+ * ```
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { ConversationOrchestrator, type QueuedMessage } from './conversation';
+ *
+ * const orchestrator = new ConversationOrchestrator({
+ *   logger,
+ *   callbacks: {
+ *     onMessage: async (chatId, text, threadId) => { ... },
+ *     onDone: async (chatId, threadId) => { ... },
+ *   },
+ * });
+ *
+ * // Process a message
+ * const result = orchestrator.processMessage(chatId, {
+ *   text: 'Hello',
+ *   messageId: 'msg-123',
+ * });
+ *
+ * // Reset a session
+ * orchestrator.reset(chatId);
+ *
+ * // Shutdown
+ * await orchestrator.shutdown();
+ * ```
+ *
+ * ## Design Principles
+ *
+ * 1. **Single Responsibility**: Each module has one clear purpose
+ * 2. **Dependency Injection**: Accepts callbacks, doesn't create them
+ * 3. **Agent-Agnostic**: Can be used by any agent type (Pilot, CLI, etc.)
+ * 4. **Interface Segregation**: Small, focused interfaces
+ */
+
+// Main entry point
+export { ConversationOrchestrator, type ConversationOrchestratorConfig } from './conversation-orchestrator.js';
+
+// Session management
+export {
+  ConversationSessionManager,
+  type ConversationSessionManagerConfig,
+} from './session-manager.js';
+
+// Message queue
+export { MessageQueue } from './message-queue.js';
+
+// Types
+export type {
+  QueuedMessage,
+  SessionState,
+  SessionCallbacks,
+  CreateSessionOptions,
+  ProcessMessageResult,
+  SessionStats,
+  MessageContext,
+} from './types.js';

--- a/src/conversation/message-queue.ts
+++ b/src/conversation/message-queue.ts
@@ -1,0 +1,123 @@
+/**
+ * MessageQueue - Queue + Resolver pattern for message streaming.
+ *
+ * This is an enhanced version of the MessageChannel pattern that:
+ * - Uses the QueuedMessage type from types.ts
+ * - Provides additional queue statistics
+ * - Supports the conversation layer architecture
+ *
+ * Usage:
+ * ```typescript
+ * const queue = new MessageQueue();
+ *
+ * // Producer: push messages
+ * queue.push({ text: 'Hello', messageId: '123' });
+ *
+ * // Consumer: async generator yields messages as they arrive
+ * for await (const msg of queue.consume()) {
+ *   // process msg
+ * }
+ *
+ * // Cleanup
+ * queue.close();
+ * ```
+ */
+
+import type { QueuedMessage } from './types.js';
+
+/**
+ * MessageQueue - Producer-consumer pattern for conversation messages.
+ *
+ * Provides an AsyncGenerator that yields QueuedMessages as they are pushed.
+ * This enables decoupled message production from consumption.
+ */
+export class MessageQueue {
+  private queue: QueuedMessage[] = [];
+  private resolver: (() => void) | null = null;
+  private closed = false;
+
+  /**
+   * Push a message to the queue.
+   * Resolves the pending promise in the consumer if waiting.
+   *
+   * @param message - The message to queue
+   * @returns true if message was queued, false if queue is closed
+   */
+  push(message: QueuedMessage): boolean {
+    if (this.closed) {
+      return false;
+    }
+    this.queue.push(message);
+    if (this.resolver) {
+      this.resolver();
+      this.resolver = null;
+    }
+    return true;
+  }
+
+  /**
+   * Generator that yields messages as they arrive.
+   * Returns when the queue is closed and drained.
+   *
+   * @yields QueuedMessage when available
+   */
+  async *consume(): AsyncGenerator<QueuedMessage> {
+    while (!this.closed || this.queue.length > 0) {
+      // Yield all queued messages
+      while (this.queue.length > 0) {
+        yield this.queue.shift()!;
+      }
+
+      // Exit if closed after draining queue
+      if (this.closed) {
+        break;
+      }
+
+      // Wait for new message
+      await new Promise<void>((resolve) => {
+        this.resolver = resolve;
+      });
+    }
+  }
+
+  /**
+   * Close the queue.
+   * The consumer will drain remaining messages and exit.
+   */
+  close(): void {
+    this.closed = true;
+    if (this.resolver) {
+      this.resolver();
+      this.resolver = null;
+    }
+  }
+
+  /**
+   * Check if the queue is closed.
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Get the current queue length.
+   */
+  length(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Check if the queue is empty.
+   */
+  isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+
+  /**
+   * Clear all pending messages.
+   * Does not close the queue.
+   */
+  clear(): void {
+    this.queue = [];
+  }
+}

--- a/src/conversation/session-manager.ts
+++ b/src/conversation/session-manager.ts
@@ -1,0 +1,248 @@
+/**
+ * SessionManager - Manages conversation session lifecycle.
+ *
+ * This is an agent-agnostic session manager that handles:
+ * - Session state tracking (per chatId)
+ * - Thread root management
+ * - Session creation, retrieval, and cleanup
+ *
+ * Unlike the agents/ SessionManager which is tightly coupled to Query/Channel,
+ * this version focuses on pure conversation state management.
+ */
+
+import type pino from 'pino';
+import type { SessionState, QueuedMessage, SessionStats } from './types.js';
+
+/**
+ * Configuration for ConversationSessionManager.
+ */
+export interface ConversationSessionManagerConfig {
+  /** Logger instance */
+  logger: pino.Logger;
+}
+
+/**
+ * Internal session data structure.
+ */
+interface InternalSession extends SessionState {
+  /** When this session was created */
+  createdAt: number;
+}
+
+/**
+ * ConversationSessionManager - Agent-agnostic session lifecycle management.
+ *
+ * Each chatId gets its own session containing conversation state.
+ * This class provides:
+ * - Session creation with default state
+ * - Thread root tracking
+ * - Session statistics
+ * - Lifecycle management (get, has, delete, closeAll)
+ */
+export class ConversationSessionManager {
+  private readonly logger: pino.Logger;
+  private readonly sessions = new Map<string, InternalSession>();
+
+  constructor(config: ConversationSessionManagerConfig) {
+    this.logger = config.logger;
+  }
+
+  /**
+   * Check if a session exists for the given chatId.
+   */
+  has(chatId: string): boolean {
+    return this.sessions.has(chatId);
+  }
+
+  /**
+   * Get an existing session for the chatId.
+   * Returns undefined if no session exists.
+   */
+  get(chatId: string): SessionState | undefined {
+    return this.sessions.get(chatId);
+  }
+
+  /**
+   * Get or create a session for the chatId.
+   * If the session doesn't exist, creates one with default state.
+   *
+   * @param chatId - The chat identifier
+   * @returns The session state
+   */
+  getOrCreate(chatId: string): SessionState {
+    let session = this.sessions.get(chatId);
+    if (!session) {
+      session = this.createDefaultSession();
+      this.sessions.set(chatId, session);
+      this.logger.debug({ chatId }, 'Session created');
+    }
+    return session;
+  }
+
+  /**
+   * Create a new session with default state.
+   */
+  private createDefaultSession(): InternalSession {
+    const now = Date.now();
+    return {
+      messageQueue: [],
+      closed: false,
+      lastActivity: now,
+      started: false,
+      createdAt: now,
+    };
+  }
+
+  /**
+   * Update the thread root for a session.
+   *
+   * @param chatId - The chat identifier
+   * @param threadRootId - The message ID to use as thread root
+   */
+  setThreadRoot(chatId: string, threadRootId: string): void {
+    const session = this.getOrCreate(chatId);
+    session.currentThreadRootId = threadRootId;
+    session.lastActivity = Date.now();
+    this.logger.debug({ chatId, threadRootId }, 'Thread root set');
+  }
+
+  /**
+   * Get the thread root for a session.
+   *
+   * @param chatId - The chat identifier
+   * @returns The thread root message ID, or undefined if not set
+   */
+  getThreadRoot(chatId: string): string | undefined {
+    return this.sessions.get(chatId)?.currentThreadRootId;
+  }
+
+  /**
+   * Delete the thread root for a session.
+   * Used during session reset to clear thread tracking.
+   *
+   * @param chatId - The chat identifier
+   * @returns true if thread root was deleted, false if not set
+   */
+  deleteThreadRoot(chatId: string): boolean {
+    const session = this.sessions.get(chatId);
+    if (session && session.currentThreadRootId) {
+      session.currentThreadRootId = undefined;
+      this.logger.debug({ chatId }, 'Thread root deleted');
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Queue a message for a session.
+   *
+   * @param chatId - The chat identifier
+   * @param message - The message to queue
+   * @returns true if message was queued, false if session is closed
+   */
+  queueMessage(chatId: string, message: QueuedMessage): boolean {
+    const session = this.getOrCreate(chatId);
+    if (session.closed) {
+      return false;
+    }
+    session.messageQueue.push(message);
+    session.lastActivity = Date.now();
+    if (session.messageResolver) {
+      session.messageResolver();
+      session.messageResolver = undefined;
+    }
+    this.logger.debug({ chatId, messageId: message.messageId }, 'Message queued');
+    return true;
+  }
+
+  /**
+   * Mark a session as started.
+   */
+  markStarted(chatId: string): void {
+    const session = this.sessions.get(chatId);
+    if (session) {
+      session.started = true;
+      session.lastActivity = Date.now();
+    }
+  }
+
+  /**
+   * Delete a session for the chatId.
+   *
+   * @param chatId - The chat identifier
+   * @returns true if session was deleted, false if it didn't exist
+   */
+  delete(chatId: string): boolean {
+    const session = this.sessions.get(chatId);
+    if (!session) {
+      return false;
+    }
+
+    // Mark as closed first
+    session.closed = true;
+
+    // Resolve any pending resolver
+    if (session.messageResolver) {
+      session.messageResolver();
+    }
+
+    // Remove from map
+    this.sessions.delete(chatId);
+    this.logger.debug({ chatId }, 'Session deleted');
+    return true;
+  }
+
+  /**
+   * Get statistics for a session.
+   *
+   * @param chatId - The chat identifier
+   * @returns Session statistics, or undefined if no session
+   */
+  getStats(chatId: string): SessionStats | undefined {
+    const session = this.sessions.get(chatId);
+    if (!session) {
+      return undefined;
+    }
+    return {
+      chatId,
+      queueLength: session.messageQueue.length,
+      isClosed: session.closed,
+      createdAt: session.createdAt,
+      lastActivity: session.lastActivity,
+      started: session.started,
+      threadRootId: session.currentThreadRootId,
+    };
+  }
+
+  /**
+   * Get the number of active sessions.
+   */
+  size(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Get all chatIds with active sessions.
+   */
+  getActiveChatIds(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+
+  /**
+   * Close all sessions and clear tracking.
+   * Used during shutdown.
+   */
+  closeAll(): void {
+    // Mark all as closed and resolve any pending resolvers
+    for (const [_chatId, session] of this.sessions) {
+      session.closed = true;
+      if (session.messageResolver) {
+        session.messageResolver();
+      }
+    }
+
+    // Clear the map
+    this.sessions.clear();
+    this.logger.info('All sessions closed');
+  }
+}

--- a/src/conversation/types.ts
+++ b/src/conversation/types.ts
@@ -1,0 +1,140 @@
+/**
+ * Types for the conversation management layer.
+ *
+ * These types define the interfaces for the conversation components,
+ * following the single responsibility principle and enabling
+ * agent-agnostic conversation management.
+ */
+
+import type { FileReference } from '../types/file-reference.js';
+
+/**
+ * Message queued for processing.
+ */
+export interface QueuedMessage {
+  /** Message text content */
+  text: string;
+  /** Unique message identifier */
+  messageId: string;
+  /** Sender's open_id for @ mentions (optional) */
+  senderOpenId?: string;
+  /** Optional file attachments */
+  attachments?: FileReference[];
+}
+
+/**
+ * Session state for each chatId.
+ *
+ * This represents the full state needed for a conversation session,
+ * including the message queue and context tracking.
+ */
+export interface SessionState {
+  /** Queue of messages waiting to be processed */
+  messageQueue: QueuedMessage[];
+  /** Resolver for the queue consumer promise */
+  messageResolver?: () => void;
+  /** Whether the session has been closed */
+  closed: boolean;
+  /** Timestamp of last activity */
+  lastActivity: number;
+  /** Whether the session has started processing */
+  started: boolean;
+  /** Current thread root message ID for replies */
+  currentThreadRootId?: string;
+}
+
+/**
+ * Callbacks for session events.
+ *
+ * These callbacks allow the consumer to handle conversation events
+ * without the conversation layer knowing about specific implementations.
+ */
+export interface SessionCallbacks {
+  /**
+   * Called when a message should be processed.
+   * @param chatId - Platform-specific chat identifier
+   * @param text - Message content
+   * @param threadId - Optional thread ID for replies
+   */
+  onMessage: (chatId: string, text: string, threadId?: string) => Promise<void>;
+
+  /**
+   * Called when a file should be processed.
+   * @param chatId - Platform-specific chat identifier
+   * @param filePath - Local file path
+   */
+  onFile?: (chatId: string, filePath: string) => Promise<void>;
+
+  /**
+   * Called when the session is done processing a turn.
+   * @param chatId - Platform-specific chat identifier
+   * @param threadId - Optional thread ID for replies
+   */
+  onDone?: (chatId: string, threadId?: string) => Promise<void>;
+
+  /**
+   * Called when an error occurs.
+   * @param chatId - Platform-specific chat identifier
+   * @param error - The error that occurred
+   * @param threadId - Optional thread ID for replies
+   */
+  onError?: (chatId: string, error: Error, threadId?: string) => Promise<void>;
+}
+
+/**
+ * Options for creating a new session.
+ */
+export interface CreateSessionOptions {
+  /** Platform-specific chat identifier */
+  chatId: string;
+  /** Initial message to queue (optional) */
+  initialMessage?: QueuedMessage;
+  /** Callbacks for session events */
+  callbacks?: SessionCallbacks;
+}
+
+/**
+ * Result of processing a message.
+ */
+export interface ProcessMessageResult {
+  /** Whether the message was successfully queued */
+  success: boolean;
+  /** Queue length after adding the message */
+  queueLength: number;
+  /** Error if queuing failed */
+  error?: Error;
+}
+
+/**
+ * Statistics about a conversation session.
+ */
+export interface SessionStats {
+  /** Chat ID for this session */
+  chatId: string;
+  /** Number of messages in queue */
+  queueLength: number;
+  /** Whether the session is closed */
+  isClosed: boolean;
+  /** When the session was created (ms since epoch) */
+  createdAt: number;
+  /** Time of last activity (ms since epoch) */
+  lastActivity: number;
+  /** Whether the session has started processing */
+  started: boolean;
+  /** Current thread root ID if set */
+  threadRootId?: string;
+}
+
+/**
+ * Message context for building enhanced content.
+ */
+export interface MessageContext {
+  /** Platform-specific chat identifier */
+  chatId: string;
+  /** Unique message identifier */
+  messageId: string;
+  /** Sender's open_id for @ mentions (optional) */
+  senderOpenId?: string;
+  /** Optional file attachments */
+  attachments?: FileReference[];
+}


### PR DESCRIPTION
## Summary

- Implements #237 - 解耦 Pilot 中的对话管理逻辑
- 创建新的 `src/conversation/` 目录，提供 Agent 无关的对话管理组件
- 重构 Pilot 使用 ConversationOrchestrator 替代 ConversationContext

## Changes

### 新增模块 (`src/conversation/`)

| 文件 | 描述 |
|------|------|
| `types.ts` | 定义共享接口 (QueuedMessage, SessionState, SessionCallbacks 等) |
| `message-queue.ts` | 生产者-消费者模式的消息队列 |
| `session-manager.ts` | Agent 无关的会话生命周期管理 |
| `conversation-orchestrator.ts` | 高层对话管理 API |
| `index.ts` | 公开导出 |

### 重构 Pilot

- 使用 `ConversationOrchestrator` 替代 `ConversationContext`
- 保持与现有 `SessionManager` (Query/Channel 管理) 的兼容性
- 添加 backward compatibility 方法 (`size`, `clearAll`, `deleteThreadRoot`)

## Test Results

```
✓ src/agents/pilot.test.ts (21 tests)
✓ src/agents/factory.test.ts (10 tests)
✓ src/agents/conversation-context.test.ts (12 tests)
✓ src/agents/index.test.ts (10 tests)

Test Files  10 passed (10)
Tests  137 passed (137)
```

## Design Principles

1. **单一职责**: 每个模块只有一个明确目的
2. **依赖注入**: SessionManager 接收回调，不创建回调
3. **Agent 无关**: ConversationOrchestrator 可用于不同 Agent 类型 (Pilot, CLI, etc.)
4. **接口隔离**: 小型、聚焦的接口

## Architecture

```
Pilot (or other Agent)
      ↓
ConversationOrchestrator
      ↓
ConversationSessionManager → Session state
      ↓
Callbacks → Platform-specific operations
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)