### PR TITLE
feat(mcp): 添加 update_card 和 wait_for_interaction MCP 工具

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -14,6 +14,7 @@ import { messageLogger } from '../feishu/message-logger.js';
 import { FeishuFileHandler } from '../platforms/feishu/feishu-file-handler.js';
 import { FeishuMessageSender } from '../platforms/feishu/feishu-message-sender.js';
 import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
+import { resolvePendingInteraction } from '../mcp/feishu-context-mcp.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
 import { BaseChannel } from './base-channel.js';
@@ -529,6 +530,19 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       },
       'Card action received'
     );
+
+    // First, try to resolve any pending wait_for_interaction calls
+    const resolved = resolvePendingInteraction(
+      message_id,
+      action.value,
+      action.type,
+      user?.sender_id?.open_id || 'unknown'
+    );
+
+    if (resolved) {
+      logger.debug({ messageId: message_id }, 'Card action resolved pending interaction');
+      return;
+    }
 
     try {
       // Try to handle via InteractionManager

--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -6,6 +6,9 @@
  * - getCardValidationError: Detailed validation error messages (via behavior testing)
  * - send_user_feedback: Message sending to Feishu
  * - send_file_to_feishu: File sending to Feishu
+ * - update_card: Update existing card message
+ * - wait_for_interaction: Wait for user card interaction
+ * - resolvePendingInteraction: Resolve pending interaction
  * - setMessageSentCallback: Callback management
  */
 
@@ -22,6 +25,7 @@ const mockClient = {
     message: {
       create: vi.fn(),
       reply: vi.fn(),
+      patch: vi.fn(),
     },
   },
 };
@@ -62,6 +66,9 @@ import * as fs from 'fs/promises';
 import {
   send_user_feedback,
   send_file_to_feishu,
+  update_card,
+  wait_for_interaction,
+  resolvePendingInteraction,
   setMessageSentCallback,
   feishuContextTools,
 } from './feishu-context-mcp.js';
