### PR TITLE
feat(auth): integrate OAuth MCP tools and add /auth command

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -38,6 +38,7 @@
 import type { StreamingUserMessage } from '../sdk/index.js';
 import { Config } from '../config/index.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
+import { createAuthSdkMcpServer } from '../auth/index.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { FileRef } from '../file-transfer/types.js';
 import { MessageChannel } from './message-channel.js';
@@ -159,7 +160,9 @@ export class Pilot extends BaseAgent {
     this.logger.info({ chatId, messageId, textLength: text.length }, 'CLI mode: executing one-shot query');
 
     // Add MCP servers
-    const mcpServers: Record<string, unknown> = {};
+    const mcpServers: Record<string, unknown> = {
+      'auth': createAuthSdkMcpServer(),
+    };
 
     // CLI mode doesn't need Feishu MCP server
     // Merge configured external MCP servers from config file
@@ -275,6 +278,7 @@ export class Pilot extends BaseAgent {
     // Add MCP servers
     const mcpServers: Record<string, unknown> = {
       'feishu-context': createFeishuSdkMcpServer(),
+      'auth': createAuthSdkMcpServer(),
     };
 
     // Merge configured external MCP servers from config file

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -17,6 +17,7 @@ import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
 import { BaseChannel } from './base-channel.js';
+import { getOAuthManager } from '../auth/index.js';
 import type {
   FeishuEventData,
   FeishuMessageEvent,
@@ -478,8 +479,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
         await this.sendMessage({
           chatId: chat_id,
           type: 'text',
-          text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+          text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /auth list - 查看已授权服务\n- /auth revoke <服务名> - 撤销授权\n- /help - 显示帮助',
         });
+        return;
+      }
+
+      // Handle /auth command
+      if (cmd === 'auth') {
+        await this.handleAuthCommand(chat_id, args);
         return;
       }
     }
@@ -498,6 +505,95 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       messageType: message_type as any,
       timestamp: create_time,
       threadId,
+    });
+  }
+
+  /**
+   * Handle /auth command for managing OAuth authorizations.
+   *
+   * Subcommands:
+   * - list: Show all authorized services
+   * - revoke <provider>: Revoke authorization for a service
+   */
+  private async handleAuthCommand(chatId: string, args: string[]): Promise<void> {
+    const subCommand = args[0]?.toLowerCase();
+
+    if (!subCommand || subCommand === 'list') {
+      // List authorized services
+      try {
+        const oauthManager = getOAuthManager();
+        const providers = await oauthManager.listAuthorizations(chatId);
+
+        if (providers.length === 0) {
+          await this.sendMessage({
+            chatId,
+            type: 'text',
+            text: '🔐 **授权管理**\n\n当前没有已授权的服务。\n\n当 Agent 需要访问第三方服务时，会引导您完成授权流程。',
+          });
+          return;
+        }
+
+        const providerList = providers.map(p => `- ${p}`).join('\n');
+        await this.sendMessage({
+          chatId,
+          type: 'text',
+          text: `🔐 **授权管理**\n\n已授权的服务:\n${providerList}\n\n使用 /auth revoke <服务名> 可撤销授权。`,
+        });
+      } catch (error) {
+        logger.error({ err: error, chatId }, 'Failed to list authorizations');
+        await this.sendMessage({
+          chatId,
+          type: 'text',
+          text: `❌ 获取授权列表失败：${error instanceof Error ? error.message : '未知错误'}`,
+        });
+      }
+      return;
+    }
+
+    if (subCommand === 'revoke') {
+      const provider = args[1];
+      if (!provider) {
+        await this.sendMessage({
+          chatId,
+          type: 'text',
+          text: '❌ 请指定要撤销的服务名\n\n用法: /auth revoke <服务名>',
+        });
+        return;
+      }
+
+      try {
+        const oauthManager = getOAuthManager();
+        const deleted = await oauthManager.revokeToken(chatId, provider);
+
+        if (deleted) {
+          await this.sendMessage({
+            chatId,
+            type: 'text',
+            text: `✅ 已撤销 **${provider}** 的授权`,
+          });
+        } else {
+          await this.sendMessage({
+            chatId,
+            type: 'text',
+            text: `⚠️ 没有找到 **${provider}** 的授权`,
+          });
+        }
+      } catch (error) {
+        logger.error({ err: error, chatId, provider }, 'Failed to revoke authorization');
+        await this.sendMessage({
+          chatId,
+          type: 'text',
+          text: `❌ 撤销授权失败：${error instanceof Error ? error.message : '未知错误'}`,
+        });
+      }
+      return;
+    }
+
+    // Unknown subcommand
+    await this.sendMessage({
+      chatId,
+      type: 'text',
+      text: `❌ 未知的授权命令: ${subCommand}\n\n可用命令:\n- /auth list - 查看已授权服务\n- /auth revoke <服务名> - 撤销授权`,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #60 - 集成第三方安全授权功能

### Problem
Auth 模块（OAuth 2.0 PKCE 流程）已实现但未集成到 Agent 系统中。用户无法通过聊天界面授权第三方服务。

### Solution

#### 1. 集成 Auth MCP Server 到 Pilot
- 在 `startAgentLoop` 中添加 `createAuthSdkMcpServer()`
- 在 `executeOnce` (CLI 模式) 中也添加了 auth MCP 服务器

#### 2. 添加 /auth 命令
- `/auth list` - 查看已授权的服务
- `/auth revoke <服务名>` - 撤销授权

#### 3. 更新 /help 帮助信息

### Auth MCP 工具列表

| 工具名 | 功能 |
|--------|------|
| `auth_check` | 检查用户是否已授权某个服务 |
| `auth_generate_url` | 生成 OAuth 授权 URL |
| `auth_request` | 发起认证 API 请求（token 不暴露给 LLM） |
| `auth_list` | 列出已授权服务 |
| `auth_revoke` | 撤销授权 |

### 核心安全原则

**Token 永远不会暴露给 LLM**

Agent 只知道授权是否存在，所有 API 调用通过 `auth_request` 工具在服务端完成，token 在服务端注入。

### 工作流程示例

```
User: 帮我在 GitHub 上创建一个仓库
Agent: (调用 auth_check) → 未授权
Agent: (调用 auth_generate_url) → 生成授权 URL
Bot: 发送卡片 "需要 GitHub 授权，请点击下方按钮"
User: 点击授权 → 完成 OAuth 流程
Agent: (调用 auth_request) → 创建仓库
Bot: "✅ 已创建仓库 xxx"
```

### Test Plan

- [x] 所有测试通过 (`npm test`)
  - 64 test files passed
  - 1083 tests passed | 8 skipped
- [x] TypeScript 编译成功 (`npm run build`)

### 关键文件变更

| 文件 | 变更 |
|------|------|
| `src/agents/pilot.ts` | 集成 auth MCP server |
| `src/channels/feishu-channel.ts` | 添加 /auth 命令处理 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)