### PR TITLE
refactor(schedule): 移除未使用的 CRUD 方法和 lastExecutedAt 维护

### DIFF
--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -2,18 +2,23 @@
  * Schedule module - Scheduled task management.
  *
  * This module provides:
- * - ScheduleManager: CRUD operations for scheduled tasks
+ * - ScheduleManager: Query operations for scheduled tasks
  * - Scheduler: Cron-based task execution
  * - ScheduleFileScanner: Scans and parses schedule markdown files
  * - ScheduleFileWatcher: Hot reload for schedule files
+ *
+ * Note: CRUD operations (create/update/delete) are handled via file system directly.
+ * Users create schedule files manually, and ScheduleFileWatcher auto-loads them.
  *
  * @see Issue #3 - Scheduled task feature
  * @see Issue #79 - Refactor to file-based configuration
  * @see Issue #89 - Blocking mechanism for scheduled tasks
  * @see Issue #123 - Remove MCP dependency, use basic tools directly
+ * @see Issue #354 - Remove unused lastExecutedAt maintenance
+ * @see Issue #355 - Remove unused CRUD methods
  */
 
-export { ScheduleManager, type ScheduledTask, type CreateScheduleOptions, type ScheduleManagerOptions } from './schedule-manager.js';
+export { ScheduleManager, type ScheduledTask, type ScheduleManagerOptions } from './schedule-manager.js';
 export { Scheduler, type SchedulerOptions, type FeedbackChannelContext } from './scheduler.js';
 export {
   ScheduleFileScanner,

--- a/src/schedule/schedule-manager.test.ts
+++ b/src/schedule/schedule-manager.test.ts
@@ -3,6 +3,9 @@
  *
  * Note: ScheduleManager has NO cache - all operations read directly from file system.
  * This ensures perfect consistency - file system is the single source of truth.
+ *
+ * CRUD operations (create/update/delete) have been removed.
+ * Tests now use file system directly to create test data.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -10,6 +13,51 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { ScheduleManager } from './schedule-manager.js';
+
+/**
+ * Helper to create a schedule file directly in the file system.
+ * Note: The task ID is generated as `schedule-${fileName}` by ScheduleFileScanner.
+ * So if you want ID "schedule-my-task", pass "my-task" as the id parameter.
+ */
+async function createScheduleFile(
+  testDir: string,
+  task: {
+    id: string;  // This is the base name (without .md), ID will be `schedule-${id}`
+    name: string;
+    cron: string;
+    prompt: string;
+    chatId: string;
+    enabled?: boolean;
+    createdAt?: string;
+  }
+): Promise<void> {
+  // id is the base name, file is `${id}.md`, generated ID will be `schedule-${id}`
+  const filePath = path.join(testDir, `${task.id}.md`);
+  const content = `---
+name: "${task.name}"
+cron: "${task.cron}"
+enabled: ${task.enabled ?? true}
+chatId: "${task.chatId}"
+createdAt: "${task.createdAt ?? new Date().toISOString()}"
+---
+${task.prompt}`;
+  await fs.writeFile(filePath, content);
+}
+
+/**
+ * Helper to get the expected task ID from base name.
+ */
+function getTaskId(baseName: string): string {
+  return `schedule-${baseName}`;
+}
+
+/**
+ * Helper to delete a schedule file directly.
+ */
+async function deleteScheduleFile(testDir: string, baseName: string): Promise<void> {
+  const filePath = path.join(testDir, `${baseName}.md`);
+  await fs.unlink(filePath).catch(() => {});
+}
 
 describe('ScheduleManager', () => {
   let manager: ScheduleManager;
@@ -31,64 +79,17 @@ describe('ScheduleManager', () => {
     }
   });
 
-  describe('create', () => {
-    it('should create a new scheduled task', async () => {
-      const task = await manager.create({
-        name: 'Test Task',
-        cron: '0 9 * * *',
-        prompt: 'Test prompt',
-        chatId: 'test-chat-id',
-      });
-
-      expect(task.id).toMatch(/^schedule-/);
-      expect(task.name).toBe('Test Task');
-      expect(task.cron).toBe('0 9 * * *');
-      expect(task.prompt).toBe('Test prompt');
-      expect(task.chatId).toBe('test-chat-id');
-      expect(task.enabled).toBe(true);
-      expect(task.createdAt).toBeDefined();
-    });
-
-    it('should persist tasks to markdown files', async () => {
-      await manager.create({
-        name: 'Task 1',
-        cron: '0 9 * * *',
-        prompt: 'Prompt 1',
-        chatId: 'chat-1',
-      });
-
-      await manager.create({
-        name: 'Task 2',
-        cron: '0 10 * * *',
-        prompt: 'Prompt 2',
-        chatId: 'chat-2',
-      });
-
-      // Verify files exist
-      const files = await fs.readdir(testDir);
-      expect(files.length).toBe(2);
-      expect(files.every(f => f.endsWith('.md'))).toBe(true);
-
-      // Create new manager to test persistence (no cache, reads from files)
-      const newManager = new ScheduleManager({ schedulesDir: testDir });
-      const tasks = await newManager.listAll();
-
-      expect(tasks).toHaveLength(2);
-      expect(tasks.map(t => t.name)).toContain('Task 1');
-      expect(tasks.map(t => t.name)).toContain('Task 2');
-    });
-  });
-
   describe('get', () => {
     it('should return task by id', async () => {
-      const created = await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'test-task',
         name: 'Test Task',
         cron: '0 9 * * *',
         prompt: 'Test prompt',
         chatId: 'test-chat',
       });
 
-      const task = await manager.get(created.id);
+      const task = await manager.get(getTaskId('test-task'));
       expect(task).toBeDefined();
       expect(task?.name).toBe('Test Task');
     });
@@ -101,21 +102,24 @@ describe('ScheduleManager', () => {
 
   describe('listByChatId', () => {
     it('should return tasks for specific chat', async () => {
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-1',
         name: 'Task 1',
         cron: '0 9 * * *',
         prompt: 'Prompt 1',
         chatId: 'chat-1',
       });
 
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-2',
         name: 'Task 2',
         cron: '0 10 * * *',
         prompt: 'Prompt 2',
         chatId: 'chat-2',
       });
 
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-3',
         name: 'Task 3',
         cron: '0 11 * * *',
         prompt: 'Prompt 3',
@@ -134,22 +138,23 @@ describe('ScheduleManager', () => {
 
   describe('listEnabled', () => {
     it('should return only enabled tasks', async () => {
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-1',
         name: 'Task 1',
         cron: '0 9 * * *',
         prompt: 'Prompt 1',
         chatId: 'chat-1',
+        enabled: true,
       });
 
-      const task2 = await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-2',
         name: 'Task 2',
         cron: '0 10 * * *',
         prompt: 'Prompt 2',
         chatId: 'chat-1',
+        enabled: false,
       });
-
-      // Disable task 2
-      await manager.toggle(task2.id, false);
 
       const enabledTasks = await manager.listEnabled();
       expect(enabledTasks).toHaveLength(1);
@@ -157,106 +162,34 @@ describe('ScheduleManager', () => {
     });
   });
 
-  describe('update', () => {
-    it('should update task fields', async () => {
-      const task = await manager.create({
-        name: 'Original Name',
+  describe('listAll', () => {
+    it('should return all tasks', async () => {
+      await createScheduleFile(testDir, {
+        id: 'task-1',
+        name: 'Task 1',
         cron: '0 9 * * *',
-        prompt: 'Original prompt',
-        chatId: 'test-chat',
+        prompt: 'Prompt 1',
+        chatId: 'chat-1',
       });
 
-      const updated = await manager.update(task.id, {
-        name: 'Updated Name',
+      await createScheduleFile(testDir, {
+        id: 'task-2',
+        name: 'Task 2',
         cron: '0 10 * * *',
+        prompt: 'Prompt 2',
+        chatId: 'chat-2',
       });
 
-      expect(updated).toBeDefined();
-      expect(updated?.name).toBe('Updated Name');
-      expect(updated?.cron).toBe('0 10 * * *');
-      expect(updated?.prompt).toBe('Original prompt'); // Unchanged
+      const allTasks = await manager.listAll();
+      expect(allTasks).toHaveLength(2);
+      expect(allTasks.map(t => t.name)).toEqual(expect.arrayContaining(['Task 1', 'Task 2']));
     });
   });
 
-  describe('toggle', () => {
-    it('should toggle task enabled status', async () => {
-      const task = await manager.create({
-        name: 'Test Task',
-        cron: '0 9 * * *',
-        prompt: 'Test prompt',
-        chatId: 'test-chat',
-      });
-
-      expect(task.enabled).toBe(true);
-
-      const disabled = await manager.toggle(task.id, false);
-      expect(disabled?.enabled).toBe(false);
-
-      const enabled = await manager.toggle(task.id, true);
-      expect(enabled?.enabled).toBe(true);
-    });
-  });
-
-  describe('delete', () => {
-    it('should delete a task', async () => {
-      const task = await manager.create({
-        name: 'Test Task',
-        cron: '0 9 * * *',
-        prompt: 'Test prompt',
-        chatId: 'test-chat',
-      });
-
-      const deleted = await manager.delete(task.id);
-      expect(deleted).toBe(true);
-
-      const notFound = await manager.get(task.id);
-      expect(notFound).toBeUndefined();
-    });
-
-    it('should return false for non-existent task', async () => {
-      const deleted = await manager.delete('non-existent-id');
-      expect(deleted).toBe(false);
-    });
-  });
-
-  describe('markExecuted', () => {
-    it('should update lastExecutedAt in memory (not in file)', async () => {
-      const task = await manager.create({
-        name: 'Test Task',
-        cron: '0 9 * * *',
-        prompt: 'Test prompt',
-        chatId: 'test-chat',
-      });
-
-      // Initially no lastExecutedAt
-      expect(manager.getLastExecutedAt(task.id)).toBeUndefined();
-
-      // Mark as executed (synchronous, in-memory only)
-      manager.markExecuted(task.id);
-
-      // Should be available in memory
-      const lastExecutedAt = manager.getLastExecutedAt(task.id);
-      expect(lastExecutedAt).toBeDefined();
-      expect(lastExecutedAt instanceof Date).toBe(true);
-
-      // Should NOT be persisted to file
-      const taskFromFile = await manager.get(task.id);
-      expect(taskFromFile?.lastExecutedAt).toBeUndefined();
-    });
-
-    it('should clear lastExecutedAt cache on delete', async () => {
-      const task = await manager.create({
-        name: 'Test Task',
-        cron: '0 9 * * *',
-        prompt: 'Test prompt',
-        chatId: 'test-chat',
-      });
-
-      manager.markExecuted(task.id);
-      expect(manager.getLastExecutedAt(task.id)).toBeDefined();
-
-      await manager.delete(task.id);
-      expect(manager.getLastExecutedAt(task.id)).toBeUndefined();
+  describe('getFileScanner', () => {
+    it('should return the file scanner instance', () => {
+      const scanner = manager.getFileScanner();
+      expect(scanner).toBeDefined();
     });
   });
 
@@ -266,30 +199,33 @@ describe('ScheduleManager', () => {
 
   describe('Issue #86: 删除任务后一致性', () => {
     it('should not show deleted task after delete (no cache)', async () => {
-      // Create a task
-      const task = await manager.create({
+      // Create a task file
+      await createScheduleFile(testDir, {
+        id: 'task-to-delete',
         name: 'Task to Delete',
         cron: '* * * * *',
         prompt: 'Test prompt',
         chatId: 'test-chat',
       });
 
+      const expectedId = getTaskId('task-to-delete');
+
       // Verify task exists
       const tasksBefore = await manager.listByChatId('test-chat');
       expect(tasksBefore).toHaveLength(1);
-      expect(tasksBefore[0].id).toBe(task.id);
+      expect(tasksBefore[0].id).toBe(expectedId);
 
-      // Delete the task
-      const deleted = await manager.delete(task.id);
-      expect(deleted).toBe(true);
+      // Delete the task file directly
+      await deleteScheduleFile(testDir, 'task-to-delete');
 
       // Verify task is removed (reads from file system, no cache)
       const tasksAfter = await manager.listByChatId('test-chat');
       expect(tasksAfter).toHaveLength(0);
     });
 
-    it('should not show deleted task in listAll after delete', async () => {
-      const task = await manager.create({
+    it('should not show deleted task in listAll after file deletion', async () => {
+      await createScheduleFile(testDir, {
+        id: 'task-to-delete',
         name: 'Task to Delete',
         cron: '* * * * *',
         prompt: 'Test',
@@ -300,28 +236,30 @@ describe('ScheduleManager', () => {
       let allTasks = await manager.listAll();
       expect(allTasks).toHaveLength(1);
 
-      // Delete
-      await manager.delete(task.id);
+      // Delete file directly
+      await deleteScheduleFile(testDir, 'task-to-delete');
 
       // Verify listAll returns empty (reads from file system)
       allTasks = await manager.listAll();
       expect(allTasks).toHaveLength(0);
     });
 
-    it('should not show deleted task in listEnabled after delete', async () => {
-      const task = await manager.create({
+    it('should not show deleted task in listEnabled after file deletion', async () => {
+      await createScheduleFile(testDir, {
+        id: 'enabled-task',
         name: 'Enabled Task',
         cron: '* * * * *',
         prompt: 'Test',
         chatId: 'chat-1',
+        enabled: true,
       });
 
       // Verify task is enabled
       let enabledTasks = await manager.listEnabled();
       expect(enabledTasks).toHaveLength(1);
 
-      // Delete
-      await manager.delete(task.id);
+      // Delete file
+      await deleteScheduleFile(testDir, 'enabled-task');
 
       // Verify listEnabled returns empty
       enabledTasks = await manager.listEnabled();
@@ -331,27 +269,26 @@ describe('ScheduleManager', () => {
 
   describe('Issue #86: 外部文件修改立即可见', () => {
     it('should see external file modifications immediately (no cache)', async () => {
-      // Create task via manager
-      const task = await manager.create({
+      const createdAt = new Date().toISOString();
+
+      // Create task file
+      await createScheduleFile(testDir, {
+        id: 'original-task',
         name: 'Original Task',
         cron: '0 9 * * *',
         prompt: 'Original',
         chatId: 'chat-1',
+        createdAt,
       });
 
-      // Get the task file path
-      const files = await fs.readdir(testDir);
-      const taskFile = files.find(f => f.includes('original-task'));
-      expect(taskFile).toBeDefined();
-
       // Manually modify the file (simulate external change)
-      const filePath = path.join(testDir, taskFile!);
+      const filePath = path.join(testDir, 'original-task.md');
       const modifiedContent = `---
 name: "Modified Task"
 cron: "0 10 * * *"
 enabled: true
 chatId: "chat-1"
-createdAt: "${task.createdAt}"
+createdAt: "${createdAt}"
 ---
 Modified prompt`;
       await fs.writeFile(filePath, modifiedContent);
@@ -366,7 +303,8 @@ Modified prompt`;
 
     it('should see external file deletion immediately (no cache)', async () => {
       // Create task
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-to-remove',
         name: 'Task to Remove',
         cron: '* * * * *',
         prompt: 'Test',
@@ -378,11 +316,7 @@ Modified prompt`;
       expect(tasks).toHaveLength(1);
 
       // Manually delete the file
-      const files = await fs.readdir(testDir);
-      const taskFile = files.find(f => f.includes('task-to-remove'));
-      if (taskFile) {
-        await fs.unlink(path.join(testDir, taskFile));
-      }
+      await deleteScheduleFile(testDir, 'task-to-remove');
 
       // No need to invalidate cache - next read sees deletion
       tasks = await manager.listAll();
@@ -393,29 +327,32 @@ Modified prompt`;
   describe('Issue #86: 多任务删除一致性', () => {
     it('should correctly handle deleting one of multiple tasks', async () => {
       // Create multiple tasks
-      const task1 = await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-1',
         name: 'Task 1',
         cron: '0 9 * * *',
         prompt: 'Prompt 1',
         chatId: 'chat-1',
       });
 
-      const task2 = await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-2',
         name: 'Task 2',
         cron: '0 10 * * *',
         prompt: 'Prompt 2',
         chatId: 'chat-1',
       });
 
-      const task3 = await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-3',
         name: 'Task 3',
         cron: '0 11 * * *',
         prompt: 'Prompt 3',
         chatId: 'chat-2',
       });
 
-      // Delete task2
-      await manager.delete(task2.id);
+      // Delete task2 file
+      await deleteScheduleFile(testDir, 'task-2');
 
       // Verify task1 and task3 still exist
       const allTasks = await manager.listAll();
@@ -425,54 +362,84 @@ Modified prompt`;
       // Verify chat-1 has only task1
       const chat1Tasks = await manager.listByChatId('chat-1');
       expect(chat1Tasks).toHaveLength(1);
-      expect(chat1Tasks[0].id).toBe(task1.id);
+      expect(chat1Tasks[0].id).toBe(getTaskId('task-1'));
 
       // Verify chat-2 has task3
       const chat2Tasks = await manager.listByChatId('chat-2');
       expect(chat2Tasks).toHaveLength(1);
-      expect(chat2Tasks[0].id).toBe(task3.id);
+      expect(chat2Tasks[0].id).toBe(getTaskId('task-3'));
     });
   });
 
   describe('No Cache: 文件系统是唯一真相', () => {
     it('should always read fresh data from files', async () => {
-      // Create task
-      const task = await manager.create({
+      const createdAt = new Date().toISOString();
+
+      // Create task file
+      await createScheduleFile(testDir, {
+        id: 'test-task',
         name: 'Test Task',
         cron: '0 9 * * *',
         prompt: 'Original',
         chatId: 'chat-1',
+        createdAt,
       });
 
+      const expectedId = getTaskId('test-task');
+
       // Read via get()
-      let fetched = await manager.get(task.id);
+      let fetched = await manager.get(expectedId);
       expect(fetched?.prompt).toBe('Original');
 
-      // Update via manager
-      await manager.update(task.id, { prompt: 'Updated' });
+      // Modify file directly
+      const filePath = path.join(testDir, 'test-task.md');
+      const modifiedContent = `---
+name: "Test Task"
+cron: "0 9 * * *"
+enabled: true
+chatId: "chat-1"
+createdAt: "${createdAt}"
+---
+Updated`;
+      await fs.writeFile(filePath, modifiedContent);
 
       // Read again - should see updated value
-      fetched = await manager.get(task.id);
+      fetched = await manager.get(expectedId);
       expect(fetched?.prompt).toBe('Updated');
     });
 
     it('should see changes from another manager instance', async () => {
-      // Create task with first manager
-      const task = await manager.create({
+      const createdAt = new Date().toISOString();
+
+      // Create task file
+      await createScheduleFile(testDir, {
+        id: 'test-task',
         name: 'Test Task',
         cron: '0 9 * * *',
         prompt: 'Original',
         chatId: 'chat-1',
+        createdAt,
       });
+
+      const expectedId = getTaskId('test-task');
 
       // Create second manager (simulating another process)
       const manager2 = new ScheduleManager({ schedulesDir: testDir });
 
-      // Update via second manager
-      await manager2.update(task.id, { prompt: 'Updated by manager2' });
+      // Modify file directly (simulating update via another process)
+      const filePath = path.join(testDir, 'test-task.md');
+      const modifiedContent = `---
+name: "Test Task"
+cron: "0 9 * * *"
+enabled: true
+chatId: "chat-1"
+createdAt: "${createdAt}"
+---
+Updated by manager2`;
+      await fs.writeFile(filePath, modifiedContent);
 
       // First manager should see the change
-      const fetched = await manager.get(task.id);
+      const fetched = await manager.get(expectedId);
       expect(fetched?.prompt).toBe('Updated by manager2');
     });
   });

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -1,18 +1,20 @@
 /**
- * Schedule Manager - CRUD operations for scheduled tasks.
+ * Schedule Manager - Query operations for scheduled tasks.
  *
  * Manages scheduled tasks that are triggered by cron expressions.
  * Tasks are persisted as markdown files in the schedules/ directory.
  *
  * Features:
- * - CRUD operations for scheduled tasks
+ * - Query operations for scheduled tasks (list, get)
  * - File-based persistence (markdown with YAML frontmatter)
  * - Scope by chatId (each chat has its own tasks)
  * - No cache: always reads from file system for consistency
+ *
+ * Note: CRUD operations (create/update/delete) are handled via file system directly.
+ * Users create schedule files manually, and ScheduleFileWatcher auto-loads them.
  */
 
 import { createLogger } from '../utils/logger.js';
-import { v4 as uuidv4 } from 'uuid';
 import { ScheduleFileScanner } from './schedule-watcher.js';
 
 const logger = createLogger('ScheduleManager');
@@ -39,21 +41,8 @@ export interface ScheduledTask {
   blocking?: boolean;
   /** Creation timestamp */
   createdAt: string;
-  /** Last execution timestamp */
+  /** Last execution timestamp (read from file, for display purposes only) */
   lastExecutedAt?: string;
-}
-
-/**
- * Options for creating a new scheduled task.
- */
-export interface CreateScheduleOptions {
-  name: string;
-  cron: string;
-  prompt: string;
-  chatId: string;
-  createdBy?: string;
-  /** Whether to block concurrent executions */
-  blocking?: boolean;
 }
 
 /**
@@ -65,40 +54,24 @@ export interface ScheduleManagerOptions {
 }
 
 /**
- * ScheduleManager - Manages CRUD operations for scheduled tasks.
+ * ScheduleManager - Manages scheduled task queries.
  *
  * No cache: all operations read directly from file system.
  * This ensures perfect consistency - file system is the single source of truth.
- *
- * Note: Execution state (lastExecutedAt) is tracked in memory, not persisted to files.
- * This prevents file contention during scheduled task execution.
  *
  * Usage:
  * ```typescript
  * const manager = new ScheduleManager({ schedulesDir: './workspace/schedules' });
  *
- * // Create a task
- * const task = await manager.create({
- *   name: 'Daily Reminder',
- *   cron: '0 9 * * *',
- *   prompt: 'Remind me to check emails',
- *   chatId: 'oc_xxx',
- * });
- *
  * // List tasks for a chat
  * const tasks = await manager.listByChatId('oc_xxx');
  *
- * // Toggle task
- * await manager.toggle(task.id, false);
- *
- * // Delete task
- * await manager.delete(task.id);
+ * // List all enabled tasks (for scheduler)
+ * const enabledTasks = await manager.listEnabled();
  * ```
  */
 export class ScheduleManager {
   private fileScanner: ScheduleFileScanner;
-  /** In-memory cache for last execution times (not persisted to files) */
-  private lastExecutedAtCache: Map<string, Date> = new Map();
 
   constructor(options: ScheduleManagerOptions) {
     this.fileScanner = new ScheduleFileScanner({ schedulesDir: options.schedulesDir });
@@ -123,47 +96,6 @@ export class ScheduleManager {
    */
   getFileScanner(): ScheduleFileScanner {
     return this.fileScanner;
-  }
-
-  /**
-   * Create a new scheduled task.
-   *
-   * @param options - Task creation options
-   * @returns The created task
-   */
-  async create(options: CreateScheduleOptions): Promise<ScheduledTask> {
-    const slug = this.generateSlug(options.name);
-    const task: ScheduledTask = {
-      id: `schedule-${slug}`,
-      name: options.name,
-      cron: options.cron,
-      prompt: options.prompt,
-      chatId: options.chatId,
-      createdBy: options.createdBy,
-      enabled: true,
-      blocking: options.blocking,
-      createdAt: new Date().toISOString(),
-    };
-
-    // Write to file
-    await this.fileScanner.writeTask(task);
-
-    logger.info({ taskId: task.id, name: task.name, chatId: task.chatId }, 'Created scheduled task');
-    return task;
-  }
-
-  /**
-   * Generate a slug from task name.
-   */
-  private generateSlug(name: string): string {
-    const baseSlug = name
-      .toLowerCase()
-      .replace(/[^a-z0-9\u4e00-\u9fff]+/g, '-')
-      .replace(/^-+|-+$/g, '');
-
-    // Add short UUID to ensure uniqueness
-    const shortId = uuidv4().slice(0, 8);
-    return `${baseSlug}-${shortId}`;
   }
 
   /**
@@ -206,95 +138,5 @@ export class ScheduleManager {
   async listAll(): Promise<ScheduledTask[]> {
     const tasks = await this.loadAll();
     return Array.from(tasks.values());
-  }
-
-  /**
-   * Update a task.
-   *
-   * @param id - Task ID
-   * @param updates - Fields to update
-   * @returns The updated task or undefined if not found
-   */
-  async update(id: string, updates: Partial<Omit<ScheduledTask, 'id' | 'createdAt'>>): Promise<ScheduledTask | undefined> {
-    const tasks = await this.loadAll();
-    const task = tasks.get(id);
-    if (!task) {
-      return undefined;
-    }
-
-    const updatedTask: ScheduledTask = {
-      ...task,
-      ...updates,
-    };
-
-    // Write to file
-    await this.fileScanner.writeTask(updatedTask);
-
-    logger.info({ taskId: id, updates }, 'Updated scheduled task');
-    return updatedTask;
-  }
-
-  /**
-   * Toggle task enabled status.
-   *
-   * @param id - Task ID
-   * @param enabled - New enabled status
-   * @returns The updated task or undefined if not found
-   */
-  toggle(id: string, enabled: boolean): Promise<ScheduledTask | undefined> {
-    return this.update(id, { enabled });
-  }
-
-  /**
-   * Update last execution time (in-memory only, not persisted to file).
-   *
-   * This method only updates the in-memory cache to avoid file contention
-   * during scheduled task execution. The schedule.md files remain read-only
-   * during execution.
-   *
-   * @param id - Task ID
-   */
-  markExecuted(id: string): void {
-    this.lastExecutedAtCache.set(id, new Date());
-    logger.debug({ taskId: id }, 'Marked task as executed (in-memory)');
-  }
-
-  /**
-   * Get the last execution time for a task.
-   *
-   * @param id - Task ID
-   * @returns Last execution time or undefined if never executed
-   */
-  getLastExecutedAt(id: string): Date | undefined {
-    return this.lastExecutedAtCache.get(id);
-  }
-
-  /**
-   * Clear the last execution time cache for a task.
-   *
-   * @param id - Task ID
-   */
-  clearLastExecutedAt(id: string): void {
-    this.lastExecutedAtCache.delete(id);
-  }
-
-  /**
-   * Delete a task.
-   *
-   * @param id - Task ID
-   * @returns true if deleted, false if not found
-   */
-  async delete(id: string): Promise<boolean> {
-    // Delete file
-    const deleted = await this.fileScanner.deleteTask(id);
-    if (!deleted) {
-      return false;
-    }
-
-    // Clear in-memory cache
-    this.lastExecutedAtCache.delete(id);
-
-    logger.info({ taskId: id }, 'Deleted scheduled task');
-    return true;
   }
 }

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -33,6 +33,48 @@ const createMockCallbacks = (): PilotCallbacks => ({
   sendFile: vi.fn().mockResolvedValue(undefined),
 });
 
+/**
+ * Helper to create a schedule file directly in the file system.
+ * Note: The task ID is generated as `schedule-${fileName}` by ScheduleFileScanner.
+ */
+async function createScheduleFile(
+  testDir: string,
+  task: {
+    id: string;  // Base name (without .md), ID will be `schedule-${id}`
+    name: string;
+    cron: string;
+    prompt: string;
+    chatId: string;
+    enabled?: boolean;
+  }
+): Promise<void> {
+  const filePath = path.join(testDir, `${task.id}.md`);
+  const content = `---
+name: "${task.name}"
+cron: "${task.cron}"
+enabled: ${task.enabled ?? true}
+chatId: "${task.chatId}"
+createdAt: "${new Date().toISOString()}"
+---
+${task.prompt}`;
+  await fs.writeFile(filePath, content);
+}
+
+/**
+ * Helper to get the expected task ID from base name.
+ */
+function getTaskId(baseName: string): string {
+  return `schedule-${baseName}`;
+}
+
+/**
+ * Helper to delete a schedule file directly.
+ */
+async function deleteScheduleFile(testDir: string, baseName: string): Promise<void> {
+  const filePath = path.join(testDir, `${baseName}.md`);
+  await fs.unlink(filePath).catch(() => {});
+}
+
 describe('Scheduler', () => {
   let scheduler: Scheduler;
   let manager: ScheduleManager;
@@ -235,8 +277,9 @@ describe('Scheduler', () => {
 
   describe('Issue #86: start/stop 不重复加载', () => {
     it('should not duplicate jobs when start is called twice', async () => {
-      // Create task in manager
-      await manager.create({
+      // Create task file directly
+      await createScheduleFile(testDir, {
+        id: 'test-task',
         name: 'Test Task',
         cron: '0 9 * * *',
         prompt: 'Test',
@@ -252,14 +295,16 @@ describe('Scheduler', () => {
     });
 
     it('should clear all jobs on stop', async () => {
-      // Create and start
-      await manager.create({
+      // Create task files directly
+      await createScheduleFile(testDir, {
+        id: 'task-1',
         name: 'Task 1',
         cron: '0 9 * * *',
         prompt: 'Test',
         chatId: 'chat-1',
       });
-      await manager.create({
+      await createScheduleFile(testDir, {
+        id: 'task-2',
         name: 'Task 2',
         cron: '0 10 * * *',
         prompt: 'Test',
@@ -276,22 +321,25 @@ describe('Scheduler', () => {
 
   describe('Issue #86: 任务删除后调度器状态', () => {
     it('should have no active job after task is deleted', async () => {
-      // Create and start
-      const task = await manager.create({
+      // Create task file directly
+      await createScheduleFile(testDir, {
+        id: 'task-to-delete',
         name: 'Task to Delete',
         cron: '0 9 * * *',
         prompt: 'Test',
         chatId: 'test-chat',
       });
 
+      const taskId = getTaskId('task-to-delete');
+
       await scheduler.start();
       expect(scheduler.getActiveJobs()).toHaveLength(1);
 
-      // Delete task from manager
-      await manager.delete(task.id);
+      // Delete task file directly
+      await deleteScheduleFile(testDir, 'task-to-delete');
 
       // Remove from scheduler (simulating task deletion flow)
-      scheduler.removeTask(task.id);
+      scheduler.removeTask(taskId);
 
       expect(scheduler.getActiveJobs()).toHaveLength(0);
     });

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -253,9 +253,6 @@ ${task.prompt}`;
         task.createdBy
       );
 
-      // Update last execution time (in-memory only, not persisted to file)
-      this.scheduleManager.markExecuted(task.id);
-
       logger.info({ taskId: task.id }, 'Scheduled task completed');
 
     } catch (error) {


### PR DESCRIPTION
## Summary

移除 `ScheduleManager` 中未被业务代码使用的方法和代码，减少代码复杂度和维护负担。

## Issue #354: 移除 lastExecutedAt 相关代码

移除以下内容：
- `lastExecutedAtCache` 私有属性
- `markExecuted()` 方法
- `getLastExecutedAt()` 方法
- `clearLastExecutedAt()` 方法
- scheduler.ts 中对 `markExecuted()` 的调用

**原因**: `getLastExecutedAt()` 只在测试中被调用，业务代码没有使用。防重复执行机制使用的是 `runningTasks: Set<string>`，与 `lastExecutedAt` 无关。

## Issue #355: 移除未使用的 CRUD 方法

移除以下内容：
- `create()` 方法
- `update()` 方法
- `toggle()` 方法
- `delete()` 方法
- `generateSlug()` 私有方法
- `CreateScheduleOptions` 接口
- uuid 依赖导入

**原因**: 这些方法只被测试代码调用，业务代码完全没有使用。用户通过手动创建 markdown 文件来添加定时任务，`ScheduleFileWatcher` 自动监听文件变化并加载。

## 保留的方法

以下方法被业务代码使用，已保留：
- `get(id)` - 按 ID 获取任务
- `listByChatId(chatId)` - 按聊天 ID 列出任务
- `listEnabled()` - 列出所有启用的任务（**Scheduler 使用**）
- `listAll()` - 列出所有任务
- `getFileScanner()` - 获取文件扫描器实例

## 影响

- 无功能影响（这些方法本来就没有被业务代码使用）
- 减少代码复杂度
- 减少维护负担
- 减少不必要的内存占用

## Verification

- ✅ 所有 1131 个测试通过
- ✅ 构建成功

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 验证 schedule 模块测试通过
- [x] 验证所有测试通过

Fixes #354
Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)