### PR TITLE
fix(channels): handle known control commands locally even when bot is mentioned

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -1,10 +1,15 @@
 /**
- * Tests for FeishuChannel command pass-through behavior when bot is mentioned.
+ * Tests for FeishuChannel command handling behavior when bot is mentioned.
  *
  * Issue #280: @bot 无法正确透传 /reset 指令给 agent
+ * Issue #307: @bot /reset 无法正确执行
  *
- * When bot is mentioned (@bot), commands should be passed through to the agent
- * instead of being handled locally by the channel.
+ * Known control commands (reset, status, help) are ALWAYS handled locally,
+ * even when bot is mentioned. This ensures /reset works correctly to cancel
+ * tasks and clear session state.
+ *
+ * Unknown commands (e.g., skill commands) are passed to the agent when bot
+ * is mentioned, allowing the agent to handle skill invocations.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -176,7 +181,7 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should pass command to agent when bot IS mentioned', async () => {
+    it('should handle known control command locally even when bot IS mentioned (Issue #307)', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: [
@@ -188,19 +193,44 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         ],
       });
 
-      // Control handler should NOT be called (command passed to agent)
+      // Control handler SHOULD be called for known control commands (Issue #307 fix)
+      // This ensures /reset works correctly to cancel tasks and clear session state
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'reset',
+          chatId: 'test-chat-id',
+        })
+      );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should pass unknown command to agent when bot IS mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/my-skill-command',
+        mentions: [
+          {
+            key: '@_user',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should NOT be called (unknown command passed to agent)
       expect(controlHandler).not.toHaveBeenCalled();
 
       // Message should be passed to agent
       expect(messageHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           chatId: 'test-chat-id',
-          content: '/reset',
+          content: '/my-skill-command',
         })
       );
     });
 
-    it('should pass command to agent when there are multiple mentions', async () => {
+    it('should handle known control command locally with multiple mentions', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: [
@@ -217,13 +247,13 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         ],
       });
 
-      // Command should be passed to agent
-      expect(controlHandler).not.toHaveBeenCalled();
-      expect(messageHandler).toHaveBeenCalledWith(
+      // Known control command should be handled locally (Issue #307)
+      expect(controlHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: '/reset',
+          type: 'reset',
         })
       );
+      expect(messageHandler).not.toHaveBeenCalled();
     });
 
     it('should handle regular messages normally (without / prefix)', async () => {

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -425,66 +425,74 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     );
 
     // Check for control commands
-    // When bot is mentioned (@bot), pass commands through to agent instead of handling locally
+    // Known control commands that should always be handled locally, even when bot is mentioned
+    const KNOWN_CONTROL_COMMANDS = new Set(['reset', 'status', 'help']);
+
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
-    if (trimmedText.startsWith('/') && !botMentioned) {
+    if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
 
-      if (this.controlHandler) {
-        const response = await this.emitControl({
-          type: cmd as any,
-          chatId: chat_id,
-          data: { args, rawText: trimmedText },
-        });
+      // Check if this is a known control command or if bot is not mentioned
+      const isKnownControlCommand = KNOWN_CONTROL_COMMANDS.has(cmd);
+      const shouldHandleLocally = isKnownControlCommand || !botMentioned;
 
-        // Only return if command was successfully handled
-        // Unknown commands (success: false) will fall through to normal message processing
-        if (response.success) {
-          if (response.message) {
-            await this.sendMessage({
-              chatId: chat_id,
-              type: 'text',
-              text: response.message,
-            });
+      if (shouldHandleLocally) {
+        if (this.controlHandler) {
+          const response = await this.emitControl({
+            type: cmd as any,
+            chatId: chat_id,
+            data: { args, rawText: trimmedText },
+          });
+
+          // Only return if command was successfully handled
+          // Unknown commands (success: false) will fall through to normal message processing
+          if (response.success) {
+            if (response.message) {
+              await this.sendMessage({
+                chatId: chat_id,
+                type: 'text',
+                text: response.message,
+              });
+            }
+            return;
           }
+          // Unknown command: fall through to emitMessage for Agent to handle
+        }
+
+        // Default command handling if no control handler registered
+        if (cmd === 'reset') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
+          });
           return;
         }
-        // Unknown command: fall through to emitMessage for Agent to handle
-      }
 
-      // Default command handling if no control handler registered
-      if (cmd === 'reset') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
-        });
-        return;
-      }
+        if (cmd === 'status') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
+          });
+          return;
+        }
 
-      if (cmd === 'status') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
-        });
-        return;
-      }
-
-      if (cmd === 'help') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
-        });
-        return;
+        if (cmd === 'help') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+          });
+          return;
+        }
       }
     }
 
-    // Log if bot is mentioned with a command (for debugging)
+    // Log if bot is mentioned with a non-control command (for debugging)
     if (botMentioned && trimmedText.startsWith('/')) {
       logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with command, passing to agent');
     }


### PR DESCRIPTION
## Summary

Fixes #307 - `@bot /reset` 无法正确执行

## Problem

当用户发送 `@bot /reset` 时，命令被传递给 Agent 处理，而不是被本地处理。这导致 reset 操作没有执行：
- 任务仍在运行
- 会话状态未清除
- 用户无法开始新任务

## Root Cause

PR #280 修改了逻辑，当 bot 被提及时，命令会传递给 Agent。这对于 skill 命令是正确的，但它也影响了应该始终被本地处理的控制命令（reset, status, help）。

## Solution

定义一组已知控制命令（`reset`, `status`, `help`），即使 bot 被提及，也始终被本地处理。未知命令仍然传递给 Agent 以便处理 skill 调用。

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | 添加 `KNOWN_CONTROL_COMMANDS` 集合，更新命令处理逻辑 |
| `src/channels/feishu-channel-mention.test.ts` | 更新测试以反映新行为 |

## Test Results

```
Test Files  64 passed (64)
Tests       1084 passed | 8 skipped (1092)
```

## Behavior Summary

| Command | Bot Mentioned | Behavior |
|---------|---------------|----------|
| `/reset` | No | ✅ Handled locally |
| `/reset` | Yes | ✅ Handled locally (NEW - Issue #307 fix) |
| `/status` | Yes | ✅ Handled locally |
| `/help` | Yes | ✅ Handled locally |
| `/my-skill` | Yes | 📤 Passed to agent (skill handling) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)