### PR TITLE
fix(runners): unify SIGINT signal handling and add signal source logging

### DIFF
--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -210,18 +210,9 @@ async function main(): Promise<void> {
   }
 }
 
-// Handle shutdown gracefully
-process.on('SIGINT', async () => {
-  const logger = await initLogger();
-  logger.info('Received SIGINT, shutting down gracefully');
-
-  console.log('\nGoodbye!');
-
-  // Flush any pending logs
-  await flushLogger();
-
-  process.exit(0);
-});
+// Note: SIGINT/SIGTERM handling is delegated to individual runners.
+// This avoids duplicate handlers and ensures proper cleanup of runner resources.
+// Each runner (primary-runner, worker-runner, etc.) registers its own signal handlers.
 
 // Handle uncaught exceptions
 process.on('uncaughtException', (error) => {

--- a/src/runners/communication-runner.ts
+++ b/src/runners/communication-runner.ts
@@ -67,16 +67,25 @@ export async function runCommunicationNode(config?: CommNodeConfig): Promise<voi
   console.log('Waiting for Execution Node to connect...');
   console.log();
 
-  // Handle shutdown
-  const shutdown = async () => {
-    logger.info('Shutting down Communication Node...');
-    console.log('\nShutting down Communication Node...');
+  // Handle shutdown with detailed logging
+  const shutdown = async (signal: string) => {
+    // Capture stack trace to help identify signal source
+    const stack = new Error('Signal source trace').stack;
+
+    logger.info({
+      signal,
+      stack: stack?.split('\n').slice(1).join('\n')
+    }, 'Received shutdown signal, shutting down Communication Node...');
+
+    console.log(`\nReceived ${signal}, shutting down Communication Node...`);
     await commNode.stop();
+
+    logger.info('Communication Node stopped, exiting');
     process.exit(0);
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
 // Re-export type for external use

--- a/src/runners/execution-runner.ts
+++ b/src/runners/execution-runner.ts
@@ -439,10 +439,17 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
   // Start connection
   connectToCommNode();
 
-  // Handle shutdown
-  const shutdown = () => {
-    logger.info('Shutting down Execution Node...');
-    console.log('\nShutting down Execution Node...');
+  // Handle shutdown with detailed logging
+  const shutdown = (signal: string) => {
+    // Capture stack trace to help identify signal source
+    const stack = new Error('Signal source trace').stack;
+
+    logger.info({
+      signal,
+      stack: stack?.split('\n').slice(1).join('\n')
+    }, 'Received shutdown signal, shutting down Execution Node...');
+
+    console.log(`\nReceived ${signal}, shutting down Execution Node...`);
 
     running = false;
 
@@ -466,11 +473,12 @@ export async function runExecutionNode(config?: ExecNodeConfig): Promise<void> {
     // Clear active feedback channels
     activeFeedbackChannels.clear();
 
+    logger.info('Execution Node stopped, exiting');
     process.exit(0);
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
 // Re-export type for external use

--- a/src/runners/primary-runner.ts
+++ b/src/runners/primary-runner.ts
@@ -74,16 +74,25 @@ export async function runPrimaryNode(config?: PrimaryNodeConfig): Promise<void> 
   console.log('✓ Primary Node ready');
   console.log();
 
-  // Handle shutdown
-  const shutdown = async () => {
-    logger.info('Shutting down Primary Node...');
-    console.log('\nShutting down Primary Node...');
+  // Handle shutdown with detailed logging
+  const shutdown = async (signal: string) => {
+    // Capture stack trace to help identify signal source
+    const stack = new Error('Signal source trace').stack;
+
+    logger.info({
+      signal,
+      stack: stack?.split('\n').slice(1).join('\n')
+    }, 'Received shutdown signal, shutting down Primary Node...');
+
+    console.log(`\nReceived ${signal}, shutting down Primary Node...`);
     await primaryNode.stop();
+
+    logger.info('Primary Node stopped, exiting');
     process.exit(0);
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
 // Re-export type for external use

--- a/src/runners/worker-runner.ts
+++ b/src/runners/worker-runner.ts
@@ -61,16 +61,25 @@ export async function runWorkerNode(config?: WorkerNodeConfig): Promise<void> {
 
   logger.info('Worker Node started successfully');
 
-  // Handle shutdown
-  const shutdown = async () => {
-    logger.info('Shutting down Worker Node...');
-    console.log('\nShutting down Worker Node...');
+  // Handle shutdown with detailed logging
+  const shutdown = async (signal: string) => {
+    // Capture stack trace to help identify signal source
+    const stack = new Error('Signal source trace').stack;
+
+    logger.info({
+      signal,
+      stack: stack?.split('\n').slice(1).join('\n')
+    }, 'Received shutdown signal, shutting down Worker Node...');
+
+    console.log(`\nReceived ${signal}, shutting down Worker Node...`);
     await workerNode.stop();
+
+    logger.info('Worker Node stopped, exiting');
     process.exit(0);
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
 }
 
 // Re-export type for external use


### PR DESCRIPTION
## Summary

Fixes #338 - 统一 SIGINT 信号处理并添加信号来源日志

## Problem

PM2 服务意外停止时日志显示收到了 SIGINT 信号，但无法确定信号来源。同时发现存在重复的 SIGINT 处理器：
- `cli-entry.ts:214` - 全局处理器
- `primary-runner.ts:85` 等 - 各 runner 的处理器

这导致：
1. 竞态条件：两个处理器同时触发，执行顺序不确定
2. 难以调试：无法追踪信号来源

## Changes

### 1. 移除 cli-entry.ts 中的 SIGINT 处理器
- 移除全局 SIGINT 处理器，让各 runner 负责自己的信号处理
- 添加注释说明设计决策

### 2. 增强 runner 的信号处理
- `shutdown` 函数添加 `signal` 参数
- 捕获堆栈跟踪帮助识别信号来源
- 记录信号类型（SIGINT/SIGTERM）
- 在退出前记录日志

### 3. 统一所有 runner 的实现
- primary-runner.ts
- worker-runner.ts
- communication-runner.ts
- execution-runner.ts

## Verification

- ✅ 所有 1119 个测试通过
- ✅ 修改的文件没有引入新的 TypeScript 错误

## About PM2 autorestart

PM2 默认不会重启 exit code 为 0 的进程（这是预期行为）。如果需要 PM2 在收到 SIGINT 后自动重启，可以考虑：
1. 使用非零 exit code（但这是不正确的语义）
2. 配置 PM2 的 `stop_exit_codes` 选项
3. 使用 PM2 的 `watch` 模式

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 验证代码修改正确
- [ ] 手动测试：启动服务并发送 SIGINT 信号，验证日志输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)