### PR TITLE
fix(schedule): 周期任务执行时保持 schedule.md 只读

### DIFF
--- a/src/schedule/schedule-file-scanner.test.ts
+++ b/src/schedule/schedule-file-scanner.test.ts
@@ -270,7 +270,7 @@ Prompt`;
       expect(content).toContain('Task prompt');
     });
 
-    it('should include optional fields when present', async () => {
+    it('should include optional fields when present (except lastExecutedAt)', async () => {
       const task = {
         id: 'schedule-task',
         name: 'Task',
@@ -281,7 +281,7 @@ Prompt`;
         prompt: 'Prompt',
         createdBy: 'ou_user1',
         createdAt: '2024-01-01T00:00:00.000Z',
-        lastExecutedAt: '2024-06-15T09:00:00.000Z',
+        lastExecutedAt: '2024-06-15T09:00:00.000Z', // Should NOT be written to file
       };
 
       const filePath = await scanner.writeTask(task);
@@ -289,7 +289,8 @@ Prompt`;
 
       expect(content).toContain('createdBy: ou_user1');
       expect(content).toContain('createdAt: "2024-01-01T00:00:00.000Z"');
-      expect(content).toContain('lastExecutedAt: "2024-06-15T09:00:00.000Z"');
+      // lastExecutedAt is NOT written to file (tracked in memory only)
+      expect(content).not.toContain('lastExecutedAt');
     });
 
     it('should create directory if it does not exist', async () => {

--- a/src/schedule/schedule-manager.test.ts
+++ b/src/schedule/schedule-manager.test.ts
@@ -220,7 +220,7 @@ describe('ScheduleManager', () => {
   });
 
   describe('markExecuted', () => {
-    it('should update lastExecutedAt', async () => {
+    it('should update lastExecutedAt in memory (not in file)', async () => {
       const task = await manager.create({
         name: 'Test Task',
         cron: '0 9 * * *',
@@ -228,12 +228,35 @@ describe('ScheduleManager', () => {
         chatId: 'test-chat',
       });
 
-      expect(task.lastExecutedAt).toBeUndefined();
+      // Initially no lastExecutedAt
+      expect(manager.getLastExecutedAt(task.id)).toBeUndefined();
 
-      await manager.markExecuted(task.id);
+      // Mark as executed (synchronous, in-memory only)
+      manager.markExecuted(task.id);
 
-      const updated = await manager.get(task.id);
-      expect(updated?.lastExecutedAt).toBeDefined();
+      // Should be available in memory
+      const lastExecutedAt = manager.getLastExecutedAt(task.id);
+      expect(lastExecutedAt).toBeDefined();
+      expect(lastExecutedAt instanceof Date).toBe(true);
+
+      // Should NOT be persisted to file
+      const taskFromFile = await manager.get(task.id);
+      expect(taskFromFile?.lastExecutedAt).toBeUndefined();
+    });
+
+    it('should clear lastExecutedAt cache on delete', async () => {
+      const task = await manager.create({
+        name: 'Test Task',
+        cron: '0 9 * * *',
+        prompt: 'Test prompt',
+        chatId: 'test-chat',
+      });
+
+      manager.markExecuted(task.id);
+      expect(manager.getLastExecutedAt(task.id)).toBeDefined();
+
+      await manager.delete(task.id);
+      expect(manager.getLastExecutedAt(task.id)).toBeUndefined();
     });
   });
 

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -70,6 +70,9 @@ export interface ScheduleManagerOptions {
  * No cache: all operations read directly from file system.
  * This ensures perfect consistency - file system is the single source of truth.
  *
+ * Note: Execution state (lastExecutedAt) is tracked in memory, not persisted to files.
+ * This prevents file contention during scheduled task execution.
+ *
  * Usage:
  * ```typescript
  * const manager = new ScheduleManager({ schedulesDir: './workspace/schedules' });
