### PR TITLE
refactor(agents): implement SkillAgent interface for Evaluator, Executor, Reporter

### DIFF
--- a/src/agents/evaluator.test.ts
+++ b/src/agents/evaluator.test.ts
@@ -186,3 +186,68 @@ describe('Evaluator class', () => {
     });
   });
 });
+
+describe('Evaluator SkillAgent Interface', () => {
+  let Evaluator: typeof import('./evaluator.js').Evaluator;
+  let isSkillAgent: typeof import('./types.js').isSkillAgent;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ Evaluator } = await import('./evaluator.js'));
+    ({ isSkillAgent } = await import('./types.js'));
+  });
+
+  it('should implement SkillAgent interface', () => {
+    const evaluator = new Evaluator({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(evaluator.type).toBe('skill');
+    expect(evaluator.name).toBe('Evaluator');
+    expect(typeof evaluator.execute).toBe('function');
+    expect(typeof evaluator.cleanup).toBe('function');
+  });
+
+  it('should pass isSkillAgent type guard', () => {
+    const evaluator = new Evaluator({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(isSkillAgent(evaluator)).toBe(true);
+  });
+
+  describe('execute', () => {
+    it('should accept string input', async () => {
+      const evaluator = new Evaluator({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of evaluator.execute('Test prompt')) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('should accept UserInput array', async () => {
+      const evaluator = new Evaluator({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of evaluator.execute([
+        { role: 'user', content: 'First message' },
+        { role: 'user', content: 'Second message' },
+      ])) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/agents/evaluator.ts
+++ b/src/agents/evaluator.ts
@@ -24,6 +24,7 @@ import { Config } from '../config/index.js';
 import type { AgentMessage, AgentInput } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
+import type { SkillAgent, UserInput } from './types.js';
 
 /**
  * Evaluator-specific allowed tools.
@@ -52,7 +53,7 @@ export interface EvaluatorConfig extends BaseAgentConfig {
  * - GLM logging
  * - Error handling
  */
-export class Evaluator extends BaseAgent {
+export class Evaluator extends BaseAgent implements SkillAgent {
   /** Agent type identifier (Issue #282) */
   readonly type = 'skill' as const;
 
@@ -250,5 +251,21 @@ Task completed successfully.
 **Now start your evaluation.**`;
 
     return prompt;
+  }
+
+  /**
+   * Execute a single task and yield results.
+   * Implements SkillAgent interface.
+   *
+   * @param input - Task input as string or structured data
+   * @yields AgentMessage responses
+   */
+  async *execute(input: string | UserInput[]): AsyncGenerator<AgentMessage> {
+    // Convert UserInput[] to string if needed
+    const prompt: string = typeof input === 'string'
+      ? input
+      : input.map(u => u.content).join('\n');
+
+    yield* this.queryStream(prompt);
   }
 }

--- a/src/agents/executor.test.ts
+++ b/src/agents/executor.test.ts
@@ -165,3 +165,68 @@ describe('Executor class', () => {
     });
   });
 });
+
+describe('Executor SkillAgent Interface', () => {
+  let Executor: typeof import('./executor.js').Executor;
+  let isSkillAgent: typeof import('./types.js').isSkillAgent;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ Executor } = await import('./executor.js'));
+    ({ isSkillAgent } = await import('./types.js'));
+  });
+
+  it('should implement SkillAgent interface', () => {
+    const executor = new Executor({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(executor.type).toBe('skill');
+    expect(executor.name).toBe('Executor');
+    expect(typeof executor.execute).toBe('function');
+    expect(typeof executor.cleanup).toBe('function');
+  });
+
+  it('should pass isSkillAgent type guard', () => {
+    const executor = new Executor({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(isSkillAgent(executor)).toBe(true);
+  });
+
+  describe('execute', () => {
+    it('should accept string input', async () => {
+      const executor = new Executor({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of executor.execute('Test prompt')) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('should accept UserInput array', async () => {
+      const executor = new Executor({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of executor.execute([
+        { role: 'user', content: 'First message' },
+        { role: 'user', content: 'Second message' },
+      ])) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -14,9 +14,10 @@
  */
 
 import * as fs from 'fs/promises';
-import type { ParsedSDKMessage } from '../types/agent.js';
+import type { ParsedSDKMessage, AgentMessage } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
+import type { SkillAgent, UserInput } from './types.js';
 
 /**
  * Executor configuration.
@@ -79,7 +80,7 @@ export interface TaskResult {
  * Extends BaseAgent to inherit common functionality while adding
  * Executor-specific features like TaskProgressEvent yielding.
  */
-export class Executor extends BaseAgent {
+export class Executor extends BaseAgent implements SkillAgent {
   /** Agent type identifier (Issue #282) */
   readonly type = 'skill' as const;
 
@@ -355,5 +356,29 @@ ${error ? `## Error\n\n${error}\n` : ''}
     }
 
     return files;
+  }
+
+  /**
+   * Execute a single task and yield results.
+   * Implements SkillAgent interface.
+   *
+   * @param input - Task input as string or structured data
+   * @yields AgentMessage responses
+   */
+  async *execute(input: string | UserInput[]): AsyncGenerator<AgentMessage> {
+    // Convert UserInput[] to string if needed
+    const prompt: string = typeof input === 'string'
+      ? input
+      : input.map(u => u.content).join('\n');
+
+    const sdkOptions = this.createSdkOptions({});
+
+    try {
+      for await (const { parsed } of this.queryOnce(prompt, sdkOptions)) {
+        yield this.formatMessage(parsed);
+      }
+    } catch (error) {
+      yield this.handleIteratorError(error, 'execute');
+    }
   }
 }

--- a/src/agents/reporter.test.ts
+++ b/src/agents/reporter.test.ts
@@ -303,3 +303,68 @@ describe('buildReportPrompt', () => {
     expect(prompt).toContain('DO NOT');
   });
 });
+
+describe('Reporter SkillAgent Interface', () => {
+  let Reporter: typeof import('./reporter.js').Reporter;
+  let isSkillAgent: typeof import('./types.js').isSkillAgent;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ Reporter } = await import('./reporter.js'));
+    ({ isSkillAgent } = await import('./types.js'));
+  });
+
+  it('should implement SkillAgent interface', () => {
+    const reporter = new Reporter({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(reporter.type).toBe('skill');
+    expect(reporter.name).toBe('Reporter');
+    expect(typeof reporter.execute).toBe('function');
+    expect(typeof reporter.cleanup).toBe('function');
+  });
+
+  it('should pass isSkillAgent type guard', () => {
+    const reporter = new Reporter({
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    expect(isSkillAgent(reporter)).toBe(true);
+  });
+
+  describe('execute', () => {
+    it('should accept string input', async () => {
+      const reporter = new Reporter({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of reporter.execute('Test prompt')) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('should accept UserInput array', async () => {
+      const reporter = new Reporter({
+        apiKey: 'test-key',
+        model: 'test-model',
+      });
+
+      const messages = [];
+      for await (const msg of reporter.execute([
+        { role: 'user', content: 'First message' },
+        { role: 'user', content: 'Second message' },
+      ])) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/agents/reporter.ts
+++ b/src/agents/reporter.ts
@@ -33,6 +33,7 @@
 import type { AgentMessage } from '../types/agent.js';
 import type { ReporterContext } from '../types/reporter.js';
 import type { TaskProgressEvent } from './executor.js';
+import type { SkillAgent, UserInput } from './types.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 
@@ -50,7 +51,7 @@ const REPORTER_ALLOWED_TOOLS = ['send_user_feedback', 'send_file_to_feishu'];
  * - GLM logging
  * - Error handling
  */
-export class Reporter extends BaseAgent {
+export class Reporter extends BaseAgent implements SkillAgent {
   /** Agent type identifier (Issue #282) */
   readonly type = 'skill' as const;
 
@@ -477,5 +478,21 @@ You ONLY format and communicate feedback to users.
 `;
 
     return prompt;
+  }
+
+  /**
+   * Execute a single task and yield results.
+   * Implements SkillAgent interface.
+   *
+   * @param input - Task input as string or structured data
+   * @yields AgentMessage responses
+   */
+  async *execute(input: string | UserInput[]): AsyncGenerator<AgentMessage> {
+    // Convert UserInput[] to string if needed
+    const prompt: string = typeof input === 'string'
+      ? input
+      : input.map(u => u.content).join('\n');
+
+    yield* this.sendFeedback(prompt);
   }
 }


### PR DESCRIPTION
## Summary

Implements #324 - Refactor Skill Agents to implement SkillAgent interface

This PR refactors the Evaluator, Executor, and Reporter classes to fully implement the SkillAgent interface defined in `src/agents/types.ts`.

## Changes

### Evaluator class (`src/agents/evaluator.ts`)
- Added `implements SkillAgent` to class declaration
- Imported SkillAgent and UserInput types from types.ts
- Added `execute(input: string | UserInput[]): AsyncGenerator<AgentMessage>` method
- Inherits `cleanup()` from BaseAgent (already satisfies interface)

### Executor class (`src/agents/executor.ts`)
- Added `implements SkillAgent` to class declaration
- Imported SkillAgent, UserInput types and AgentMessage type
- Added `execute(input: string | UserInput[]): AsyncGenerator<AgentMessage>` method
- Inherits `cleanup()` from BaseAgent (already satisfies interface)

### Reporter class (`src/agents/reporter.ts`)
- Added `implements SkillAgent` to class declaration
- Imported SkillAgent and UserInput types from types.ts
- Added `execute(input: string | UserInput[]): AsyncGenerator<AgentMessage>` method
- Inherits `cleanup()` from BaseAgent (already satisfies interface)

### Tests
- Added SkillAgent Interface test suite for each agent covering:
  - Interface implementation verification (type, name, execute, cleanup)
  - Type guard validation (isSkillAgent)
  - execute() method with string input
  - execute() method with UserInput array

## Verification

- ✅ All 47 tests pass for the three modified agents
- ✅ All 1112 tests pass in full test suite
- ✅ No new TypeScript errors introduced
- ✅ No behavior changes to existing functionality
- ✅ All Skill Agents implement complete SkillAgent interface

## Checklist

- [x] Code tested
- [x] Follows project code conventions
- [x] No behavior changes to existing functionality
- [x] All Skill Agents implement complete SkillAgent interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)