### PR TITLE
refactor(mcp): migrate MCP tools to SDK abstraction layer (Issue #292)

### DIFF
--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -12,7 +12,7 @@
  */
 
 import { z } from 'zod';
-import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
 import { createLogger } from '../utils/logger.js';
 import { getOAuthManager, OAuthManager } from './oauth-manager.js';
 import type { OAuthProviderConfig } from './types.js';
@@ -80,17 +80,19 @@ function getManager(): OAuthManager {
 }
 
 /**
- * Auth MCP tools for Agent SDK.
+ * Auth MCP tool definitions for Agent SDK.
+ *
+ * Uses InlineToolDefinition format for SDK abstraction.
  */
-export const authSdkTools = [
-  tool(
-    'auth_check',
-    'Check if the user has authorized a service. Returns whether authorization exists and if the token is expired.',
-    {
+export const authToolDefinitions: InlineToolDefinition[] = [
+  {
+    name: 'auth_check',
+    description: 'Check if the user has authorized a service. Returns whether authorization exists and if the token is expired.',
+    parameters: z.object({
       provider: z.string().describe('Provider name (e.g., "github", "gitlab", "notion")'),
       chatId: z.string().describe('Chat ID from the task context'),
-    },
-    async ({ provider, chatId }) => {
+    }),
+    handler: async ({ provider, chatId }) => {
       try {
         const manager = getManager();
         const result = await manager.checkToken(chatId, provider);
@@ -107,13 +109,12 @@ export const authSdkTools = [
       } catch (error) {
         return toolError(`Failed to check authorization: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
-
-  tool(
-    'auth_generate_url',
-    'Generate an OAuth authorization URL for a service. Returns the URL and state. The user must visit this URL to authorize. Use with send_user_feedback to send the URL to the user.',
-    {
+    },
+  },
+  {
+    name: 'auth_generate_url',
+    description: 'Generate an OAuth authorization URL for a service. Returns the URL and state. The user must visit this URL to authorize. Use with send_user_feedback to send the URL to the user.',
+    parameters: z.object({
       providerName: z.string().describe('Provider name (e.g., "github", "gitlab")'),
       authUrl: z.string().describe('OAuth authorization endpoint URL'),
       tokenUrl: z.string().describe('OAuth token endpoint URL'),
@@ -122,8 +123,8 @@ export const authSdkTools = [
       scopes: z.string().describe('Space-separated OAuth scopes to request'),
       callbackUrl: z.string().describe('OAuth callback URL (must match the registered redirect URI)'),
       chatId: z.string().describe('Chat ID from the task context'),
-    },
-    async ({ providerName, authUrl, tokenUrl, clientId, clientSecret, scopes, callbackUrl, chatId }) => {
+    }),
+    handler: async ({ providerName, authUrl, tokenUrl, clientId, clientSecret, scopes, callbackUrl, chatId }) => {
       try {
         const provider: OAuthProviderConfig = {
           name: providerName,
@@ -148,21 +149,20 @@ export const authSdkTools = [
       } catch (error) {
         return toolError(`Failed to generate authorization URL: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
-
-  tool(
-    'auth_request',
-    'Make an authenticated API request on behalf of the user. The token is injected server-side and never exposed. Use this to call APIs after the user has authorized.',
-    {
+    },
+  },
+  {
+    name: 'auth_request',
+    description: 'Make an authenticated API request on behalf of the user. The token is injected server-side and never exposed. Use this to call APIs after the user has authorized.',
+    parameters: z.object({
       chatId: z.string().describe('Chat ID from the task context'),
       provider: z.string().describe('Provider name (e.g., "github", "gitlab")'),
       method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).describe('HTTP method'),
       url: z.string().describe('Full API URL to call'),
       headers: z.record(z.string(), z.string()).optional().describe('Additional headers (Authorization header is added automatically)'),
       body: z.unknown().optional().describe('Request body (for POST/PUT/PATCH)'),
-    },
-    async ({ chatId, provider, method, url, headers, body }) => {
+    }),
+    handler: async ({ chatId, provider, method, url, headers, body }) => {
       try {
         const manager = getManager();
         const result = await manager.makeAuthenticatedRequest(chatId, provider, {
@@ -191,16 +191,15 @@ export const authSdkTools = [
       } catch (error) {
         return toolError(`API request failed: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
-
-  tool(
-    'auth_list',
-    'List all services the user has authorized in this chat.',
-    {
-      chatId: z.string().describe('Chat ID from the task context'),
     },
-    async ({ chatId }) => {
+  },
+  {
+    name: 'auth_list',
+    description: 'List all services the user has authorized in this chat.',
+    parameters: z.object({
+      chatId: z.string().describe('Chat ID from the task context'),
+    }),
+    handler: async ({ chatId }) => {
       try {
         const manager = getManager();
         const providers = await manager.listAuthorizations(chatId);
@@ -215,17 +214,16 @@ export const authSdkTools = [
       } catch (error) {
         return toolError(`Failed to list authorizations: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
-
-  tool(
-    'auth_revoke',
-    'Revoke authorization for a service. This deletes the stored token.',
-    {
+    },
+  },
+  {
+    name: 'auth_revoke',
+    description: 'Revoke authorization for a service. This deletes the stored token.',
+    parameters: z.object({
       chatId: z.string().describe('Chat ID from the task context'),
       provider: z.string().describe('Provider name to revoke'),
-    },
-    async ({ chatId, provider }) => {
+    }),
+    handler: async ({ chatId, provider }) => {
       try {
         const manager = getManager();
         const deleted = await manager.revokeToken(chatId, provider);
@@ -238,17 +236,25 @@ export const authSdkTools = [
       } catch (error) {
         return toolError(`Failed to revoke authorization: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
+    },
+  },
 ];
+
+/**
+ * Auth MCP tools for Agent SDK (SDK-compatible format).
+ *
+ * @deprecated Use authToolDefinitions with getProvider().createMcpServer() instead.
+ */
+export const authSdkTools = authToolDefinitions.map(def => getProvider().createInlineTool(def));
 
 /**
  * Create SDK MCP server for authentication tools.
  */
 export function createAuthSdkMcpServer() {
-  return createSdkMcpServer({
+  return getProvider().createMcpServer({
+    type: 'inline',
     name: 'auth',
     version: '1.0.0',
-    tools: authSdkTools,
+    tools: authToolDefinitions,
   });
 }

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -584,13 +584,10 @@ export const feishuContextTools = {
 /**
  * SDK-compatible tool definitions.
  *
- * Converts feishuContextTools to the format expected by the Agent SDK:
- * - Array format (not object with keys)
- * - Zod schemas for input validation
- * - Proper SdkMcpToolDefinition structure
+ * Uses InlineToolDefinition format for SDK abstraction.
  */
 import { z } from 'zod';
-import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
+import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
 
 /**
  * Helper to create a successful tool result.
@@ -602,18 +599,22 @@ function toolSuccess(text: string): { content: Array<{ type: 'text'; text: strin
   };
 }
 
-// SDK-compatible tools array
-export const feishuSdkTools = [
-  tool(
-    'send_user_feedback',
-    'Send a message to a Feishu chat. Requires explicit format: "text" or "card". Use this to report progress, provide updates, or send rich content.\n\n**Thread Support:**\nWhen parentMessageId is provided, the message is sent as a reply to that message, creating a thread in Feishu.\n\n**Card Format Requirements:**\nWhen format="card", content must be a valid Feishu card object with the following structure:\n\n{\n  "config": {"wide_screen_mode": true},\n  "header": {"title": {"tag": "plain_text", "content": "Title"}, "template": "blue"},\n  "elements": [\n    {"tag": "markdown", "content": "**Bold** and *italic* text"},\n    {"tag": "hr"},\n    {"tag": "div", "text": {"tag": "plain_text", "content": "Plain text content"}}\n  ]\n}\n\n**Key Elements to Use:**\n- {"tag": "markdown", "content": "..."} - For markdown formatted text\n- {"tag": "hr"} - For horizontal dividers\n- {"tag": "div", "text": {"tag": "plain_text", "content": "..."}} - For plain text in containers\n- {"tag": "column_set", ...} - For tables (see below)\n\n⚠️ **IMPORTANT: Markdown Tables NOT Supported**\nFeishu cards do NOT support Markdown table syntax (| col1 | col2 |). Tables will render as raw text.\n\n**Use column_set for Tables Instead:**\nCreate a column_set element with columns array. Each column has width "weighted" and weight for proportions.\nFor data rows, use multiple column_set elements with alternating background_style ("grey" vs "").\n\n**Reference:**\n- Markdown: https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags\n- Column Set: https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/column-set',
-    {
+/**
+ * Feishu MCP tool definitions for Agent SDK.
+ *
+ * Uses InlineToolDefinition format for SDK abstraction.
+ */
+export const feishuToolDefinitions: InlineToolDefinition[] = [
+  {
+    name: 'send_user_feedback',
+    description: 'Send a message to a Feishu chat. Requires explicit format: "text" or "card". Use this to report progress, provide updates, or send rich content.\n\n**Thread Support:**\nWhen parentMessageId is provided, the message is sent as a reply to that message, creating a thread in Feishu.\n\n**Card Format Requirements:**\nWhen format="card", content must be a valid Feishu card object with the following structure:\n\n{\n  "config": {"wide_screen_mode": true},\n  "header": {"title": {"tag": "plain_text", "content": "Title"}, "template": "blue"},\n  "elements": [\n    {"tag": "markdown", "content": "**Bold** and *italic* text"},\n    {"tag": "hr"},\n    {"tag": "div", "text": {"tag": "plain_text", "content": "Plain text content"}}\n  ]\n}\n\n**Key Elements to Use:**\n- {"tag": "markdown", "content": "..."} - For markdown formatted text\n- {"tag": "hr"} - For horizontal dividers\n- {"tag": "div", "text": {"tag": "plain_text", "content": "..."}} - For plain text in containers\n- {"tag": "column_set", ...} - For tables (see below)\n\n⚠️ **IMPORTANT: Markdown Tables NOT Supported**\nFeishu cards do NOT support Markdown table syntax (| col1 | col2 |). Tables will render as raw text.\n\n**Use column_set for Tables Instead:**\nCreate a column_set element with columns array. Each column has width "weighted" and weight for proportions.\nFor data rows, use multiple column_set elements with alternating background_style ("grey" vs "").\n\n**Reference:**\n- Markdown: https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags\n- Column Set: https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/column-set',
+    parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. String for text messages, object for cards (must follow Feishu card structure - see tool description).'),
       format: z.enum(['text', 'card']).describe('Format specifier (required): "text" for plain text, "card" for interactive cards with VALID structure.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies. When provided, the message is sent as a reply to this message.'),
-    },
-    async ({ content, format, chatId, parentMessageId }) => {
+    }),
+    handler: async ({ content, format, chatId, parentMessageId }) => {
       try {
         const result = await send_user_feedback({ content, format, chatId, parentMessageId });
         if (result.success) {
@@ -627,16 +628,16 @@ export const feishuSdkTools = [
         // Return as soft error to avoid SDK subprocess crash
         return toolSuccess(`⚠️ Feedback failed: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
-  tool(
-    'send_file_to_feishu',
-    'Send a file to a Feishu chat. Supports images, audio, video, and documents.',
-    {
+    },
+  },
+  {
+    name: 'send_file_to_feishu',
+    description: 'Send a file to a Feishu chat. Supports images, audio, video, and documents.',
+    parameters: z.object({
       filePath: z.string().describe('Path to the file to send (relative to workspace or absolute)'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
-    },
-    async ({ filePath, chatId }) => {
+    }),
+    handler: async ({ filePath, chatId }) => {
       try {
         const result = await send_file_to_feishu({ filePath, chatId });
         if (result.success) {
@@ -650,9 +651,16 @@ export const feishuSdkTools = [
         // Return as soft error to avoid SDK subprocess crash
         return toolSuccess(`⚠️ File send failed: ${error instanceof Error ? error.message : String(error)}`);
       }
-    }
-  ),
+    },
+  },
 ];
+
+/**
+ * SDK-compatible tools array.
+ *
+ * @deprecated Use feishuToolDefinitions with getProvider().createMcpServer() instead.
+ */
+export const feishuSdkTools = feishuToolDefinitions.map(def => getProvider().createInlineTool(def));
 
 /**
  * SDK MCP Server factory for Feishu context tools.
@@ -679,9 +687,10 @@ export const feishuSdkTools = [
  * to the Agent SDK.
  */
 export function createFeishuSdkMcpServer() {
-  return createSdkMcpServer({
+  return getProvider().createMcpServer({
+    type: 'inline',
     name: 'feishu-context',
     version: '1.0.0',
-    tools: feishuSdkTools,
+    tools: feishuToolDefinitions,
   });
 }


### PR DESCRIPTION
## Summary

- Migrates MCP tools from direct SDK imports to SDK abstraction layer
- Uses `getProvider().createInlineTool()` and `getProvider().createMcpServer()`
- Introduces `InlineToolDefinition` format for tool definitions

## Changes

### src/auth/auth-mcp.ts
- Replaced direct import of `tool` and `createSdkMcpServer` from SDK
- Added `authToolDefinitions` using `InlineToolDefinition[]` format
- Updated `createAuthSdkMcpServer()` to use `getProvider().createMcpServer()`
- Marked `authSdkTools` as deprecated (now derived from definitions)

### src/mcp/feishu-context-mcp.ts
- Replaced direct import of `tool` and `createSdkMcpServer` from SDK
- Added `feishuToolDefinitions` using `InlineToolDefinition[]` format
- Updated `createFeishuSdkMcpServer()` to use `getProvider().createMcpServer()`
- Marked `feishuSdkTools` as deprecated (now derived from definitions)

## File Changes

```
src/auth/auth-mcp.ts
├── authToolDefinitions - New InlineToolDefinition[] format
├── authSdkTools - Now derived from definitions (deprecated)
└── createAuthSdkMcpServer() - Uses getProvider().createMcpServer()

src/mcp/feishu-context-mcp.ts
├── feishuToolDefinitions - New InlineToolDefinition[] format
├── feishuSdkTools - Now derived from definitions (deprecated)
└── createFeishuSdkMcpServer() - Uses getProvider().createMcpServer()
```

## Test Results

```
Test Files  3 passed
Tests       98 passed
- MCP tests: 37 passed ✓
- Auth tests: 44 passed ✓
- SDK tests: 17 passed ✓

Build: Success ✓
```

## Related

- Issue: #292
- Parent Issue: #244
- Phase: 3/4
- Depends on: #291 (already closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)