### PR TITLE
fix(sdk): prevent infinite restart loop with backoff and circuit breaker

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -43,6 +43,7 @@ import type { FileRef } from '../file-transfer/types.js';
 import { MessageChannel } from './message-channel.js';
 import { SessionManager } from './session-manager.js';
 import { ConversationOrchestrator } from '../conversation/index.js';
+import { RestartManager } from '../utils/restart-manager.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -123,6 +124,7 @@ export class Pilot extends BaseAgent {
   // Separated concerns
   private readonly sessionManager: SessionManager;
   private readonly conversationOrchestrator: ConversationOrchestrator;
+  private readonly restartManager: RestartManager;
 
   constructor(config: PilotConfig) {
     super(config);
@@ -132,6 +134,27 @@ export class Pilot extends BaseAgent {
     // Initialize separated managers
     this.sessionManager = new SessionManager({ logger: this.logger });
     this.conversationOrchestrator = new ConversationOrchestrator({ logger: this.logger });
+
+    // Initialize restart manager with backoff and circuit breaker
+    this.restartManager = new RestartManager({
+      maxRestarts: 3,
+      initialDelayMs: 1000,
+      maxDelayMs: 30000,
+      backoffMultiplier: 2,
+      cooldownMs: 60000, // Reset failure count after 1 minute of stability
+      onCircuitOpen: (chatId, failureCount) => {
+        this.logger.error(
+          { chatId, failureCount },
+          'Circuit breaker opened - too many restart failures. Manual intervention required.'
+        );
+      },
+      onRestart: (chatId, attempt, delay) => {
+        this.logger.info(
+          { chatId, attempt, delay },
+          'Scheduling restart with backoff'
+        );
+      },
+    });
   }
 
   protected getAgentName(): string {
@@ -325,13 +348,15 @@ export class Pilot extends BaseAgent {
    * removes the Query and Channel from the maps.
    *
    * If the iterator ends without explicit close, we attempt to restart the agent loop
-   * and notify the user, preserving the conversation context.
+   * with exponential backoff via RestartManager. A circuit breaker prevents infinite
+   * restart loops after too many consecutive failures.
    */
   private async processIterator(
     chatId: string,
     iterator: AsyncGenerator<{ parsed: { type: string; content?: string } }>
   ): Promise<void> {
     let iteratorError: Error | null = null;
+    let hadSuccessfulResult = false;
 
     try {
       for await (const { parsed } of iterator) {
@@ -343,7 +368,10 @@ export class Pilot extends BaseAgent {
 
         // Check for completion
         if (parsed.type === 'result') {
+          hadSuccessfulResult = true;
           this.logger.debug({ chatId, content: parsed.content }, 'Result received, turn complete');
+          // Reset restart failure count on successful completion
+          this.restartManager.recordSuccess(chatId);
           if (this.callbacks.onDone) {
             const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
             await this.callbacks.onDone(chatId, threadRoot);
@@ -372,20 +400,42 @@ export class Pilot extends BaseAgent {
     }
 
     // Iterator ended without explicit close - this is unexpected
-    // Remove the stale session tracking, then attempt to restart
+    // Remove the stale session tracking, then check if we should restart
     this.sessionManager.deleteTracking(chatId);
-    this.logger.warn({ chatId, error: iteratorError?.message }, 'Agent loop ended unexpectedly, attempting restart');
+    this.logger.warn({ chatId, error: iteratorError?.message }, 'Agent loop ended unexpectedly');
 
-    // Notify user about the restart
+    // Check with RestartManager if we should attempt restart
+    if (!this.restartManager.shouldRestart(chatId)) {
+      // Circuit breaker is open - too many failures
+      const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
+      const failureCount = this.restartManager.getFailureCount(chatId);
+      await this.callbacks.sendMessage(
+        chatId,
+        `🚫 会话重启失败次数过多 (${failureCount} 次)，已停止自动重连。请发送新消息重试，或使用 /reset 重置会话。`,
+        threadRoot
+      );
+      this.logger.error({ chatId, failureCount }, 'Circuit breaker open - not attempting restart');
+      return;
+    }
+
+    // Get delay and record the restart attempt
+    const delay = this.restartManager.getDelay(chatId);
+    this.restartManager.recordRestart(chatId);
+
+    // Notify user about the restart with delay info
     const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
+    const delaySeconds = (delay / 1000).toFixed(1);
     const restartMessage = iteratorError
-      ? `⚠️ 会话遇到错误，正在重新连接... (${iteratorError.message})`
-      : '⚠️ 会话意外断开，正在重新连接...';
+      ? `⚠️ 会话遇到错误，${delaySeconds}秒后重新连接... (${iteratorError.message})`
+      : `⚠️ 会话意外断开，${delaySeconds}秒后重新连接...`;
     await this.callbacks.sendMessage(chatId, restartMessage, threadRoot);
+
+    // Wait with backoff before restarting
+    await new Promise(resolve => setTimeout(resolve, delay));
 
     // Restart the agent loop to preserve context for future messages
     this.startAgentLoop(chatId);
-    this.logger.info({ chatId }, 'Agent loop restarted');
+    this.logger.info({ chatId, delay }, 'Agent loop restarted with backoff');
   }
 
   /**
@@ -509,6 +559,8 @@ You can read these files using the Read tool with the local paths above.`;
     if (deleted) {
       // Also clear thread root
       this.conversationOrchestrator.deleteThreadRoot(chatId);
+      // Reset restart manager state to clear any circuit breaker
+      this.restartManager.reset(chatId);
       this.logger.info({ chatId }, 'State reset for chatId');
     } else {
       this.logger.debug({ chatId }, 'No state to reset for chatId');

--- a/src/utils/restart-manager.test.ts
+++ b/src/utils/restart-manager.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RestartManager } from './restart-manager.js';
+
+describe('RestartManager', () => {
+  let manager: RestartManager;
+  const chatId = 'test-chat-123';
+
+  beforeEach(() => {
+    manager = new RestartManager({
+      maxRestarts: 3,
+      initialDelayMs: 100,
+      maxDelayMs: 1000,
+      backoffMultiplier: 2,
+      cooldownMs: 1000,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('shouldRestart', () => {
+    it('should allow restart initially', () => {
+      expect(manager.shouldRestart(chatId)).toBe(true);
+    });
+
+    it('should allow restarts up to maxRestarts', () => {
+      manager.recordRestart(chatId); // 1
+      expect(manager.shouldRestart(chatId)).toBe(true);
+
+      manager.recordRestart(chatId); // 2
+      expect(manager.shouldRestart(chatId)).toBe(true);
+
+      manager.recordRestart(chatId); // 3
+      expect(manager.shouldRestart(chatId)).toBe(false); // Circuit opens
+    });
+
+    it('should block restarts when circuit is open', () => {
+      // Trigger circuit open
+      for (let i = 0; i < 3; i++) {
+        manager.recordRestart(chatId);
+      }
+      expect(manager.isCircuitOpen(chatId)).toBe(true);
+      expect(manager.shouldRestart(chatId)).toBe(false);
+    });
+
+    it('should reset failure count after cooldown period', () => {
+      manager.recordRestart(chatId);
+      manager.recordRestart(chatId);
+      expect(manager.getFailureCount(chatId)).toBe(2);
+
+      // Advance past cooldown period
+      vi.advanceTimersByTime(1500);
+
+      // Should reset and allow restart
+      expect(manager.shouldRestart(chatId)).toBe(true);
+      expect(manager.getFailureCount(chatId)).toBe(0);
+    });
+  });
+
+  describe('getDelay', () => {
+    it('should return initial delay for first failure', () => {
+      expect(manager.getDelay(chatId)).toBe(100);
+    });
+
+    it('should use exponential backoff', () => {
+      manager.recordRestart(chatId);
+      expect(manager.getDelay(chatId)).toBe(200); // 100 * 2^1
+
+      manager.recordRestart(chatId);
+      expect(manager.getDelay(chatId)).toBe(400); // 100 * 2^2
+    });
+
+    it('should cap delay at maxDelayMs', () => {
+      const strictManager = new RestartManager({
+        initialDelayMs: 500,
+        maxDelayMs: 600,
+        backoffMultiplier: 2,
+      });
+
+      strictManager.recordRestart(chatId);
+      expect(strictManager.getDelay(chatId)).toBe(600); // Would be 1000, capped to 600
+    });
+  });
+
+  describe('recordRestart', () => {
+    it('should increment failure count', () => {
+      expect(manager.getFailureCount(chatId)).toBe(0);
+
+      manager.recordRestart(chatId);
+      expect(manager.getFailureCount(chatId)).toBe(1);
+
+      manager.recordRestart(chatId);
+      expect(manager.getFailureCount(chatId)).toBe(2);
+    });
+
+    it('should call onRestart callback', () => {
+      const onRestart = vi.fn();
+      const callbackManager = new RestartManager({
+        onRestart,
+        initialDelayMs: 100,
+      });
+
+      callbackManager.recordRestart(chatId);
+
+      expect(onRestart).toHaveBeenCalledWith(chatId, 1, 100);
+    });
+  });
+
+  describe('recordSuccess', () => {
+    it('should reset failure count', () => {
+      manager.recordRestart(chatId);
+      manager.recordRestart(chatId);
+      expect(manager.getFailureCount(chatId)).toBe(2);
+
+      manager.recordSuccess(chatId);
+
+      expect(manager.getFailureCount(chatId)).toBe(0);
+      expect(manager.isCircuitOpen(chatId)).toBe(false);
+    });
+  });
+
+  describe('reset', () => {
+    it('should manually reset state', () => {
+      // Trigger circuit open
+      for (let i = 0; i < 3; i++) {
+        manager.recordRestart(chatId);
+      }
+      expect(manager.isCircuitOpen(chatId)).toBe(true);
+
+      manager.reset(chatId);
+
+      expect(manager.isCircuitOpen(chatId)).toBe(false);
+      expect(manager.getFailureCount(chatId)).toBe(0);
+    });
+  });
+
+  describe('circuit breaker callbacks', () => {
+    it('should call onCircuitOpen when circuit opens', () => {
+      const onCircuitOpen = vi.fn();
+      const callbackManager = new RestartManager({
+        maxRestarts: 2,
+        onCircuitOpen,
+      });
+
+      callbackManager.recordRestart(chatId);
+      expect(onCircuitOpen).not.toHaveBeenCalled();
+
+      callbackManager.recordRestart(chatId);
+      expect(onCircuitOpen).toHaveBeenCalledWith(chatId, 2);
+    });
+  });
+
+  describe('multiple chats', () => {
+    it('should track state independently per chat', () => {
+      const chat1 = 'chat-1';
+      const chat2 = 'chat-2';
+
+      manager.recordRestart(chat1);
+      manager.recordRestart(chat1);
+
+      expect(manager.getFailureCount(chat1)).toBe(2);
+      expect(manager.getFailureCount(chat2)).toBe(0);
+
+      manager.recordRestart(chat2);
+      expect(manager.getFailureCount(chat2)).toBe(1);
+    });
+  });
+});

--- a/src/utils/restart-manager.ts
+++ b/src/utils/restart-manager.ts
@@ -1,0 +1,231 @@
+/**
+ * Restart Manager with exponential backoff and circuit breaker.
+ *
+ * Prevents infinite restart loops when SDK subprocess fails repeatedly.
+ * Implements:
+ * - Exponential backoff between restarts
+ * - Circuit breaker to stop restarts after too many failures
+ * - Automatic recovery after cooldown period
+ */
+
+/**
+ * Configuration for RestartManager.
+ */
+export interface RestartManagerConfig {
+  /** Maximum number of restart attempts before opening circuit (default: 3) */
+  maxRestarts?: number;
+  /** Initial delay in milliseconds (default: 1000ms) */
+  initialDelayMs?: number;
+  /** Maximum delay in milliseconds (default: 30000ms) */
+  maxDelayMs?: number;
+  /** Backoff multiplier (default: 2) */
+  backoffMultiplier?: number;
+  /** Cooldown period in milliseconds before resetting failure count (default: 60000ms) */
+  cooldownMs?: number;
+  /** Callback when circuit opens */
+  onCircuitOpen?: (chatId: string, failureCount: number) => void;
+  /** Callback before restart attempt */
+  onRestart?: (chatId: string, attempt: number, delay: number) => void;
+}
+
+/**
+ * State for a single chat's restart tracking.
+ */
+interface ChatRestartState {
+  /** Number of consecutive failures */
+  failureCount: number;
+  /** Timestamp of last failure */
+  lastFailureTime: number;
+  /** Whether circuit is open (restarts blocked) */
+  circuitOpen: boolean;
+}
+
+/**
+ * Default configuration values.
+ */
+const DEFAULT_CONFIG: Required<Omit<RestartManagerConfig, 'onCircuitOpen' | 'onRestart'>> = {
+  maxRestarts: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 30000,
+  backoffMultiplier: 2,
+  cooldownMs: 60000, // 1 minute
+};
+
+/**
+ * Manages restart logic with backoff and circuit breaker pattern.
+ *
+ * Usage:
+ * ```typescript
+ * const manager = new RestartManager({
+ *   maxRestarts: 3,
+ *   onCircuitOpen: (chatId) => logger.warn(`Circuit opened for ${chatId}`),
+ * });
+ *
+ * if (manager.shouldRestart(chatId)) {
+ *   const delay = manager.getDelay(chatId);
+ *   await sleep(delay);
+ *   // perform restart
+ *   manager.recordRestart(chatId);
+ * } else {
+ *   // circuit is open, don't restart
+ * }
+ * ```
+ */
+export class RestartManager {
+  private readonly config: Required<RestartManagerConfig>;
+  private readonly states = new Map<string, ChatRestartState>();
+
+  constructor(config: RestartManagerConfig = {}) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+      onCircuitOpen: config.onCircuitOpen,
+      onRestart: config.onRestart,
+    };
+  }
+
+  /**
+   * Check if restart is allowed for a chat.
+   * Returns false if circuit is open or cooldown period has passed.
+   *
+   * @param chatId - Chat identifier
+   * @returns true if restart should be attempted
+   */
+  shouldRestart(chatId: string): boolean {
+    const state = this.getOrCreateState(chatId);
+
+    // Check if cooldown period has passed - reset failure count
+    const timeSinceLastFailure = Date.now() - state.lastFailureTime;
+    if (state.failureCount > 0 && timeSinceLastFailure > this.config.cooldownMs) {
+      this.resetState(chatId);
+      return true;
+    }
+
+    // Check if circuit is open
+    if (state.circuitOpen) {
+      return false;
+    }
+
+    // Check if max restarts exceeded
+    if (state.failureCount >= this.config.maxRestarts) {
+      this.openCircuit(chatId);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Get the delay before next restart attempt.
+   * Uses exponential backoff.
+   *
+   * @param chatId - Chat identifier
+   * @returns Delay in milliseconds
+   */
+  getDelay(chatId: string): number {
+    const state = this.getOrCreateState(chatId);
+    const baseDelay = this.config.initialDelayMs *
+      Math.pow(this.config.backoffMultiplier, state.failureCount);
+    return Math.min(baseDelay, this.config.maxDelayMs);
+  }
+
+  /**
+   * Record a restart attempt for a chat.
+   * Increments failure count and updates last failure time.
+   * Opens circuit if max restarts exceeded.
+   *
+   * @param chatId - Chat identifier
+   */
+  recordRestart(chatId: string): void {
+    const state = this.getOrCreateState(chatId);
+
+    // Calculate delay before incrementing (uses current failure count)
+    const delay = this.getDelay(chatId);
+
+    state.failureCount++;
+    state.lastFailureTime = Date.now();
+
+    this.config.onRestart?.(chatId, state.failureCount, delay);
+
+    // Open circuit if max restarts exceeded
+    if (state.failureCount >= this.config.maxRestarts) {
+      this.openCircuit(chatId);
+    }
+  }
+
+  /**
+   * Record a successful operation, resetting the failure count.
+   * Call this when the agent loop completes successfully.
+   *
+   * @param chatId - Chat identifier
+   */
+  recordSuccess(chatId: string): void {
+    this.resetState(chatId);
+  }
+
+  /**
+   * Manually reset the restart state for a chat.
+   * Call this after user intervention or explicit reset.
+   *
+   * @param chatId - Chat identifier
+   */
+  reset(chatId: string): void {
+    this.resetState(chatId);
+  }
+
+  /**
+   * Get current failure count for a chat.
+   *
+   * @param chatId - Chat identifier
+   * @returns Number of consecutive failures
+   */
+  getFailureCount(chatId: string): number {
+    return this.getOrCreateState(chatId).failureCount;
+  }
+
+  /**
+   * Check if circuit is open for a chat.
+   *
+   * @param chatId - Chat identifier
+   * @returns true if circuit is open (restarts blocked)
+   */
+  isCircuitOpen(chatId: string): boolean {
+    return this.getOrCreateState(chatId).circuitOpen;
+  }
+
+  /**
+   * Get or create state for a chat.
+   */
+  private getOrCreateState(chatId: string): ChatRestartState {
+    let state = this.states.get(chatId);
+    if (!state) {
+      state = {
+        failureCount: 0,
+        lastFailureTime: 0,
+        circuitOpen: false,
+      };
+      this.states.set(chatId, state);
+    }
+    return state;
+  }
+
+  /**
+   * Reset state for a chat.
+   */
+  private resetState(chatId: string): void {
+    this.states.set(chatId, {
+      failureCount: 0,
+      lastFailureTime: 0,
+      circuitOpen: false,
+    });
+  }
+
+  /**
+   * Open the circuit for a chat.
+   */
+  private openCircuit(chatId: string): void {
+    const state = this.getOrCreateState(chatId);
+    state.circuitOpen = true;
+    this.config.onCircuitOpen?.(chatId, state.failureCount);
+  }
+}

--- a/src/utils/sdk.test.ts
+++ b/src/utils/sdk.test.ts
@@ -343,6 +343,32 @@ describe('buildSdkEnv', () => {
       process.env.DEBUG_CLAUDE_AGENT_SDK = originalValue;
     }
   });
+
+  it('should not duplicate nodeBinDir in PATH if already present', () => {
+    const nodeBinDir = getNodeBinDir();
+    const originalPath = process.env.PATH;
+
+    // Set PATH to already include nodeBinDir at the start
+    // Use a unique path to avoid confusion with /usr/bin which is both nodeBinDir and common path
+    process.env.PATH = `${nodeBinDir}:/some/other/path:/bin`;
+
+    const result = buildSdkEnv('test-key');
+
+    // PATH should start with nodeBinDir and not contain it twice at the start
+    expect(result.PATH).toBeDefined();
+    expect(result.PATH).toContain(nodeBinDir);
+
+    // Count occurrences of nodeBinDir - should be exactly 1
+    const nodeBinDirCount = (result.PATH?.match(new RegExp(nodeBinDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
+    expect(nodeBinDirCount).toBe(1);
+
+    // Restore original PATH
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  });
 });
 
 describe('extractText', () => {

--- a/src/utils/sdk.ts
+++ b/src/utils/sdk.ts
@@ -398,7 +398,11 @@ export function buildSdkEnv(
   sdkDebug: boolean = true
 ): Record<string, string | undefined> {
   const nodeBinDir = getNodeBinDir();
-  const newPath = `${nodeBinDir}:${process.env.PATH || ''}`;
+  const originalPath = process.env.PATH || '';
+  // Avoid duplicating nodeBinDir if it's already in PATH
+  const newPath = originalPath.includes(nodeBinDir)
+    ? originalPath
+    : `${nodeBinDir}:${originalPath}`;
 
   // Priority (highest to lowest):
   // 1. Our forced values (API_KEY, PATH, BASE_URL, DEBUG)


### PR DESCRIPTION
## Summary

Fixes #313 - Prevents infinite restart loops when SDK subprocess fails.

### Problem
When SDK subprocess fails (e.g., due to missing PATH), the agent loop restarts immediately without any backoff, causing:
1. **Infinite restart loops** - Agent keeps failing and restarting
2. **Feishu API rate limiting** - High-frequency error messages trigger API limits
3. **Poor user experience** - Users see spam of error messages

### Solution

#### 1. PATH Deduplication in `buildSdkEnv`
- Check if `nodeBinDir` is already in PATH before adding
- Prevents redundant PATH entries

#### 2. RestartManager with Exponential Backoff
- **Max 3 restart attempts** before opening circuit breaker
- **Exponential backoff**: 1s → 2s → 4s (capped at 30s)
- **60s cooldown** to reset failure count after stability
- **Circuit breaker** stops restarts after max failures

#### 3. Integration with Pilot
- `processIterator` now uses `RestartManager` for restart decisions
- Successful result resets failure count
- User sees delay info in reconnect messages
- `/reset` also clears circuit breaker state

## Changes

| File | Description |
|------|-------------|
| `src/utils/restart-manager.ts` | New RestartManager class with backoff and circuit breaker |
| `src/utils/restart-manager.test.ts` | Comprehensive tests for RestartManager |
| `src/utils/sdk.ts` | PATH deduplication in buildSdkEnv |
| `src/utils/sdk.test.ts` | Test for PATH deduplication |
| `src/agents/pilot.ts` | Integrate RestartManager into processIterator |

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    RestartManager Flow                       │
├─────────────────────────────────────────────────────────────┤
│                                                             │
│  Agent Loop Fails                                           │
│       │                                                     │
│       ▼                                                     │
│  ┌─────────────────┐                                        │
│  │ shouldRestart() │─── No ──► Circuit breaker open        │
│  └────────┬────────┘           (stop restarts)              │
│           │                                                 │
│          Yes                                                │
│           │                                                 │
│           ▼                                                 │
│  ┌─────────────────┐                                        │
│  │   getDelay()    │───► Exponential backoff               │
│  └────────┬────────┘    (1s → 2s → 4s → ...)               │
│           │                                                 │
│           ▼                                                 │
│  ┌─────────────────┐                                        │
│  │ recordRestart() │───► Increment failure count            │
│  └────────┬────────┘    Open circuit if max reached         │
│           │                                                 │
│           ▼                                                 │
│  Wait delay, then restart                                   │
│                                                             │
│  On success: recordSuccess() ──► Reset failure count        │
│                                                             │
└─────────────────────────────────────────────────────────────┘
```

## User Experience

### Before
```
⚠️ 会话遇到错误，正在重新连接... (Error)
⚠️ 会话遇到错误，正在重新连接... (Error)
⚠️ 会话遇到错误，正在重新连接... (Error)
... (infinite loop)
```

### After
```
⚠️ 会话遇到错误，1.0秒后重新连接... (Error)
⚠️ 会话遇到错误，2.0秒后重新连接... (Error)
⚠️ 会话遇到错误，4.0秒后重新连接... (Error)
🚫 会话重启失败次数过多 (3 次)，已停止自动重连。请发送新消息重试，或使用 /reset 重置会话。
```

## Test Results

```
Test Files  65 passed (65)
Tests       1097 passed | 8 skipped (1105)
Duration    8.79s
```

## Checklist

- [x] Code tested
- [x] Follows project code conventions
- [x] Added necessary documentation (inline comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)