### PR TITLE
refactor(sdk): complete SDK migration - verify and close Issue #293

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -304,7 +304,7 @@ export abstract class BaseAgent {
   }
 
   /**
-   * Convert legacy AsyncIterable<SDKUserMessage> to SDK UserInput format.
+   * Convert legacy AsyncIterable<StreamingUserMessage> to SDK UserInput format.
    */
   private convertInputToUserInput(input: AsyncIterable<unknown>): UserInput[] | string {
     // For string input, just return it


### PR DESCRIPTION
## Summary

- Update comment in `base-agent.ts` to use correct type name
- Change `SDKUserMessage` to `StreamingUserMessage` in comment
- This is a documentation cleanup to reflect the completed SDK abstraction migration

## Verification

All tasks from #293 have been verified:

### 1. 验证无直接 SDK 导入 ✅
所有业务逻辑文件不再直接导入 `@anthropic-ai/claude-agent-sdk`：
- `src/agents/base-agent.ts` - 无直接 SDK 导入
- `src/agents/pilot.ts` - 无直接 SDK 导入
- `src/agents/site-miner.ts` - 无直接 SDK 导入
- `src/agents/session-manager.ts` - 无直接 SDK 导入
- `src/agents/message-channel.ts` - 无直接 SDK 导入
- `src/auth/auth-mcp.ts` - 无直接 SDK 导入
- `src/utils/sdk.ts` - 无直接 SDK 导入
- `src/types/agent.ts` - 无直接 SDK 导入

只有 `src/sdk/providers/claude/` 目录有直接导入（这是合理的，因为它是 SDK 提供者实现层）。

### 2. 更新类型定义 ✅
- `src/types/agent.ts` 使用统一类型 `StreamingUserMessage`（从 `../sdk/index.js` 导入）
- `SDKUserMessage` 别名已移除

### 3. 更新 tsconfig.json ✅
- 当前配置已足够，无需修改

### 4. 验证 ✅
- `npm run build` - 成功
- `npm test` - 1078 tests passed, 8 skipped

## Related

- Closes #293
- Parent Issue: #244
- Phase: 4/4
- Depends on: #291 (closed), #292 (closed via PR #297)

🤖 Generated with [Claude Code](https://claude.com/claude-code)