### PR TITLE
refactor(agents): add agent type classification and shared capability (Issue #282)

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,13 @@
 /**
  * Agents module - All agent types and base class.
  *
+ * Agent Categories (Issue #282):
+ * - ChatAgent: Conversational agents (Pilot)
+ * - TaskAgent: Task-oriented agents (Evaluator, Executor, Reporter)
+ * - ToolAgent: Tool-specific agents (SiteMiner)
+ *
+ * Design principle: "Composition over inheritance"
+ *
  * Provides:
  * - BaseAgent: Abstract base class for all agents
  * - Evaluator: Task completion evaluation specialist
@@ -10,6 +17,30 @@
  * - SessionManager: Pilot session lifecycle management
  * - ConversationContext: Pilot conversation context tracking
  */
+
+// Type definitions for agent classification
+export {
+  type AgentCategory,
+  type AgentType,
+  type ChatAgentType,
+  type TaskAgentType,
+  type ToolAgentType,
+  type TaskAgentRole,
+  type AgentLifecyclePhase,
+  type AgentLifecycleEvent,
+  type LifecycleObserver,
+  isChatAgent,
+  isTaskAgent,
+  isToolAgent,
+} from './types.js';
+
+// Task agent capability (composition-based shared functionality)
+export {
+  TaskAgentCapability,
+  type TaskAgentCapabilityOptions,
+  getTaskAgentTools,
+  TASK_AGENT_TOOLS,
+} from './task-agent-capability.js';
 
 // Base class
 export {

--- a/src/agents/task-agent-capability.test.ts
+++ b/src/agents/task-agent-capability.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for Task Agent Capability module.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TaskAgentCapability, getTaskAgentTools, TASK_AGENT_TOOLS } from './task-agent-capability.js';
+import type { AgentLifecycleEvent, TaskAgentRole } from './types.js';
+
+describe('TaskAgentCapability', () => {
+  describe('Constructor', () => {
+    it('should create capability with required options', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+      });
+
+      expect(capability.getRole()).toBe('evaluator');
+      expect(capability.getAgentName()).toBe('TestEvaluator');
+      expect(capability.getLifecyclePhase()).toBe('created');
+      expect(capability.isInitialized()).toBe(false);
+    });
+
+    it('should accept lifecycle event callback', () => {
+      const onLifecycleEvent = vi.fn();
+      const capability = new TaskAgentCapability({
+        role: 'executor',
+        agentName: 'TestExecutor',
+        onLifecycleEvent,
+      });
+
+      capability.initialize();
+
+      expect(onLifecycleEvent).toHaveBeenCalled();
+      const events = onLifecycleEvent.mock.calls.map(call => call[0]);
+      expect(events.some((e: AgentLifecycleEvent) => e.currentPhase === 'initializing')).toBe(true);
+      expect(events.some((e: AgentLifecycleEvent) => e.currentPhase === 'ready')).toBe(true);
+    });
+  });
+
+  describe('Initialization', () => {
+    it('should transition lifecycle phases during initialize', () => {
+      const phases: string[] = [];
+      const capability = new TaskAgentCapability({
+        role: 'reporter',
+        agentName: 'TestReporter',
+        onLifecycleEvent: (event) => phases.push(event.currentPhase),
+      });
+
+      capability.initialize();
+
+      expect(phases).toEqual(['initializing', 'ready']);
+      expect(capability.isInitialized()).toBe(true);
+      expect(capability.getLifecyclePhase()).toBe('ready');
+    });
+
+    it('should not reinitialize if already initialized', () => {
+      const phases: string[] = [];
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+        onLifecycleEvent: (event) => phases.push(event.currentPhase),
+      });
+
+      capability.initialize();
+      capability.initialize(); // Second call
+
+      expect(phases).toEqual(['initializing', 'ready']); // No duplicate transitions
+    });
+  });
+
+  describe('isReady', () => {
+    it('should return false before initialization', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+      });
+
+      expect(capability.isReady()).toBe(false);
+    });
+
+    it('should return true after initialization', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+      });
+
+      capability.initialize();
+
+      expect(capability.isReady()).toBe(true);
+    });
+
+    it('should return false after cleanup', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+      });
+
+      capability.initialize();
+      capability.cleanup();
+
+      expect(capability.isReady()).toBe(false);
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('should transition to disposed after cleanup', () => {
+      const phases: string[] = [];
+      const capability = new TaskAgentCapability({
+        role: 'executor',
+        agentName: 'TestExecutor',
+        onLifecycleEvent: (event) => phases.push(event.currentPhase),
+      });
+
+      capability.initialize();
+      capability.cleanup();
+
+      expect(phases).toContain('cleanup');
+      expect(phases).toContain('disposed');
+      expect(capability.getLifecyclePhase()).toBe('disposed');
+      expect(capability.isInitialized()).toBe(false);
+    });
+  });
+
+  describe('getAgentType', () => {
+    it('should return correct agent type for evaluator', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'Evaluator',
+      });
+
+      const type = capability.getAgentType();
+
+      expect(type.category).toBe('task');
+      expect(type.name).toBe('Evaluator');
+      expect(type.role).toBe('evaluator');
+    });
+
+    it('should return correct agent type for executor', () => {
+      const capability = new TaskAgentCapability({
+        role: 'executor',
+        agentName: 'Executor',
+      });
+
+      const type = capability.getAgentType();
+
+      expect(type.category).toBe('task');
+      expect(type.name).toBe('Executor');
+      expect(type.role).toBe('executor');
+    });
+
+    it('should return correct agent type for reporter', () => {
+      const capability = new TaskAgentCapability({
+        role: 'reporter',
+        agentName: 'Reporter',
+      });
+
+      const type = capability.getAgentType();
+
+      expect(type.category).toBe('task');
+      expect(type.name).toBe('Reporter');
+      expect(type.role).toBe('reporter');
+    });
+  });
+
+  describe('getFileManager', () => {
+    it('should return TaskFileManager instance', () => {
+      const capability = new TaskAgentCapability({
+        role: 'evaluator',
+        agentName: 'TestEvaluator',
+      });
+
+      expect(capability.getFileManager()).toBeDefined();
+    });
+  });
+});
+
+describe('getTaskAgentTools', () => {
+  it('should return correct tools for evaluator', () => {
+    const tools = getTaskAgentTools('evaluator');
+    expect(tools).toEqual(['Read', 'Grep', 'Glob', 'Write']);
+  });
+
+  it('should return correct tools for executor', () => {
+    const tools = getTaskAgentTools('executor');
+    expect(tools).toEqual([]);
+  });
+
+  it('should return correct tools for reporter', () => {
+    const tools = getTaskAgentTools('reporter');
+    expect(tools).toEqual(['send_user_feedback', 'send_file_to_feishu']);
+  });
+
+  it('should return a copy of the tools array', () => {
+    const tools1 = getTaskAgentTools('evaluator');
+    const tools2 = getTaskAgentTools('evaluator');
+    expect(tools1).not.toBe(tools2); // Different array references
+    expect(tools1).toEqual(tools2); // Same content
+  });
+});
+
+describe('TASK_AGENT_TOOLS', () => {
+  it('should have tools defined for all roles', () => {
+    const roles: TaskAgentRole[] = ['evaluator', 'executor', 'reporter'];
+
+    for (const role of roles) {
+      expect(TASK_AGENT_TOOLS[role]).toBeDefined();
+      expect(Array.isArray(TASK_AGENT_TOOLS[role])).toBe(true);
+    }
+  });
+});

