### PR TITLE
refactor(types): consolidate file reference types to unified location

### DIFF
--- a/src/file-transfer/types.ts
+++ b/src/file-transfer/types.ts
@@ -238,3 +238,33 @@ export function createOutboundFile(
     threadId: options?.threadId,
   };
 }
+
+/**
+ * Legacy factory function for backward compatibility.
+ * @deprecated Use createFileRef instead
+ */
+export function createFileReference(
+  fileName: string,
+  source: 'user' | 'agent',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    storageKey?: string;
+    chatId?: string;
+    expiresInMs?: number;
+  }
+): FileReference {
+  const now = Date.now();
+  return {
+    id: uuidv4(),
+    fileName,
+    mimeType: options?.mimeType,
+    size: options?.size,
+    source,
+    localPath: options?.storageKey, // Map storageKey to localPath
+    storageKey: options?.storageKey, // Keep for backward compatibility
+    chatId: options?.chatId,
+    createdAt: now,
+    expiresAt: options?.expiresInMs ? now + options.expiresInMs : undefined,
+  };
+}

--- a/src/types/file-reference.ts
+++ b/src/types/file-reference.ts
@@ -1,133 +1,32 @@
 /**
  * File reference types for communication between nodes.
  *
- * When Communication Node and Execution Node are deployed separately,
- * file references (FileReference) are used to pass file identifiers
- * instead of local file paths.
- */
-
-import { v4 as uuidv4 } from 'uuid';
-
-/**
- * File reference - unique identifier for files passed between nodes.
+ * @deprecated This module is deprecated. Import from '../file-transfer/types.js' instead.
+ * All types and functions are now consolidated in the unified file-transfer module.
  *
- * @example
- * // When user uploads a file, comm node creates a fileRef
- * const fileRef: FileReference = {
- *   id: 'uuid-xxx',
- *   fileName: 'report.pdf',
- *   mimeType: 'application/pdf',
- *   size: 1024000,
- *   source: 'user',
- *   storageKey: '/data/files/uuid-xxx/report.pdf',
- *   createdAt: Date.now(),
- *   expiresAt: Date.now() + 24 * 60 * 60 * 1000,
- * };
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
  */
-export interface FileReference {
-  /** Unique file identifier (UUID) */
-  id: string;
 
-  /** Original file name */
-  fileName: string;
+// Re-export all types and functions from the unified location
+export {
+  // Base types
+  type FileRef,
+  type InboundAttachment,
+  type OutboundFile,
 
-  /** MIME type */
-  mimeType?: string;
+  // Legacy compatibility types
+  type FileReference,
+  type FileAttachment,
 
-  /** File size (bytes) */
-  size?: number;
+  // Request/Response types
+  type FileUploadRequest,
+  type FileUploadResponse,
+  type FileDownloadResponse,
+  type StoredFile,
 
-  /** File source */
-  source: 'user' | 'agent';
-
-  /**
-   * File storage location (internal use by comm node)
-   * - Local storage: absolute path
-   * - S3 storage: S3 key
-   */
-  storageKey?: string;
-
-  /** Creation timestamp */
-  createdAt: number;
-
-  /** Expiration timestamp (optional, for auto cleanup) */
-  expiresAt?: number;
-
-  /** Associated chatId (optional, for context association) */
-  chatId?: string;
-}
-
-/**
- * File upload request - exec node uploads file to comm node.
- */
-export interface FileUploadRequest {
-  /** File name */
-  fileName: string;
-
-  /** MIME type */
-  mimeType?: string;
-
-  /** File content (base64 encoded) */
-  content: string;
-
-  /** Associated chatId (optional) */
-  chatId?: string;
-}
-
-/**
- * File upload response.
- */
-export interface FileUploadResponse {
-  /** File reference after successful upload */
-  fileRef: FileReference;
-}
-
-/**
- * File download response.
- */
-export interface FileDownloadResponse {
-  /** File reference */
-  fileRef: FileReference;
-
-  /** File content (base64 encoded) */
-  content: string;
-}
-
-/**
- * File storage info (internal use).
- */
-export interface StoredFile {
-  /** File reference */
-  ref: FileReference;
-
-  /** Local storage path */
-  localPath: string;
-}
-
-/**
- * Factory function to create a FileReference.
- */
-export function createFileReference(
-  fileName: string,
-  source: 'user' | 'agent',
-  options?: {
-    mimeType?: string;
-    size?: number;
-    storageKey?: string;
-    chatId?: string;
-    expiresInMs?: number;
-  }
-): FileReference {
-  const now = Date.now();
-  return {
-    id: uuidv4(),
-    fileName,
-    mimeType: options?.mimeType,
-    size: options?.size,
-    source,
-    storageKey: options?.storageKey,
-    chatId: options?.chatId,
-    createdAt: now,
-    expiresAt: options?.expiresInMs ? now + options.expiresInMs : undefined,
-  };
-}
+  // Factory functions
+  createFileRef,
+  createInboundAttachment,
+  createOutboundFile,
+  createFileReference,
+} from '../file-transfer/types.js';


### PR DESCRIPTION
## Summary

- Completes the type consolidation task from Issue #194
- Adds `createFileReference` function to `file-transfer/types.ts` for backward compatibility
- Converts `src/types/file-reference.ts` to a re-export module with `@deprecated` notice
- All file-related types are now consolidated in `src/file-transfer/types.ts`

## Changes

| File | Change |
|------|--------|
| `src/file-transfer/types.ts` | Added `createFileReference` function (deprecated) |
| `src/types/file-reference.ts` | Converted to re-export module with deprecation notice |

## Benefits

| Aspect | Before | After |
|--------|--------|-------|
| Type definitions | 2 locations (duplicate) | 1 unified location |
| Code lines | 134 lines | 32 lines (re-export) |
| Backward compatibility | N/A | Fully maintained |

## Test Results

```
Test Files  45 passed (45)
Tests       770 passed (770)
```

## Related

- Issue: #194 (Type consolidation task)
- This PR completes the remaining type consolidation work from the file transfer refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)