### PR TITLE
refactor(agents): define unified Agent type interfaces (Phase 1 of #282)

### DIFF
--- a/src/agents/evaluator.ts
+++ b/src/agents/evaluator.ts
@@ -53,6 +53,12 @@ export interface EvaluatorConfig extends BaseAgentConfig {
  * - Error handling
  */
 export class Evaluator extends BaseAgent {
+  /** Agent type identifier (Issue #282) */
+  readonly type = 'skill' as const;
+
+  /** Agent name for logging */
+  readonly name = 'Evaluator';
+
   private fileManager: TaskFileManager;
 
   constructor(config: EvaluatorConfig) {

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -80,6 +80,12 @@ export interface TaskResult {
  * Executor-specific features like TaskProgressEvent yielding.
  */
 export class Executor extends BaseAgent {
+  /** Agent type identifier (Issue #282) */
+  readonly type = 'skill' as const;
+
+  /** Agent name for logging */
+  readonly name = 'Executor';
+
   private readonly config: ExecutorConfig;
   private fileManager: TaskFileManager;
 

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,7 +9,25 @@
  * - Pilot: Platform-agnostic direct chat with streaming input
  * - SessionManager: Pilot session lifecycle management
  * - ConversationContext: Pilot conversation context tracking
+ *
+ * Agent Type Classification (Issue #282):
+ * - ChatAgent: Continuous conversation agents (Pilot)
+ * - SkillAgent: Single-shot task agents (Evaluator, Executor, Reporter)
+ * - Subagent: SkillAgent that can be used as a tool (SiteMiner)
  */
+
+// Type definitions
+export {
+  type ChatAgent,
+  type SkillAgent,
+  type Subagent,
+  type UserInput,
+  type AgentConfig,
+  type AgentFactoryInterface,
+  isChatAgent,
+  isSkillAgent,
+  isSubagent,
+} from './types.js';
 
 // Base class
 export {

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -118,6 +118,12 @@ interface MessageData {
  * - ConversationOrchestrator for conversation management (from #237)
  */
 export class Pilot extends BaseAgent {
+  /** Agent type identifier (Issue #282) */
+  readonly type = 'chat' as const;
+
+  /** Agent name for logging */
+  readonly name = 'Pilot';
+
   private readonly callbacks: PilotCallbacks;
 
   // Separated concerns

--- a/src/agents/reporter.ts
+++ b/src/agents/reporter.ts
@@ -51,6 +51,12 @@ const REPORTER_ALLOWED_TOOLS = ['send_user_feedback', 'send_file_to_feishu'];
  * - Error handling
  */
 export class Reporter extends BaseAgent {
+  /** Agent type identifier (Issue #282) */
+  readonly type = 'skill' as const;
+
+  /** Agent name for logging */
+  readonly name = 'Reporter';
+
   constructor(config: BaseAgentConfig) {
     super(config);
   }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,327 @@
+/**
+ * Agent Type Definitions - Unified interfaces for Agent classification.
+ *
+ * This module defines the core interfaces for the Agent architecture as described in Issue #282:
+ *
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │                      Agent 体系                              │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │                                                             │
+ * │  ┌─────────────────┐     ┌─────────────────────────────┐   │
+ * │  │  ChatAgent      │     │  SkillAgent                 │   │
+ * │  │  (对话型)        │     │  (技能型)                   │   │
+ * │  │                 │     │                             │   │
+ * │  │  ┌───────────┐  │     │  ┌─────────┐ ┌─────────┐   │   │
+ * │  │  │  Pilot    │  │     │  │Evaluator│ │Executor │...│   │
+ * │  │  └───────────┘  │     │  └─────────┘ └─────────┘   │   │
+ * │  └─────────────────┘     └─────────────────────────────┘   │
+ * │           │                           │                     │
+ * │           │ 调用工具                   │ 被封装              │
+ * │           ▼                           ▼                     │
+ * │  ┌─────────────────────────────────────────────────────┐   │
+ * │  │  Subagent (工具封装)                                 │   │
+ * │  │  ┌───────────┐                                      │   │
+ * │  │  │ SiteMiner │  ← SkillAgent + 独立 MCP Server      │   │
+ * │  │  └───────────┘                                      │   │
+ * │  └─────────────────────────────────────────────────────┘   │
+ * │                                                             │
+ * └─────────────────────────────────────────────────────────────┘
+ *
+ * Key Design Principles:
+ * 1. **ChatAgent** - For continuous conversation with streaming input/output
+ * 2. **SkillAgent** - For single-shot task execution (input → output)
+ * 3. **Subagent** - SkillAgent that can be encapsulated as a tool
+ *
+ * @module agents/types
+ */
+
+import type { AgentMessage } from '../types/agent.js';
+import type { InlineToolDefinition, McpServerConfig } from '../sdk/types.js';
+
+// ============================================================================
+// User Input Types
+// ============================================================================
+
+/**
+ * User input for agent processing.
+ */
+export interface UserInput {
+  /** User role */
+  role: 'user';
+  /** Message content */
+  content: string;
+  /** Optional metadata */
+  metadata?: {
+    /** Chat ID for context */
+    chatId?: string;
+    /** Parent message ID for thread replies */
+    parentMessageId?: string;
+    /** File references attached to the message */
+    fileRefs?: Array<{
+      name: string;
+      path: string;
+      type: string;
+    }>;
+  };
+}
+
+// ============================================================================
+// ChatAgent Interface (对话型 Agent)
+// ============================================================================
+
+/**
+ * ChatAgent - Continuous conversation agent with streaming input/output.
+ *
+ * Characteristics:
+ * - Maintains persistent conversation session
+ * - Streaming input from user
+ * - Streaming output to user
+ * - Maintains session state across messages
+ *
+ * Current implementations:
+ * - `Pilot` - Main conversational agent with user
+ *
+ * @example
+ * ```typescript
+ * const chatAgent: ChatAgent = new Pilot(config);
+ * await chatAgent.start();
+ *
+ * // Process user messages
+ * for await (const response of chatAgent.handleInput(userInputStream)) {
+ *   console.log(response.content);
+ * }
+ *
+ * // Reset session when done
+ * chatAgent.reset();
+ * ```
+ */
+export interface ChatAgent {
+  /** Agent type identifier */
+  readonly type: 'chat';
+
+  /** Agent name for logging */
+  readonly name: string;
+
+  /**
+   * Start the agent session.
+   * Called once before processing any messages.
+   */
+  start(): Promise<void>;
+
+  /**
+   * Handle streaming user input and yield responses.
+   *
+   * @param input - AsyncGenerator yielding user messages
+   * @yields AgentMessage responses
+   */
+  handleInput(input: AsyncGenerator<UserInput>): AsyncGenerator<AgentMessage>;
+
+  /**
+   * Reset the agent session.
+   * Clears conversation history and state.
+   */
+  reset(): void;
+
+  /**
+   * Cleanup resources.
+   * Called when agent is no longer needed.
+   */
+  cleanup(): void;
+}
+
+// ============================================================================
+// SkillAgent Interface (技能型 Agent)
+// ============================================================================
+
+/**
+ * SkillAgent - Single-shot task execution agent.
+ *
+ * Characteristics:
+ * - Single task execution (input → output)
+ * - No persistent session state (or limited state)
+ * - Returns results and terminates
+ *
+ * Current implementations:
+ * - `Evaluator` - Evaluates task completion
+ * - `Executor` - Executes specific tasks
+ * - `Reporter` - Generates user feedback reports
+ *
+ * @example
+ * ```typescript
+ * const skillAgent: SkillAgent = new Evaluator(config);
+ *
+ * // Execute single task
+ * for await (const response of skillAgent.execute(taskInput)) {
+ *   console.log(response.content);
+ * }
+ *
+ * skillAgent.cleanup();
+ * ```
+ */
+export interface SkillAgent {
+  /** Agent type identifier */
+  readonly type: 'skill';
+
+  /** Agent name for logging */
+  readonly name: string;
+
+  /**
+   * Execute a single task and yield results.
+   *
+   * @param input - Task input as string or structured data
+   * @yields AgentMessage responses
+   */
+  execute(input: string | UserInput[]): AsyncGenerator<AgentMessage>;
+
+  /**
+   * Cleanup resources.
+   * Called when agent is no longer needed.
+   */
+  cleanup(): void;
+}
+
+// ============================================================================
+// Subagent Interface (工具封装型 Agent)
+// ============================================================================
+
+/**
+ * Subagent - SkillAgent that can be encapsulated as a tool.
+ *
+ * Characteristics:
+ * - Extends SkillAgent capabilities
+ * - Can be exposed as an inline tool for other agents
+ * - May have its own isolated MCP server
+ *
+ * Current implementations:
+ * - `SiteMiner` - Playwright-based site mining, exposed as tool
+ *
+ * @example
+ * ```typescript
+ * const subagent: Subagent = createSiteMiner();
+ *
+ * // Use as SkillAgent
+ * for await (const response of subagent.execute(taskInput)) {
+ *   console.log(response.content);
+ * }
+ *
+ * // Or use as tool definition for other agents
+ * const toolDef = subagent.asTool();
+ * // toolDef can be added to another agent's MCP server
+ *
+ * // Get MCP server config if running standalone
+ * const mcpConfig = subagent.getMcpServer();
+ * ```
+ */
+export interface Subagent extends SkillAgent {
+  /**
+   * Get the agent's tool definition for use by other agents.
+   *
+   * Returns an InlineToolDefinition that can be added to an
+   * inline MCP server, allowing other agents to invoke this
+   * subagent as a tool.
+   *
+   * @returns Tool definition for MCP registration
+   */
+  asTool(): InlineToolDefinition;
+
+  /**
+   * Get MCP server configuration for standalone execution.
+   *
+   * Returns configuration for running this subagent with its
+   * own isolated MCP server (e.g., for context isolation).
+   *
+   * @returns MCP server configuration, or undefined if not applicable
+   */
+  getMcpServer(): McpServerConfig | undefined;
+}
+
+// ============================================================================
+// Agent Type Guards
+// ============================================================================
+
+/**
+ * Type guard to check if an agent is a ChatAgent.
+ */
+export function isChatAgent(agent: unknown): agent is ChatAgent {
+  return (
+    typeof agent === 'object' &&
+    agent !== null &&
+    'type' in agent &&
+    (agent as { type: string }).type === 'chat'
+  );
+}
+
+/**
+ * Type guard to check if an agent is a SkillAgent.
+ */
+export function isSkillAgent(agent: unknown): agent is SkillAgent {
+  return (
+    typeof agent === 'object' &&
+    agent !== null &&
+    'type' in agent &&
+    (agent as { type: string }).type === 'skill'
+  );
+}
+
+/**
+ * Type guard to check if an agent is a Subagent.
+ */
+export function isSubagent(agent: unknown): agent is Subagent {
+  return (
+    isSkillAgent(agent) &&
+    'asTool' in agent &&
+    typeof (agent as { asTool: unknown }).asTool === 'function'
+  );
+}
+
+// ============================================================================
+// Agent Factory Types
+// ============================================================================
+
+/**
+ * Configuration for creating agents.
+ */
+export interface AgentConfig {
+  /** API key for authentication */
+  apiKey: string;
+  /** Model identifier */
+  model: string;
+  /** Optional API base URL */
+  apiBaseUrl?: string;
+  /** Permission mode for tool execution */
+  permissionMode?: 'default' | 'bypassPermissions';
+}
+
+/**
+ * Factory for creating Agent instances.
+ *
+ * @example
+ * ```typescript
+ * const factory = new AgentFactory(config);
+ *
+ * // Create ChatAgent
+ * const pilot = factory.createChatAgent('pilot', callbacks);
+ *
+ * // Create SkillAgent
+ * const evaluator = factory.createSkillAgent('evaluator');
+ *
+ * // Create Subagent
+ * const siteMiner = factory.createSubagent('site-miner');
+ * ```
+ */
+export interface AgentFactoryInterface {
+  /**
+   * Create a ChatAgent instance.
+   */
+  createChatAgent(name: string, ...args: unknown[]): ChatAgent;
+
+  /**
+   * Create a SkillAgent instance.
+   */
+  createSkillAgent(name: string, ...args: unknown[]): SkillAgent;
+
+  /**
+   * Create a Subagent instance.
+   */
+  createSubagent(name: string, ...args: unknown[]): Subagent;
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1** of #282 - Define type interfaces for Agent classification.

## Changes

### New File: `src/agents/types.ts`

| Type | Description |
|------|-------------|
| `ChatAgent` | Continuous conversation agents (Pilot) |
| `SkillAgent` | Single-shot task execution agents (Evaluator, Executor, Reporter) |
| `Subagent` | SkillAgent that can be used as a tool (SiteMiner) |
| `UserInput` | Standardized input type |
| `AgentConfig` | Base configuration for agents |
| `AgentFactoryInterface` | Factory interface for creating agents |
| Type Guards | `isChatAgent`, `isSkillAgent`, `isSubagent` |

### Updated Agents

- **Pilot**: Added `type: 'chat'` and `name: 'Pilot'` properties
- **Evaluator**: Added `type: 'skill'` and `name: 'Evaluator'` properties
- **Executor**: Added `type: 'skill'` and `name: 'Executor'` properties
- **Reporter**: Added `type: 'skill'` and `name: 'Reporter'` properties

### Updated Exports

- Export new types from `src/agents/index.ts`

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                      Agent 体系                              │
├─────────────────────────────────────────────────────────────┤
│                                                             │
│  ┌─────────────────┐     ┌─────────────────────────────┐   │
│  │  ChatAgent      │     │  SkillAgent                 │   │
│  │  (对话型)        │     │  (技能型)                   │   │
│  │                 │     │                             │   │
│  │  ┌───────────┐  │     │  ┌─────────┐ ┌─────────┐   │   │
│  │  │  Pilot    │  │     │  │Evaluator│ │Executor │...│   │
│  │  └───────────┘  │     │  └─────────┘ └─────────┘   │   │
│  └─────────────────┘     └─────────────────────────────┘   │
│           │                           │                     │
│           │ 调用工具                   │ 被封装              │
│           ▼                           ▼                     │
│  ┌─────────────────────────────────────────────────────┐   │
│  │  Subagent (工具封装)                                 │   │
│  │  ┌───────────┐                                      │   │
│  │  │ SiteMiner │  ← SkillAgent + 独立 MCP Server      │   │
│  │  └───────────┘                                      │   │
│  └─────────────────────────────────────────────────────┘   │
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

## Key Design Decisions

1. **ChatAgent** - For agents that maintain persistent conversation sessions with streaming input/output
2. **SkillAgent** - For agents that execute single-shot tasks (input → output)
3. **Subagent** - Extends SkillAgent with tool encapsulation capability

## Test Results

```
✓ src/agents/factory.test.ts (10 tests)
✓ src/agents/conversation-context.test.ts (12 tests)
✓ src/agents/index.test.ts (10 tests)
✓ src/agents/site-miner.test.ts (7 tests)
✓ src/agents/pilot.test.ts (7 tests)
... and more

Test Files  10 passed (10)
Tests       137 passed (137)
Duration    810ms
```

## Next Steps (Phase 2)

- [ ] Refactor Pilot to implement ChatAgent interface
- [ ] Refactor Evaluator/Executor/Reporter to implement SkillAgent interface
- [ ] Refactor SiteMiner to implement Subagent interface
- [ ] Update AgentFactory to use new types

Fixes #282 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)