### PR TITLE
feat(messaging): add message level routing system (Issue #266)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -192,6 +192,43 @@ export interface ChannelsConfig {
 }
 
 /**
+ * Messaging routing configuration section.
+ *
+ * Controls how messages are routed between admin and user chats.
+ * @see Issue #266
+ */
+export interface MessagingConfig {
+  /** Admin chat configuration */
+  admin?: {
+    /** Admin chat ID (receives all messages including progress/debug) */
+    chatId?: string;
+    /** Enable/disable admin chat routing */
+    enabled?: boolean;
+  };
+  /** Message routing configuration */
+  routing?: {
+    /** Message levels visible to users (debug, progress, info, notice, important, error, result) */
+    userLevels?: string[];
+    /** Task lifecycle message visibility */
+    taskLifecycle?: {
+      /** Show task start message */
+      showStart?: boolean;
+      /** Show progress messages */
+      showProgress?: boolean;
+      /** Show task complete message */
+      showComplete?: boolean;
+    };
+    /** Error handling options */
+    errors?: {
+      /** Show stack traces to users */
+      showStack?: boolean;
+      /** Who can see detailed errors: 'admin' | 'all' */
+      showDetails?: 'admin' | 'all';
+    };
+  };
+}
+
+/**
  * Run mode for the application.
  * - comm: Communication Node (Feishu WebSocket handler)
  * - exec: Execution Node (Pilot/Agent handler)
@@ -221,6 +258,8 @@ export interface DisclaudeConfig {
   transport?: TransportConfig;
   /** Channels configuration */
   channels?: ChannelsConfig;
