### PR TITLE
revert(sdk): 恢复 SDK Options 配置为原始格式

### DIFF
--- a/src/agents/base-agent.test.ts
+++ b/src/agents/base-agent.test.ts
@@ -71,7 +71,7 @@ class TestAgent extends BaseAgent {
   }
 
   async *testQueryOnce(input: string) {
-    yield* this.queryOnce(input, {});
+    yield* this.queryOnce(input, { settingSources: ['project'] });
   }
 
   testFormatMessage(parsed: IteratorYieldResult['parsed']) {
@@ -127,7 +127,7 @@ describe('BaseAgent', () => {
       const options = agent.testCreateSdkOptions();
 
       expect(options.cwd).toBeDefined();
-      expect(options.permissionMode).toBe('bypass');
+      expect(options.permissionMode).toBe('bypassPermissions');
       expect(options.settingSources).toContain('project');
       expect(options.env).toBeDefined();
     });

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -149,7 +149,7 @@ export abstract class BaseAgent {
   protected createSdkOptions(extra: SdkOptionsExtra = {}): AgentQueryOptions {
     const options: AgentQueryOptions = {
       cwd: extra.cwd ?? Config.getWorkspaceDir(),
-      permissionMode: this.permissionMode === 'bypassPermissions' ? 'bypass' : 'default',
+      permissionMode: this.permissionMode,
       settingSources: ['project'],
     };
 

--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -124,7 +124,7 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
   // Build SDK options with forked context for isolation
   const sdkOptions: AgentQueryOptions = {
     cwd: Config.getWorkspaceDir(),
-    permissionMode: 'bypass',
+    permissionMode: 'bypassPermissions',
     settingSources: ['project'],
     // Only allow Playwright MCP tools + basic file operations for saving evidence
     allowedTools: [
@@ -151,8 +151,6 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
       loggingConfig.sdkDebug
     ),
     model: agentConfig.model,
-    // Fork context to run in isolation - prevents stdio conflicts
-    context: 'fork',
   };
 
   // Build the prompt

--- a/src/sdk/providers/claude/options-adapter.ts
+++ b/src/sdk/providers/claude/options-adapter.ts
@@ -25,11 +25,9 @@ export function adaptOptions(options: AgentQueryOptions): Record<string, unknown
     sdkOptions.model = options.model;
   }
 
-  // 权限模式
+  // 权限模式（直接传递，无需转换）
   if (options.permissionMode) {
-    sdkOptions.permissionMode = options.permissionMode === 'bypass'
-      ? 'bypassPermissions'
-      : options.permissionMode;
+    sdkOptions.permissionMode = options.permissionMode;
   }
 
   // 设置来源
@@ -54,11 +52,6 @@ export function adaptOptions(options: AgentQueryOptions): Record<string, unknown
   // 环境变量
   if (options.env) {
     sdkOptions.env = options.env;
-  }
-
-  // 上下文隔离
-  if (options.context) {
-    sdkOptions.context = options.context;
   }
 
   return sdkOptions;

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -171,7 +171,7 @@ export type McpServerConfig = StdioMcpServerConfig | InlineMcpServerConfig;
 // ============================================================================
 
 /** 权限模式 */
-export type PermissionMode = 'default' | 'bypass';
+export type PermissionMode = 'default' | 'bypassPermissions';
 
 /** 查询选项（Provider 无关） */
 export interface AgentQueryOptions {
@@ -189,10 +189,8 @@ export interface AgentQueryOptions {
   mcpServers?: Record<string, McpServerConfig>;
   /** 环境变量 */
   env?: Record<string, string | undefined>;
-  /** 设置来源 */
-  settingSources?: string[];
-  /** 上下文隔离模式 */
-  context?: 'fork' | 'none';
+  /** 设置来源（必填） */
+  settingSources: string[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- 恢复 `PermissionMode` 类型从 `'bypass'` 到原始的 `'bypassPermissions'`
- 将 `settingSources` 改为必填字段
- 移除非标准 SDK 的 `context` 字段

## 修改文件

- `src/sdk/types.ts`: 更新 `PermissionMode` 和 `AgentQueryOptions` 类型定义
- `src/sdk/providers/claude/options-adapter.ts`: 移除 `permissionMode` 转换逻辑和 `context` 处理
- `src/agents/base-agent.ts`: 直接使用 `permissionMode` 而非转换
- `src/agents/site-miner.ts`: 使用 `'bypassPermissions'`，移除 `context: 'fork'`
- `src/agents/base-agent.test.ts`: 更新测试期望值

## Test plan

- [x] 运行 `src/agents/base-agent.test.ts` - 15 tests passed
- [x] 运行 `src/sdk/factory.test.ts` - 17 tests passed  
- [x] 运行 `src/agents/site-miner.test.ts` - 10 tests passed

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)