--- a/src/agents/task-agent-capability.ts
+++ b/src/agents/task-agent-capability.ts
@@ -1,0 +1,193 @@
+/**
+ * Task Agent Capability - Shared capability for task-oriented agents.
+ *
+ * This module provides reusable capabilities for task agents (Evaluator, Executor, Reporter)
+ * through composition rather than inheritance.
+ *
+ * Design principle: "Composition over inheritance"
+ * - Agents compose these capabilities instead of inheriting from a base class
+ * - Each capability is independent and testable in isolation
+ *
+ * @module agents/task-agent-capability
+ */
+
+import { Config } from '../config/index.js';
+import { TaskFileManager } from '../task/task-files.js';
+import type { TaskAgentRole, AgentLifecyclePhase, AgentLifecycleEvent } from './types.js';
+
+/**
+ * Options for TaskAgentCapability.
+ */
+export interface TaskAgentCapabilityOptions {
+  /** Agent role */
+  role: TaskAgentRole;
+  /** Agent name for logging */
+  agentName: string;
+  /** Optional subdirectory for task files */
+  subdirectory?: string;
+  /** Lifecycle event callback */
+  onLifecycleEvent?: (event: AgentLifecycleEvent) => void;
+}
+
+/**
+ * Task Agent Capability - Provides shared functionality for task agents.
+ *
+ * This class encapsulates common capabilities needed by task-oriented agents:
+ * - File management via TaskFileManager
+ * - Lifecycle state tracking
+ * - Role-based classification
+ *
+ * @example
+ * ```typescript
+ * class Evaluator extends BaseAgent {
+ *   private taskCapability: TaskAgentCapability;
+ *
+ *   constructor(config: EvaluatorConfig) {
+ *     super(config);
+ *     this.taskCapability = new TaskAgentCapability({
+ *       role: 'evaluator',
+ *       agentName: 'Evaluator',
+ *       subdirectory: config.subdirectory,
+ *     });
+ *   }
+ *
+ *   getAgentType(): TaskAgentType {
+ *     return this.taskCapability.getAgentType();
+ *   }
+ * }
+ * ```
+ */
+export class TaskAgentCapability {
+  private readonly role: TaskAgentRole;
+  private readonly agentName: string;
+  private readonly fileManager: TaskFileManager;
+  private readonly onLifecycleEvent?: (event: AgentLifecycleEvent) => void;
+
+  private lifecyclePhase: AgentLifecyclePhase = 'created';
+  private initialized = false;
+
+  constructor(options: TaskAgentCapabilityOptions) {
+    this.role = options.role;
+    this.agentName = options.agentName;
+    this.onLifecycleEvent = options.onLifecycleEvent;
+    this.fileManager = new TaskFileManager(
+      Config.getWorkspaceDir(),
+      options.subdirectory
+    );
+  }
+
+  /**
+   * Get the agent role.
+   */
+  getRole(): TaskAgentRole {
+    return this.role;
+  }
+
+  /**
+   * Get the agent name.
+   */
+  getAgentName(): string {
+    return this.agentName;
+  }
+
+  /**
+   * Get the file manager instance.
+   */
+  getFileManager(): TaskFileManager {
+    return this.fileManager;
+  }
+
+  /**
+   * Get agent type information.
+   */
+  getAgentType(): { category: 'task'; name: string; role: TaskAgentRole } {
+    return {
+      category: 'task',
+      name: this.agentName,
+      role: this.role,
+    };
+  }
+
+  /**
+   * Check if initialized.
+   */
+  isInitialized(): boolean {
+    return this.initialized;
+  }
+
+  /**
+   * Mark as initialized.
+   */
+  setInitialized(value: boolean): void {
+    this.initialized = value;
+  }
+
+  /**
+   * Get current lifecycle phase.
+   */
+  getLifecyclePhase(): AgentLifecyclePhase {
+    return this.lifecyclePhase;
+  }
+
+  /**
+   * Transition to a new lifecycle phase.
+   */
+  transitionPhase(newPhase: AgentLifecyclePhase): void {
+    const previousPhase = this.lifecyclePhase;
+    this.lifecyclePhase = newPhase;
+
+    this.onLifecycleEvent?.({
+      agentName: this.agentName,
+      previousPhase,
+      currentPhase: newPhase,
+      timestamp: new Date(),
+    });
+  }
+
+  /**
+   * Check if ready for operations.
+   */
+  isReady(): boolean {
+    return this.initialized && this.lifecyclePhase === 'ready';
+  }
+
+  /**
+   * Initialize the capability.
+   * Transitions lifecycle phase from created -> initializing -> ready.
+   */
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.transitionPhase('initializing');
+    this.initialized = true;
+    this.transitionPhase('ready');
+  }
+
+  /**
+   * Cleanup the capability.
+   * Transitions lifecycle phase to cleanup -> disposed.
+   */
+  cleanup(): void {
+    this.transitionPhase('cleanup');
+    this.initialized = false;
+    this.transitionPhase('disposed');
+  }
+}
+
+/**
+ * Allowed tools configuration for each task agent role.
+ */
+export const TASK_AGENT_TOOLS: Record<TaskAgentRole, string[]> = {
+  evaluator: ['Read', 'Grep', 'Glob', 'Write'],
+  executor: [], // Executor uses all tools via permissionMode: bypassPermissions
+  reporter: ['send_user_feedback', 'send_file_to_feishu'],
+} as const;
+
+/**
+ * Get allowed tools for a task agent role.
+ */
+export function getTaskAgentTools(role: TaskAgentRole): string[] {
+  return [...TASK_AGENT_TOOLS[role]];
+}