+  /** Message routing configuration */
+  messaging?: MessagingConfig;
   /** Global environment variables applied to all agent processes */
   env?: Record<string, string>;
 }

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Message routing module for level-based message routing.
+ *
+ * This module implements Issue #266: Message Level Routing System
+ *
+ * Features:
+ * - Routes execution progress to admin chats
+ * - Routes only key interactions to user chats
+ * - Configurable message levels
+ * - Throttling for progress messages
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   MessageRouter,
+ *   RoutedOutputAdapter,
+ *   MessageLevel,
+ *   createDefaultRouteConfig,
+ * } from './messaging/index.js';
+ *
+ * // Create router
+ * const config = createDefaultRouteConfig('user_chat_id');
+ * config.adminChatId = 'admin_chat_id';
+ *
+ * const router = new MessageRouter({
+ *   config,
+ *   sender: feishuMessageSender,
+ * });
+ *
+ * // Create output adapter
+ * const adapter = new RoutedOutputAdapter({ router });
+ *
+ * // Use adapter
+ * await adapter.write('Task completed', 'result');
+ * ```
+ *
+ * @see Issue #266
+ */
+
+// Types
+export {
+  MessageLevel,
+  DEFAULT_USER_LEVELS,
+  ALL_LEVELS,
+  type RoutedMessage,
+  type RoutedMessageMetadata,
+  type MessageRouteConfig,
+  type IMessageRouter,
+  type IMessageSender,
+  mapAgentMessageTypeToLevel,
+} from './types.js';
+
+// Router
+export {
+  MessageRouter,
+  type MessageRouterOptions,
+  createDefaultRouteConfig,
+} from './message-router.js';
+
+// Output Adapter
+export {
+  RoutedOutputAdapter,
+  SimpleUserOutputAdapter,
+  type RoutedOutputAdapterOptions,
+} from './routed-output-adapter.js';

--- a/src/messaging/message-router.test.ts
+++ b/src/messaging/message-router.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for Message Router (src/messaging/)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MessageRouter,
+  RoutedOutputAdapter,
+  SimpleUserOutputAdapter,
+  MessageLevel,
+  DEFAULT_USER_LEVELS,
+  mapAgentMessageTypeToLevel,
+  createDefaultRouteConfig,
+  type IMessageSender,
+  type MessageRouteConfig,
+} from './index.js';
+
+describe('Message Level Types', () => {
+  describe('MessageLevel enum', () => {
+    it('should have all expected levels', () => {
+      expect(MessageLevel.DEBUG).toBe('debug');
+      expect(MessageLevel.PROGRESS).toBe('progress');
+      expect(MessageLevel.INFO).toBe('info');
+      expect(MessageLevel.NOTICE).toBe('notice');
+      expect(MessageLevel.IMPORTANT).toBe('important');
+      expect(MessageLevel.ERROR).toBe('error');
+      expect(MessageLevel.RESULT).toBe('result');
+    });
+  });
+
+  describe('DEFAULT_USER_LEVELS', () => {
+    it('should include notice, important, error, result', () => {
+      expect(DEFAULT_USER_LEVELS).toContain(MessageLevel.NOTICE);
+      expect(DEFAULT_USER_LEVELS).toContain(MessageLevel.IMPORTANT);
+      expect(DEFAULT_USER_LEVELS).toContain(MessageLevel.ERROR);
+      expect(DEFAULT_USER_LEVELS).toContain(MessageLevel.RESULT);
+    });
+
+    it('should not include debug, progress, info', () => {
+      expect(DEFAULT_USER_LEVELS).not.toContain(MessageLevel.DEBUG);
+      expect(DEFAULT_USER_LEVELS).not.toContain(MessageLevel.PROGRESS);
+      expect(DEFAULT_USER_LEVELS).not.toContain(MessageLevel.INFO);
+    });
+  });
+
+  describe('mapAgentMessageTypeToLevel', () => {
+    it('should map tool_progress to PROGRESS', () => {
+      expect(mapAgentMessageTypeToLevel('tool_progress')).toBe(MessageLevel.PROGRESS);
+    });
+
+    it('should map tool_use to DEBUG', () => {
+      expect(mapAgentMessageTypeToLevel('tool_use')).toBe(MessageLevel.DEBUG);
+    });
+
+    it('should map tool_result to DEBUG', () => {
+      expect(mapAgentMessageTypeToLevel('tool_result')).toBe(MessageLevel.DEBUG);
+    });
+
+    it('should map error to ERROR', () => {
+      expect(mapAgentMessageTypeToLevel('error')).toBe(MessageLevel.ERROR);
+    });
+
+    it('should map result to RESULT', () => {
+      expect(mapAgentMessageTypeToLevel('result')).toBe(MessageLevel.RESULT);
+    });
+
+    it('should map completion message to DEBUG', () => {
+      expect(mapAgentMessageTypeToLevel('result', '✅ Complete')).toBe(MessageLevel.DEBUG);
+    });
+
+    it('should map notification to NOTICE', () => {
+      expect(mapAgentMessageTypeToLevel('notification')).toBe(MessageLevel.NOTICE);
+    });
+
+    it('should map task_completion to RESULT', () => {
+      expect(mapAgentMessageTypeToLevel('task_completion')).toBe(MessageLevel.RESULT);
+    });
+
+    it('should map max_iterations_warning to IMPORTANT', () => {
+      expect(mapAgentMessageTypeToLevel('max_iterations_warning')).toBe(MessageLevel.IMPORTANT);
+    });
+
+    it('should map status to INFO', () => {
+      expect(mapAgentMessageTypeToLevel('status')).toBe(MessageLevel.INFO);
+    });
+
+    it('should map text to INFO', () => {
+      expect(mapAgentMessageTypeToLevel('text')).toBe(MessageLevel.INFO);
+    });
+  });
+});
+
+describe('MessageRouter', () => {
+  let mockSender: IMessageSender;
+  let router: MessageRouter;
+
+  beforeEach(() => {
+    mockSender = {
+      sendText: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  describe('with admin chat configured', () => {
+    beforeEach(() => {
+      const config: MessageRouteConfig = {
+        adminChatId: 'admin-chat-id',
+        userChatId: 'user-chat-id',
+        userMessageLevels: DEFAULT_USER_LEVELS,
+      };
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should route DEBUG to admin only', async () => {
+      await router.route({ content: 'Debug message', level: MessageLevel.DEBUG });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(1);
+      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Debug message');
+    });
+
+    it('should route PROGRESS to admin only', async () => {
+      await router.route({ content: 'Progress message', level: MessageLevel.PROGRESS });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(1);
+      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Progress message');
+    });
+
+    it('should route ERROR to both admin and user', async () => {
+      await router.route({ content: 'Error message', level: MessageLevel.ERROR });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Error message');
+      expect(mockSender.sendText).toHaveBeenCalledWith('user-chat-id', 'Error message');
+    });
+
+    it('should route RESULT to both admin and user', async () => {
+      await router.route({ content: 'Result message', level: MessageLevel.RESULT });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+    });
+
+    it('should route NOTICE to both admin and user', async () => {
+      await router.route({ content: 'Notice message', level: MessageLevel.NOTICE });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+    });
+
+    it('should get correct targets for each level', () => {
+      expect(router.getTargets(MessageLevel.DEBUG)).toEqual(['admin-chat-id']);
+      expect(router.getTargets(MessageLevel.PROGRESS)).toEqual(['admin-chat-id']);
+      expect(router.getTargets(MessageLevel.ERROR)).toEqual(['admin-chat-id', 'user-chat-id']);
+      expect(router.getTargets(MessageLevel.RESULT)).toEqual(['admin-chat-id', 'user-chat-id']);
+    });
+
+    it('should check user visibility correctly', () => {
+      expect(router.isUserVisible(MessageLevel.DEBUG)).toBe(false);
+      expect(router.isUserVisible(MessageLevel.PROGRESS)).toBe(false);
+      expect(router.isUserVisible(MessageLevel.ERROR)).toBe(true);
+      expect(router.isUserVisible(MessageLevel.RESULT)).toBe(true);
+    });
+
+    it('should have admin chat configured', () => {
+      expect(router.hasAdminChat()).toBe(true);
+      expect(router.getAdminChatId()).toBe('admin-chat-id');
+    });
+
+    it('should return user chat ID', () => {
+      expect(router.getUserChatId()).toBe('user-chat-id');
+    });
+  });
+
+  describe('without admin chat', () => {
+    beforeEach(() => {
+      const config: MessageRouteConfig = {
+        userChatId: 'user-chat-id',
+        userMessageLevels: DEFAULT_USER_LEVELS,
+      };
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should route all user-visible messages to user chat', async () => {
+      await router.route({ content: 'Result', level: MessageLevel.RESULT });
+      expect(mockSender.sendText).toHaveBeenCalledWith('user-chat-id', 'Result');
+    });
+
+    it('should not route debug messages when no admin', async () => {
+      await router.route({ content: 'Debug', level: MessageLevel.DEBUG });
+      expect(mockSender.sendText).not.toHaveBeenCalled();
+    });
+
+    it('should not have admin chat', () => {
+      expect(router.hasAdminChat()).toBe(false);
+      expect(router.getAdminChatId()).toBeUndefined();
+    });
+  });
+
+  describe('with same admin and user chat', () => {
+    beforeEach(() => {
+      const config: MessageRouteConfig = {
+        adminChatId: 'same-chat-id',
+        userChatId: 'same-chat-id',
+        userMessageLevels: DEFAULT_USER_LEVELS,
+      };
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should send message only once', async () => {
+      await router.route({ content: 'Error', level: MessageLevel.ERROR });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(1);
+      expect(mockSender.sendText).toHaveBeenCalledWith('same-chat-id', 'Error');
+    });
+  });
+
+  describe('with custom user levels', () => {
+    beforeEach(() => {
+      const config: MessageRouteConfig = {
+        adminChatId: 'admin-chat-id',
+        userChatId: 'user-chat-id',
+        userMessageLevels: [MessageLevel.ERROR, MessageLevel.RESULT], // Only errors and results
+      };
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should not route NOTICE to user', async () => {
+      await router.route({ content: 'Notice', level: MessageLevel.NOTICE });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(1);
+      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Notice');
+    });
+
+    it('should route ERROR to both', async () => {
+      await router.route({ content: 'Error', level: MessageLevel.ERROR });
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('update methods', () => {
+    beforeEach(() => {
+      const config = createDefaultRouteConfig('user-chat-id');
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should update user levels', () => {
+      router.setUserLevels([MessageLevel.ERROR]);
+      expect(router.isUserVisible(MessageLevel.ERROR)).toBe(true);
+      expect(router.isUserVisible(MessageLevel.RESULT)).toBe(false);
+    });
+
+    it('should update admin chat ID', () => {
+      expect(router.hasAdminChat()).toBe(false);
+      router.setAdminChatId('new-admin-id');
+      expect(router.hasAdminChat()).toBe(true);
+      expect(router.getAdminChatId()).toBe('new-admin-id');
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      const config: MessageRouteConfig = {
+        adminChatId: 'admin-chat-id',
+        userChatId: 'user-chat-id',
+      };
+      router = new MessageRouter({ config, sender: mockSender });
+    });
+
+    it('should continue sending to other targets on error', async () => {
+      mockSender.sendText = vi.fn()
+        .mockRejectedValueOnce(new Error('Failed to admin'))
+        .mockResolvedValueOnce(undefined);
+
+      await router.route({ content: 'Error', level: MessageLevel.ERROR });
+
+      // Should attempt to send to both, even though first failed
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe('createDefaultRouteConfig', () => {
+  it('should create config with user chat ID', () => {
+    const config = createDefaultRouteConfig('my-chat-id');
+    expect(config.userChatId).toBe('my-chat-id');
+  });
+
+  it('should include default user levels', () => {
+    const config = createDefaultRouteConfig('my-chat-id');
+    expect(config.userMessageLevels).toEqual(DEFAULT_USER_LEVELS);
+  });
+
+  it('should include default task lifecycle settings', () => {
+    const config = createDefaultRouteConfig('my-chat-id');
+    expect(config.showTaskLifecycle?.showStart).toBe(false);
+    expect(config.showTaskLifecycle?.showProgress).toBe(false);
+    expect(config.showTaskLifecycle?.showComplete).toBe(true);
+  });
+
+  it('should include default error settings', () => {
+    const config = createDefaultRouteConfig('my-chat-id');
+    expect(config.errors?.showStack).toBe(false);
+    expect(config.errors?.showDetails).toBe('admin');
+  });
+});
+
+describe('RoutedOutputAdapter', () => {
+  let mockRouter: { route: ReturnType<typeof vi.fn>; getTargets: ReturnType<typeof vi.fn>; getUserChatId: ReturnType<typeof vi.fn> };
+  let adapter: RoutedOutputAdapter;
+
+  beforeEach(() => {
+    mockRouter = {
+      route: vi.fn().mockResolvedValue(undefined),
+      getTargets: vi.fn().mockReturnValue(['user-chat-id']),
+      getUserChatId: vi.fn().mockReturnValue('user-chat-id'),
+    };
+    adapter = new RoutedOutputAdapter({ router: mockRouter as any });
+  });
+
+  it('should route message with mapped level', async () => {
+    await adapter.write('Task completed', 'result');
+    expect(mockRouter.route).toHaveBeenCalledWith({
+      content: 'Task completed',
+      level: MessageLevel.RESULT,
+      metadata: { originalType: 'result' },
+    });
+  });
+
+  it('should skip empty content', async () => {
+    await adapter.write('   ', 'text');
+    expect(mockRouter.route).not.toHaveBeenCalled();
+  });
+
+  it('should track user message sent', async () => {
+    mockRouter.getTargets.mockReturnValue(['user-chat-id']);
+
+    expect(adapter.hasSentUserMessage()).toBe(false);
+    await adapter.write('Hello', 'result');
+    expect(adapter.hasSentUserMessage()).toBe(true);
+  });
+
+  it('should not track if user not in targets', async () => {
+    mockRouter.getTargets.mockReturnValue(['admin-chat-id']);
+    mockRouter.getUserChatId.mockReturnValue('user-chat-id');
+
+    await adapter.write('Debug', 'tool_progress');
+
+    expect(adapter.hasSentUserMessage()).toBe(false);
+  });
+
+  it('should reset tracking', async () => {
+    mockRouter.getTargets.mockReturnValue(['user-chat-id']);
+
+    await adapter.write('Hello', 'result');
+    expect(adapter.hasSentUserMessage()).toBe(true);
+
+    adapter.resetTracking();
+    expect(adapter.hasSentUserMessage()).toBe(false);
+  });
+
+  it('should include tool name in metadata', async () => {
+    await adapter.write('Running command', 'tool_progress', { toolName: 'Bash' });
+    expect(mockRouter.route).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { toolName: 'Bash', originalType: 'tool_progress' },
+      })
+    );
+  });
+});
+
+describe('SimpleUserOutputAdapter', () => {
+  let mockSendText: ReturnType<typeof vi.fn>;
+  let adapter: SimpleUserOutputAdapter;
+
+  beforeEach(() => {
+    mockSendText = vi.fn().mockResolvedValue(undefined);
+    adapter = new SimpleUserOutputAdapter(mockSendText, 'chat-id');
+  });
+
+  it('should send text to chat', async () => {
+    await adapter.write('Hello', 'text');
+    expect(mockSendText).toHaveBeenCalledWith('chat-id', 'Hello');
+  });
+
+  it('should skip empty content', async () => {
+    await adapter.write('', 'text');
+    expect(mockSendText).not.toHaveBeenCalled();
+  });
+
+  it('should ignore message type', async () => {
+    await adapter.write('Error', 'error');
+    expect(mockSendText).toHaveBeenCalledWith('chat-id', 'Error');
+  });
+});

--- a/src/messaging/message-router.ts
+++ b/src/messaging/message-router.ts
@@ -1,0 +1,176 @@
+/**
+ * Message router implementation for level-based message routing.
+ *
+ * Routes messages to appropriate chats based on their level:
+ * - Admin chat receives all messages (progress, debug, etc.)
+ * - User chat receives only key messages (results, errors, confirmations)
+ *
+ * @see Issue #266
+ */
+
+import type { ILogger } from '../utils/logger.js';
+import {
+  type IMessageRouter,
+  type IMessageSender,
+  type MessageRouteConfig,
+  type RoutedMessage,
+  MessageLevel,
+  DEFAULT_USER_LEVELS,
+} from './types.js';
+
+/**
+ * Message router options.
+ */
+export interface MessageRouterOptions {
+  /** Routing configuration */
+  config: MessageRouteConfig;
+  /** Message sender implementation */
+  sender: IMessageSender;
+  /** Logger instance */
+  logger?: ILogger;
+}
+
+/**
+ * Message router implementation.
+ *
+ * Routes messages to admin and/or user chats based on message level.
+ */
+export class MessageRouter implements IMessageRouter {
+  private readonly config: MessageRouteConfig;
+  private readonly sender: IMessageSender;
+  private readonly logger?: ILogger;
+  private readonly userLevels: Set<MessageLevel>;
+
+  constructor(options: MessageRouterOptions) {
+    this.config = options.config;
+    this.sender = options.sender;
+    this.logger = options.logger;
+
+    // Initialize user-visible levels
+    const levels = options.config.userMessageLevels ?? DEFAULT_USER_LEVELS;
+    this.userLevels = new Set(levels);
+  }
+
+  /**
+   * Route a message to appropriate chat(s).
+   */
+  async route(message: RoutedMessage): Promise<void> {
+    const targets = this.getTargets(message.level);
+    const targetCount = targets.length;
+
+    if (targetCount === 0) {
+      this.logger?.debug('MessageRouter: No targets for message', {
+        level: message.level,
+        content: message.content.substring(0, 50),
+      });
+      return;
+    }
+
+    this.logger?.debug('MessageRouter: Routing message', {
+      level: message.level,
+      targets,
+      contentLength: message.content.length,
+    });
+
+    // Send to all targets in parallel
+    const sendPromises = targets.map(async (chatId) => {
+      try {
+        await this.sender.sendText(chatId, message.content);
+      } catch (error) {
+        this.logger?.error('MessageRouter: Failed to send message', {
+          chatId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // Don't throw - we want to continue sending to other targets
+      }
+    });
+
+    await Promise.allSettled(sendPromises);
+  }
+
+  /**
+   * Get the target chat IDs for a message level.
+   */
+  getTargets(level: MessageLevel): string[] {
+    const targets: string[] = [];
+
+    // Admin chat receives all messages (if configured)
+    if (this.config.adminChatId) {
+      targets.push(this.config.adminChatId);
+    }
+
+    // User chat receives messages based on level
+    if (this.config.userChatId && this.userLevels.has(level)) {
+      // Avoid duplicate if admin and user chat are the same
+      if (this.config.adminChatId !== this.config.userChatId) {
+        targets.push(this.config.userChatId);
+      }
+    }
+
+    return targets;
+  }
+
+  /**
+   * Check if a level is visible to users.
+   */
+  isUserVisible(level: MessageLevel): boolean {
+    return this.userLevels.has(level);
+  }
+
+  /**
+   * Check if admin chat is configured.
+   */
+  hasAdminChat(): boolean {
+    return !!this.config.adminChatId;
+  }
+
+  /**
+   * Get the admin chat ID.
+   */
+  getAdminChatId(): string | undefined {
+    return this.config.adminChatId;
+  }
+
+  /**
+   * Get the user chat ID.
+   */
+  getUserChatId(): string {
+    return this.config.userChatId;
+  }
+
+  /**
+   * Update the user-visible levels.
+   */
+  setUserLevels(levels: MessageLevel[]): void {
+    this.userLevels.clear();
+    levels.forEach((level) => this.userLevels.add(level));
+    this.logger?.info('MessageRouter: Updated user levels', { levels });
+  }
+
+  /**
+   * Update the admin chat ID.
+   */
+  setAdminChatId(chatId: string | undefined): void {
+    (this.config as { adminChatId?: string }).adminChatId = chatId;
+    this.logger?.info('MessageRouter: Updated admin chat ID', { chatId });
+  }
+}
+
+/**
+ * Create a default message router configuration.
+ */
+export function createDefaultRouteConfig(userChatId: string): MessageRouteConfig {
+  return {
+    userChatId,
+    userMessageLevels: [...DEFAULT_USER_LEVELS],
+    showTaskLifecycle: {
+      showStart: false,
+      showProgress: false,
+      showComplete: true,
+    },
+    errors: {
+      showStack: false,
+      showDetails: 'admin',
+    },
+  };
+}

--- a/src/messaging/routed-output-adapter.ts
+++ b/src/messaging/routed-output-adapter.ts
@@ -1,0 +1,167 @@
+/**
+ * Routed output adapter for level-based message routing.
+ *
+ * This adapter wraps a MessageRouter to provide OutputAdapter interface.
+ * It maps AgentMessageType to MessageLevel and routes messages accordingly.
+ *
+ * @see Issue #266
+ */
+
+import type { AgentMessageType } from '../types/agent.js';
+import type { OutputAdapter, MessageMetadata } from '../utils/output-adapter.js';
+import type { IMessageRouter, RoutedMessageMetadata } from './types.js';
+import { MessageLevel, mapAgentMessageTypeToLevel } from './types.js';
+
+/**
+ * Options for RoutedOutputAdapter.
+ */
+export interface RoutedOutputAdapterOptions {
+  /** Message router instance */
+  router: IMessageRouter;
+  /** Default chat ID for messages (used when router has no admin configured) */
+  defaultChatId?: string;
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+/**
+ * Output adapter that routes messages based on their level.
+ *
+ * Features:
+ * - Maps AgentMessageType to MessageLevel
+ * - Routes to admin/user chats via MessageRouter
+ * - Throttles progress messages
+ * - Tracks if user-visible messages were sent
+ */
+export class RoutedOutputAdapter implements OutputAdapter {
+  private readonly router: IMessageRouter;
+  private readonly defaultChatId?: string;
+  private readonly debug: boolean;
+
+  // Throttle state for progress messages
+  private progressThrottleMap = new Map<string, number>();
+  private readonly throttleIntervalMs = 2000;
+
+  // Track if user-visible message was sent
+  private userMessageSent = false;
+
+  constructor(options: RoutedOutputAdapterOptions) {
+    this.router = options.router;
+    this.defaultChatId = options.defaultChatId;
+    this.debug = options.debug ?? false;
+  }
+
+  /**
+   * Write content with message type routing.
+   */
+  async write(
+    content: string,
+    messageType: AgentMessageType = 'text',
+    metadata?: MessageMetadata
+  ): Promise<void> {
+    // Skip empty content
+    const trimmedContent = content.trim();
+    if (!trimmedContent) {
+      return;
+    }
+
+    // Map message type to level
+    const level = mapAgentMessageTypeToLevel(messageType, content);
+
+    // Throttle progress messages
+    if (messageType === 'tool_progress') {
+      const toolName = metadata?.toolName ?? 'unknown';
+      if (!this.shouldSendProgress(toolName)) {
+        return;
+      }
+    }
+
+    // Build routed message
+    const routedMessage = {
+      content: trimmedContent,
+      level,
+      metadata: this.buildMetadata(metadata, messageType),
+    };
+
+    // Track if user will see this message
+    if (this.router.getTargets(level).includes(this.router.getUserChatId())) {
+      this.userMessageSent = true;
+    }
+
+    // Route the message
+    await this.router.route(routedMessage);
+  }
+
+  /**
+   * Check if any user-visible message was sent.
+   */
+  hasSentUserMessage(): boolean {
+    return this.userMessageSent;
+  }
+
+  /**
+   * Reset tracking for a new task.
+   */
+  resetTracking(): void {
+    this.userMessageSent = false;
+    this.progressThrottleMap.clear();
+  }
+
+  /**
+   * Build routed message metadata.
+   */
+  private buildMetadata(
+    metadata?: MessageMetadata,
+    messageType?: AgentMessageType
+  ): RoutedMessageMetadata | undefined {
+    if (!metadata && !messageType) {
+      return undefined;
+    }
+
+    return {
+      toolName: metadata?.toolName,
+      originalType: messageType,
+    };
+  }
+
+  /**
+   * Check if a progress message should be sent (throttling).
+   */
+  private shouldSendProgress(toolName: string): boolean {
+    const key = `progress:${toolName}`;
+    const now = Date.now();
+    const lastSent = this.progressThrottleMap.get(key);
+
+    if (lastSent === undefined || now - lastSent >= this.throttleIntervalMs) {
+      this.progressThrottleMap.set(key, now);
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Create a simple output adapter that only sends to user chat.
+ * This is for backward compatibility when no admin chat is configured.
+ */
+export class SimpleUserOutputAdapter implements OutputAdapter {
+  private readonly sendText: (chatId: string, text: string) => Promise<void>;
+  private readonly chatId: string;
+
+  constructor(
+    sendText: (chatId: string, text: string) => Promise<void>,
+    chatId: string
+  ) {
+    this.sendText = sendText;
+    this.chatId = chatId;
+  }
+
+  async write(content: string, _messageType?: AgentMessageType): Promise<void> {
+    const trimmed = content.trim();
+    if (!trimmed) {
+      return;
+    }
+    await this.sendText(this.chatId, trimmed);
+  }
+}

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -1,0 +1,185 @@
+/**
+ * Message routing types for implementing message level-based routing.
+ *
+ * This module defines the types for the message routing system that:
+ * - Routes execution progress to admin chats
+ * - Routes only key interactions to user chats
+ *
+ * @see Issue #266
+ */
+
+import type { AgentMessageType } from '../types/agent.js';
+
+/**
+ * Message level enum for routing decisions.
+ *
+ * - DEBUG: Debug information → Admin only
+ * - PROGRESS: Execution progress → Admin only
+ * - INFO: General information → Admin only
+ * - NOTICE: Notification → User + Admin
+ * - IMPORTANT: Important information → User + Admin (strong alert)
+ * - ERROR: Error information → User + Admin
+ * - RESULT: Final result → User + Admin
+ */
+export enum MessageLevel {
+  DEBUG = 'debug',
+  PROGRESS = 'progress',
+  INFO = 'info',
+  NOTICE = 'notice',
+  IMPORTANT = 'important',
+  ERROR = 'error',
+  RESULT = 'result',
+}
+
+/**
+ * Default message levels visible to users.
+ */
+export const DEFAULT_USER_LEVELS: MessageLevel[] = [
+  MessageLevel.NOTICE,
+  MessageLevel.IMPORTANT,
+  MessageLevel.ERROR,
+  MessageLevel.RESULT,
+];
+
+/**
+ * All message levels (admin receives all).
+ */
+export const ALL_LEVELS: MessageLevel[] = [
+  MessageLevel.DEBUG,
+  MessageLevel.PROGRESS,
+  MessageLevel.INFO,
+  MessageLevel.NOTICE,
+  MessageLevel.IMPORTANT,
+  MessageLevel.ERROR,
+  MessageLevel.RESULT,
+];
+
+/**
+ * Message routed through the routing system.
+ */
+export interface RoutedMessage {
+  /** Message content */
+  content: string;
+  /** Message level for routing decision */
+  level: MessageLevel;
+  /** Optional metadata */
+  metadata?: RoutedMessageMetadata;
+}
+
+/**
+ * Metadata for routed messages.
+ */
+export interface RoutedMessageMetadata {
+  /** Tool name if this is a tool message */
+  toolName?: string;
+  /** Task ID if this is part of a task */
+  taskId?: string;
+  /** Original message type from agent */
+  originalType?: AgentMessageType;
+}
+
+/**
+ * Configuration for message routing.
+ */
+export interface MessageRouteConfig {
+  /** Admin chat ID (receives all messages) */
+  adminChatId?: string;
+  /** User chat ID (receives filtered messages) */
+  userChatId: string;
+  /** Message levels visible to users */
+  userMessageLevels?: MessageLevel[];
+  /** Whether to show task lifecycle messages to users */
+  showTaskLifecycle?: {
+    showStart?: boolean;
+    showProgress?: boolean;
+    showComplete?: boolean;
+  };
+  /** Error handling options */
+  errors?: {
+    /** Whether to show stack traces to users */
+    showStack?: boolean;
+    /** Who can see detailed errors: 'admin' | 'all' */
+    showDetails?: 'admin' | 'all';
+  };
+}
+
+/**
+ * Message router interface.
+ */
+export interface IMessageRouter {
+  /**
+   * Route a message to appropriate chat(s).
+   * @param message - The message to route
+   */
+  route(message: RoutedMessage): Promise<void>;
+
+  /**
+   * Get the target chat IDs for a message level.
+   * @param level - The message level
+   * @returns Array of chat IDs to send to
+   */
+  getTargets(level: MessageLevel): string[];
+}
+
+/**
+ * Message sender interface for the router.
+ */
+export interface IMessageSender {
+  /**
+   * Send a text message to a chat.
+   * @param chatId - Target chat ID
+   * @param content - Message content
+   */
+  sendText(chatId: string, content: string): Promise<void>;
+
+  /**
+   * Send a card message to a chat.
+   * @param chatId - Target chat ID
+   * @param card - Card content
+   * @param description - Card description
+   */
+  sendCard?(chatId: string, card: Record<string, unknown>, description?: string): Promise<void>;
+}
+
+/**
+ * Map AgentMessageType to MessageLevel.
+ */
+export function mapAgentMessageTypeToLevel(
+  messageType: AgentMessageType,
+  content?: string
+): MessageLevel {
+  switch (messageType) {
+    case 'tool_progress':
+      return MessageLevel.PROGRESS;
+
+    case 'tool_use':
+    case 'tool_result':
+      return MessageLevel.DEBUG;
+
+    case 'error':
+      return MessageLevel.ERROR;
+
+    case 'result':
+      // Check if it's a completion message (internal, not user-facing)
+      if (content?.startsWith('✅ Complete')) {
+        return MessageLevel.DEBUG;
+      }
+      return MessageLevel.RESULT;
+
+    case 'notification':
+      return MessageLevel.NOTICE;
+
+    case 'task_completion':
+      return MessageLevel.RESULT;
+
+    case 'max_iterations_warning':
+      return MessageLevel.IMPORTANT;
+
+    case 'status':
+      return MessageLevel.INFO;
+
+    case 'text':
+    default:
+      return MessageLevel.INFO;
+  }
+}


### PR DESCRIPTION
## Summary

- Implements #266 - Message Level Routing System
- Creates a routing system that separates execution progress (admin only) from key user interactions
- Provides configurable message levels for fine-grained control

## Components

### MessageLevel Enum
- 7 levels: `debug`, `progress`, `info`, `notice`, `important`, `error`, `result`
- Maps `AgentMessageType` to appropriate routing levels
- Default user levels: `notice`, `important`, `error`, `result`

### MessageRouter
- Routes messages to admin/user chats based on level
- Admin receives all messages (if configured)
- User receives filtered key messages only
- Supports custom level configuration
- Handles duplicate targets (same admin/user chat)

### RoutedOutputAdapter
- Implements `OutputAdapter` interface
- Wraps `MessageRouter` for routing
- Throttles progress messages (2s interval)
- Tracks user-visible message status

## Configuration

New `messaging` config section in `disclaude.config.yaml`:

```yaml
messaging:
  admin:
    chatId: "admin_chat_id"  # Receives all messages
    enabled: true
  routing:
    userLevels:
      - notice
      - important
      - error
      - result
    taskLifecycle:
      showStart: false
      showProgress: false
      showComplete: true
    errors:
      showStack: false
      showDetails: "admin"