@@ -94,6 +97,8 @@ export interface ScheduleManagerOptions {
  */
 export class ScheduleManager {
   private fileScanner: ScheduleFileScanner;
+  /** In-memory cache for last execution times (not persisted to files) */
+  private lastExecutedAtCache: Map<string, Date> = new Map();
 
   constructor(options: ScheduleManagerOptions) {
     this.fileScanner = new ScheduleFileScanner({ schedulesDir: options.schedulesDir });
@@ -241,12 +246,36 @@ export class ScheduleManager {
   }
 
   /**
-   * Update last execution time.
+   * Update last execution time (in-memory only, not persisted to file).
+   *
+   * This method only updates the in-memory cache to avoid file contention
+   * during scheduled task execution. The schedule.md files remain read-only
+   * during execution.
    *
    * @param id - Task ID
    */
-  async markExecuted(id: string): Promise<void> {
-    await this.update(id, { lastExecutedAt: new Date().toISOString() });
+  markExecuted(id: string): void {
+    this.lastExecutedAtCache.set(id, new Date());
+    logger.debug({ taskId: id }, 'Marked task as executed (in-memory)');
+  }
+
+  /**
+   * Get the last execution time for a task.
+   *
+   * @param id - Task ID
+   * @returns Last execution time or undefined if never executed
+   */
+  getLastExecutedAt(id: string): Date | undefined {
+    return this.lastExecutedAtCache.get(id);
+  }
+
+  /**
+   * Clear the last execution time cache for a task.
+   *
+   * @param id - Task ID
+   */
+  clearLastExecutedAt(id: string): void {
+    this.lastExecutedAtCache.delete(id);
   }
 
   /**
@@ -261,6 +290,9 @@ export class ScheduleManager {
     if (!deleted) {
       return false;
     }
+
+    // Clear in-memory cache
+    this.lastExecutedAtCache.delete(id);
 
     logger.info({ taskId: id }, 'Deleted scheduled task');
     return true;

--- a/src/schedule/schedule-watcher.ts
+++ b/src/schedule/schedule-watcher.ts
@@ -255,9 +255,8 @@ export class ScheduleFileScanner {
     if (task.createdAt) {
       frontmatter.push(`createdAt: "${task.createdAt}"`);
     }
-    if (task.lastExecutedAt) {
-      frontmatter.push(`lastExecutedAt: "${task.lastExecutedAt}"`);
-    }
+    // Note: lastExecutedAt is intentionally NOT written to file
+    // Execution state is tracked in memory only to prevent file contention
 
     frontmatter.push('---', '');
 

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -253,8 +253,8 @@ ${task.prompt}`;
         task.createdBy
       );
 
-      // Update last execution time
-      await this.scheduleManager.markExecuted(task.id);
+      // Update last execution time (in-memory only, not persisted to file)
+      this.scheduleManager.markExecuted(task.id);
 
       logger.info({ taskId: task.id }, 'Scheduled task completed');
 


### PR DESCRIPTION
## Summary

Implements #344 - 周期任务执行时保持 schedule.md 文件只读，将执行状态改为内存缓存管理。

## 问题描述

当前周期任务执行时会更新 `lastExecutedAt` 字段到 schedule.md 文件，这会导致：
1. **文件竞争** - 执行中的任务修改文件可能与其他操作冲突
2. **Git 变更** - 产生不必要的文件变更记录
3. **状态污染** - 执行逻辑与状态管理耦合

## 解决方案

1. 在 `ScheduleManager` 中添加内存缓存 `lastExecutedAtCache` 跟踪最后执行时间
2. `markExecuted()` 方法改为同步方法，只更新内存缓存，不写入文件
3. 添加 `getLastExecutedAt()` 和 `clearLastExecutedAt()` 方法访问内存缓存
4. `ScheduleFileScanner.writeTask()` 不再写入 `lastExecutedAt` 字段到文件
5. 任务删除时自动清理内存缓存

## Changes

### ScheduleManager (`src/schedule/schedule-manager.ts`)
- 添加 `lastExecutedAtCache: Map<string, Date>` 内存缓存
- `markExecuted()` 改为同步方法，只更新内存缓存
- 添加 `getLastExecutedAt()` 方法获取最后执行时间
- 添加 `clearLastExecutedAt()` 方法清理缓存
- `delete()` 方法同时清理内存缓存

### ScheduleFileScanner (`src/schedule/schedule-watcher.ts`)
- `writeTask()` 不再写入 `lastExecutedAt` 字段
- 添加注释说明执行状态仅保存在内存中

### Scheduler (`src/schedule/scheduler.ts`)
- 更新调用 `markExecuted()` 为同步调用

### Tests
- 更新 `schedule-manager.test.ts` 测试新的内存缓存行为
- 更新 `schedule-file-scanner.test.ts` 验证不再写入 `lastExecutedAt`

## 验收标准

- [x] 不再在执行时更新 lastExecutedAt 字段到文件
- [x] 最后执行时间通过内存缓存记录
- [x] schedule.md 只用于任务定义，不用于执行状态追踪

## Verification

- ✅ 所有 65 个 schedule 相关测试通过
- ✅ 构建成功
- ✅ TypeScript 编译通过

## Test plan

- [x] 运行单元测试
- [x] 运行构建
- [x] 验证 markExecuted() 不写入文件
- [x] 验证 getLastExecutedAt() 返回内存中的值

Fixes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)