### PR TITLE
feat(sdk): add Agent SDK abstraction layer (Phase 1)

### DIFF
--- a/src/sdk/factory.test.ts
+++ b/src/sdk/factory.test.ts
@@ -1,0 +1,197 @@
+/**
+ * SDK 抽象层测试
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import {
+  getProvider,
+  registerProvider,
+  setDefaultProvider,
+  getDefaultProviderType,
+  getAvailableProviders,
+  clearProviderCache,
+  isProviderAvailable,
+} from './factory.js';
+import { ClaudeSDKProvider } from './providers/claude/index.js';
+import type { IAgentSDKProvider, ProviderInfo, AgentMessage, AgentQueryOptions, UserInput, StreamQueryResult } from './index.js';
+
+describe('SDK Factory', () => {
+  beforeEach(() => {
+    clearProviderCache();
+  });
+
+  afterEach(() => {
+    clearProviderCache();
+    // 重置为默认 provider
+    try {
+      setDefaultProvider('claude');
+    } catch {
+      // ignore
+    }
+  });
+
+  describe('getProvider', () => {
+    it('should return Claude provider by default', () => {
+      const provider = getProvider();
+      expect(provider).toBeInstanceOf(ClaudeSDKProvider);
+    });
+
+    it('should return cached provider instance', () => {
+      const provider1 = getProvider('claude');
+      const provider2 = getProvider('claude');
+      expect(provider1).toBe(provider2);
+    });
+
+    it('should throw for unknown provider type', () => {
+      expect(() => getProvider('unknown')).toThrow('Unknown provider type: unknown');
+    });
+  });
+
+  describe('registerProvider', () => {
+    it('should register new provider type', () => {
+      class MockProvider implements IAgentSDKProvider {
+        name = 'mock';
+        version = '1.0.0';
+        getInfo(): ProviderInfo {
+          return { name: this.name, version: this.version, available: true };
+        }
+        async *queryOnce(_input: string | UserInput[], _options: AgentQueryOptions): AsyncGenerator<AgentMessage> {
+          // Mock implementation
+        }
+        queryStream(_input: AsyncGenerator<UserInput>, _options: AgentQueryOptions): StreamQueryResult {
+          return {
+            handle: { close: () => {}, cancel: () => {} },
+            iterator: async function* (): AsyncGenerator<AgentMessage> {}(),
+          };
+        }
+        createInlineTool = () => ({});
+        createMcpServer = () => ({});
+        validateConfig = () => true;
+        dispose = () => {};
+      }
+
+      registerProvider('mock', () => new MockProvider());
+      const provider = getProvider('mock');
+      expect(provider.name).toBe('mock');
+    });
+  });
+
+  describe('setDefaultProvider', () => {
+    it('should change default provider type', () => {
+      expect(getDefaultProviderType()).toBe('claude');
+    });
+
+    it('should throw for unknown provider type', () => {
+      expect(() => setDefaultProvider('unknown')).toThrow('Unknown provider type: unknown');
+    });
+  });
+
+  describe('getAvailableProviders', () => {
+    it('should return list of available providers', () => {
+      const providers = getAvailableProviders();
+      expect(Array.isArray(providers)).toBe(true);
+      expect(providers.length).toBeGreaterThan(0);
+      expect(providers.some(p => p.name === 'claude')).toBe(true);
+    });
+  });
+
+  describe('isProviderAvailable', () => {
+    it('should return true for registered provider', () => {
+      // 注意：实际可用性取决于 ANTHROPIC_API_KEY 环境变量
+      const result = isProviderAvailable('claude');
+      expect(typeof result).toBe('boolean');
+    });
+
+    it('should return false for unknown provider', () => {
+      expect(isProviderAvailable('unknown')).toBe(false);
+    });
+  });
+
+  describe('clearProviderCache', () => {
+    it('should clear all cached providers', () => {
+      getProvider('claude'); // 缓存 provider
+      clearProviderCache();
+      // 无法直接验证缓存是否清空，但不应抛出错误
+      expect(() => clearProviderCache()).not.toThrow();
+    });
+
+    it('should clear specific provider cache', () => {
+      getProvider('claude');
+      clearProviderCache('claude');
+      // 不应抛出错误
+      expect(() => clearProviderCache('claude')).not.toThrow();
+    });
+  });
+});
+
+describe('ClaudeSDKProvider', () => {
+  let provider: ClaudeSDKProvider;
+
+  beforeEach(() => {
+    provider = new ClaudeSDKProvider();
+  });
+
+  afterEach(() => {
+    provider.dispose();
+  });
+
+  describe('getInfo', () => {
+    it('should return provider info', () => {
+      const info = provider.getInfo();
+      expect(info.name).toBe('claude');
+      expect(info.version).toBe('0.2.19');
+      expect(typeof info.available).toBe('boolean');
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('should return boolean', () => {
+      const result = provider.validateConfig();
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('createInlineTool', () => {
+    it('should create a tool', () => {
+      const toolDef = {
+        name: 'test_tool',
+        description: 'A test tool',
+        parameters: z.object({ input: z.string() }),
+        handler: async () => 'result',
+      };
+      const tool = provider.createInlineTool(toolDef);
+      expect(tool).toBeDefined();
+    });
+  });
+
+  describe('queryOnce', () => {
+    it('should throw if disposed', async () => {
+      provider.dispose();
+      await expect(async () => {
+        const gen = provider.queryOnce('test', {});
+        await gen.next();
+      }).rejects.toThrow('Provider has been disposed');
+    });
+  });
+
+  describe('queryStream', () => {
+    it('should throw if disposed', () => {
+      provider.dispose();
+      async function* inputGen(): AsyncGenerator<UserInput> {
+        yield { role: 'user', content: 'test' };
+      }
+      expect(() => {
+        provider.queryStream(inputGen(), {});
+      }).toThrow('Provider has been disposed');
+    });
+  });
+
+  describe('dispose', () => {
+    it('should mark provider as disposed', () => {
+      provider.dispose();
+      // 再次调用 dispose 不应抛出错误
+      expect(() => provider.dispose()).not.toThrow();
+    });
+  });
+});

--- a/src/sdk/factory.ts
+++ b/src/sdk/factory.ts
@@ -1,0 +1,162 @@
+/**
+ * Agent SDK Provider 工厂
+ *
+ * 提供创建和管理 Provider 实例的统一入口。
+ * 支持运行时切换不同的 Agent SDK 实现。
+ */
+
+import type { IAgentSDKProvider, ProviderFactory, ProviderConstructor } from './interface.js';
+import type { ProviderInfo } from './types.js';
+import { ClaudeSDKProvider } from './providers/index.js';
+
+/**
+ * 已注册的 Provider 类型
+ */
+export type ProviderType = 'claude' | string;
+
+/**
+ * Provider 注册表
+ */
+const providerRegistry = new Map<ProviderType, ProviderFactory>([
+  ['claude', () => new ClaudeSDKProvider()],
+]);
+
+/**
+ * 默认 Provider 类型
+ */
+let defaultProviderType: ProviderType = 'claude';
+
+/**
+ * 缓存的 Provider 实例
+ */
+const providerCache = new Map<ProviderType, IAgentSDKProvider>();
+
+/**
+ * 获取 Provider 实例
+ *
+ * 如果缓存中存在则返回缓存的实例，否则创建新实例。
+ *
+ * @param type - Provider 类型，默认使用 defaultProviderType
+ * @returns Provider 实例
+ * @throws 如果 Provider 类型未注册
+ */
+export function getProvider(type?: ProviderType): IAgentSDKProvider {
+  const providerType = type ?? defaultProviderType;
+
+  // 检查缓存
+  const cached = providerCache.get(providerType);
+  if (cached) {
+    return cached;
+  }
+
+  // 获取工厂函数
+  const factory = providerRegistry.get(providerType);
+  if (!factory) {
+    throw new Error(`Unknown provider type: ${providerType}. Available: ${[...providerRegistry.keys()].join(', ')}`);
+  }
+
+  // 创建并缓存实例
+  const provider = factory();
+  providerCache.set(providerType, provider);
+
+  return provider;
+}
+
+/**
+ * 注册新的 Provider 类型
+ *
+ * @param type - Provider 类型名称
+ * @param factory - Provider 工厂函数
+ */
+export function registerProvider(type: ProviderType, factory: ProviderFactory): void {
+  providerRegistry.set(type, factory);
+  // 清除该类型的缓存
+  providerCache.delete(type);
+}
+
+/**
+ * 注册 Provider 类（构造函数）
+ *
+ * @param type - Provider 类型名称
+ * @param constructor - Provider 构造函数
+ */
+export function registerProviderClass(type: ProviderType, constructor: ProviderConstructor): void {
+  registerProvider(type, () => new constructor());
+}
+
+/**
+ * 设置默认 Provider 类型
+ *
+ * @param type - Provider 类型
+ */
+export function setDefaultProvider(type: ProviderType): void {
+  if (!providerRegistry.has(type)) {
+    throw new Error(`Unknown provider type: ${type}. Available: ${[...providerRegistry.keys()].join(', ')}`);
+  }
+  defaultProviderType = type;
+}
+
+/**
+ * 获取默认 Provider 类型
+ */
+export function getDefaultProviderType(): ProviderType {
+  return defaultProviderType;
+}
+
+/**
+ * 获取所有已注册的 Provider 信息
+ */
+export function getAvailableProviders(): ProviderInfo[] {
+  const infos: ProviderInfo[] = [];
+
+  for (const [type, factory] of providerRegistry) {
+    try {
+      const provider = factory();
+      infos.push(provider.getInfo());
+    } catch {
+      infos.push({
+        name: type,
+        version: 'unknown',
+        available: false,
+        unavailableReason: 'Failed to create provider instance',
+      });
+    }
+  }
+
+  return infos;
+}
+
+/**
+ * 清除 Provider 缓存
+ *
+ * 用于测试或需要重新创建 Provider 实例时。
+ *
+ * @param type - 可选，指定要清除的 Provider 类型。不指定则清除全部。
+ */
+export function clearProviderCache(type?: ProviderType): void {
+  if (type) {
+    providerCache.delete(type);
+  } else {
+    providerCache.clear();
+  }
+}
+
+/**
+ * 检查 Provider 是否可用
+ *
+ * @param type - Provider 类型
+ * @returns Provider 是否可用
+ */
+export function isProviderAvailable(type: ProviderType): boolean {
+  const factory = providerRegistry.get(type);
+  if (!factory) {
+    return false;
+  }
+
+  try {
+    const provider = factory();
+    return provider.validateConfig();
+  } catch {
+    return false;
+  }
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Agent SDK 抽象层
+ *
+ * 提供与具体 Agent SDK（Claude、OpenAI、GLM 等）无关的统一接口。
+ * 上层业务代码通过此模块访问 Agent SDK 功能，
+ * 无需关心底层使用的是哪个 SDK。
+ *
+ * ## 目录结构
+ *
+ * ```
+ * src/sdk/
+ * ├── index.ts                 # 本文件 - 公开导出
+ * ├── types.ts                 # 统一类型定义
+ * ├── interface.ts             # IAgentSDKProvider 接口
+ * ├── factory.ts               # Provider 工厂
+ * └── providers/
+ *     ├── index.ts
+ *     └── claude/              # Claude SDK 实现
+ *         ├── index.ts
+ *         ├── provider.ts
+ *         ├── message-adapter.ts
+ *         └── options-adapter.ts
+ * ```
+ *
+ * ## 使用示例
+ *
+ * ```typescript
+ * import { getProvider } from './sdk';
+ *
+ * // 获取默认 Provider
+ * const provider = getProvider();
+ *
+ * // 一次性查询
+ * for await (const message of provider.queryOnce('Hello', options)) {
+ *   console.log(message.content);
+ * }
+ *
+ * // 流式查询
+ * const result = provider.queryStream(inputGenerator, options);
+ * for await (const message of result.iterator) {
+ *   console.log(message.content);
+ * }
+ * ```
+ *
+ * ## 扩展新 Provider
+ *
+ * ```typescript
+ * import { registerProvider, type IAgentSDKProvider } from './sdk';
+ *
+ * class OpenAIProvider implements IAgentSDKProvider {
+ *   // 实现接口方法...
+ * }
+ *
+ * registerProvider('openai', () => new OpenAIProvider());
+ * ```
+ *
+ * @module sdk
+ */
+
+// ============================================================================
+// 类型导出
+// ============================================================================
+
+export type {
+  // 内容类型
+  ContentBlock,
+  TextContentBlock,
+  ImageContentBlock,
+
+  // 消息类型
+  UserInput,
+  AgentMessage,
+  AgentMessageType,
+  MessageRole,
+  AgentMessageMetadata,
+
+  // 工具类型
+  ToolUseBlock,
+  ToolResultBlock,
+  InlineToolDefinition,
+
+  // MCP 配置
+  McpServerConfig,
+  StdioMcpServerConfig,
+  InlineMcpServerConfig,
+
+  // 查询选项
+  AgentQueryOptions,
+  PermissionMode,
+
+  // 查询结果
+  QueryHandle,
+  StreamQueryResult,
+
+  // 统计
+  QueryUsageStats,
+  ProviderInfo,
+} from './types.js';
+
+// ============================================================================
+// 接口导出
+// ============================================================================
+
+export type {
+  IAgentSDKProvider,
+  ProviderFactory,
+  ProviderConstructor,
+} from './interface.js';
+
+// ============================================================================
+// Provider 导出
+// ============================================================================
+
+export { ClaudeSDKProvider } from './providers/index.js';
+
+// ============================================================================
+// 工厂函数导出
+// ============================================================================
+
+export {
+  getProvider,
+  registerProvider,
+  registerProviderClass,
+  setDefaultProvider,
+  getDefaultProviderType,
+  getAvailableProviders,
+  clearProviderCache,
+  isProviderAvailable,
+  type ProviderType,
+} from './factory.js';

--- a/src/sdk/interface.ts
+++ b/src/sdk/interface.ts
@@ -1,0 +1,124 @@
+/**
+ * Agent SDK 抽象层 - Provider 接口定义
+ *
+ * 定义了所有 Agent SDK Provider 必须实现的接口，
+ * 使上层业务代码与具体的 SDK 实现解耦。
+ */
+
+import type {
+  AgentMessage,
+  AgentQueryOptions,
+  InlineToolDefinition,
+  McpServerConfig,
+  ProviderInfo,
+  StreamQueryResult,
+  UserInput,
+} from './types';
+
+/**
+ * Agent SDK Provider 接口
+ *
+ * 所有 Agent SDK 实现（Claude、OpenAI、GLM 等）都需要实现此接口。
+ */
+export interface IAgentSDKProvider {
+  // ==========================================================================
+  // Provider 信息
+  // ==========================================================================
+
+  /** Provider 名称（如 'claude', 'openai', 'glm'） */
+  readonly name: string;
+
+  /** Provider 版本 */
+  readonly version: string;
+
+  /** 获取 Provider 信息 */
+  getInfo(): ProviderInfo;
+
+  // ==========================================================================
+  // 查询方法
+  // ==========================================================================
+
+  /**
+   * 一次性查询（静态输入）
+   *
+   * 用于任务型 Agent（Evaluator、Executor、Reporter、SiteMiner 等），
+   * 接受静态输入，返回消息流。
+   *
+   * @param input - 输入内容（字符串或用户消息数组）
+   * @param options - 查询选项
+   * @returns 消息异步迭代器
+   */
+  queryOnce(
+    input: string | UserInput[],
+    options: AgentQueryOptions
+  ): AsyncGenerator<AgentMessage>;
+
+  /**
+   * 流式查询（动态输入）
+   *
+   * 用于对话型 Agent（Pilot），接受动态输入流，
+   * 支持会话持久化和多轮对话。
+   *
+   * @param input - 输入异步生成器
+   * @param options - 查询选项
+   * @returns 流式查询结果（包含句柄和迭代器）
+   */
+  queryStream(
+    input: AsyncGenerator<UserInput>,
+    options: AgentQueryOptions
+  ): StreamQueryResult;
+
+  // ==========================================================================
+  // 工具和 MCP 服务器
+  // ==========================================================================
+
+  /**
+   * 创建内联 MCP 工具
+   *
+   * 将工具定义转换为 SDK 特定的工具格式。
+   *
+   * @param definition - 工具定义
+   * @returns SDK 特定的工具对象
+   */
+  createInlineTool(definition: InlineToolDefinition): unknown;
+
+  /**
+   * 创建 MCP 服务器
+   *
+   * 根据 MCP 服务器配置创建 SDK 特定的 MCP 服务器实例。
+   *
+   * @param config - MCP 服务器配置
+   * @returns SDK 特定的 MCP 服务器对象
+   */
+  createMcpServer(config: McpServerConfig): unknown;
+
+  // ==========================================================================
+  // 生命周期
+  // ==========================================================================
+
+  /**
+   * 验证配置
+   *
+   * 检查 Provider 是否正确配置并可用。
+   *
+   * @returns 配置是否有效
+   */
+  validateConfig(): boolean;
+
+  /**
+   * 清理资源
+   *
+   * 释放 Provider 占用的资源。
+   */
+  dispose(): void;
+}
+
+/**
+ * Provider 工厂函数类型
+ */
+export type ProviderFactory = () => IAgentSDKProvider;
+
+/**
+ * Provider 构造函数类型
+ */
+export type ProviderConstructor = new () => IAgentSDKProvider;

--- a/src/sdk/providers/claude/index.ts
+++ b/src/sdk/providers/claude/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Claude SDK Provider 模块导出
+ */
+
+export { ClaudeSDKProvider } from './provider.js';
+export { adaptSDKMessage, adaptUserInput } from './message-adapter.js';
+export { adaptOptions, adaptInput } from './options-adapter.js';

--- a/src/sdk/providers/claude/message-adapter.ts
+++ b/src/sdk/providers/claude/message-adapter.ts
@@ -1,0 +1,291 @@
+/**
+ * Claude SDK 消息适配器
+ *
+ * 将 Claude SDK 的 SDKMessage 转换为统一的 AgentMessage 类型。
+ */
+
+import type { SDKMessage, SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  AgentMessage,
+  AgentMessageMetadata,
+  UserInput,
+} from '../../types.js';
+
+/**
+ * 适配 Claude SDK 消息为统一的 AgentMessage
+ *
+ * @param message - Claude SDK 消息
+ * @returns 统一的 AgentMessage
+ */
+export function adaptSDKMessage(message: SDKMessage): AgentMessage {
+  const metadata: AgentMessageMetadata = {};
+
+  // 提取 session_id
+  if ('session_id' in message && message.session_id) {
+    metadata.sessionId = message.session_id;
+  }
+
+  switch (message.type) {
+    case 'assistant': {
+      const apiMessage = message.message;
+      if (!apiMessage || !Array.isArray(apiMessage.content)) {
+        return {
+          type: 'text',
+          content: '',
+          role: 'assistant',
+          raw: message,
+        };
+      }
+
+      // 定义 SDK 内容块类型（包含 tool_use）
+      type SdkContentBlock = { type: string; [key: string]: unknown };
+
+      // 提取工具使用块
+      const toolBlocks = apiMessage.content.filter(
+        (block: SdkContentBlock) => block.type === 'tool_use'
+      );
+
+      // 提取文本块
+      const textBlocks = apiMessage.content.filter(
+        (block: SdkContentBlock) => block.type === 'text' && 'text' in block
+      );
+
+      // 构建内容
+      const contentParts: string[] = [];
+
+      // 处理工具使用
+      if (toolBlocks.length > 0) {
+        const block = toolBlocks[0]; // 取第一个工具使用
+        if ('name' in block && 'input' in block) {
+          metadata.toolName = block.name as string;
+          metadata.toolInput = block.input;
+          contentParts.push(formatToolInput(block.name as string, block.input as Record<string, unknown>));
+        }
+      }
+
+      // 处理文本
+      const textParts = textBlocks
+        .filter((block: SdkContentBlock) => 'text' in block)
+        .map((block: SdkContentBlock) => String((block as unknown as { text: string }).text));
+
+      if (textParts.length > 0) {
+        contentParts.push(textParts.join(''));
+      }
+
+      return {
+        type: toolBlocks.length > 0 ? 'tool_use' : 'text',
+        content: contentParts.join('\n'),
+        role: 'assistant',
+        metadata,
+        raw: message,
+      };
+    }
+
+    case 'tool_progress': {
+      if ('tool_name' in message && 'elapsed_time_seconds' in message) {
+        const toolName = message.tool_name as string;
+        const elapsed = message.elapsed_time_seconds as number;
+        metadata.toolName = toolName;
+        metadata.elapsedMs = elapsed * 1000;
+        return {
+          type: 'tool_progress',
+          content: `⏳ Running ${toolName} (${elapsed.toFixed(1)}s)`,
+          role: 'assistant',
+          metadata,
+          raw: message,
+        };
+      }
+      return {
+        type: 'text',
+        content: '',
+        role: 'assistant',
+        raw: message,
+      };
+    }
+
+    case 'tool_use_summary': {
+      if ('summary' in message) {
+        return {
+          type: 'tool_result',
+          content: `✓ ${message.summary as string}`,
+          role: 'assistant',
+          metadata,
+          raw: message,
+        };
+      }
+      return {
+        type: 'text',
+        content: '',
+        role: 'assistant',
+        raw: message,
+      };
+    }
+
+    case 'result': {
+      if (message.subtype === 'success') {
+        let statsText = '✅ Complete';
+
+        if ('usage' in message && message.usage) {
+          const usage = message.usage as {
+            total_cost?: number;
+            total_tokens?: number;
+            input_tokens?: number;
+            output_tokens?: number;
+          };
+
+          const parts: string[] = [];
+
+          if (usage.total_cost !== undefined) {
+            metadata.costUsd = usage.total_cost;
+            parts.push(`Cost: $${usage.total_cost.toFixed(4)}`);
+          }
+          if (usage.total_tokens !== undefined) {
+            parts.push(`Tokens: ${(usage.total_tokens / 1000).toFixed(1)}k`);
+          }
+          if (usage.input_tokens !== undefined) {
+            metadata.inputTokens = usage.input_tokens;
+          }
+          if (usage.output_tokens !== undefined) {
+            metadata.outputTokens = usage.output_tokens;
+          }
+
+          if (parts.length > 0) {
+            statsText += ` | ${parts.join(' | ')}`;
+          }
+        }
+
+        return {
+          type: 'result',
+          content: statsText,
+          role: 'assistant',
+          metadata,
+          raw: message,
+        };
+      }
+
+      if (message.subtype === 'error_during_execution' && 'errors' in message) {
+        const errors = message.errors as string[];
+        return {
+          type: 'error',
+          content: `❌ Error: ${errors.join(', ')}`,
+          role: 'assistant',
+          metadata,
+          raw: message,
+        };
+      }
+
+      return {
+        type: 'text',
+        content: '',
+        role: 'assistant',
+        raw: message,
+      };
+    }
+
+    case 'system': {
+      if (message.subtype === 'status') {
+        if ('status' in message && message.status === 'compacting') {
+          return {
+            type: 'status',
+            content: '🔄 Compacting conversation history...',
+            role: 'system',
+            metadata,
+            raw: message,
+          };
+        }
+      }
+
+      // 忽略其他系统消息
+      return {
+        type: 'text',
+        content: '',
+        role: 'system',
+        raw: message,
+      };
+    }
+
+    case 'user':
+    case 'stream_event':
+    default:
+      // 忽略用户消息回显和流事件
+      return {
+        type: 'text',
+        content: '',
+        role: 'user',
+        raw: message,
+      };
+  }
+}
+
+/**
+ * 适配统一 UserInput 为 Claude SDK SDKUserMessage
+ *
+ * @param input - 统一的用户输入
+ * @returns Claude SDK SDKUserMessage
+ */
+export function adaptUserInput(input: UserInput): SDKUserMessage {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: input.content,
+    },
+    parent_tool_use_id: null,
+    session_id: '',
+  };
+}
+
+/**
+ * 格式化工具输入用于显示
+ */
+function formatToolInput(toolName: string, input: Record<string, unknown> | undefined): string {
+  if (!input) {
+    return `🔧 ${toolName}`;
+  }
+
+  switch (toolName) {
+    case 'Bash': {
+      const cmd = input.command as string | undefined;
+      return `🔧 Running: ${cmd || '<no command>'}`;
+    }
+    case 'Edit': {
+      const filePath = (input.file_path as string | undefined) || (input.filePath as string | undefined);
+      return `🔧 Editing: ${filePath || '<unknown file>'}`;
+    }
+    case 'Read': {
+      const readPath = input.file_path as string | undefined;
+      return `🔧 Reading: ${readPath || '<unknown file>'}`;
+    }
+    case 'Write': {
+      const writePath = input.file_path as string | undefined;
+      return `🔧 Writing: ${writePath || '<unknown file>'}`;
+    }
+    case 'Grep': {
+      const pattern = input.pattern as string | undefined;
+      return pattern ? `🔧 Searching for "${pattern}"` : `🔧 Searching`;
+    }
+    case 'Glob': {
+      const globPattern = input.pattern as string | undefined;
+      return `🔧 Finding files: ${globPattern || '<no pattern>'}`;
+    }
+    default: {
+      const str = safeStringify(input, 60);
+      return `🔧 ${toolName}: ${str}`;
+    }
+  }
+}
+
+/**
+ * 安全地序列化对象
+ */
+function safeStringify(obj: unknown, maxLength: number = 100): string {
+  try {
+    const str = JSON.stringify(obj);
+    if (str.length <= maxLength) {
+      return str;
+    }
+    return `${str.slice(0, maxLength - 3)}...`;
+  } catch {
+    return String(obj);
+  }
+}

