### PR TITLE
fix(test): correct import paths in schedule test files (Issue #262)

### DIFF
--- a/src/schedule/schedule-file-scanner.test.ts
+++ b/src/schedule/schedule-file-scanner.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { ScheduleFileScanner } from './schedule-file-scanner.js';
+import { ScheduleFileScanner } from './schedule-watcher.js';
 
 describe('ScheduleFileScanner', () => {
   let scanner: ScheduleFileScanner;

--- a/src/schedule/schedule-file-watcher.test.ts
+++ b/src/schedule/schedule-file-watcher.test.ts
@@ -11,8 +11,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { ScheduleFileWatcher } from './schedule-file-watcher.js';
-import type { ScheduleFileTask } from './schedule-file-scanner.js';
+import { ScheduleFileWatcher, type ScheduleFileTask } from './schedule-watcher.js';
 
 // Helper to wait for async events
 const waitFor = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary

- Fixes #262 - Corrects import paths in schedule test files
- Fixes 2 failing test suites by updating import statements

## Changes

| File | Before | After |
|------|--------|-------|
| `schedule-file-scanner.test.ts` | `import from './schedule-file-scanner.js'` | `import from './schedule-watcher.js'` |
| `schedule-file-watcher.test.ts` | `import from './schedule-file-watcher.js'` | `import from './schedule-watcher.js'` |

## Root Cause

The `ScheduleFileScanner` and `ScheduleFileWatcher` classes are both defined in `schedule-watcher.ts`, but the test files had incorrect import paths referencing non-existent files (`schedule-file-scanner.js` and `schedule-file-watcher.js`).

## Test Results

```
Before: 53 passed | 2 failed (55 files)
After:  55 passed | 0 failed (55 files)
Tests:  927 passed | 8 skipped
```

## Files Changed

```
src/schedule/schedule-file-scanner.test.ts (1 line changed)
src/schedule/schedule-file-watcher.test.ts (2 lines changed)
```

## Test plan

- [x] Run `npx vitest run src/schedule/schedule-file-scanner.test.ts` - 23 tests pass
- [x] Run `npx vitest run src/schedule/schedule-file-watcher.test.ts` - 14 tests pass (8 skipped for CI reliability)
- [x] Run full test suite - 927 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)