--- a/src/agents/types.test.ts
+++ b/src/agents/types.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for Agent Types module.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isChatAgent,
+  isTaskAgent,
+  isToolAgent,
+  type ChatAgentType,
+  type TaskAgentType,
+  type ToolAgentType,
+} from './types.js';
+
+describe('Agent Types', () => {
+  describe('Type Guards', () => {
+    it('should identify ChatAgent correctly', () => {
+      const agent: ChatAgentType = {
+        category: 'chat',
+        name: 'Pilot',
+      };
+      expect(isChatAgent(agent)).toBe(true);
+      expect(isTaskAgent(agent)).toBe(false);
+      expect(isToolAgent(agent)).toBe(false);
+    });
+
+    it('should identify TaskAgent correctly', () => {
+      const agent: TaskAgentType = {
+        category: 'task',
+        name: 'Evaluator',
+        role: 'evaluator',
+      };
+      expect(isChatAgent(agent)).toBe(false);
+      expect(isTaskAgent(agent)).toBe(true);
+      expect(isToolAgent(agent)).toBe(false);
+    });
+
+    it('should identify ToolAgent correctly', () => {
+      const agent: ToolAgentType = {
+        category: 'tool',
+        name: 'SiteMiner',
+        domain: 'web-scraping',
+      };
+      expect(isChatAgent(agent)).toBe(false);
+      expect(isTaskAgent(agent)).toBe(false);
+      expect(isToolAgent(agent)).toBe(true);
+    });
+
+    it('should handle all task agent roles', () => {
+      const roles: Array<'evaluator' | 'executor' | 'reporter'> = ['evaluator', 'executor', 'reporter'];
+
+      for (const role of roles) {
+        const agent: TaskAgentType = {
+          category: 'task',
+          name: `Test${role}`,
+          role,
+        };
+        expect(isTaskAgent(agent)).toBe(true);
+        expect(agent.role).toBe(role);
+      }
+    });
+  });
+
+  describe('Type Definitions', () => {
+    it('should have correct category types', () => {
+      const chatAgent: ChatAgentType = { category: 'chat', name: 'Test' };
+      const taskAgent: TaskAgentType = { category: 'task', name: 'Test', role: 'evaluator' };
+      const toolAgent: ToolAgentType = { category: 'tool', name: 'Test', domain: 'test' };
+
+      expect(chatAgent.category).toBe('chat');
+      expect(taskAgent.category).toBe('task');
+      expect(toolAgent.category).toBe('tool');
+    });
+  });
+});

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,130 @@
+/**
+ * Agent Types - Type definitions for agent classification.
+ *
+ * This module defines the three main agent categories:
+ * - ChatAgent: Conversational agents (Pilot)
+ * - TaskAgent: Task-oriented agents (Evaluator, Executor, Reporter)
+ * - ToolAgent: Tool-specific agents (SiteMiner)
+ *
+ * Design principle: "Composition over inheritance"
+ * These types provide classification and documentation, not a new inheritance hierarchy.
+ *
+ * @module agents/types
+ */
+
+/**
+ * Agent category classification.
+ */
+export type AgentCategory = 'chat' | 'task' | 'tool';
+
+/**
+ * Base interface for all agent types.
+ */
+export interface AgentType {
+  /** Agent category */
+  readonly category: AgentCategory;
+  /** Agent name for logging */
+  readonly name: string;
+}
+
+/**
+ * Chat agent - handles conversational interactions.
+ *
+ * Characteristics:
+ * - Streaming input mode
+ * - Persistent sessions
+ * - Platform-specific callbacks
+ *
+ * Example: Pilot
+ */
+export interface ChatAgentType extends AgentType {
+  readonly category: 'chat';
+}
+
+/**
+ * Task agent role types.
+ */
+export type TaskAgentRole = 'evaluator' | 'executor' | 'reporter';
+
+/**
+ * Task agent - handles task execution workflow.
+ *
+ * Characteristics:
+ * - Task evaluation and execution
+ * - File-based communication
+ * - Progress event streaming
+ *
+ * Examples: Evaluator, Executor, Reporter
+ */
+export interface TaskAgentType extends AgentType {
+  readonly category: 'task';
+  /** Task-specific role */
+  readonly role: TaskAgentRole;
+}
+
+/**
+ * Tool agent - handles specific tool operations.
+ *
+ * Characteristics:
+ * - Focused on single tool/domain
+ * - Isolated context
+ * - Structured output
+ *
+ * Example: SiteMiner
+ */
+export interface ToolAgentType extends AgentType {
+  readonly category: 'tool';
+  /** Tool/domain this agent handles */
+  readonly domain: string;
+}
+
+/**
+ * Lifecycle phases for agents.
+ */
+export type AgentLifecyclePhase = 'created' | 'initializing' | 'ready' | 'active' | 'cleanup' | 'disposed';
+
+/**
+ * Lifecycle event for agent state changes.
+ */
+export interface AgentLifecycleEvent {
+  /** Agent name */
+  agentName: string;
+  /** Previous phase */
+  previousPhase: AgentLifecyclePhase;
+  /** Current phase */
+  currentPhase: AgentLifecyclePhase;
+  /** Timestamp */
+  timestamp: Date;
+  /** Optional error if transition failed */
+  error?: Error;
+}
+
+/**
+ * Lifecycle observer callback.
+ */
+export type LifecycleObserver = (event: AgentLifecycleEvent) => void;
+
+// ============================================================================
+// Agent Type Guards
+// ============================================================================
+
+/**
+ * Type guard to check if an agent is a ChatAgent.
+ */
+export function isChatAgent(agent: AgentType): agent is ChatAgentType {
+  return agent.category === 'chat';
+}
+
+/**
+ * Type guard to check if an agent is a TaskAgent.
+ */
+export function isTaskAgent(agent: AgentType): agent is TaskAgentType {
+  return agent.category === 'task';
+}
+
+/**
+ * Type guard to check if an agent is a ToolAgent.
+ */
+export function isToolAgent(agent: AgentType): agent is ToolAgentType {
+  return agent.category === 'tool';
+}