@@ -540,6 +547,213 @@ describe('Feishu Context MCP Tools', () => {
       expect(result.feishuCode).toBe(99991663);
       expect(result.feishuMsg).toBe('permission denied');
       expect(result.feishuLogId).toBe('log-123');
+    });
+  });
+
+  describe('update_card', () => {
+    it('should have update_card tool definition', () => {
+      expect(feishuContextTools.update_card).toBeDefined();
+      expect(feishuContextTools.update_card.description).toContain('Update an existing interactive card');
+      expect(feishuContextTools.update_card.handler).toBe(update_card);
+    });
+
+    it('should require messageId', async () => {
+      const result = await update_card({
+        messageId: '',
+        card: { config: {}, header: {}, elements: [] },
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('messageId is required');
+    });
+
+    it('should require card', async () => {
+      const result = await update_card({
+        messageId: 'msg-123',
+        card: null as unknown as Record<string, unknown>,
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('card is required');
+    });
+
+    it('should require chatId', async () => {
+      const result = await update_card({
+        messageId: 'msg-123',
+        card: { config: {}, header: {}, elements: [] },
+        chatId: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('chatId is required');
+    });
+
+    it('should validate card structure', async () => {
+      const result = await update_card({
+        messageId: 'msg-123',
+        card: { invalid: 'structure' },
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid card structure');
+    });
+
+    it('should update card in CLI mode', async () => {
+      const result = await update_card({
+        messageId: 'msg-123',
+        card: {
+          config: { wide_screen_mode: true },
+          header: {
+            title: { tag: 'plain_text', content: 'Updated Card' },
+            template: 'blue',
+          },
+          elements: [{ tag: 'markdown', content: '**Updated**' }],
+        },
+        chatId: 'cli-test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('CLI mode');
+    });
+
+    it('should call Feishu API patch endpoint', async () => {
+      mockClient.im.message.patch.mockResolvedValueOnce({});
+
+      const card = {
+        config: { wide_screen_mode: true },
+        header: {
+          title: { tag: 'plain_text', content: 'Updated Card' },
+          template: 'blue',
+        },
+        elements: [{ tag: 'markdown', content: '**Updated**' }],
+      };
+
+      const result = await update_card({
+        messageId: 'msg-123',
+        card,
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockClient.im.message.patch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: { message_id: 'msg-123' },
+        })
+      );
+    });
+
+    it('should handle API errors', async () => {
+      mockClient.im.message.patch.mockRejectedValueOnce(new Error('Patch failed'));
+
+      const result = await update_card({
+        messageId: 'msg-123',
+        card: {
+          config: { wide_screen_mode: true },
+          header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
+          elements: [],
+        },
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Patch failed');
+    });
+  });
+
+  describe('wait_for_interaction', () => {
+    it('should have wait_for_interaction tool definition', () => {
+      expect(feishuContextTools.wait_for_interaction).toBeDefined();
+      expect(feishuContextTools.wait_for_interaction.description).toContain('Wait for the user to interact');
+      expect(feishuContextTools.wait_for_interaction.handler).toBe(wait_for_interaction);
+    });
+
+    it('should require messageId', async () => {
+      const result = await wait_for_interaction({
+        messageId: '',
+        chatId: 'chat-123',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('messageId is required');
+    });
+
+    it('should require chatId', async () => {
+      const result = await wait_for_interaction({
+        messageId: 'msg-123',
+        chatId: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('chatId is required');
+    });
+
+    it('should simulate interaction in CLI mode', async () => {
+      const result = await wait_for_interaction({
+        messageId: 'msg-123',
+        chatId: 'cli-test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.actionValue).toBe('simulated');
+      expect(result.actionType).toBe('button');
+    });
+
+    it('should resolve when interaction is received', async () => {
+      // Start waiting for interaction
+      const waitPromise = wait_for_interaction({
+        messageId: 'msg-456',
+        chatId: 'chat-123',
+        timeoutSeconds: 5,
+      });
+
+      // Simulate interaction being received
+      setTimeout(() => {
+        resolvePendingInteraction('msg-456', 'confirm', 'button', 'user-789');
+      }, 50);
+
+      const result = await waitPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.actionValue).toBe('confirm');
+      expect(result.actionType).toBe('button');
+      expect(result.userId).toBe('user-789');
+    });
+
+    it('should timeout if no interaction received', async () => {
+      const result = await wait_for_interaction({
+        messageId: 'msg-timeout',
+        chatId: 'chat-123',
+        timeoutSeconds: 1,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('timeout');
+    });
+
+    it('should reject duplicate wait for same message', async () => {
+      // Start first wait
+      const firstWait = wait_for_interaction({
+        messageId: 'msg-dup',
+        chatId: 'chat-123',
+        timeoutSeconds: 5,
+      });
+
+      // Try to wait again for same message
+      const secondResult = await wait_for_interaction({
+        messageId: 'msg-dup',
+        chatId: 'chat-123',
+        timeoutSeconds: 1,
+      });
+
+      expect(secondResult.success).toBe(false);
+      expect(secondResult.error).toContain('Already waiting');
+
+      // Clean up first wait
+      resolvePendingInteraction('msg-dup', 'cancel', 'button', 'user-1');
+      await firstWait;
     });
   });
 });

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -522,6 +522,282 @@ export async function send_file_to_feishu(params: {
   }
 }
 
+// ============================================================================
+// Card Interaction Tools (Issue #275 Phase 4)
+// ============================================================================
+
+/**
+ * Pending interaction tracker for wait_for_interaction tool.
+ */
+interface PendingInteraction {
+  messageId: string;
+  chatId: string;
+  resolve: (action: { actionValue: string; actionType: string; userId: string }) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Global map of pending interactions waiting for user response.
+ */
+const pendingInteractions = new Map<string, PendingInteraction>();
+
+/**
+ * Handle incoming card action for wait_for_interaction.
+ * Called by FeishuChannel when a card action is received.
+ *
+ * @param messageId - The card message ID
+ * @param actionValue - The action value from the button click
+ * @param actionType - The action type (button, menu, etc.)
+ * @param userId - The user who triggered the action
+ */
+export function resolvePendingInteraction(
+  messageId: string,
+  actionValue: string,
+  actionType: string,
+  userId: string
+): boolean {
+  const pending = pendingInteractions.get(messageId);
+  if (pending) {
+    clearTimeout(pending.timeout);
+    pendingInteractions.delete(messageId);
+    pending.resolve({ actionValue, actionType, userId });
+    logger.debug({ messageId, actionValue, actionType, userId }, 'Pending interaction resolved');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Tool: Update an existing interactive card message.
+ *
+ * Updates the content of a previously sent interactive card.
+ * Requires the message_id of the card to update.
+ *
+ * @param params - Tool parameters
+ * @returns Result object with success status
+ */
+export async function update_card(params: {
+  messageId: string;
+  card: Record<string, unknown>;
+  chatId: string;
+}): Promise<{
+  success: boolean;
+  message: string;
+  error?: string;
+}> {
+  const { messageId, card, chatId } = params;
+
+  logger.info({
+    messageId,
+    chatId,
+    cardPreview: JSON.stringify(card).substring(0, 100),
+  }, 'update_card called');
+
+  try {
+    if (!messageId) {
+      throw new Error('messageId is required');
+    }
+    if (!card) {
+      throw new Error('card is required');
+    }
+    if (!chatId) {
+      throw new Error('chatId is required');
+    }
+
+    // Validate card structure
+    if (!isValidFeishuCard(card)) {
+      const validationError = getCardValidationError(card);
+      return {
+        success: false,
+        error: `Invalid card structure: ${validationError}`,
+        message: `❌ Card validation failed. ${validationError}`,
+      };
+    }
+
+    // CLI mode: Log the update instead of calling API
+    if (chatId.startsWith('cli-')) {
+      logger.info({ messageId, chatId }, 'CLI mode: Card update simulated');
+      return {
+        success: true,
+        message: `✅ Card updated (CLI mode)`,
+      };
+    }
+
+    // Read credentials from Config
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET must be configured');
+    }
+
+    // Create Lark client
+    const client = new lark.Client({
+      appId,
+      appSecret,
+      domain: lark.Domain.Feishu,
+    });
+
+    // Update the card using patch API
+    await client.im.message.patch({
+      path: {
+        message_id: messageId,
+      },
+      params: {
+        receive_id_type: 'chat_id',
+      },
+      data: {
+        content: JSON.stringify(card),
+      },
+    });
+
+    logger.debug({ messageId, chatId }, 'Card updated successfully');
+
+    return {
+      success: true,
+      message: `✅ Card updated successfully`,
+    };
+
+  } catch (error) {
+    logger.error({
+      err: error,
+      messageId,
+      chatId,
+    }, 'update_card failed');
+
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ Failed to update card: ${errorMessage}`,
+    };
+  }
+}
+
+/**
+ * Tool: Wait for user to interact with a card.
+ *
+ * Registers a wait handler for the specified card and returns when
+ * the user clicks a button or interacts with the card.
+ *
+ * Note: This tool will block until the user interacts or timeout is reached.
+ * The interaction is resolved via resolvePendingInteraction() called by FeishuChannel.
+ *
+ * @param params - Tool parameters
+ * @returns Result object with the action taken by the user
+ */
+export async function wait_for_interaction(params: {
+  messageId: string;
+  chatId: string;
+  timeoutSeconds?: number;
+}): Promise<{
+  success: boolean;
+  message: string;
+  actionValue?: string;
+  actionType?: string;
+  userId?: string;
+  error?: string;
+}> {
+  const { messageId, chatId, timeoutSeconds = 300 } = params;
+
+  logger.info({
+    messageId,
+    chatId,
+    timeoutSeconds,
+  }, 'wait_for_interaction called');
+
+  try {
+    if (!messageId) {
+      throw new Error('messageId is required');
+    }
+    if (!chatId) {
+      throw new Error('chatId is required');
+    }
+
+    // CLI mode: Simulate immediate response
+    if (chatId.startsWith('cli-')) {
+      logger.info({ messageId, chatId }, 'CLI mode: Simulating interaction response');
+      return {
+        success: true,
+        message: `✅ Interaction received (CLI mode - simulated)`,
+        actionValue: 'simulated',
+        actionType: 'button',
+        userId: 'cli-user',
+      };
+    }
+
+    // Check if there's already a pending interaction for this message
+    if (pendingInteractions.has(messageId)) {
+      return {
+        success: false,
+        error: 'Already waiting for interaction on this message',
+        message: '❌ Another wait is already pending for this card',
+      };
+    }
+
+    // Create a promise that resolves when the user interacts
+    const interactionPromise = new Promise<{
+      actionValue: string;
+      actionType: string;
+      userId: string;
+    }>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingInteractions.delete(messageId);
+        reject(new Error(`Interaction timeout after ${timeoutSeconds} seconds`));
+      }, timeoutSeconds * 1000);
+
+      pendingInteractions.set(messageId, {
+        messageId,
+        chatId,
+        resolve,
+        reject,
+        timeout,
+      });
+
+      logger.debug({ messageId, chatId, timeoutSeconds }, 'Waiting for interaction');
+    });
+
+    // Wait for the interaction
+    const result = await interactionPromise;
+
+    logger.info({
+      messageId,
+      chatId,
+      actionValue: result.actionValue,
+      actionType: result.actionType,
+      userId: result.userId,
+    }, 'Interaction received');
+
+    return {
+      success: true,
+      message: `✅ User interaction received: ${result.actionValue}`,
+      actionValue: result.actionValue,
+      actionType: result.actionType,
+      userId: result.userId,
+    };
+
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    // Clean up pending interaction on error
+    pendingInteractions.delete(messageId);
+
+    logger.error({
+      err: error,
+      messageId,
+      chatId,
+    }, 'wait_for_interaction failed');
+
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ Wait failed: ${errorMessage}`,
+    };
+  }
+}
+
 /**
  * Tool definitions for Agent SDK integration.
  *
@@ -578,6 +854,50 @@ export const feishuContextTools = {
       required: ['filePath', 'chatId'],
     },
     handler: send_file_to_feishu,
+  },
+  update_card: {
+    description: 'Update an existing interactive card message. Use this to change the content of a card that was already sent, such as updating a progress indicator or changing button states.',
+    parameters: {
+      type: 'object',
+      properties: {
+        messageId: {
+          type: 'string',
+          description: 'The message ID of the card to update',
+        },
+        card: {
+          type: 'object',
+          description: 'The new card content (must be a valid Feishu card structure)',
+        },
+        chatId: {
+          type: 'string',
+          description: 'Feishu chat ID where the card was sent',
+        },
+      },
+      required: ['messageId', 'card', 'chatId'],
+    },
+    handler: update_card,
+  },
+  wait_for_interaction: {
+    description: 'Wait for the user to interact with a card (click a button, select from menu, etc.). This tool blocks until the user interacts or a timeout is reached. Returns the action value from the button or menu that was clicked.',
+    parameters: {
+      type: 'object',
+      properties: {
+        messageId: {
+          type: 'string',
+          description: 'The message ID of the card to wait for',
+        },
+        chatId: {
+          type: 'string',
+          description: 'Feishu chat ID where the card was sent',
+        },
+        timeoutSeconds: {
+          type: 'number',
+          description: 'Maximum time to wait in seconds (default: 300)',
+        },
+      },
+      required: ['messageId', 'chatId'],
+    },
+    handler: wait_for_interaction,
   },
 };
 
@@ -650,6 +970,48 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
       } catch (error) {
         // Return as soft error to avoid SDK subprocess crash
         return toolSuccess(`⚠️ File send failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'update_card',
+    description: 'Update an existing interactive card message. Use this to change the content of a card that was already sent.\n\n**Use Cases:**\n- Update progress indicators\n- Change button states (enable/disable)\n- Show results after user action\n- Display dynamic content\n\n**Note:** The card must have been sent previously using send_user_feedback with format="card".',
+    parameters: z.object({
+      messageId: z.string().describe('The message ID of the card to update (from the original send_user_feedback response)'),
+      card: z.object({}).passthrough().describe('The new card content (must be a valid Feishu card structure with config, header, elements)'),
+      chatId: z.string().describe('Feishu chat ID where the card was sent'),
+    }),
+    handler: async ({ messageId, card, chatId }) => {
+      try {
+        const result = await update_card({ messageId, card, chatId });
+        if (result.success) {
+          return toolSuccess(result.message);
+        } else {
+          return toolSuccess(`⚠️ ${result.message}`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Card update failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'wait_for_interaction',
+    description: 'Wait for the user to interact with a card (click a button, select from menu, etc.).\n\n**This tool blocks** until the user interacts or a timeout is reached.\n\n**Returns:**\n- actionValue: The value of the button or menu option that was clicked\n- actionType: The type of interaction (button, menu, etc.)\n- userId: The ID of the user who interacted\n\n**Use Cases:**\n- Wait for user confirmation before proceeding\n- Get user selection from a menu\n- Handle multi-step card workflows\n\n**Note:** This tool will timeout after the specified duration (default: 5 minutes).',
+    parameters: z.object({
+      messageId: z.string().describe('The message ID of the card to wait for'),
+      chatId: z.string().describe('Feishu chat ID where the card was sent'),
+      timeoutSeconds: z.number().optional().describe('Maximum time to wait in seconds (default: 300 = 5 minutes)'),
+    }),
+    handler: async ({ messageId, chatId, timeoutSeconds }) => {
+      try {
+        const result = await wait_for_interaction({ messageId, chatId, timeoutSeconds });
+        if (result.success) {
+          return toolSuccess(`${result.message}\nAction: ${result.actionValue}\nType: ${result.actionType}\nUser: ${result.userId}`);
+        } else {
+          return toolSuccess(`⚠️ ${result.message}`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Wait failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -8,6 +8,8 @@
  * Tools provided:
  * - send_user_feedback: Send a message to a Feishu chat
  * - send_file_to_feishu: Send a file to a Feishu chat
+ * - update_card: Update an existing interactive card
+ * - wait_for_interaction: Wait for user to interact with a card
  *
  * Environment Variables Required:
  * - FEISHU_APP_ID: Feishu app ID
@@ -19,7 +21,7 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { send_user_feedback, send_file_to_feishu } from './feishu-context-mcp.js';
+import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction } from './feishu-context-mcp.js';
 
 const logger = createLogger('FeishuMCPServer');
 
@@ -84,6 +86,50 @@ async function handleMessage(message: unknown) {
                   required: ['filePath', 'chatId'],
                 },
               },
+              {
+                name: 'update_card',
+                description: 'Update an existing interactive card message.',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    messageId: {
+                      type: 'string',
+                      description: 'The message ID of the card to update',
+                    },
+                    card: {
+                      type: 'object',
+                      description: 'The new card content',
+                    },
+                    chatId: {
+                      type: 'string',
+                      description: 'Feishu chat ID where the card was sent',
+                    },
+                  },
+                  required: ['messageId', 'card', 'chatId'],
+                },
+              },
+              {
+                name: 'wait_for_interaction',
+                description: 'Wait for user to interact with a card. Blocks until interaction or timeout.',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    messageId: {
+                      type: 'string',
+                      description: 'The message ID of the card to wait for',
+                    },
+                    chatId: {
+                      type: 'string',
+                      description: 'Feishu chat ID where the card was sent',
+                    },
+                    timeoutSeconds: {
+                      type: 'number',
+                      description: 'Maximum time to wait in seconds (default: 300)',
+                    },
+                  },
+                  required: ['messageId', 'chatId'],
+                },
+              },
             ],
           },
         };
@@ -123,6 +169,42 @@ async function handleMessage(message: unknown) {
                 type: 'text',
                 text: result.success
                   ? result.message
+                  : `⚠️ ${result.message}`,
+              }],
+            },
+          };
+        }
+
+        if (name === 'update_card') {
+          const args = toolArgs as { messageId: string; card: Record<string, unknown>; chatId: string };
+          const result = await update_card(args);
+
+          return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              content: [{
+                type: 'text',
+                text: result.success
+                  ? result.message
+                  : `⚠️ ${result.message}`,
+              }],
+            },
+          };
+        }
+
+        if (name === 'wait_for_interaction') {
+          const args = toolArgs as { messageId: string; chatId: string; timeoutSeconds?: number };
+          const result = await wait_for_interaction(args);
+
+          return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              content: [{
+                type: 'text',
+                text: result.success
+                  ? `${result.message}\nAction: ${result.actionValue}\nType: ${result.actionType}\nUser: ${result.userId}`
                   : `⚠️ ${result.message}`,
               }],
             },


### PR DESCRIPTION
## Summary

Implements #275 Phase 4 - 飞书卡片交互 MCP 工具集成

本 PR 实现了 Issue #275 的 Phase 4（MCP 工具集成），添加了两个新的 MCP 工具来支持交互式卡片功能。

## 新增功能

### 1. `update_card` 工具
更新已发送的交互式卡片消息。

**用途：**
- 更新进度指示器
- 改变按钮状态（启用/禁用）
- 在用户操作后显示结果
- 显示动态内容

**参数：**
- `messageId`: 要更新的卡片消息 ID
- `card`: 新的卡片内容（必须是有效的飞书卡片结构）
- `chatId`: 飞书聊天 ID

### 2. `wait_for_interaction` 工具
等待用户与卡片交互（点击按钮、选择菜单等）。

**返回值：**
- `actionValue`: 被点击的按钮或菜单选项的值
- `actionType`: 交互类型（button、menu 等）
- `userId`: 执行交互的用户 ID

**参数：**
- `messageId`: 要等待的卡片消息 ID
- `chatId`: 飞书聊天 ID
- `timeoutSeconds`: 最大等待时间（默认 300 秒）

### 3. `resolvePendingInteraction` 函数
内部函数，用于解析等待中的交互请求。由 FeishuChannel 在收到卡片操作时调用。

## 技术实现

### 文件修改

| 文件 | 变更 |
|------|------|
| `src/mcp/feishu-context-mcp.ts` | +362 行（新工具实现） |
| `src/mcp/feishu-mcp-server.ts` | +84 行（工具定义） |
| `src/channels/feishu-channel.ts` | +14 行（集成调用） |
| `src/mcp/feishu-context-mcp.test.ts` | +214 行（测试用例） |

### 实现细节

1. **update_card**: 使用飞书 `im.message.patch` API 更新卡片内容
2. **wait_for_interaction**: 使用 Promise 和 Map 实现异步等待机制
3. **resolvePendingInteraction**: 在 FeishuChannel.handleCardAction 中被调用

## 验收标准

- [x] 点击卡片按钮能够正确触发回调（Phase 1 已实现）
- [x] 能够识别不同按钮的 action_key（Phase 1 已实现）
- [x] 能够获取按钮携带的 value 数据（Phase 1 已实现）
- [x] 支持动态更新卡片内容（本 PR 实现）
- [x] 支持交互超时处理（本 PR 实现）
- [x] 支持等待用户交互（本 PR 实现）

## Verification

- ✅ 所有 1148 个测试通过
- ✅ 新增 15 个测试用例
- ✅ 构建成功
- ✅ TypeScript 编译通过

## Usage

```typescript
// 更新卡片
const updateResult = await update_card({
  messageId: 'om_xxx',
  card: {
    config: { wide_screen_mode: true },
    header: {
      title: { tag: 'plain_text', content: 'Updated Card' },
      template: 'green',
    },
    elements: [
      { tag: 'markdown', content: '✅ Task completed!' },
    ],
  },
  chatId: 'oc_xxx',
});

// 等待用户交互
const interactionResult = await wait_for_interaction({
  messageId: 'om_xxx',
  chatId: 'oc_xxx',
  timeoutSeconds: 60,
});

if (interactionResult.success) {
  console.log(`User ${interactionResult.userId} clicked: ${interactionResult.actionValue}`);
}
```

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 运行构建 `npm run build`
- [x] 验证 update_card 工具
- [x] 验证 wait_for_interaction 工具
- [x] 验证 CLI 模式下的模拟行为

Fixes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)