--- a/src/sdk/providers/claude/options-adapter.ts
+++ b/src/sdk/providers/claude/options-adapter.ts
@@ -1,0 +1,143 @@
+/**
+ * Claude SDK 选项适配器
+ *
+ * 将统一的 AgentQueryOptions 转换为 Claude SDK 特定的选项格式。
+ */
+
+import type { AgentQueryOptions, InlineMcpServerConfig, McpServerConfig } from '../../types.js';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+
+/**
+ * 适配统一选项为 Claude SDK 选项
+ *
+ * @param options - 统一的查询选项
+ * @returns Claude SDK 选项对象
+ */
+export function adaptOptions(options: AgentQueryOptions): Record<string, unknown> {
+  const sdkOptions: Record<string, unknown> = {};
+
+  // 基本选项
+  if (options.cwd) {
+    sdkOptions.cwd = options.cwd;
+  }
+
+  if (options.model) {
+    sdkOptions.model = options.model;
+  }
+
+  // 权限模式
+  if (options.permissionMode) {
+    sdkOptions.permissionMode = options.permissionMode === 'bypass'
+      ? 'bypassPermissions'
+      : options.permissionMode;
+  }
+
+  // 设置来源
+  if (options.settingSources) {
+    sdkOptions.settingSources = options.settingSources;
+  }
+
+  // 工具配置
+  if (options.allowedTools) {
+    sdkOptions.allowedTools = options.allowedTools;
+  }
+
+  if (options.disallowedTools) {
+    sdkOptions.disallowedTools = options.disallowedTools;
+  }
+
+  // MCP 服务器
+  if (options.mcpServers) {
+    sdkOptions.mcpServers = adaptMcpServers(options.mcpServers);
+  }
+
+  // 环境变量
+  if (options.env) {
+    sdkOptions.env = options.env;
+  }
+
+  // 上下文隔离
+  if (options.context) {
+    sdkOptions.context = options.context;
+  }
+
+  return sdkOptions;
+}
+
+/**
+ * 适配 MCP 服务器配置
+ *
+ * @param mcpServers - 统一的 MCP 服务器配置
+ * @returns Claude SDK MCP 服务器配置
+ */
+function adaptMcpServers(
+  mcpServers: Record<string, McpServerConfig>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [name, config] of Object.entries(mcpServers)) {
+    if (config.type === 'inline') {
+      result[name] = adaptInlineMcpServer(config);
+    } else {
+      // stdio 模式直接传递
+      result[name] = {
+        command: config.command,
+        args: config.args,
+        env: config.env,
+      };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * 适配内联 MCP 服务器
+ *
+ * @param config - 内联 MCP 服务器配置
+ * @returns Claude SDK MCP 服务器实例
+ */
+function adaptInlineMcpServer(config: InlineMcpServerConfig): unknown {
+  if (!config.tools || config.tools.length === 0) {
+    return createSdkMcpServer({
+      name: config.name,
+      version: config.version,
+      tools: [],
+    });
+  }
+
+  // 将统一工具定义转换为 SDK 工具
+  // 使用双重类型断言来处理 Zod schema 类型兼容性
+  const sdkTools = config.tools.map(t =>
+    tool(t.name, t.description, t.parameters as unknown as Parameters<typeof tool>[2], t.handler)
+  );
+
+  return createSdkMcpServer({
+    name: config.name,
+    version: config.version,
+    tools: sdkTools,
+  });
+}
+
+/**
+ * 适配输入为 Claude SDK 格式
+ *
+ * @param input - 统一输入（字符串或 UserInput 数组）
+ * @returns Claude SDK 格式的输入
+ */
+export function adaptInput(input: string | import('../../types.js').UserInput[]): unknown {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  // 转换 UserInput 数组为 SDK 格式
+  return input.map(userInput => ({
+    type: 'user',
+    message: {
+      role: 'user',
+      content: userInput.content,
+    },
+    parent_tool_use_id: null,
+    session_id: '',
+  }));
+}

--- a/src/sdk/providers/claude/provider.ts
+++ b/src/sdk/providers/claude/provider.ts
@@ -1,0 +1,142 @@
+/**
+ * Claude SDK Provider 实现
+ *
+ * 实现 IAgentSDKProvider 接口，封装 Claude Agent SDK 的功能。
+ */
+
+import { query, tool, createSdkMcpServer, type SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { IAgentSDKProvider } from '../../interface.js';
+import type {
+  AgentMessage,
+  AgentQueryOptions,
+  InlineToolDefinition,
+  McpServerConfig,
+  ProviderInfo,
+  StreamQueryResult,
+  UserInput,
+} from '../../types.js';
+import { adaptSDKMessage, adaptUserInput } from './message-adapter.js';
+import { adaptOptions, adaptInput } from './options-adapter.js';
+
+/**
+ * Claude SDK Provider
+ *
+ * 封装 @anthropic-ai/claude-agent-sdk 的功能，
+ * 提供与 IAgentSDKProvider 接口一致的 API。
+ */
+export class ClaudeSDKProvider implements IAgentSDKProvider {
+  readonly name = 'claude';
+  readonly version = '0.2.19';
+
+  private disposed = false;
+
+  getInfo(): ProviderInfo {
+    const available = this.validateConfig();
+    return {
+      name: this.name,
+      version: this.version,
+      available,
+      unavailableReason: available ? undefined : 'ANTHROPIC_API_KEY not set',
+    };
+  }
+
+  async *queryOnce(
+    input: string | UserInput[],
+    options: AgentQueryOptions
+  ): AsyncGenerator<AgentMessage> {
+    if (this.disposed) {
+      throw new Error('Provider has been disposed');
+    }
+
+    const sdkOptions = adaptOptions(options);
+    const adaptedInput = adaptInput(input);
+
+    const queryResult = query({
+      prompt: adaptedInput as Parameters<typeof query>[0]['prompt'],
+      options: sdkOptions as Parameters<typeof query>[0]['options'],
+    });
+
+    for await (const message of queryResult) {
+      yield adaptSDKMessage(message);
+    }
+  }
+
+  queryStream(
+    input: AsyncGenerator<UserInput>,
+    options: AgentQueryOptions
+  ): StreamQueryResult {
+    if (this.disposed) {
+      throw new Error('Provider has been disposed');
+    }
+
+    const sdkOptions = adaptOptions(options);
+
+    // 创建输入适配器生成器
+    async function* adaptInputStream(): AsyncGenerator<SDKUserMessage> {
+      for await (const userInput of input) {
+        yield adaptUserInput(userInput);
+      }
+    }
+
+    const queryResult = query({
+      prompt: adaptInputStream(),
+      options: sdkOptions as Parameters<typeof query>[0]['options'],
+    });
+
+    // 创建消息适配迭代器
+    async function* adaptIterator(): AsyncGenerator<AgentMessage> {
+      for await (const message of queryResult) {
+        yield adaptSDKMessage(message);
+      }
+    }
+
+    return {
+      handle: {
+        close: () => {
+          if ('close' in queryResult && typeof queryResult.close === 'function') {
+            queryResult.close();
+          }
+        },
+        cancel: () => {
+          if ('cancel' in queryResult && typeof queryResult.cancel === 'function') {
+            queryResult.cancel();
+          }
+        },
+        sessionId: undefined,
+      },
+      iterator: adaptIterator(),
+    };
+  }
+
+  createInlineTool(definition: InlineToolDefinition): unknown {
+    return tool(
+      definition.name,
+      definition.description,
+      definition.parameters as unknown as Parameters<typeof tool>[2],
+      definition.handler
+    );
+  }
+
+  createMcpServer(config: McpServerConfig): unknown {
+    if (config.type === 'inline') {
+      const tools = (config.tools?.map(t => this.createInlineTool(t)) ?? []) as Parameters<typeof createSdkMcpServer>[0]['tools'];
+      return createSdkMcpServer({
+        name: config.name,
+        version: config.version,
+        tools,
+      });
+    }
+
+    // stdio 模式不支持通过此方法创建
+    throw new Error('stdio MCP servers are not supported by ClaudeSDKProvider.createMcpServer');
+  }
+
+  validateConfig(): boolean {
+    // 检查 API 密钥是否配置
+    return !!process.env.ANTHROPIC_API_KEY;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+  }
+}

--- a/src/sdk/providers/index.ts
+++ b/src/sdk/providers/index.ts
@@ -1,0 +1,5 @@
+/**
+ * SDK Providers 模块导出
+ */
+
+export { ClaudeSDKProvider } from './claude/index.js';

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -1,0 +1,236 @@
+/**
+ * Agent SDK 抽象层 - 统一类型定义
+ *
+ * 这些类型与任何特定的 Agent SDK（Claude、OpenAI 等）无关，
+ * 提供统一的接口供上层业务代码使用。
+ */
+
+import type { ZodSchema } from 'zod';
+
+// ============================================================================
+// 内容块类型
+// ============================================================================
+
+/** 文本内容块 */
+export interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+/** 图像内容块 */
+export interface ImageContentBlock {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+/** 内容块联合类型 */
+export type ContentBlock = TextContentBlock | ImageContentBlock;
+
+// ============================================================================
+// 用户输入类型
+// ============================================================================
+
+/** 用户输入消息 */
+export interface UserInput {
+  role: 'user';
+  content: string | ContentBlock[];
+}
+
+// ============================================================================
+// Agent 消息类型（统一的 SDK 消息抽象）
+// ============================================================================
+
+/** 消息角色 */
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+/** Agent 消息元数据 */
+export interface AgentMessageMetadata {
+  /** 工具名称 */
+  toolName?: string;
+  /** 工具输入参数 */
+  toolInput?: unknown;
+  /** 工具输出结果 */
+  toolOutput?: unknown;
+  /** 已执行时间（毫秒） */
+  elapsedMs?: number;
+  /** 费用（美元） */
+  costUsd?: number;
+  /** 输入 token 数 */
+  inputTokens?: number;
+  /** 输出 token 数 */
+  outputTokens?: number;
+  /** 消息 ID */
+  messageId?: string;
+  /** 停止原因 */
+  stopReason?: string;
+  /** 会话 ID */
+  sessionId?: string;
+}
+
+/** Agent 消息类型 */
+export type AgentMessageType =
+  | 'text'           // 文本内容
+  | 'tool_use'       // 工具调用开始
+  | 'tool_progress'  // 工具执行中
+  | 'tool_result'    // 工具执行完成
+  | 'result'         // 查询完成
+  | 'error'          // 错误
+  | 'status';        // 系统状态
+
+/** 统一的 Agent 消息类型（与特定 SDK 无关） */
+export interface AgentMessage {
+  /** 消息类型 */
+  type: AgentMessageType;
+  /** 消息内容 */
+  content: string;
+  /** 消息角色 */
+  role: MessageRole;
+  /** 消息元数据 */
+  metadata?: AgentMessageMetadata;
+  /** 原始消息（用于调试） */
+  raw?: unknown;
+}
+
+// ============================================================================
+// 工具使用信息
+// ============================================================================
+
+/** 工具使用块 */
+export interface ToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/** 工具结果块 */
+export interface ToolResultBlock {
+  type: 'tool_result';
+  toolUseId: string;
+  content: string;
+  isError?: boolean;
+}
+
+// ============================================================================
+// MCP 服务器配置
+// ============================================================================
+
+/** 内联工具定义 */
+export interface InlineToolDefinition<TParams = unknown, TResult = unknown> {
+  /** 工具名称 */
+  name: string;
+  /** 工具描述 */
+  description: string;
+  /** 参数 Schema（Zod） */
+  parameters: ZodSchema<TParams>;
+  /** 处理函数 */
+  handler: (params: TParams) => Promise<TResult>;
+}
+
+/** stdio 模式 MCP 服务器配置 */
+export interface StdioMcpServerConfig {
+  type: 'stdio';
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** 内联模式 MCP 服务器配置 */
+export interface InlineMcpServerConfig {
+  type: 'inline';
+  name: string;
+  version: string;
+  tools?: InlineToolDefinition[];
+}
+
+/** MCP 服务器配置联合类型 */
+export type McpServerConfig = StdioMcpServerConfig | InlineMcpServerConfig;
+
+// ============================================================================
+// 查询选项
+// ============================================================================
+
+/** 权限模式 */
+export type PermissionMode = 'default' | 'bypass';
+
+/** 查询选项（Provider 无关） */
+export interface AgentQueryOptions {
+  /** 工作目录 */
+  cwd?: string;
+  /** 使用的模型 */
+  model?: string;
+  /** 权限模式 */
+  permissionMode?: PermissionMode;
+  /** 允许使用的工具列表 */
+  allowedTools?: string[];
+  /** 禁用的工具列表 */
+  disallowedTools?: string[];
+  /** MCP 服务器配置 */
+  mcpServers?: Record<string, McpServerConfig>;
+  /** 环境变量 */
+  env?: Record<string, string | undefined>;
+  /** 设置来源 */
+  settingSources?: string[];
+  /** 上下文隔离模式 */
+  context?: 'fork' | 'none';
+}
+
+// ============================================================================
+// 查询句柄和结果
+// ============================================================================
+
+/** 查询句柄（用于控制查询生命周期） */
+export interface QueryHandle {
+  /** 关闭查询 */
+  close(): void;
+  /** 取消查询 */
+  cancel(): void;
+  /** 会话 ID */
+  readonly sessionId?: string;
+}
+
+/** 流式查询结果 */
+export interface StreamQueryResult {
+  /** 查询句柄 */
+  handle: QueryHandle;
+  /** 消息迭代器 */
+  iterator: AsyncGenerator<AgentMessage>;
+}
+
+// ============================================================================
+// 使用统计
+// ============================================================================
+
+/** 查询使用统计 */
+export interface QueryUsageStats {
+  /** 输入 token 数 */
+  inputTokens: number;
+  /** 输出 token 数 */
+  outputTokens: number;
+  /** 总 token 数 */
+  totalTokens: number;
+  /** 费用（美元） */
+  costUsd: number;
+  /** 缓存读取 token 数 */
+  cacheReadTokens?: number;
+  /** 缓存写入 token 数 */
+  cacheWriteTokens?: number;
+}
+
+// ============================================================================
+// Provider 信息
+// ============================================================================
+
+/** Provider 信息 */
+export interface ProviderInfo {
+  /** Provider 名称 */
+  name: string;
+  /** Provider 版本 */
+  version: string;
+  /** 是否可用 */
+  available: boolean;
+  /** 不可用原因 */
+  unavailableReason?: string;
+}


### PR DESCRIPTION
## Summary

- Implements #244 - Phase 1 of the Agent SDK abstraction layer design
- Creates a unified interface for Agent SDKs, decoupling the application from `@anthropic-ai/claude-agent-sdk`
- Provides the foundation for supporting multiple Agent SDK providers (Claude, OpenAI, GLM, etc.)

## Changes

### New Files

| File | Description |
|------|-------------|
| `src/sdk/types.ts` | Unified type definitions (AgentMessage, UserInput, etc.) |
| `src/sdk/interface.ts` | IAgentSDKProvider interface definition |
| `src/sdk/factory.ts` | Provider factory with registration and caching |
| `src/sdk/index.ts` | Public exports |
| `src/sdk/providers/claude/provider.ts` | Claude SDK implementation |
| `src/sdk/providers/claude/message-adapter.ts` | SDKMessage → AgentMessage adapter |
| `src/sdk/providers/claude/options-adapter.ts` | QueryOptions adapter |
| `src/sdk/factory.test.ts` | Unit tests (17 tests) |

### Architecture

```
src/sdk/
├── index.ts                 # Public exports
├── types.ts                 # Unified types (SDK-agnostic)
├── interface.ts             # IAgentSDKProvider interface
├── factory.ts               # Provider factory
└── providers/
    └── claude/              # Claude SDK implementation
        ├── provider.ts
        ├── message-adapter.ts
        └── options-adapter.ts
```

### Key Types

```typescript
// Unified message type (SDK-agnostic)
interface AgentMessage {
  type: 'text' | 'tool_use' | 'tool_progress' | 'tool_result' | 'result' | 'error' | 'status';
  content: string;
  role: 'user' | 'assistant' | 'system';
  metadata?: AgentMessageMetadata;
}

// Provider interface
interface IAgentSDKProvider {
  readonly name: string;
  readonly version: string;
  queryOnce(input: string | UserInput[], options: AgentQueryOptions): AsyncGenerator<AgentMessage>;
  queryStream(input: AsyncGenerator<UserInput>, options: AgentQueryOptions): StreamQueryResult;
  createInlineTool(definition: InlineToolDefinition): unknown;
  createMcpServer(config: McpServerConfig): unknown;
  validateConfig(): boolean;
  dispose(): void;
}
```

## Benefits

| Aspect | Before | After |
|--------|--------|-------|
| SDK coupling | Direct import from Claude SDK | Abstracted through interface |
| Replaceability | Hard to switch SDKs | Easy to add new providers |
| Testability | Difficult to mock | Can mock Provider |
| Type safety | SDK-specific types leak | Unified types |

## Test Results

```
✓ src/sdk/factory.test.ts (17 tests) 5ms

Test Files  47 passed (47)
Tests       857 passed (857)
```

## Next Steps (Future Phases)

- **Phase 2**: Migrate BaseAgent to use abstract interface
- **Phase 3**: Migrate MCP tools to use abstract interface  
- **Phase 4**: Remove direct SDK imports, cleanup

## Related

- Issue: #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)