### PR DESCRIPTION
## Summary

- Implements Phase 1 of #282 - Agent type classification and shared capability
- Adds type definitions for three agent categories: ChatAgent, TaskAgent, ToolAgent
- Creates TaskAgentCapability for composition-based shared functionality
- Provides type guards for agent classification

## New Components

### src/agents/types.ts

| Type | Description |
|------|-------------|
| `AgentCategory` | `'chat' \| 'task' \| 'tool'` |
| `ChatAgentType` | Conversational agents (Pilot) |
| `TaskAgentType` | Task agents (Evaluator, Executor, Reporter) |
| `ToolAgentType` | Tool agents (SiteMiner) |
| Type Guards | `isChatAgent`, `isTaskAgent`, `isToolAgent` |

### src/agents/task-agent-capability.ts

| Feature | Description |
|---------|-------------|
| `TaskAgentCapability` | Shared capability for task agents |
| Lifecycle management | Phase transitions with callbacks |
| File manager access | TaskFileManager instance |
| Tool configuration | `TASK_AGENT_TOOLS` for each role |

## Design Principle

**"Composition over inheritance"** - Agents compose capabilities instead of inheriting from intermediate base classes.

```
┌─────────────────────────────────────────────────────────────┐
│                    Agent Categories                         │
├─────────────────────────────────────────────────────────────┤
│                                                             │
│  ChatAgent (Pilot)                                          │
│  ├── Streaming input mode                                   │
│  ├── Persistent sessions                                    │
│  └── Platform-specific callbacks                            │
│                                                             │
│  TaskAgent (Evaluator/Executor/Reporter)                    │
│  ├── Uses TaskAgentCapability (composition)                 │
│  ├── File-based communication                               │
│  └── Progress event streaming                               │
│                                                             │
│  ToolAgent (SiteMiner)                                      │
│  ├── Focused on single tool/domain                          │
│  ├── Isolated context                                       │
│  └── Structured output                                      │
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

## Usage Example

```typescript
import { 
  TaskAgentCapability, 
  getTaskAgentTools,
  isTaskAgent,
  type TaskAgentType 
} from './agents/index.js';

