### PR TITLE
refactor(agents): migrate BaseAgent to SDK abstraction layer (Issue #291)

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -18,6 +18,7 @@ import type {
   AgentQueryOptions,
   UserInput,
   QueryHandle,
+  StreamingUserMessage,
 } from '../sdk/types.js';
 import { buildSdkEnv } from '../utils/sdk.js';
 import { Config } from '../config/index.js';
@@ -261,7 +262,7 @@ export abstract class BaseAgent {
    * @returns QueryStreamResult with handle and iterator
    */
   protected createQueryStream(
-    input: AsyncGenerator<import('@anthropic-ai/claude-agent-sdk').SDKUserMessage>,
+    input: AsyncGenerator<StreamingUserMessage>,
     options: AgentQueryOptions
   ): QueryStreamResult {
     // Convert SDK UserMessage to SDK UserInput

--- a/src/agents/message-channel.ts
+++ b/src/agents/message-channel.ts
@@ -1,7 +1,7 @@
 /**
  * MessageChannel - Producer-consumer pattern for SDK message streaming.
  *
- * Provides an AsyncGenerator that yields SDKUserMessages as they are pushed.
+ * Provides an AsyncGenerator that yields StreamingUserMessages as they are pushed.
  * This enables the Pilot agent to forward user messages to the SDK's streaming
  * input without using streamInput() directly.
  *
@@ -22,10 +22,10 @@
  * ```
  */
 
-import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { StreamingUserMessage } from '../sdk/index.js';
 
 export class MessageChannel {
-  private queue: SDKUserMessage[] = [];
+  private queue: StreamingUserMessage[] = [];
   private resolver: (() => void) | null = null;
   private closed = false;
 
@@ -33,9 +33,9 @@ export class MessageChannel {
    * Push a message to the channel.
    * Resolves the pending promise in the generator if waiting.
    *
-   * @param message - The SDK user message to push
+   * @param message - The user message to push
    */
-  push(message: SDKUserMessage): void {
+  push(message: StreamingUserMessage): void {
     if (this.closed) {
       return;
     }
@@ -50,9 +50,9 @@ export class MessageChannel {
    * Generator that yields messages as they arrive.
    * Returns when the channel is closed and queue is empty.
    *
-   * @yields SDKUserMessage when available
+   * @yields StreamingUserMessage when available
    */
-  async *generator(): AsyncGenerator<SDKUserMessage> {
+  async *generator(): AsyncGenerator<StreamingUserMessage> {
     while (!this.closed || this.queue.length > 0) {
       // Yield all queued messages
       while (this.queue.length > 0) {

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -35,7 +35,7 @@
  * - Error handling
  */
 
-import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { StreamingUserMessage } from '../sdk/index.js';
 import { Config } from '../config/index.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
@@ -249,7 +249,7 @@ export class Pilot extends BaseAgent {
     // Build the user message
     const enhancedContent = this.buildEnhancedContent(chatId, { text, messageId, senderOpenId, attachments });
 
-    const userMessage: SDKUserMessage = {
+    const userMessage: StreamingUserMessage = {
       type: 'user',
       message: {
         role: 'user',

--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -11,6 +11,8 @@ import {
   type SiteMinerResult,
 } from './site-miner.js';
 import { Config } from '../config/index.js';
+import * as sdkModule from '../sdk/index.js';
+import type { AgentMessage, IAgentSDKProvider } from '../sdk/index.js';
 
 // Mock the Config module
 vi.mock('../config/index.js', () => ({
@@ -38,9 +40,12 @@ vi.mock('../config/index.js', () => ({
   },
 }));
 
-// Mock the SDK query function
-vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
-  query: vi.fn(),
+// Mock the SDK provider
+const mockQueryOnce = vi.fn();
+vi.mock('../sdk/index.js', () => ({
+  getProvider: vi.fn(() => ({
+    queryOnce: mockQueryOnce,
+  })),
 }));
 
 describe('SiteMiner', () => {
@@ -78,8 +83,7 @@ describe('SiteMiner', () => {
     });
 
     it('should handle successful mining operation', async () => {
-      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
-      mockQuery.mockImplementation(async function* () {
+      mockQueryOnce.mockImplementation(async function* () {
         yield {
           type: 'result',
           content: JSON.stringify({
@@ -89,7 +93,8 @@ describe('SiteMiner', () => {
             summary: 'Found the title',
             confidence: 0.95,
           }),
-        };
+          role: 'assistant',
+        } as AgentMessage;
       });
 
       const result = await runSiteMiner({
@@ -103,8 +108,7 @@ describe('SiteMiner', () => {
     });
 
     it('should handle query error', async () => {
-      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
-      mockQuery.mockImplementation(async function* () {
+      mockQueryOnce.mockImplementation(async function* () {
         throw new Error('Query failed');
       });
 
@@ -118,12 +122,12 @@ describe('SiteMiner', () => {
     });
 
     it('should handle malformed JSON response', async () => {
-      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
-      mockQuery.mockImplementation(async function* () {
+      mockQueryOnce.mockImplementation(async function* () {
         yield {
           type: 'result',
           content: 'This is not valid JSON',
-        };
+          role: 'assistant',
+        } as AgentMessage;
       });
 
       const result = await runSiteMiner({
@@ -136,12 +140,12 @@ describe('SiteMiner', () => {
     });
 
     it('should handle partial JSON response', async () => {
-      const mockQuery = vi.mocked(await import('@anthropic-ai/claude-agent-sdk')).query;
-      mockQuery.mockImplementation(async function* () {
+      mockQueryOnce.mockImplementation(async function* () {
         yield {
           type: 'result',
           content: 'Here is the result: {"success": true, "information_found": {"title": "Test"}, "confidence": 0.8} and some extra text',
-        };
+          role: 'assistant',
+        } as AgentMessage;
       });
 
       const result = await runSiteMiner({

--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -13,7 +13,7 @@
  * @module agents/site-miner
  */
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import { getProvider, type AgentQueryOptions } from '../sdk/index.js';
 import { Config } from '../config/index.js';
 import { createLogger } from '../utils/logger.js';
 import { buildSdkEnv } from '../utils/sdk.js';
@@ -122,9 +122,9 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
   }
 
   // Build SDK options with forked context for isolation
-  const sdkOptions: Record<string, unknown> = {
+  const sdkOptions: AgentQueryOptions = {
     cwd: Config.getWorkspaceDir(),
-    permissionMode: 'bypassPermissions',
+    permissionMode: 'bypass',
     settingSources: ['project'],
     // Only allow Playwright MCP tools + basic file operations for saving evidence
     allowedTools: [
@@ -143,7 +143,7 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
       'mcp__playwright__browser_press',
       'mcp__playwright__browser_file_upload',
     ],
-    mcpServers,
+    mcpServers: mcpServers as Record<string, import('../sdk/types.js').McpServerConfig>,
     env: buildSdkEnv(
       agentConfig.apiKey,
       agentConfig.apiBaseUrl,
@@ -168,32 +168,31 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
       logger.warn({ url, timeout }, 'Site mining timed out');
     }, timeout);
 
+    // Get SDK provider
+    const provider = getProvider();
+
     // Run the query in isolated context
-    const queryResult = query({
-      prompt,
-      options: sdkOptions as Parameters<typeof query>[0]['options'],
-      signal: controller.signal,
-    });
+    const queryIterator = provider.queryOnce(prompt, sdkOptions);
 
     // Collect results
     let finalContent = '';
     let resultReceived = false;
 
-    for await (const message of queryResult) {
+    for await (const message of queryIterator) {
+      // Check for abort
+      if (controller.signal.aborted) {
+        break;
+      }
+
       // Parse message type
       if (message.type === 'result') {
         resultReceived = true;
-        finalContent = typeof message.content === 'string'
-          ? message.content
-          : JSON.stringify(message.content);
+        finalContent = message.content;
         logger.debug({ contentLength: finalContent.length }, 'Result received');
-      } else if (message.type === 'assistant') {
+      } else if (message.type === 'text') {
         // Intermediate output
-        const content = typeof message.content === 'string'
-          ? message.content
-          : '';
-        if (content) {
-          logger.debug({ contentLength: content.length }, 'Intermediate output');
+        if (message.content) {
+          logger.debug({ contentLength: message.content.length }, 'Intermediate output');
         }
       }
     }
@@ -340,7 +339,7 @@ function parseSiteMinerResult(content: string, url: string): SiteMinerResult {
 /**
  * Export a factory function for convenience.
  */
-export function createSiteMiner(config?: Partial<BaseAgentConfig>): typeof runSiteMiner {
+export function createSiteMiner(_config?: Partial<BaseAgentConfig>): typeof runSiteMiner {
   // SiteMiner uses global config, but this allows for future customization
   return runSiteMiner;
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -69,6 +69,8 @@ export type {
 
   // 消息类型
   UserInput,
+  StreamingUserMessage,
+  StreamingMessageContent,
   AgentMessage,
   AgentMessageType,
   MessageRole,

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -37,6 +37,24 @@ export interface UserInput {
   content: string | ContentBlock[];
 }
 
+/** API 消息格式（用于流式输入） */
+export interface StreamingMessageContent {
+  role: 'user' | 'assistant';
+  content: string | ContentBlock[];
+}
+
+/**
+ * 流式用户消息（用于 MessageChannel 和 Pilot）
+ *
+ * 这是 SDKUserMessage 的统一抽象，与具体 SDK 无关。
+ */
+export interface StreamingUserMessage {
+  type: 'user';
+  message: StreamingMessageContent;
+  parent_tool_use_id: string | null;
+  session_id: string;
+}
+
 // ============================================================================
 // Agent 消息类型（统一的 SDK 消息抽象）
 // ============================================================================

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,7 @@
-import type { SDKUserMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { StreamingUserMessage } from '../sdk/index.js';
+
+// Re-export for backward compatibility
+export type { StreamingUserMessage };
 
 // Agent message type enum
 export type AgentMessageType =
@@ -68,4 +71,4 @@ export interface AgentOptions {
  * Union type for agent input supporting both string prompts and streaming message arrays.
  * This enables Streaming Input Mode for multi-turn conversation support.
  */
-export type AgentInput = string | AsyncIterable<SDKUserMessage>;
+export type AgentInput = string | AsyncIterable<StreamingUserMessage>;

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -1,7 +1,6 @@
 /**
- * Shared utilities for Claude Agent SDK integration.
+ * Shared utilities for Agent SDK integration.
  */
-import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type {
   AgentMessage,
   ContentBlock,
@@ -142,8 +141,21 @@ function formatEditToolUse(input: Record<string, unknown>): string {
  *
  * IMPORTANT: Accumulates ALL content blocks from assistant messages,
  * not just the first one. This ensures all tool uses and text are sent.
+ *
+ * @deprecated Use SDK provider's message adapter instead. This function
+ * is kept for backward compatibility with existing tests.
+ *
+ * @param message - SDK message (type erased for SDK independence)
+ * @returns Parsed message structure
  */
-export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
+export function parseSDKMessage(message: unknown): ParsedSDKMessage {
+  // Type guard: ensure message is an object with type property
+  if (!message || typeof message !== 'object') {
+    return { type: 'text', content: '' };
+  }
+
+  const msg = message as Record<string, unknown>;
+
   const result: ParsedSDKMessage = {
     type: 'text',
     content: '',
@@ -151,13 +163,13 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
   };
 
   // Extract session_id from any message that has it
-  if ('session_id' in message && message.session_id) {
-    result.sessionId = message.session_id;
+  if ('session_id' in msg && msg.session_id) {
+    result.sessionId = msg.session_id as string;
   }
 
-  switch (message.type) {
+  switch (msg.type) {
     case 'assistant': {
-      const apiMessage = message.message;
+      const apiMessage = msg.message as Record<string, unknown> | undefined;
       if (!apiMessage || !Array.isArray(apiMessage.content)) {
         return { type: 'text', content: '' };
       }
@@ -218,9 +230,9 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
     case 'tool_progress': {
       // Tool execution progress update
       // SDKToolProgressMessage has tool_name and elapsed_time_seconds fields
-      if ('tool_name' in message && 'elapsed_time_seconds' in message) {
-        const toolName = message.tool_name as string;
-        const elapsed = message.elapsed_time_seconds as number;
+      if ('tool_name' in msg && 'elapsed_time_seconds' in msg) {
+        const toolName = msg.tool_name as string;
+        const elapsed = msg.elapsed_time_seconds as number;
         result.type = 'tool_progress';
         result.content = `⏳ Running ${toolName} (${elapsed.toFixed(1)}s)`;
         result.metadata = {
@@ -235,8 +247,8 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
     case 'tool_use_summary': {
       // Tool execution completed
       // SDKToolUseSummaryMessage has summary field, not name
-      if ('summary' in message) {
-        const summary = message.summary as string;
+      if ('summary' in msg) {
+        const summary = msg.summary as string;
         result.type = 'tool_result';
         result.content = `✓ ${summary}`;
         return result;
@@ -245,12 +257,12 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
     }
 
     case 'result': {
-      if (message.subtype === 'success') {
+      if (msg.subtype === 'success') {
         // Successful completion with usage stats
         let statsText = '✅ Complete';
 
-        if ('usage' in message && message.usage) {
-          const usage = message.usage as { total_cost?: number; total_tokens?: number };
+        if ('usage' in msg && msg.usage) {
+          const usage = msg.usage as { total_cost?: number; total_tokens?: number };
           const parts: string[] = [];
 
           if (usage.total_cost !== undefined) {
@@ -268,14 +280,14 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
         result.type = 'result';
         result.content = statsText;
         result.metadata = {
-          cost: (message.usage as { total_cost?: number })?.total_cost,
-          tokens: (message.usage as { total_tokens?: number })?.total_tokens,
+          cost: (msg.usage as { total_cost?: number })?.total_cost,
+          tokens: (msg.usage as { total_tokens?: number })?.total_tokens,
         };
         return result;
       }
 
-      if (message.subtype === 'error_during_execution' && 'errors' in message) {
-        const errors = message.errors as string[];
+      if (msg.subtype === 'error_during_execution' && 'errors' in msg) {
+        const errors = msg.errors as string[];
         result.type = 'error';
         result.content = `❌ Error: ${errors.join(', ')}`;
         return result;
@@ -285,19 +297,19 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
     }
 
     case 'system': {
-      if (message.subtype === 'status') {
+      if (msg.subtype === 'status') {
         // System status update (e.g., compacting)
-        if ('status' in message && message.status === 'compacting') {
+        if ('status' in msg && msg.status === 'compacting') {
           result.type = 'status';
           result.content = '🔄 Compacting conversation history...';
           return result;
         }
       }
 
-      if (message.subtype === 'hook_started') {
+      if (msg.subtype === 'hook_started') {
         // Hook execution started
-        if ('hook' in message && 'event' in message) {
-          const hook = message.hook as string;
+        if ('hook' in msg && 'event' in msg) {
+          const hook = msg.hook as string;
           result.type = 'notification';
           result.content = `🪝 Hook: ${hook}`;
           result.metadata = { status: hook };
@@ -305,11 +317,11 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
         }
       }
 
-      if (message.subtype === 'hook_response') {
+      if (msg.subtype === 'hook_response') {
         // Hook execution completed
-        if ('hook' in message && 'outcome' in message) {
-          const hook = message.hook as string;
-          const outcome = message.outcome as string;
+        if ('hook' in msg && 'outcome' in msg) {
+          const hook = msg.hook as string;
+          const outcome = msg.outcome as string;
           result.type = 'notification';
           result.content = `🪝 Hook ${hook}: ${outcome}`;
           result.metadata = { status: outcome };
@@ -317,12 +329,12 @@ export function parseSDKMessage(message: SDKMessage): ParsedSDKMessage {
         }
       }
 
-      if (message.subtype === 'task_notification') {
+      if (msg.subtype === 'task_notification') {
         // Task completion notification
-        if ('status' in message && 'task_id' in message) {
-          const status = message.status as string;
+        if ('status' in msg && 'task_id' in msg) {
+          const status = msg.status as string;
           result.type = 'notification';
-          result.content = `📋 Task ${message.task_id as string}: ${status}`;
+          result.content = `📋 Task ${msg.task_id as string}: ${status}`;
           result.metadata = { status };
           return result;
         }


### PR DESCRIPTION
## Summary

- Phase 2 of #244 - Migrate BaseAgent to SDK abstraction layer
- Remove direct SDK imports from agent-related files
- Add StreamingUserMessage type for unified message handling

## Changes

### SDK Types (src/sdk/types.ts, src/sdk/index.ts)
- Add `StreamingUserMessage` interface for streaming input mode
- Add `StreamingMessageContent` interface
- Export new types from SDK index

### Agent Types (src/types/agent.ts)
- Replace `SDKUserMessage` import with `StreamingUserMessage` from SDK
- Re-export `StreamingUserMessage` for backward compatibility

### BaseAgent (src/agents/base-agent.ts)
- Import `StreamingUserMessage` from SDK abstraction layer
- Update `createQueryStream` parameter type

### Pilot (src/agents/pilot.ts)
- Replace `SDKUserMessage` import with `StreamingUserMessage`

### MessageChannel (src/agents/message-channel.ts)
- Replace `SDKUserMessage` with `StreamingUserMessage`
- Update documentation to reflect SDK-agnostic design

### SiteMiner (src/agents/site-miner.ts)
- Replace direct `query` import from Claude SDK with `getProvider`
- Use SDK provider's `queryOnce` method for queries
- Update test file to mock SDK provider instead of Claude SDK

### Utils (src/utils/sdk.ts)
- Remove `SDKMessage` type import
- Change `parseSDKMessage` parameter to `unknown` type
- Mark function as deprecated (use SDK provider's message adapter instead)

## Architecture

```
Before:
┌─────────────┐     ┌───────────────────────────────┐
│  BaseAgent  │────>│ @anthropic-ai/claude-agent-sdk │
│  Pilot      │     │  (SDKUserMessage, query, etc.)  │
│  SiteMiner  │     └───────────────────────────────┘
└─────────────┘

After:
┌─────────────┐     ┌───────────────────┐     ┌───────────────────────────────┐
│  BaseAgent  │────>│ SDK Abstraction   │────>│ @anthropic-ai/claude-agent-sdk │
│  Pilot      │     │ (StreamingUserMsg │     │  (only in providers/claude/)   │
│  SiteMiner  │     │  getProvider())   │     └───────────────────────────────┘
└─────────────┘     └───────────────────┘
```

## Test Results

```
Test Files  4 passed (4)
Tests       71 passed (71)
```

## Files Changed

```
src/sdk/types.ts                  (+27 lines, StreamingUserMessage type)
src/sdk/index.ts                  (+2 lines, exports)
src/types/agent.ts                (modified, use SDK types)
src/agents/base-agent.ts          (modified, remove direct SDK import)
src/agents/pilot.ts               (modified, use StreamingUserMessage)
src/agents/message-channel.ts     (modified, use StreamingUserMessage)
src/agents/site-miner.ts          (modified, use getProvider)
src/agents/site-miner.test.ts     (modified, mock SDK provider)
src/utils/sdk.ts                  (modified, deprecate parseSDKMessage)
```

## Related

- Fixes #291
- Parent Issue: #244
- Phase: 2/4
- Milestone: 0.3.2

## Test plan

- [x] Run `npx vitest run src/agents/site-miner.test.ts` - 10 tests pass
- [x] Run `npx vitest run src/agents/base-agent.test.ts` - 15 tests pass
- [x] Run `npx vitest run src/agents/pilot.test.ts` - 21 tests pass
- [x] Run `npx vitest run src/utils/sdk.test.ts` - 25 tests pass
- [x] TypeScript type check passes for modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)