### PR TITLE
refactor(agents): 统一 Agent 工厂方法

### DIFF
--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -4,9 +4,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentFactory } from './factory.js';
-import { Evaluator } from './evaluator.js';
-import { Executor } from './executor.js';
-import { Reporter } from './reporter.js';
 import { Pilot } from './pilot.js';
 import { Config } from '../config/index.js';
 
@@ -33,97 +30,6 @@ describe('AgentFactory', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-  });
-
-  describe('createEvaluator', () => {
-    it('should create Evaluator with default config', () => {
-      const evaluator = AgentFactory.createEvaluator();
-
-      expect(evaluator).toBeInstanceOf(Evaluator);
-      expect(Config.getAgentConfig).toHaveBeenCalled();
-    });
-
-    it('should create Evaluator with custom subdirectory', () => {
-      const evaluator = AgentFactory.createEvaluator({}, 'regular');
-
-      expect(evaluator).toBeInstanceOf(Evaluator);
-    });
-
-    it('should allow overriding config options', () => {
-      const evaluator = AgentFactory.createEvaluator({
-        apiKey: 'custom-key',
-        model: 'custom-model',
-      });
-
-      expect(evaluator).toBeInstanceOf(Evaluator);
-    });
-  });
-
-  describe('createExecutor', () => {
-    it('should create Executor with default config', () => {
-      const executor = AgentFactory.createExecutor();
-
-      expect(executor).toBeInstanceOf(Executor);
-      expect(Config.getAgentConfig).toHaveBeenCalled();
-    });
-
-    it('should create Executor with abort signal', () => {
-      const controller = new AbortController();
-      const executor = AgentFactory.createExecutor({}, controller.signal);
-
-      expect(executor).toBeInstanceOf(Executor);
-    });
-
-    it('should allow overriding config options', () => {
-      const executor = AgentFactory.createExecutor({
-        apiKey: 'custom-key',
-        model: 'custom-model',
-      });
-
-      expect(executor).toBeInstanceOf(Executor);
-    });
-  });
-
-  describe('createReporter', () => {
-    it('should create Reporter with default config', () => {
-      const reporter = AgentFactory.createReporter();
-
-      expect(reporter).toBeInstanceOf(Reporter);
-      expect(Config.getAgentConfig).toHaveBeenCalled();
-    });
-
-    it('should allow overriding config options', () => {
-      const reporter = AgentFactory.createReporter({
-        apiKey: 'custom-key',
-        model: 'custom-model',
-      });
-
-      expect(reporter).toBeInstanceOf(Reporter);
-    });
-  });
-
-  describe('createPilot', () => {
-    const mockCallbacks = {
-      sendMessage: vi.fn(),
-      sendCard: vi.fn(),
-      sendFile: vi.fn(),
-    };
-
-    it('should create Pilot with callbacks', () => {
-      const pilot = AgentFactory.createPilot(mockCallbacks);
-
-      expect(pilot).toBeInstanceOf(Pilot);
-      expect(Config.getAgentConfig).toHaveBeenCalled();
-    });
-
-    it('should allow overriding config options', () => {
-      const pilot = AgentFactory.createPilot(mockCallbacks, {
-        apiKey: 'custom-key',
-        model: 'custom-model',
-      });
-
-      expect(pilot).toBeInstanceOf(Pilot);
-    });
   });
 
   // ============================================================================

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,21 +1,24 @@
 /**
  * AgentFactory - Factory for creating Agent instances with unified configuration.
  *
- * Provides factory methods to create Agent instances with default configuration
- * from Config.getAgentConfig(), simplifying agent instantiation and ensuring
- * consistent configuration across all agents.
- *
  * Implements AgentFactoryInterface from #282 Phase 3 for unified agent creation.
+ * All agent creation goes through the type-specific methods:
+ * - createChatAgent: Create chat agents (pilot)
+ * - createSkillAgent: Create skill agents (evaluator, executor, reporter)
+ * - createSubagent: Create subagents (site-miner)
  *
  * @example
  * ```typescript
- * // Using typed factory methods (AgentFactoryInterface)
+ * // Create a Pilot (ChatAgent)
  * const pilot = AgentFactory.createChatAgent('pilot', callbacks);
- * const evaluator = AgentFactory.createSkillAgent('evaluator');
  *
- * // Using convenience methods (backward compatible)
- * const evaluator = AgentFactory.createEvaluator();
- * const executor = AgentFactory.createExecutor();
+ * // Create skill agents
+ * const evaluator = AgentFactory.createSkillAgent('evaluator');
+ * const executor = AgentFactory.createSkillAgent('executor', {}, abortSignal);
+ * const reporter = AgentFactory.createSkillAgent('reporter');
+ *
+ * // Create a subagent
+ * const siteMiner = AgentFactory.createSubagent('site-miner');
  * ```
  *
  * @module agents/factory
@@ -47,15 +50,13 @@ export interface AgentCreateOptions {
 /**
  * Factory for creating Agent instances with unified configuration.
  *
- * This class provides static factory methods for creating all agent types.
+ * This class implements AgentFactoryInterface with type-specific factory methods:
+ * - createChatAgent(name, ...args): ChatAgent
+ * - createSkillAgent(name, ...args): SkillAgent
+ * - createSubagent(name, ...args): Subagent
+ *
  * Each method fetches default configuration from Config.getAgentConfig()
  * and allows optional overrides.
- *
- * The static methods createChatAgent, createSkillAgent, createSubagent
- * follow the AgentFactoryInterface contract for unified agent creation by type.
- *
- * Note: Uses static methods for backward compatibility. The static methods
- * follow the AgentFactoryInterface signature pattern.
  */
 export class AgentFactory {
   /**
@@ -75,126 +76,40 @@ export class AgentFactory {
     };
   }
 
+  // ============================================================================
+  // AgentFactoryInterface Implementation
+  // ============================================================================
+
   /**
-   * Create an Evaluator agent.
+   * Create a ChatAgent instance by name.
    *
-   * @param options - Optional configuration overrides
-   * @param subdirectory - Optional subdirectory for task files
-   * @returns Configured Evaluator instance
+   * @param name - Agent name ('pilot')
+   * @param args - Additional arguments:
+   *   - args[0]: PilotCallbacks - Platform-specific callbacks
+   *   - args[1]: AgentCreateOptions - Optional configuration overrides
+   * @returns ChatAgent instance
    *
    * @example
    * ```typescript
-   * // With default config
-   * const evaluator = AgentFactory.createEvaluator();
-   *
-   * // With custom subdirectory
-   * const evaluator = AgentFactory.createEvaluator({}, 'regular');
-   * ```
-   */
-  static createEvaluator(options: AgentCreateOptions = {}, subdirectory?: string): Evaluator {
-    const config: EvaluatorConfig = {
-      ...this.getBaseConfig(options),
-      subdirectory,
-    };
-
-    return new Evaluator(config);
-  }
-
-  /**
-   * Create an Executor agent.
-   *
-   * @param options - Optional configuration overrides
-   * @param abortSignal - Optional abort signal for cancellation
-   * @returns Configured Executor instance
-   *
-   * @example
-   * ```typescript
-   * // With default config
-   * const executor = AgentFactory.createExecutor();
-   *
-   * // With abort signal
-   * const controller = new AbortController();
-   * const executor = AgentFactory.createExecutor({}, controller.signal);
-   * ```
-   */
-  static createExecutor(options: AgentCreateOptions = {}, abortSignal?: AbortSignal): Executor {
-    const config: ExecutorConfig = {
-      ...this.getBaseConfig(options),
-      abortSignal,
-    };
-
-    return new Executor(config);
-  }
-
-  /**
-   * Create a Reporter agent.
-   *
-   * @param options - Optional configuration overrides
-   * @returns Configured Reporter instance
-   *
-   * @example
-   * ```typescript
-   * const reporter = AgentFactory.createReporter();
-   * ```
-   */
-  static createReporter(options: AgentCreateOptions = {}): Reporter {
-    const config: BaseAgentConfig = this.getBaseConfig(options);
-
-    return new Reporter(config);
-  }
-
-  /**
-   * Create a Pilot agent.
-   *
-   * @param callbacks - Platform-specific callbacks for Pilot
-   * @param options - Optional configuration overrides
-   * @returns Configured Pilot instance
-   *
-   * @example
-   * ```typescript
-   * const pilot = AgentFactory.createPilot({
+   * const pilot = AgentFactory.createChatAgent('pilot', {
    *   sendMessage: async (chatId, text) => { ... },
    *   sendCard: async (chatId, card) => { ... },
    *   sendFile: async (chatId, filePath) => { ... },
    * });
    * ```
    */
-  static createPilot(
-    callbacks: PilotCallbacks,
-    options: AgentCreateOptions = {}
-  ): Pilot {
-    const baseConfig = this.getBaseConfig(options);
-    const config: PilotConfig = {
-      ...baseConfig,
-      callbacks,
-    };
-
-    return new Pilot(config);
-  }
-
-  // ============================================================================
-  // AgentFactoryInterface Implementation (Issue #282 Phase 3)
-  // ============================================================================
-
-  /**
-   * Create a ChatAgent instance by name.
-   *
-   * Part of AgentFactoryInterface - provides unified agent creation by type.
-   *
-   * @param name - Agent name ('pilot')
-   * @param args - Additional arguments (callbacks for Pilot)
-   * @returns ChatAgent instance
-   *
-   * @example
-   * ```typescript
-   * const pilot = AgentFactory.createChatAgent('pilot', callbacks);
-   * ```
-   */
   static createChatAgent(name: string, ...args: unknown[]): ChatAgent {
     if (name === 'pilot') {
       const callbacks = args[0] as PilotCallbacks;
       const options = (args[1] as AgentCreateOptions) || {};
-      return this.createPilot(callbacks, options);
+
+      const baseConfig = this.getBaseConfig(options);
+      const config: PilotConfig = {
+        ...baseConfig,
+        callbacks,
+      };
+
+      return new Pilot(config);
     }
     throw new Error(`Unknown ChatAgent: ${name}`);
   }
@@ -202,16 +117,31 @@ export class AgentFactory {
   /**
    * Create a SkillAgent instance by name.
    *
-   * Part of AgentFactoryInterface - provides unified agent creation by type.
-   *
    * @param name - Agent name ('evaluator', 'executor', 'reporter')
-   * @param args - Additional arguments (options, subdirectory, abortSignal, etc.)
+   * @param args - Additional arguments:
+   *   - For 'evaluator':
+   *     - args[0]: AgentCreateOptions - Optional configuration overrides
+   *     - args[1]: string - Optional subdirectory for task files
+   *   - For 'executor':
+   *     - args[0]: AgentCreateOptions - Optional configuration overrides
+   *     - args[1]: AbortSignal - Optional abort signal for cancellation
+   *   - For 'reporter':
+   *     - args[0]: AgentCreateOptions - Optional configuration overrides
    * @returns SkillAgent instance
    *
    * @example
    * ```typescript
+   * // Evaluator with default config
    * const evaluator = AgentFactory.createSkillAgent('evaluator');
-   * const executor = AgentFactory.createSkillAgent('executor');
+   *
+   * // Evaluator with subdirectory
+   * const evaluator = AgentFactory.createSkillAgent('evaluator', {}, 'regular');
+   *
+   * // Executor with abort signal
+   * const controller = new AbortController();
+   * const executor = AgentFactory.createSkillAgent('executor', {}, controller.signal);
+   *
+   * // Reporter
    * const reporter = AgentFactory.createSkillAgent('reporter');
    * ```
    */
@@ -219,17 +149,26 @@ export class AgentFactory {
     const options = (args[0] as AgentCreateOptions) || {};
 
     switch (name) {
-      case 'evaluator':
+      case 'evaluator': {
         const subdirectory = args[1] as string | undefined;
-        // Evaluator has type='skill' and will implement SkillAgent fully after PR #335
-        return this.createEvaluator(options, subdirectory) as unknown as SkillAgent;
-      case 'executor':
+        const config: EvaluatorConfig = {
+          ...this.getBaseConfig(options),
+          subdirectory,
+        };
+        return new Evaluator(config) as unknown as SkillAgent;
+      }
+      case 'executor': {
         const abortSignal = args[1] as AbortSignal | undefined;
-        // Executor has type='skill' and will implement SkillAgent fully after PR #335
-        return this.createExecutor(options, abortSignal) as unknown as SkillAgent;
-      case 'reporter':
-        // Reporter has type='skill' and will implement SkillAgent fully after PR #335
-        return this.createReporter(options) as unknown as SkillAgent;
+        const config: ExecutorConfig = {
+          ...this.getBaseConfig(options),
+          abortSignal,
+        };
+        return new Executor(config) as unknown as SkillAgent;
+      }
+      case 'reporter': {
+        const config: BaseAgentConfig = this.getBaseConfig(options);
+        return new Reporter(config) as unknown as SkillAgent;
+      }
       default:
         throw new Error(`Unknown SkillAgent: ${name}`);
     }
@@ -238,10 +177,9 @@ export class AgentFactory {
   /**
    * Create a Subagent instance by name.
    *
-   * Part of AgentFactoryInterface - provides unified agent creation by type.
-   *
    * @param name - Agent name ('site-miner')
-   * @param args - Additional arguments
+   * @param args - Additional arguments:
+   *   - args[0]: Partial<BaseAgentConfig> - Optional configuration overrides
    * @returns Subagent instance
    *
    * @example
@@ -251,8 +189,6 @@ export class AgentFactory {
    */
   static createSubagent(name: string, ...args: unknown[]): Subagent {
     if (name === 'site-miner') {
-      // SiteMiner uses global config, createSiteMiner returns the runSiteMiner function
-      // The returned object needs to implement Subagent interface
       const config = args[0] as Partial<BaseAgentConfig> | undefined;
 
       // Check if Playwright is available
@@ -261,11 +197,7 @@ export class AgentFactory {
       }
 
       // Create and return the SiteMiner instance
-      // Note: This assumes SiteMiner has been refactored to implement Subagent
-      // (PR #336). For now, we return the factory function wrapped as Subagent.
       const siteMinerFactory = createSiteMiner(config);
-
-      // Return as Subagent (will be properly typed after PR #336 merges)
       return siteMinerFactory as unknown as Subagent;
     }
     throw new Error(`Unknown Subagent: ${name}`);

--- a/src/agents/index.test.ts
+++ b/src/agents/index.test.ts
@@ -59,10 +59,9 @@ describe('Agents Module Exports', () => {
     it('should export AgentFactory as class', async () => {
       const { AgentFactory } = await import('./index.js');
       expect(typeof AgentFactory).toBe('function');
-      expect(typeof AgentFactory.createEvaluator).toBe('function');
-      expect(typeof AgentFactory.createExecutor).toBe('function');
-      expect(typeof AgentFactory.createReporter).toBe('function');
-      expect(typeof AgentFactory.createPilot).toBe('function');
+      expect(typeof AgentFactory.createChatAgent).toBe('function');
+      expect(typeof AgentFactory.createSkillAgent).toBe('function');
+      expect(typeof AgentFactory.createSubagent).toBe('function');
     });
   });
 });

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -102,7 +102,7 @@ export class PrimaryNode extends EventEmitter {
 
   // Local execution
   private localExecEnabled: boolean;
-  private sharedPilot?: ReturnType<typeof AgentFactory.createPilot>;
+  private sharedPilot?: ReturnType<typeof AgentFactory.createChatAgent>;
   private activeFeedbackChannels = new Map<string, FeedbackContext>();
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
@@ -433,7 +433,7 @@ export class PrimaryNode extends EventEmitter {
     console.log('Initializing local execution capability...');
 
     // Create shared Pilot instance
-    this.sharedPilot = AgentFactory.createPilot({
+    this.sharedPilot = AgentFactory.createChatAgent('pilot', {
       sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
         const ctx = this.activeFeedbackChannels.get(chatId);
         if (ctx) {

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -70,7 +70,7 @@ export class WorkerNode {
   private fileClient: FileClient;
 
   // Shared Pilot instance
-  private sharedPilot?: ReturnType<typeof AgentFactory.createPilot>;
+  private sharedPilot?: ReturnType<typeof AgentFactory.createChatAgent>;
   private activeFeedbackChannels = new Map<string, FeedbackContext>();
 
   // Scheduler
@@ -129,7 +129,7 @@ export class WorkerNode {
   private async initPilot(): Promise<void> {
     console.log('Initializing execution capability...');
 
-    this.sharedPilot = AgentFactory.createPilot({
+    this.sharedPilot = AgentFactory.createChatAgent('pilot', {
       sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
         const ctx = this.activeFeedbackChannels.get(chatId);
         if (ctx) {

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -76,7 +76,7 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
    *
    * Uses AgentFactory for consistent configuration (Issue #129).
    */
-  const sharedPilot = AgentFactory.createPilot({
+  const sharedPilot = AgentFactory.createChatAgent('pilot', {
     sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
       const ctx = activeFeedbackChannels.get(chatId);
       if (ctx) {


### PR DESCRIPTION
## Summary

Implements #326 - 更新 AgentFactory 使用新的类型接口，移除旧的便捷方法。

## Changes

### AgentFactory (`src/agents/factory.ts`)
- `createChatAgent(name, ...args)` 方法 - 创建 ChatAgent 实例（当前支持 'pilot'）
- `createSkillAgent(name, ...args)` 方法 - 创建 SkillAgent 实例（支持 'evaluator', 'executor', 'reporter'）
- `createSubagent(name, ...args)` 方法 - 创建 Subagent 实例（当前支持 'site-miner'）
- **移除向后兼容方法**: `createEvaluator`, `createExecutor`, `createReporter`, `createPilot`

### Updated Callers
- `src/runners/execution-runner.ts`: `createPilot` → `createChatAgent('pilot', ...)`
- `src/nodes/worker-node.ts`: `createPilot` → `createChatAgent('pilot', ...)`
- `src/nodes/primary-node.ts`: `createPilot` → `createChatAgent('pilot', ...)`

### Tests (`src/agents/factory.test.ts`, `src/agents/index.test.ts`)
- 移除旧方法的测试
- 更新模块导出测试验证新接口方法

## Verification

- ✅ 所有 1115 个测试通过
- ✅ 20 个 factory 测试通过
- ✅ 无 TypeScript 错误

## API Usage

```typescript
// ChatAgent - Pilot
const pilot = AgentFactory.createChatAgent('pilot', callbacks);

// SkillAgent - Evaluator, Executor, Reporter
const evaluator = AgentFactory.createSkillAgent('evaluator');
const executor = AgentFactory.createSkillAgent('executor', {}, abortSignal);
const reporter = AgentFactory.createSkillAgent('reporter');

// Subagent - SiteMiner
const siteMiner = AgentFactory.createSubagent('site-miner');
```

## Related

- Parent Issue: #282 (Agent 架构重构)
- Depends on: PR #335 (SkillAgent 接口实现)
- Related: PR #336 (SiteMiner Subagent 实现)

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 运行 factory 测试 `npx vitest run src/agents/factory.test.ts`
- [x] 类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)