// Create capability for a task agent
const capability = new TaskAgentCapability({
  role: 'evaluator',
  agentName: 'Evaluator',
});

// Get agent type information
const agentType: TaskAgentType = capability.getAgentType();
// { category: 'task', name: 'Evaluator', role: 'evaluator' }

// Check agent type
if (isTaskAgent(agentType)) {
  console.log('This is a task agent with role:', agentType.role);
}

// Get allowed tools for the role
const tools = getTaskAgentTools('evaluator');
// ['Read', 'Grep', 'Glob', 'Write']
```

## Test Results

```
Test Files  55 passed (55)
Tests       920 passed (920)
```

- ✅ 5 tests for `types.ts`
- ✅ 17 tests for `task-agent-capability.ts`

## Files Changed

```
src/agents/types.ts                    (new, 108 lines)
src/agents/types.test.ts               (new, 71 lines)
src/agents/task-agent-capability.ts    (new, 177 lines)
src/agents/task-agent-capability.test.ts (new, 197 lines)
src/agents/index.ts                    (modified, added exports)
```

## Next Steps (Future PRs)

- [ ] Migrate existing agents to use TaskAgentCapability
- [ ] Add lifecycle observer integration
- [ ] Add ChatAgentCapability for Pilot

## Related

- Issue: #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)