```

## Message Routing Rules

| Message Type | Level | User Chat | Admin Chat |
|-------------|-------|-----------|------------|
| Tool use/result | DEBUG | ❌ | ✅ |
| Tool progress | PROGRESS | ❌ | ✅ |
| Status updates | INFO | ❌ | ✅ |
| Notifications | NOTICE | ✅ | ✅ |
| Important warnings | IMPORTANT | ✅ | ✅ |
| Errors | ERROR | ✅ | ✅ |
| Final results | RESULT | ✅ | ✅ |

## Files Changed

```
src/messaging/
├── index.ts                    # Module exports
├── types.ts                    # Level enum and interfaces
├── message-router.ts           # Router implementation
├── routed-output-adapter.ts    # OutputAdapter implementation
└── message-router.test.ts      # 45 tests

src/config/types.ts             # Added MessagingConfig
```

## Test Results

```
✓ src/messaging/message-router.test.ts (45 tests)

Test Files  45 passed (45)
Tests       787 passed (787)
```

## Usage Example

```typescript
import {
  MessageRouter,
  RoutedOutputAdapter,
  createDefaultRouteConfig,
} from './messaging/index.js';

// Create router
const config = createDefaultRouteConfig('user_chat_id');
config.adminChatId = 'admin_chat_id';

const router = new MessageRouter({
  config,
  sender: feishuMessageSender,
});

// Create output adapter
const adapter = new RoutedOutputAdapter({ router });

// Use adapter
await adapter.write('Task completed', 'result');
// → Sent to both admin and user

await adapter.write('Using Bash: ls', 'tool_progress');
// → Sent to admin only
```

## Next Steps (Future Enhancements)

- [ ] Integrate with existing FeishuChannel
- [ ] Add Feishu card support for rich messages
- [ ] Add support for admin-only notifications
- [ ] Add metrics/logging for routing decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)