### PR TITLE
revert(sdk): 恢复 SDK Options 配置为原始格式

### DIFF
--- a/src/agents/base-agent.test.ts
+++ b/src/agents/base-agent.test.ts
@@ -71,7 +71,7 @@ class TestAgent extends BaseAgent {
   }
 
   async *testQueryOnce(input: string) {
-    yield* this.queryOnce(input, {});
+    yield* this.queryOnce(input, { settingSources: ['project'] });
   }
 
   testFormatMessage(parsed: IteratorYieldResult['parsed']) {
@@ -127,7 +127,7 @@ describe('BaseAgent', () => {
       const options = agent.testCreateSdkOptions();
 
       expect(options.cwd).toBeDefined();
-      expect(options.permissionMode).toBe('bypass');
+      expect(options.permissionMode).toBe('bypassPermissions');
       expect(options.settingSources).toContain('project');
       expect(options.env).toBeDefined();
     });

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -149,7 +149,7 @@ export abstract class BaseAgent {
   protected createSdkOptions(extra: SdkOptionsExtra = {}): AgentQueryOptions {
     const options: AgentQueryOptions = {
       cwd: extra.cwd ?? Config.getWorkspaceDir(),
-      permissionMode: this.permissionMode === 'bypassPermissions' ? 'bypass' : 'default',
+      permissionMode: this.permissionMode,
       settingSources: ['project'],
     };
 

--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -124,7 +124,7 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
   // Build SDK options with forked context for isolation
   const sdkOptions: AgentQueryOptions = {
     cwd: Config.getWorkspaceDir(),
-    permissionMode: 'bypass',
+    permissionMode: 'bypassPermissions',
     settingSources: ['project'],
     // Only allow Playwright MCP tools + basic file operations for saving evidence
     allowedTools: [
@@ -151,8 +151,6 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
       loggingConfig.sdkDebug
     ),
     model: agentConfig.model,
-    // Fork context to run in isolation - prevents stdio conflicts
-    context: 'fork',
   };
 
   // Build the prompt

--- a/src/sdk/factory.test.ts
+++ b/src/sdk/factory.test.ts
@@ -169,7 +169,7 @@ describe('ClaudeSDKProvider', () => {
     it('should throw if disposed', async () => {
       provider.dispose();
       await expect(async () => {
-        const gen = provider.queryOnce('test', {});
+        const gen = provider.queryOnce('test', { settingSources: ['project'] });
         await gen.next();
       }).rejects.toThrow('Provider has been disposed');
     });
@@ -182,7 +182,7 @@ describe('ClaudeSDKProvider', () => {
         yield { role: 'user', content: 'test' };
       }
       expect(() => {
-        provider.queryStream(inputGen(), {});
+        provider.queryStream(inputGen(), { settingSources: ['project'] });
       }).toThrow('Provider has been disposed');
     });
   });

--- a/src/sdk/providers/claude/options-adapter.ts
+++ b/src/sdk/providers/claude/options-adapter.ts
@@ -25,17 +25,13 @@ export function adaptOptions(options: AgentQueryOptions): Record<string, unknown
     sdkOptions.model = options.model;
   }
 
-  // 权限模式
+  // 权限模式 - 直接传递，使用原始 SDK 格式
   if (options.permissionMode) {
-    sdkOptions.permissionMode = options.permissionMode === 'bypass'
-      ? 'bypassPermissions'
-      : options.permissionMode;
+    sdkOptions.permissionMode = options.permissionMode;
   }
 
-  // 设置来源
-  if (options.settingSources) {
-    sdkOptions.settingSources = options.settingSources;
-  }
+  // 设置来源（必填）
+  sdkOptions.settingSources = options.settingSources;
 
   // 工具配置
   if (options.allowedTools) {
@@ -54,11 +50,6 @@ export function adaptOptions(options: AgentQueryOptions): Record<string, unknown
   // 环境变量
   if (options.env) {
     sdkOptions.env = options.env;
-  }
-
-  // 上下文隔离
-  if (options.context) {
-    sdkOptions.context = options.context;
   }
 
   return sdkOptions;

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -171,7 +171,7 @@ export type McpServerConfig = StdioMcpServerConfig | InlineMcpServerConfig;
 // ============================================================================
 
 /** 权限模式 */
-export type PermissionMode = 'default' | 'bypass';
+export type PermissionMode = 'default' | 'bypassPermissions';
 
 /** 查询选项（Provider 无关） */
 export interface AgentQueryOptions {
@@ -189,10 +189,8 @@ export interface AgentQueryOptions {
   mcpServers?: Record<string, McpServerConfig>;
   /** 环境变量 */
   env?: Record<string, string | undefined>;
-  /** 设置来源 */
-  settingSources?: string[];
-  /** 上下文隔离模式 */
-  context?: 'fork' | 'none';
+  /** 设置来源（必填） */
+  settingSources: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #304 - 恢复 SDK Options 配置为原始格式，与 Claude SDK 保持兼容。

## 变更内容

### 1. permissionMode 值恢复

| 之前 | 之后 |
|------|------|
| `'bypass'` | `'bypassPermissions'` |

```typescript
// 现在是
permissionMode?: 'default' | 'bypassPermissions';

// 之前是
permissionMode?: 'default' | 'bypass';
```

### 2. settingSources 必填

```typescript
// 现在是必填
settingSources: string[];

// 之前是可选
settingSources?: string[];
```

### 3. 移除 context 字段

```typescript
// 移除此字段
context?: 'fork' | 'none';
```

## 修改的文件

| 文件 | 变更说明 |
|------|----------|
| `src/sdk/types.ts` | PermissionMode 类型、AgentQueryOptions 接口更新 |
| `src/sdk/providers/claude/options-adapter.ts` | 移除转换逻辑，直接传递值 |
| `src/agents/base-agent.ts` | 直接使用 permissionMode，无需转换 |
| `src/agents/site-miner.ts` | 使用新格式 |
| `src/agents/base-agent.test.ts` | 测试更新 |
| `src/sdk/factory.test.ts` | 测试更新 |

## 测试结果

```
Test Files  64 passed (64)
Tests       1083 passed | 8 skipped (1091)
Duration    8.80s
```

## 关联

- Fixes #304
- Related PR #247 (SDK 抽象层 Phase 1)
- Related PR #279 (SDK 抽象层 Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)