### PR TITLE
feat(auth): add secure third-party OAuth authentication system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "disclaude",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "disclaude",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.19",
         "@anthropic-ai/sdk": "^0.32.0",

--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -1,0 +1,254 @@
+/**
+ * MCP tools for OAuth authentication.
+ *
+ * These tools allow agents to:
+ * - Check if authorization is needed
+ * - Generate authorization URLs for any OAuth provider
+ * - Make authenticated API requests (token never exposed to LLM)
+ * - List and revoke authorizations
+ *
+ * Key principle: Tokens are NEVER exposed to the LLM.
+ * The LLM only knows whether authorization exists and can make API calls.
+ */
+
+import { z } from 'zod';
+import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { createLogger } from '../utils/logger.js';
+import { getOAuthManager, OAuthManager } from './oauth-manager.js';
+import type { OAuthProviderConfig } from './types.js';
+
+const logger = createLogger('AuthMCP');
+
+/**
+ * Helper to create a successful tool result.
+ */
+function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * Helper to create an error tool result (soft error, not thrown).
+ */
+function toolError(text: string): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{ type: 'text', text: `⚠️ ${text}` }],
+  };
+}
+
+/**
+ * Create authorization card for Feishu.
+ * This is a helper for agents to easily send authorization UI.
+ */
+export function createAuthCard(authUrl: string, provider: string): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: `🔗 ${provider} 授权` },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: `需要授权访问您的 **${provider}** 账号。点击下方按钮完成授权。`,
+      },
+      {
+        tag: 'action',
+        actions: [
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: `授权 ${provider}` },
+            url: authUrl,
+            type: 'primary',
+          },
+        ],
+      },
+      {
+        tag: 'markdown',
+        content: '_💡 授权信息将加密存储，AI 无法直接查看您的凭证_',
+      },
+    ],
+  };
+}
+
+/**
+ * Get OAuth manager instance (allows injection for testing).
+ */
+function getManager(): OAuthManager {
+  return getOAuthManager();
+}
+
+/**
+ * Auth MCP tools for Agent SDK.
+ */
+export const authSdkTools = [
+  tool(
+    'auth_check',
+    'Check if the user has authorized a service. Returns whether authorization exists and if the token is expired.',
+    {
+      provider: z.string().describe('Provider name (e.g., "github", "gitlab", "notion")'),
+      chatId: z.string().describe('Chat ID from the task context'),
+    },
+    async ({ provider, chatId }) => {
+      try {
+        const manager = getManager();
+        const result = await manager.checkToken(chatId, provider);
+
+        if (!result.hasToken) {
+          return toolSuccess(`No authorization found for ${provider}. The user needs to authorize this service first.`);
+        }
+
+        if (result.isExpired) {
+          return toolSuccess(`Authorization for ${provider} exists but has expired. The user needs to re-authorize.`);
+        }
+
+        return toolSuccess(`✅ Authorization for ${provider} is valid.`);
+      } catch (error) {
+        return toolError(`Failed to check authorization: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  ),
+
+  tool(
+    'auth_generate_url',
+    'Generate an OAuth authorization URL for a service. Returns the URL and state. The user must visit this URL to authorize. Use with send_user_feedback to send the URL to the user.',
+    {
+      providerName: z.string().describe('Provider name (e.g., "github", "gitlab")'),
+      authUrl: z.string().describe('OAuth authorization endpoint URL'),
+      tokenUrl: z.string().describe('OAuth token endpoint URL'),
+      clientId: z.string().describe('OAuth client ID'),
+      clientSecret: z.string().describe('OAuth client secret'),
+      scopes: z.string().describe('Space-separated OAuth scopes to request'),
+      callbackUrl: z.string().describe('OAuth callback URL (must match the registered redirect URI)'),
+      chatId: z.string().describe('Chat ID from the task context'),
+    },
+    async ({ providerName, authUrl, tokenUrl, clientId, clientSecret, scopes, callbackUrl, chatId }) => {
+      try {
+        const provider: OAuthProviderConfig = {
+          name: providerName,
+          authUrl,
+          tokenUrl,
+          clientId,
+          clientSecret,
+          scopes: scopes.split(' ').filter(Boolean),
+          callbackUrl,
+        };
+
+        const manager = getManager();
+        const result = manager.generateAuthUrl(provider, chatId);
+
+        logger.info({ chatId, provider: providerName }, 'Authorization URL generated');
+
+        return toolSuccess(
+          `Authorization URL generated:\n\n` +
+          `**URL:** ${result.url}\n\n` +
+          `Send this URL to the user so they can authorize. After authorization, the user should return and continue.`
+        );
+      } catch (error) {
+        return toolError(`Failed to generate authorization URL: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  ),
+
+  tool(
+    'auth_request',
+    'Make an authenticated API request on behalf of the user. The token is injected server-side and never exposed. Use this to call APIs after the user has authorized.',
+    {
+      chatId: z.string().describe('Chat ID from the task context'),
+      provider: z.string().describe('Provider name (e.g., "github", "gitlab")'),
+      method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).describe('HTTP method'),
+      url: z.string().describe('Full API URL to call'),
+      headers: z.record(z.string(), z.string()).optional().describe('Additional headers (Authorization header is added automatically)'),
+      body: z.unknown().optional().describe('Request body (for POST/PUT/PATCH)'),
+    },
+    async ({ chatId, provider, method, url, headers, body }) => {
+      try {
+        const manager = getManager();
+        const result = await manager.makeAuthenticatedRequest(chatId, provider, {
+          method,
+          url,
+          headers: headers as Record<string, string> | undefined,
+          body,
+        });
+
+        if (!result.success) {
+          if (result.status === 401) {
+            return toolError(
+              `Authentication required for ${provider}. The user needs to authorize this service first. ` +
+              `Use auth_check to verify authorization status.`
+            );
+          }
+          return toolError(`API request failed (${result.status}): ${result.error}`);
+        }
+
+        // Return data as formatted JSON
+        const dataStr = typeof result.data === 'string'
+          ? result.data
+          : JSON.stringify(result.data, null, 2);
+
+        return toolSuccess(`API request successful (${result.status}):\n\n\`\`\`json\n${dataStr}\n\`\`\``);
+      } catch (error) {
+        return toolError(`API request failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  ),
+
+  tool(
+    'auth_list',
+    'List all services the user has authorized in this chat.',
+    {
+      chatId: z.string().describe('Chat ID from the task context'),
+    },
+    async ({ chatId }) => {
+      try {
+        const manager = getManager();
+        const providers = await manager.listAuthorizations(chatId);
+
+        if (providers.length === 0) {
+          return toolSuccess('No authorizations found for this chat.');
+        }
+
+        return toolSuccess(
+          `Authorized services:\n${providers.map(p => `- ${p}`).join('\n')}`
+        );
+      } catch (error) {
+        return toolError(`Failed to list authorizations: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  ),
+
+  tool(
+    'auth_revoke',
+    'Revoke authorization for a service. This deletes the stored token.',
+    {
+      chatId: z.string().describe('Chat ID from the task context'),
+      provider: z.string().describe('Provider name to revoke'),
+    },
+    async ({ chatId, provider }) => {
+      try {
+        const manager = getManager();
+        const deleted = await manager.revokeToken(chatId, provider);
+
+        if (deleted) {
+          return toolSuccess(`✅ Authorization for ${provider} has been revoked.`);
+        } else {
+          return toolSuccess(`No authorization found for ${provider} to revoke.`);
+        }
+      } catch (error) {
+        return toolError(`Failed to revoke authorization: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+  ),
+];
+
+/**
+ * Create SDK MCP server for authentication tools.
+ */
+export function createAuthSdkMcpServer() {
+  return createSdkMcpServer({
+    name: 'auth',
+    version: '1.0.0',
+    tools: authSdkTools,
+  });
+}

--- a/src/auth/crypto.test.ts
+++ b/src/auth/crypto.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for auth/crypto.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  encrypt,
+  decrypt,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+  isEncrypted,
+} from './crypto.js';
+
+describe('Crypto', () => {
+  describe('encrypt and decrypt', () => {
+    it('should encrypt and decrypt a string', () => {
+      const plaintext = 'my-secret-token';
+      const key = 'test-encryption-key';
+
+      const encrypted = encrypt(plaintext, key);
+      const decrypted = decrypt(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should produce different ciphertext for same plaintext', () => {
+      const plaintext = 'my-secret-token';
+      const key = 'test-encryption-key';
+
+      const encrypted1 = encrypt(plaintext, key);
+      const encrypted2 = encrypt(plaintext, key);
+
+      expect(encrypted1).not.toBe(encrypted2);
+      expect(decrypt(encrypted1, key)).toBe(plaintext);
+      expect(decrypt(encrypted2, key)).toBe(plaintext);
+    });
+
+    it('should fail to decrypt with wrong key', () => {
+      const plaintext = 'my-secret-token';
+      const key1 = 'test-encryption-key-1';
+      const key2 = 'test-encryption-key-2';
+
+      const encrypted = encrypt(plaintext, key1);
+
+      expect(() => decrypt(encrypted, key2)).toThrow();
+    });
+
+    it('should handle empty strings', () => {
+      const plaintext = '';
+      const key = 'test-encryption-key';
+
+      const encrypted = encrypt(plaintext, key);
+      const decrypted = decrypt(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+
+    it('should handle unicode characters', () => {
+      const plaintext = '你好世界 🎉';
+      const key = 'test-encryption-key';
+
+      const encrypted = encrypt(plaintext, key);
+      const decrypted = decrypt(encrypted, key);
+
+      expect(decrypted).toBe(plaintext);
+    });
+  });
+
+  describe('isEncrypted', () => {
+    it('should return true for encrypted values', () => {
+      const encrypted = encrypt('test', 'key');
+      expect(isEncrypted(encrypted)).toBe(true);
+    });
+
+    it('should return false for plain strings', () => {
+      expect(isEncrypted('hello world')).toBe(false);
+      expect(isEncrypted('{"foo":"bar"}')).toBe(false);
+    });
+  });
+
+  describe('PKCE', () => {
+    it('should generate valid code verifier', () => {
+      const verifier = generateCodeVerifier();
+
+      // Should be 43 characters (32 bytes base64url encoded)
+      expect(verifier.length).toBeGreaterThanOrEqual(43);
+      expect(verifier.length).toBeLessThanOrEqual(128);
+
+      // Should only contain base64url characters
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should generate different verifiers', () => {
+      const verifier1 = generateCodeVerifier();
+      const verifier2 = generateCodeVerifier();
+
+      expect(verifier1).not.toBe(verifier2);
+    });
+
+    it('should generate valid code challenge', () => {
+      const verifier = generateCodeVerifier();
+      const challenge = generateCodeChallenge(verifier);
+
+      // Should be 43 characters (SHA256 base64url encoded)
+      expect(challenge.length).toBe(43);
+
+      // Should only contain base64url characters
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('should generate deterministic challenge', () => {
+      const verifier = 'test-verifier';
+
+      const challenge1 = generateCodeChallenge(verifier);
+      const challenge2 = generateCodeChallenge(verifier);
+
+      expect(challenge1).toBe(challenge2);
+    });
+  });
+
+  describe('generateState', () => {
+    it('should generate 32 character hex string', () => {
+      const state = generateState();
+
+      expect(state.length).toBe(32);
+      expect(state).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('should generate different states', () => {
+      const state1 = generateState();
+      const state2 = generateState();
+
+      expect(state1).not.toBe(state2);
+    });
+  });
+});

--- a/src/auth/crypto.ts
+++ b/src/auth/crypto.ts
@@ -1,0 +1,189 @@
+/**
+ * Cryptographic utilities for secure token storage.
+ *
+ * Uses AES-256-GCM for encryption with PBKDF2 key derivation.
+ */
+
+import * as crypto from 'crypto';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('AuthCrypto');
+
+/**
+ * Encryption algorithm constants.
+ */
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32; // 256 bits
+const IV_LENGTH = 16; // 128 bits
+const SALT_LENGTH = 32;
+const AUTH_TAG_LENGTH = 16;
+const PBKDF2_ITERATIONS = 100000;
+
+/**
+ * Get encryption key from environment or config.
+ * Falls back to a generated key if not configured (development only).
+ */
+export function getEncryptionKey(): string {
+  // Try environment variable first
+  const envKey = process.env.AUTH_ENCRYPTION_KEY;
+  if (envKey) {
+    return envKey;
+  }
+
+  // Generate a warning for development
+  logger.warn(
+    'AUTH_ENCRYPTION_KEY not set. Using generated key. ' +
+    'Set AUTH_ENCRYPTION_KEY environment variable for production.'
+  );
+
+  // Return a fixed development key (NOT for production)
+  return 'dev-key-please-set-AUTH_ENCRYPTION_KEY-in-production';
+}
+
+/**
+ * Derive encryption key from password using PBKDF2.
+ */
+function deriveKey(password: string, salt: Buffer): Buffer {
+  return crypto.pbkdf2Sync(
+    password,
+    salt,
+    PBKDF2_ITERATIONS,
+    KEY_LENGTH,
+    'sha256'
+  );
+}
+
+/**
+ * Encrypted data structure.
+ */
+interface EncryptedData {
+  /** Base64 encoded salt */
+  s: string;
+  /** Base64 encoded IV */
+  i: string;
+  /** Base64 encoded auth tag */
+  t: string;
+  /** Base64 encoded ciphertext */
+  c: string;
+}
+
+/**
+ * Encrypt a string value.
+ *
+ * @param plaintext - Text to encrypt
+ * @param key - Encryption key (optional, uses default if not provided)
+ * @returns Encrypted data as JSON string
+ */
+export function encrypt(plaintext: string, key?: string): string {
+  const encryptionKey = key || getEncryptionKey();
+
+  // Generate random salt and IV
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const iv = crypto.randomBytes(IV_LENGTH);
+
+  // Derive key
+  const derivedKey = deriveKey(encryptionKey, salt);
+
+  // Create cipher
+  const cipher = crypto.createCipheriv(ALGORITHM, derivedKey, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  // Encrypt
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, 'utf8'),
+    cipher.final(),
+  ]);
+
+  // Get auth tag
+  const authTag = cipher.getAuthTag();
+
+  // Create encrypted data object
+  const encryptedData: EncryptedData = {
+    s: salt.toString('base64'),
+    i: iv.toString('base64'),
+    t: authTag.toString('base64'),
+    c: encrypted.toString('base64'),
+  };
+
+  return JSON.stringify(encryptedData);
+}
+
+/**
+ * Decrypt an encrypted string.
+ *
+ * @param encryptedString - Encrypted data as JSON string
+ * @param key - Encryption key (optional, uses default if not provided)
+ * @returns Decrypted plaintext
+ * @throws Error if decryption fails
+ */
+export function decrypt(encryptedString: string, key?: string): string {
+  const encryptionKey = key || getEncryptionKey();
+
+  try {
+    // Parse encrypted data
+    const data: EncryptedData = JSON.parse(encryptedString);
+
+    // Decode components
+    const salt = Buffer.from(data.s, 'base64');
+    const iv = Buffer.from(data.i, 'base64');
+    const authTag = Buffer.from(data.t, 'base64');
+    const encrypted = Buffer.from(data.c, 'base64');
+
+    // Derive key
+    const derivedKey = deriveKey(encryptionKey, salt);
+
+    // Create decipher
+    const decipher = crypto.createDecipheriv(ALGORITHM, derivedKey, iv, {
+      authTagLength: AUTH_TAG_LENGTH,
+    });
+
+    // Set auth tag
+    decipher.setAuthTag(authTag);
+
+    // Decrypt
+    const decrypted = Buffer.concat([
+      decipher.update(encrypted),
+      decipher.final(),
+    ]);
+
+    return decrypted.toString('utf8');
+  } catch (error) {
+    logger.error({ err: error }, 'Decryption failed');
+    throw new Error('Failed to decrypt data. Key may be incorrect.');
+  }
+}
+
+/**
+ * Generate a random code verifier for PKCE.
+ * RFC 7636 recommends 43-128 characters.
+ */
+export function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+/**
+ * Generate code challenge from verifier for PKCE.
+ * Uses SHA256 and base64url encoding (S256 method).
+ */
+export function generateCodeChallenge(verifier: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(verifier)
+    .digest('base64url');
+}
+
+/**
+ * Generate a random state string for CSRF protection.
+ */
+export function generateState(): string {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * Check if a value appears to be encrypted.
+ * Simple check: encrypted values start with '{"s":'
+ */
+export function isEncrypted(value: string): boolean {
+  return value.startsWith('{"s":');
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Authentication module for secure third-party OAuth.
+ *
+ * This module provides:
+ * - OAuth 2.0 PKCE flow management
+ * - Encrypted token storage
+ * - MCP tools for agent integration
+ *
+ * Key principle: Tokens are NEVER exposed to the LLM.
+ */
+
+// Types
+export type {
+  OAuthProviderConfig,
+  OAuthToken,
+  PKCECodes,
+  OAuthState,
+  AuthUrlResult,
+  CallbackResult,
+  TokenCheckResult,
+  ApiRequestConfig,
+  ApiResponse,
+  AuthConfig,
+} from './types.js';
+
+// Crypto utilities
+export {
+  encrypt,
+  decrypt,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+} from './crypto.js';
+
+// Token storage
+export { TokenStore, getTokenStore } from './token-store.js';
+
+// OAuth manager
+export { OAuthManager, getOAuthManager } from './oauth-manager.js';
+
+// MCP tools
+export { authSdkTools, createAuthSdkMcpServer, createAuthCard } from './auth-mcp.js';

--- a/src/auth/oauth-manager.test.ts
+++ b/src/auth/oauth-manager.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests for auth/oauth-manager.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { OAuthManager } from './oauth-manager.js';
+import { TokenStore } from './token-store.js';
+import type { OAuthProviderConfig, OAuthToken } from './types.js';
+
+// Mock fetch for token exchange
+const originalFetch = global.fetch;
+
+describe('OAuthManager', () => {
+  let tempDir: string;
+  let tokenStore: TokenStore;
+  let manager: OAuthManager;
+
+  const mockProvider: OAuthProviderConfig = {
+    name: 'test-provider',
+    authUrl: 'https://example.com/oauth/authorize',
+    tokenUrl: 'https://example.com/oauth/token',
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    scopes: ['read', 'write'],
+    callbackUrl: 'http://localhost:3000/auth/callback',
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oauth-manager-test-'));
+    const storagePath = path.join(tempDir, 'tokens.json');
+    tokenStore = new TokenStore(storagePath);
+    manager = new OAuthManager(tokenStore);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    global.fetch = originalFetch;
+    manager.stopCallbackServer();
+  });
+
+  describe('generateAuthUrl', () => {
+    it('should generate a valid authorization URL', () => {
+      const result = manager.generateAuthUrl(mockProvider, 'chat-1');
+
+      expect(result.url).toContain('https://example.com/oauth/authorize');
+      expect(result.url).toContain('client_id=test-client-id');
+      expect(result.url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback');
+      expect(result.url).toContain('scope=read+write');
+      expect(result.url).toContain('response_type=code');
+      expect(result.url).toContain('code_challenge_method=S256');
+      expect(result.state).toBeDefined();
+    });
+
+    it('should generate different states for different calls', () => {
+      const result1 = manager.generateAuthUrl(mockProvider, 'chat-1');
+      const result2 = manager.generateAuthUrl(mockProvider, 'chat-1');
+
+      expect(result1.state).not.toBe(result2.state);
+    });
+
+    it('should include PKCE code challenge', () => {
+      const result = manager.generateAuthUrl(mockProvider, 'chat-1');
+
+      expect(result.url).toContain('code_challenge=');
+    });
+  });
+
+  describe('handleCallback', () => {
+    it('should return error for invalid state', async () => {
+      const result = await manager.handleCallback('test-code', 'invalid-state');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid or expired');
+    });
+
+    it('should exchange code for token and store it', async () => {
+      // First generate an auth URL to create a state
+      const { state } = manager.generateAuthUrl(mockProvider, 'chat-1');
+
+      // Mock fetch for token exchange
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'read write',
+        }),
+      });
+
+      const result = await manager.handleCallback('test-code', state);
+
+      expect(result.success).toBe(true);
+      expect(result.chatId).toBe('chat-1');
+      expect(result.provider).toBe('test-provider');
+
+      // Verify token was stored
+      const storedToken = await tokenStore.getToken('chat-1', 'test-provider');
+      expect(storedToken).not.toBeNull();
+      expect(storedToken!.accessToken).toBe('test-access-token');
+    });
+
+    it('should handle token exchange failure', async () => {
+      const { state } = manager.generateAuthUrl(mockProvider, 'chat-1');
+
+      // Mock fetch failure
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'Invalid grant',
+      });
+
+      const result = await manager.handleCallback('test-code', state);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Token exchange failed');
+    });
+  });
+
+  describe('checkToken', () => {
+    it('should return false when no token exists', async () => {
+      const result = await manager.checkToken('chat-1', 'github');
+
+      expect(result.hasToken).toBe(false);
+    });
+
+    it('should return true when valid token exists', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 3600000, // 1 hour from now
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      const result = await manager.checkToken('chat-1', 'github');
+
+      expect(result.hasToken).toBe(true);
+      expect(result.isExpired).toBe(false);
+    });
+
+    it('should return expired when token is expired', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now() - 7200000, // 2 hours ago
+        expiresAt: Date.now() - 3600000, // Expired 1 hour ago
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      const result = await manager.checkToken('chat-1', 'github');
+
+      expect(result.hasToken).toBe(true);
+      expect(result.isExpired).toBe(true);
+    });
+  });
+
+  describe('makeAuthenticatedRequest', () => {
+    it('should return 401 when no token exists', async () => {
+      const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {
+        method: 'GET',
+        url: 'https://api.github.com/user',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe(401);
+    });
+
+    it('should return 401 when token is expired', async () => {
+      const token: OAuthToken = {
+        accessToken: 'expired-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now() - 7200000,
+        expiresAt: Date.now() - 3600000,
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {
+        method: 'GET',
+        url: 'https://api.github.com/user',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe(401);
+    });
+
+    it('should make authenticated request', async () => {
+      const token: OAuthToken = {
+        accessToken: 'valid-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 3600000,
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      // Mock fetch
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ login: 'testuser' }),
+      });
+
+      const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {
+        method: 'GET',
+        url: 'https://api.github.com/user',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ login: 'testuser' });
+
+      // Verify Authorization header was set
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/user',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer valid-token',
+          }),
+        })
+      );
+    });
+
+    it('should handle API error', async () => {
+      const token: OAuthToken = {
+        accessToken: 'valid-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 3600000,
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      // Mock fetch with error
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: async () => 'Not Found',
+      });
+
+      const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {
+        method: 'GET',
+        url: 'https://api.github.com/nonexistent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.status).toBe(404);
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('should delete existing token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+
+      const result = await manager.revokeToken('chat-1', 'github');
+
+      expect(result).toBe(true);
+      expect(await tokenStore.getToken('chat-1', 'github')).toBeNull();
+    });
+
+    it('should return false for non-existent token', async () => {
+      const result = await manager.revokeToken('chat-1', 'github');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listAuthorizations', () => {
+    it('should list authorized providers', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await tokenStore.setToken('chat-1', 'github', token);
+      await tokenStore.setToken('chat-1', 'gitlab', token);
+      await tokenStore.setToken('chat-2', 'notion', token);
+
+      const providers = await manager.listAuthorizations('chat-1');
+
+      expect(providers).toHaveLength(2);
+      expect(providers).toContain('github');
+      expect(providers).toContain('gitlab');
+    });
+  });
+});

--- a/src/auth/oauth-manager.ts
+++ b/src/auth/oauth-manager.ts
@@ -1,0 +1,451 @@
+/**
+ * OAuth 2.0 PKCE flow manager.
+ *
+ * Manages OAuth authorization flows with PKCE for security.
+ * Supports any OAuth 2.0 compatible provider.
+ */
+
+import * as http from 'http';
+import * as url from 'url';
+import { createLogger } from '../utils/logger.js';
+import { getTokenStore, TokenStore } from './token-store.js';
+import {
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+} from './crypto.js';
+import type {
+  OAuthProviderConfig,
+  OAuthToken,
+  OAuthState,
+  AuthUrlResult,
+  CallbackResult,
+  TokenCheckResult,
+  ApiRequestConfig,
+  ApiResponse,
+} from './types.js';
+
+const logger = createLogger('OAuthManager');
+
+/**
+ * In-memory store for pending OAuth states.
+ * States are short-lived (5 minutes) so memory storage is acceptable.
+ */
+const pendingStates = new Map<string, OAuthState>();
+
+/**
+ * Clean up expired states (older than 5 minutes).
+ */
+function cleanupExpiredStates(): void {
+  const now = Date.now();
+  const maxAge = 5 * 60 * 1000; // 5 minutes
+
+  for (const [state, data] of pendingStates.entries()) {
+    if (now - data.createdAt > maxAge) {
+      pendingStates.delete(state);
+      logger.debug({ state }, 'Expired OAuth state removed');
+    }
+  }
+}
+
+/**
+ * OAuth manager for handling authorization flows.
+ */
+export class OAuthManager {
+  private readonly tokenStore: TokenStore;
+  private callbackServer: http.Server | null = null;
+
+  constructor(tokenStore?: TokenStore) {
+    this.tokenStore = tokenStore || getTokenStore();
+  }
+
+  /**
+   * Generate an authorization URL for a provider.
+   *
+   * @param provider - Provider configuration
+   * @param chatId - Chat ID initiating the flow
+   * @returns Authorization URL and state for tracking
+   */
+  generateAuthUrl(
+    provider: OAuthProviderConfig,
+    chatId: string
+  ): AuthUrlResult {
+    // Clean up old states
+    cleanupExpiredStates();
+
+    // Generate PKCE codes
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = generateCodeChallenge(codeVerifier);
+
+    // Generate state for CSRF protection
+    const state = generateState();
+
+    // Store state for callback verification
+    const oauthState: OAuthState = {
+      state,
+      chatId,
+      provider: provider.name,
+      pkce: { codeVerifier, codeChallenge },
+      createdAt: Date.now(),
+      providerConfig: provider,
+    };
+    pendingStates.set(state, oauthState);
+
+    // Build authorization URL
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: provider.clientId,
+      redirect_uri: provider.callbackUrl,
+      scope: provider.scopes.join(' '),
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    const authUrl = `${provider.authUrl}?${params.toString()}`;
+
+    logger.info({ chatId, provider: provider.name, state }, 'Authorization URL generated');
+
+    return { url: authUrl, state };
+  }
+
+  /**
+   * Handle OAuth callback - exchange code for token.
+   *
+   * @param code - Authorization code from callback
+   * @param state - State from callback
+   * @returns Callback result with success status
+   */
+  async handleCallback(code: string, state: string): Promise<CallbackResult> {
+    // Clean up old states
+    cleanupExpiredStates();
+
+    // Verify state
+    const oauthState = pendingStates.get(state);
+    if (!oauthState) {
+      logger.error({ state }, 'Invalid or expired OAuth state');
+      return {
+        success: false,
+        chatId: '',
+        provider: '',
+        error: 'Invalid or expired authorization state. Please try again.',
+      };
+    }
+
+    // Remove state (one-time use)
+    pendingStates.delete(state);
+
+    try {
+      // Exchange code for token
+      const token = await this.exchangeCodeForToken(
+        code,
+        oauthState.pkce.codeVerifier,
+        oauthState.providerConfig
+      );
+
+      // Store token
+      await this.tokenStore.setToken(
+        oauthState.chatId,
+        oauthState.provider,
+        token
+      );
+
+      logger.info(
+        { chatId: oauthState.chatId, provider: oauthState.provider },
+        'OAuth callback successful'
+      );
+
+      return {
+        success: true,
+        chatId: oauthState.chatId,
+        provider: oauthState.provider,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(
+        { err: error, chatId: oauthState.chatId, provider: oauthState.provider },
+        'Token exchange failed'
+      );
+
+      return {
+        success: false,
+        chatId: oauthState.chatId,
+        provider: oauthState.provider,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Exchange authorization code for access token.
+   */
+  private async exchangeCodeForToken(
+    code: string,
+    codeVerifier: string,
+    provider: OAuthProviderConfig
+  ): Promise<OAuthToken> {
+    const params = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: provider.callbackUrl,
+      client_id: provider.clientId,
+      client_secret: provider.clientSecret,
+      code_verifier: codeVerifier,
+    });
+
+    const response = await fetch(provider.tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: params.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Token exchange failed: ${response.status} - ${text}`);
+    }
+
+    const data = (await response.json()) as Record<string, unknown>;
+
+    // Calculate expiration time
+    const expiresIn = typeof data.expires_in === 'number' ? data.expires_in : 3600;
+    const expiresAt = Date.now() + expiresIn * 1000;
+
+    return {
+      accessToken: String(data.access_token),
+      refreshToken: data.refresh_token ? String(data.refresh_token) : undefined,
+      tokenType: String(data.token_type || 'Bearer'),
+      expiresAt,
+      scope: typeof data.scope === 'string' ? data.scope : undefined,
+      createdAt: Date.now(),
+    };
+  }
+
+  /**
+   * Check if a valid token exists for a provider.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns Token check result
+   */
+  async checkToken(chatId: string, provider: string): Promise<TokenCheckResult> {
+    const token = await this.tokenStore.getToken(chatId, provider);
+
+    if (!token) {
+      return { hasToken: false, provider };
+    }
+
+    const isExpired = token.expiresAt ? token.expiresAt < Date.now() : false;
+
+    return {
+      hasToken: true,
+      isExpired,
+      provider,
+    };
+  }
+
+  /**
+   * Make an authenticated API request on behalf of the user.
+   * Token is injected server-side, never exposed to LLM.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @param config - API request configuration
+   * @returns API response
+   */
+  async makeAuthenticatedRequest<T = unknown>(
+    chatId: string,
+    provider: string,
+    config: ApiRequestConfig
+  ): Promise<ApiResponse<T>> {
+    const accessToken = await this.tokenStore.getAccessToken(chatId, provider);
+
+    if (!accessToken) {
+      return {
+        success: false,
+        status: 401,
+        error: `No valid token found for ${provider}. Please authorize first.`,
+      };
+    }
+
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+        ...config.headers,
+      };
+
+      // Add Content-Type for requests with body
+      if (config.body) {
+        headers['Content-Type'] = 'application/json';
+      }
+
+      const response = await fetch(config.url, {
+        method: config.method,
+        headers,
+        body: config.body ? JSON.stringify(config.body) : undefined,
+      });
+
+      const status = response.status;
+
+      if (!response.ok) {
+        const text = await response.text();
+        logger.error(
+          { chatId, provider, status, error: text },
+          'API request failed'
+        );
+
+        return {
+          success: false,
+          status,
+          error: text,
+        };
+      }
+
+      // Try to parse JSON, fall back to text
+      let data: T;
+      const contentType = response.headers.get('content-type');
+      if (contentType?.includes('application/json')) {
+        data = (await response.json()) as T;
+      } else {
+        data = (await response.text()) as T;
+      }
+
+      return {
+        success: true,
+        status,
+        data,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error(
+        { err: error, chatId, provider },
+        'API request error'
+      );
+
+      return {
+        success: false,
+        status: 0,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Revoke (delete) a token.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns true if token was deleted
+   */
+  async revokeToken(chatId: string, provider: string): Promise<boolean> {
+    return this.tokenStore.deleteToken(chatId, provider);
+  }
+
+  /**
+   * List all authorized providers for a chat.
+   *
+   * @param chatId - Chat identifier
+   * @returns Array of provider names
+   */
+  async listAuthorizations(chatId: string): Promise<string[]> {
+    return this.tokenStore.listProviders(chatId);
+  }
+
+  /**
+   * Start a callback server for OAuth redirects.
+   *
+   * @param port - Port to listen on
+   * @returns Server URL
+   */
+  async startCallbackServer(port: number = 3000): Promise<string> {
+    if (this.callbackServer) {
+      return `http://localhost:${port}`;
+    }
+
+    return new Promise((resolve, reject) => {
+      this.callbackServer = http.createServer(async (req, res) => {
+        try {
+          const reqUrl = new url.URL(req.url || '/', `http://localhost:${port}`);
+
+          if (reqUrl.pathname === '/auth/callback') {
+            const code = reqUrl.searchParams.get('code');
+            const state = reqUrl.searchParams.get('state');
+            const error = reqUrl.searchParams.get('error');
+
+            if (error) {
+              res.writeHead(400, { 'Content-Type': 'text/html' });
+              res.end(`<h1>Authorization Failed</h1><p>${error}</p>`);
+              return;
+            }
+
+            if (!code || !state) {
+              res.writeHead(400, { 'Content-Type': 'text/html' });
+              res.end('<h1>Invalid Callback</h1><p>Missing code or state.</p>');
+              return;
+            }
+
+            const result = await this.handleCallback(code, state);
+
+            if (result.success) {
+              res.writeHead(200, { 'Content-Type': 'text/html' });
+              res.end(`
+                <h1>Authorization Successful</h1>
+                <p>You have successfully authorized <strong>${result.provider}</strong>.</p>
+                <p>You can close this window and return to your chat.</p>
+              `);
+            } else {
+              res.writeHead(400, { 'Content-Type': 'text/html' });
+              res.end(`
+                <h1>Authorization Failed</h1>
+                <p>${result.error || 'Unknown error'}</p>
+              `);
+            }
+          } else {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('Not Found');
+          }
+        } catch (error) {
+          logger.error({ err: error }, 'Callback server error');
+          res.writeHead(500, { 'Content-Type': 'text/plain' });
+          res.end('Internal Server Error');
+        }
+      });
+
+      this.callbackServer.listen(port, () => {
+        logger.info({ port }, 'OAuth callback server started');
+        resolve(`http://localhost:${port}`);
+      });
+
+      this.callbackServer.on('error', reject);
+    });
+  }
+
+  /**
+   * Stop the callback server.
+   */
+  stopCallbackServer(): void {
+    if (this.callbackServer) {
+      this.callbackServer.close();
+      this.callbackServer = null;
+      logger.info('OAuth callback server stopped');
+    }
+  }
+}
+
+/**
+ * Singleton OAuth manager instance.
+ */
+let oauthManagerInstance: OAuthManager | null = null;
+
+/**
+ * Get the global OAuth manager instance.
+ */
+export function getOAuthManager(): OAuthManager {
+  if (!oauthManagerInstance) {
+    oauthManagerInstance = new OAuthManager();
+  }
+  return oauthManagerInstance;
+}

--- a/src/auth/token-store.test.ts
+++ b/src/auth/token-store.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for auth/token-store.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { TokenStore } from './token-store.js';
+import type { OAuthToken } from './types.js';
+
+describe('TokenStore', () => {
+  let tempDir: string;
+  let store: TokenStore;
+
+  beforeEach(async () => {
+    // Create temp directory for each test
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'token-store-test-'));
+    const storagePath = path.join(tempDir, 'tokens.json');
+    store = new TokenStore(storagePath);
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('setToken and getToken', () => {
+    it('should store and retrieve a token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-access-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token);
+      const retrieved = await store.getToken('chat-1', 'github');
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.accessToken).toBe('test-access-token');
+      expect(retrieved!.tokenType).toBe('Bearer');
+    });
+
+    it('should store multiple tokens for different providers', async () => {
+      const githubToken: OAuthToken = {
+        accessToken: 'github-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      const gitlabToken: OAuthToken = {
+        accessToken: 'gitlab-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', githubToken);
+      await store.setToken('chat-1', 'gitlab', gitlabToken);
+
+      const retrievedGithub = await store.getToken('chat-1', 'github');
+      const retrievedGitlab = await store.getToken('chat-1', 'gitlab');
+
+      expect(retrievedGithub!.accessToken).toBe('github-token');
+      expect(retrievedGitlab!.accessToken).toBe('gitlab-token');
+    });
+
+    it('should store tokens for different chats', async () => {
+      const token1: OAuthToken = {
+        accessToken: 'token-chat-1',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      const token2: OAuthToken = {
+        accessToken: 'token-chat-2',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token1);
+      await store.setToken('chat-2', 'github', token2);
+
+      const retrieved1 = await store.getToken('chat-1', 'github');
+      const retrieved2 = await store.getToken('chat-2', 'github');
+
+      expect(retrieved1!.accessToken).toBe('token-chat-1');
+      expect(retrieved2!.accessToken).toBe('token-chat-2');
+    });
+
+    it('should return null for non-existent token', async () => {
+      const retrieved = await store.getToken('unknown-chat', 'unknown-provider');
+      expect(retrieved).toBeNull();
+    });
+
+    it('should update existing token', async () => {
+      const token1: OAuthToken = {
+        accessToken: 'old-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      const token2: OAuthToken = {
+        accessToken: 'new-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token1);
+      await store.setToken('chat-1', 'github', token2);
+
+      const retrieved = await store.getToken('chat-1', 'github');
+      expect(retrieved!.accessToken).toBe('new-token');
+    });
+  });
+
+  describe('hasToken', () => {
+    it('should return true for existing token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token);
+
+      expect(await store.hasToken('chat-1', 'github')).toBe(true);
+    });
+
+    it('should return false for non-existent token', async () => {
+      expect(await store.hasToken('unknown-chat', 'github')).toBe(false);
+    });
+  });
+
+  describe('deleteToken', () => {
+    it('should delete an existing token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token);
+      const deleted = await store.deleteToken('chat-1', 'github');
+
+      expect(deleted).toBe(true);
+      expect(await store.getToken('chat-1', 'github')).toBeNull();
+    });
+
+    it('should return false for non-existent token', async () => {
+      const deleted = await store.deleteToken('unknown-chat', 'github');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('listProviders', () => {
+    it('should list all providers for a chat', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token);
+      await store.setToken('chat-1', 'gitlab', token);
+      await store.setToken('chat-2', 'notion', token);
+
+      const providers = await store.listProviders('chat-1');
+
+      expect(providers).toHaveLength(2);
+      expect(providers).toContain('github');
+      expect(providers).toContain('gitlab');
+      expect(providers).not.toContain('notion');
+    });
+
+    it('should return empty array for chat with no tokens', async () => {
+      const providers = await store.listProviders('unknown-chat');
+      expect(providers).toEqual([]);
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('should return the access token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'test-access-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+
+      await store.setToken('chat-1', 'github', token);
+
+      const accessToken = await store.getAccessToken('chat-1', 'github');
+      expect(accessToken).toBe('test-access-token');
+    });
+
+    it('should return null for expired token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'expired-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now() - 7200000, // 2 hours ago
+        expiresAt: Date.now() - 3600000, // Expired 1 hour ago
+      };
+
+      await store.setToken('chat-1', 'github', token);
+
+      const accessToken = await store.getAccessToken('chat-1', 'github');
+      expect(accessToken).toBeNull();
+    });
+
+    it('should return token for non-expired token', async () => {
+      const token: OAuthToken = {
+        accessToken: 'valid-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 3600000, // Expires in 1 hour
+      };
+
+      await store.setToken('chat-1', 'github', token);
+
+      const accessToken = await store.getAccessToken('chat-1', 'github');
+      expect(accessToken).toBe('valid-token');
+    });
+  });
+
+  describe('persistence', () => {
+    it('should persist tokens across store instances', async () => {
+      const storagePath = path.join(tempDir, 'persistent-tokens.json');
+
+      // Create first store and save token
+      const store1 = new TokenStore(storagePath);
+      const token: OAuthToken = {
+        accessToken: 'persistent-token',
+        tokenType: 'Bearer',
+        createdAt: Date.now(),
+      };
+      await store1.setToken('chat-1', 'github', token);
+
+      // Create second store with same path
+      const store2 = new TokenStore(storagePath);
+      const retrieved = await store2.getToken('chat-1', 'github');
+
+      expect(retrieved!.accessToken).toBe('persistent-token');
+    });
+  });
+});

--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,0 +1,247 @@
+/**
+ * Token storage for OAuth tokens.
+ *
+ * Stores tokens encrypted on disk, keyed by chatId + provider.
+ * File-based storage for simplicity (no database required).
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import { Config } from '../config/index.js';
+import { encrypt, decrypt } from './crypto.js';
+import type { OAuthToken } from './types.js';
+
+const logger = createLogger('TokenStore');
+
+/**
+ * Token storage file structure.
+ */
+interface TokenStorageFile {
+  /** Version for migration support */
+  version: 1;
+  /** Tokens keyed by "chatId:provider" */
+  tokens: Record<string, string>; // encrypted OAuthToken JSON
+}
+
+/**
+ * Token store for managing OAuth tokens.
+ *
+ * Tokens are stored encrypted in a JSON file.
+ * Key format: `${chatId}:${provider}`
+ */
+export class TokenStore {
+  private readonly storagePath: string;
+  private cache: TokenStorageFile | null = null;
+
+  constructor(storagePath?: string) {
+    // Default to .auth-tokens.json in workspace directory
+    this.storagePath = storagePath || path.join(
+      Config.getWorkspaceDir(),
+      '.auth-tokens.json'
+    );
+  }
+
+  /**
+   * Get the storage key for a chatId + provider combination.
+   */
+  private getKey(chatId: string, provider: string): string {
+    return `${chatId}:${provider}`;
+  }
+
+  /**
+   * Load the token storage file.
+   */
+  private async load(): Promise<TokenStorageFile> {
+    if (this.cache) {
+      return this.cache;
+    }
+
+    try {
+      const content = await fs.readFile(this.storagePath, 'utf-8');
+      const data = JSON.parse(content) as TokenStorageFile;
+
+      // Validate version
+      if (data.version !== 1) {
+        throw new Error(`Unsupported token storage version: ${data.version}`);
+      }
+
+      this.cache = data;
+      return data;
+    } catch (error) {
+      // File doesn't exist or is invalid - return empty structure
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        const empty: TokenStorageFile = { version: 1, tokens: {} };
+        this.cache = empty;
+        return empty;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Save the token storage file.
+   */
+  private async save(data: TokenStorageFile): Promise<void> {
+    // Ensure directory exists
+    const dir = path.dirname(this.storagePath);
+    await fs.mkdir(dir, { recursive: true });
+
+    // Write atomically using temp file
+    const tempPath = `${this.storagePath}.tmp`;
+    await fs.writeFile(tempPath, JSON.stringify(data, null, 2), 'utf-8');
+    await fs.rename(tempPath, this.storagePath);
+
+    // Update cache
+    this.cache = data;
+
+    logger.debug({ path: this.storagePath }, 'Token storage saved');
+  }
+
+  /**
+   * Store a token for a chatId + provider.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @param token - OAuth token to store
+   */
+  async setToken(
+    chatId: string,
+    provider: string,
+    token: OAuthToken
+  ): Promise<void> {
+    const data = await this.load();
+    const key = this.getKey(chatId, provider);
+
+    // Encrypt token before storage
+    const encrypted = encrypt(JSON.stringify(token));
+    data.tokens[key] = encrypted;
+
+    await this.save(data);
+    logger.info({ chatId, provider }, 'Token stored');
+  }
+
+  /**
+   * Get a token for a chatId + provider.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns OAuth token or null if not found
+   */
+  async getToken(chatId: string, provider: string): Promise<OAuthToken | null> {
+    const data = await this.load();
+    const key = this.getKey(chatId, provider);
+
+    const encrypted = data.tokens[key];
+    if (!encrypted) {
+      return null;
+    }
+
+    try {
+      const decrypted = decrypt(encrypted);
+      return JSON.parse(decrypted) as OAuthToken;
+    } catch (error) {
+      logger.error({ err: error, chatId, provider }, 'Failed to decrypt token');
+      return null;
+    }
+  }
+
+  /**
+   * Check if a token exists for a chatId + provider.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns true if token exists (may be expired)
+   */
+  async hasToken(chatId: string, provider: string): Promise<boolean> {
+    const data = await this.load();
+    const key = this.getKey(chatId, provider);
+    return key in data.tokens;
+  }
+
+  /**
+   * Delete a token for a chatId + provider.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns true if token was deleted
+   */
+  async deleteToken(chatId: string, provider: string): Promise<boolean> {
+    const data = await this.load();
+    const key = this.getKey(chatId, provider);
+
+    if (!(key in data.tokens)) {
+      return false;
+    }
+
+    delete data.tokens[key];
+    await this.save(data);
+
+    logger.info({ chatId, provider }, 'Token deleted');
+    return true;
+  }
+
+  /**
+   * List all providers that have tokens for a chatId.
+   *
+   * @param chatId - Chat identifier
+   * @returns Array of provider names
+   */
+  async listProviders(chatId: string): Promise<string[]> {
+    const data = await this.load();
+    const prefix = `${chatId}:`;
+
+    const providers: string[] = [];
+    for (const key of Object.keys(data.tokens)) {
+      if (key.startsWith(prefix)) {
+        providers.push(key.slice(prefix.length));
+      }
+    }
+
+    return providers;
+  }
+
+  /**
+   * Get the decrypted access token for API calls.
+   *
+   * @param chatId - Chat identifier
+   * @param provider - Provider name
+   * @returns Access token or null if not found
+   */
+  async getAccessToken(chatId: string, provider: string): Promise<string | null> {
+    const token = await this.getToken(chatId, provider);
+    if (!token) {
+      return null;
+    }
+
+    // Check if expired
+    if (token.expiresAt && token.expiresAt < Date.now()) {
+      logger.info({ chatId, provider }, 'Token is expired');
+      return null;
+    }
+
+    return token.accessToken;
+  }
+
+  /**
+   * Clear the in-memory cache.
+   */
+  clearCache(): void {
+    this.cache = null;
+  }
+}
+
+/**
+ * Singleton token store instance.
+ */
+let tokenStoreInstance: TokenStore | null = null;
+
+/**
+ * Get the global token store instance.
+ */
+export function getTokenStore(): TokenStore {
+  if (!tokenStoreInstance) {
+    tokenStoreInstance = new TokenStore();
+  }
+  return tokenStoreInstance;
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,151 @@
+/**
+ * Authentication types for OAuth 2.0 PKCE flow.
+ *
+ * This module defines types for secure third-party authentication
+ * that keeps tokens isolated from the LLM.
+ */
+
+/**
+ * OAuth provider configuration.
+ * Not pre-defined - agents can use any OAuth-compatible service.
+ */
+export interface OAuthProviderConfig {
+  /** Provider name (e.g., 'github', 'gitlab', 'notion') */
+  name: string;
+  /** OAuth 2.0 authorization endpoint URL */
+  authUrl: string;
+  /** OAuth 2.0 token endpoint URL */
+  tokenUrl: string;
+  /** OAuth client ID */
+  clientId: string;
+  /** OAuth client secret */
+  clientSecret: string;
+  /** OAuth scopes to request */
+  scopes: string[];
+  /** Callback URL for OAuth redirect */
+  callbackUrl: string;
+}
+
+/**
+ * OAuth token stored for a chat.
+ */
+export interface OAuthToken {
+  /** Access token (encrypted) */
+  accessToken: string;
+  /** Refresh token (encrypted, optional) */
+  refreshToken?: string;
+  /** Token type (usually 'Bearer') */
+  tokenType: string;
+  /** Expiration timestamp (Unix milliseconds) */
+  expiresAt?: number;
+  /** Granted scopes */
+  scope?: string;
+  /** When the token was created */
+  createdAt: number;
+}
+
+/**
+ * PKCE code verifier and challenge.
+ */
+export interface PKCECodes {
+  /** Random code verifier (43-128 characters) */
+  codeVerifier: string;
+  /** SHA256 hash of verifier, base64url encoded */
+  codeChallenge: string;
+}
+
+/**
+ * OAuth state for tracking authorization flows.
+ */
+export interface OAuthState {
+  /** Unique state identifier */
+  state: string;
+  /** Chat ID that initiated the flow */
+  chatId: string;
+  /** Provider name */
+  provider: string;
+  /** PKCE codes for this flow */
+  pkce: PKCECodes;
+  /** When this state was created */
+  createdAt: number;
+  /** Provider configuration (stored temporarily) */
+  providerConfig: OAuthProviderConfig;
+}
+
+/**
+ * Result of OAuth authorization URL generation.
+ */
+export interface AuthUrlResult {
+  /** Authorization URL to redirect user to */
+  url: string;
+  /** State identifier for tracking */
+  state: string;
+}
+
+/**
+ * Result of OAuth callback handling.
+ */
+export interface CallbackResult {
+  /** Whether authorization was successful */
+  success: boolean;
+  /** Chat ID that initiated the flow */
+  chatId: string;
+  /** Provider name */
+  provider: string;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Result of token check.
+ */
+export interface TokenCheckResult {
+  /** Whether a valid token exists */
+  hasToken: boolean;
+  /** Whether the token is expired */
+  isExpired?: boolean;
+  /** Provider name */
+  provider: string;
+}
+
+/**
+ * API request configuration for authenticated requests.
+ */
+export interface ApiRequestConfig {
+  /** HTTP method */
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  /** API endpoint URL */
+  url: string;
+  /** Request headers */
+  headers?: Record<string, string>;
+  /** Request body (for POST/PUT/PATCH) */
+  body?: unknown;
+}
+
+/**
+ * API response from authenticated request.
+ */
+export interface ApiResponse<T = unknown> {
+  /** Whether the request was successful */
+  success: boolean;
+  /** Response status code */
+  status: number;
+  /** Response data */
+  data?: T;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Authorization configuration in disclaude.config.yaml.
+ */
+export interface AuthConfig {
+  /** Encryption key for token storage (or env var name) */
+  encryptionKey?: string;
+  /** Token storage path */
+  storagePath?: string;
+  /** Callback server port */
+  callbackPort?: number;
+  /** Callback URL base */
+  callbackUrl?: string;
+}


### PR DESCRIPTION
## Summary

- Implements #60 - Secure third party auth with minimal design
- Creates a secure OAuth 2.0 PKCE authentication system
- Enables agents to access third-party APIs on behalf of users

## Key Principle

**Tokens are NEVER exposed to the LLM.** The agent only knows:
- Whether authorization exists (via `auth_check`)
- Can make authenticated API requests (via `auth_request`, token injected server-side)

## Features

| Feature | Description |
|---------|-------------|
| OAuth 2.0 PKCE | Secure in-chat authorization flow |
| Encrypted storage | AES-256-GCM encryption for tokens |
| Dynamic providers | No pre-defined list - agents handle any OAuth provider |
| MCP tools | Agent integration via standard MCP tools |

## Components

| File | Description |
|------|-------------|
| `types.ts` | OAuth type definitions |
| `crypto.ts` | AES-256-GCM encryption, PKCE utilities |
| `token-store.ts` | Encrypted file-based token storage |
| `oauth-manager.ts` | OAuth flow management, API request proxy |
| `auth-mcp.ts` | MCP tools for agent integration |

## MCP Tools Provided

| Tool | Description |
|------|-------------|
| `auth_check` | Check if user has authorized a service |
| `auth_generate_url` | Generate OAuth authorization URL for any provider |
| `auth_request` | Make authenticated API request (token never exposed) |
| `auth_list` | List authorized services |
| `auth_revoke` | Revoke authorization |

## Usage Example

```
User: "帮我查看我的 GitHub 仓库列表"

Agent:
1. Calls auth_check(chatId, "github") → Not authorized
2. Generates auth URL via auth_generate_url with GitHub OAuth config
3. Sends Feishu card with authorization button
4. User authorizes → callback stores token encrypted
5. Calls auth_request(chatId, "github", {method: "GET", url: "https://api.github.com/user/repos"})
6. Returns repository list to user
```

## Design Decisions

Per issue requirements:
- ✅ No pre-defined provider list (agents configure dynamically)
- ✅ No automatic token renewal
- ✅ No multi-user isolation (single chat scope)
- ✅ Minimal change principle

## Test Results

```
✓ src/auth/oauth-manager.test.ts (16 tests)
✓ src/auth/token-store.test.ts (15 tests)
✓ src/auth/crypto.test.ts (13 tests)

Test Files  3 passed (3)
Tests  44 passed (44)
```

Full test suite: 884 tests pass ✅

## Future Enhancements

- [ ] Token refresh support (when needed)
- [ ] Multi-user isolation (when needed)
- [ ] Callback server for automatic OAuth flow handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)