### PR TITLE
refactor(task): 统一 Reflection 模式 - 简化迭代逻辑 (#283)

### DIFF
--- a/src/task/dialogue-orchestrator.ts
+++ b/src/task/dialogue-orchestrator.ts
@@ -8,6 +8,13 @@
  * - Direct architecture: No intermediate layers, no JSON parsing
  * - Loop continues until max iterations reached or final_result.md detected
  *
+ * ## Integration with ReflectionController (Issue #283)
+ *
+ * This module uses ReflectionController for:
+ * - Iteration management with configurable termination conditions
+ * - Unified metrics collection
+ * - Event-based observability
+ *
  * ## File-Driven Architecture
  *
  * - Evaluator writes: iterations/iter-N/evaluation.md
@@ -31,6 +38,14 @@ import type { EvaluatorConfig } from '../agents/evaluator.js';
 import { IterationBridge } from './iteration-bridge.js';
 import { DialogueMessageTracker } from './dialogue-message-tracker.js';
 import { TaskFileManager } from './task-files.js';
+import {
+  ReflectionController,
+  TerminationConditions,
+  type ReflectionContext,
+  type ReflectionEvaluationResult,
+  type ReflectionEvent,
+  type ReflectionMetrics,
+} from './reflection.js';
 
 const logger = createLogger('DialogueOrchestrator', {});
 
@@ -44,6 +59,8 @@ export interface DialogueOrchestratorConfig {
 
 /**
  * DialogueOrchestrator - Manages streaming dialogue loop with Eval-Execute.
+ *
+ * Uses ReflectionController for unified iteration management (Issue #283).
  *
  * File-driven architecture:
  * - Message tracking delegated to DialogueMessageTracker
@@ -68,9 +85,10 @@ export class DialogueOrchestrator {
   private fileManager: TaskFileManager;
 
   private taskId: string = '';
-  private currentIterationTaskDone = false;
   private currentChatId?: string;
   private iterationCount: number = 0;
+  private reflectionController?: ReflectionController;
+  private taskComplete = false;
 
   constructor(config: DialogueOrchestratorConfig) {
     this.evaluatorConfig = config.evaluatorConfig;
@@ -90,6 +108,15 @@ export class DialogueOrchestrator {
   }
 
   /**
+   * Get the reflection metrics (if available).
+   *
+   * @returns Reflection metrics or undefined
+   */
+  getReflectionMetrics(): ReflectionMetrics | undefined {
+    return this.reflectionController?.getMetrics();
+  }
+
+  /**
    * Dispose resources held by the dialogue orchestrator.
    *
    * **IMPORTANT**: Call this method when the dialogue is complete to prevent memory leaks.
@@ -101,49 +128,17 @@ export class DialogueOrchestrator {
     this.taskId = '';
     this.currentChatId = undefined;
     this.messageTracker.reset();
+    this.reflectionController?.resetMetrics();
   }
 
   /**
-   * Process a single dialogue iteration with REAL-TIME streaming Evaluator-Executor communication.
-   *
-   * File-driven Flow:
-   *   1. Create IterationBridge with task context
-   *   2. Run iteration with streaming: Agent messages are yielded immediately
-   *   3. Check for final_result.md to determine task completion
-   *
-   * @param iteration - Current iteration number
-   * @returns Async iterable of AgentMessage (real-time execution output)
+   * Create a termination condition that checks for final_result.md.
    */
-  private async *processIterationStreaming(
-    iteration: number
-  ): AsyncIterable<AgentMessage> {
-    logger.debug({ iteration }, 'Processing iteration with file-driven Eval-Execute architecture');
-
-    // Create IterationBridge with all necessary context
-    const bridge = new IterationBridge({
-      evaluatorConfig: this.evaluatorConfig,
-      iteration,
-      taskId: this.taskId,
-      chatId: this.currentChatId,
-    });
-
-    // Run the iteration with streaming
-    for await (const msg of bridge.runIterationStreaming()) {
-      // Yield the message for immediate delivery to user
-      yield msg;
-    }
-
-    // Check for task completion via final_result.md (created by Executor)
-    const hasFinalResult = await this.fileManager.hasFinalResult(this.taskId);
-
-    // Log completion status
-    logger.info({
-      iteration,
-      hasFinalResult,
-    }, 'Streaming iteration complete');
-
-    // Update completion status for return value check
-    this.currentIterationTaskDone = hasFinalResult;
+  private createFinalResultCondition(taskId: string) {
+    return async (_context: ReflectionContext, _result: ReflectionEvaluationResult): Promise<boolean> => {
+      const hasFinalResult = await this.fileManager.hasFinalResult(taskId);
+      return hasFinalResult;
+    };
   }
 
   /**
@@ -153,6 +148,11 @@ export class DialogueOrchestrator {
    * - Evaluator writes evaluation.md
    * - Executor reads evaluation.md and writes execution.md + final_result.md
    * - Task completion detected when final_result.md is created
+   *
+   * **Uses ReflectionController** (Issue #283) for:
+   * - Iteration management
+   * - Metrics collection
+   * - Event-based observability
    *
    * @param taskPath - Path to Task.md file
    * @param _originalRequest - Original user request text (unused)
@@ -169,71 +169,75 @@ export class DialogueOrchestrator {
     // Extract taskId from the parent directory name (e.g., /path/to/tasks/cli-123/task.md -> cli-123)
     const taskDir = path.dirname(taskPath);
     this.taskId = path.basename(taskDir);
-    this.currentIterationTaskDone = false;
     this.currentChatId = chatId;
     this.iterationCount = 0;
-
-    let iteration = 0;
+    this.taskComplete = false;
 
     logger.info(
       { taskId: this.taskId, chatId, taskPath, maxIterations: this.maxIterations },
-      'Starting file-driven Eval-Execute dialogue flow'
+      'Starting file-driven Eval-Execute dialogue flow with ReflectionController'
     );
 
-    // Main dialogue loop: Evaluator → Executor → Evaluator → Executor → ...
-    while (iteration < this.maxIterations) {
-      iteration++;
-      this.iterationCount = iteration;
+    // Create ReflectionController with evaluateFirst mode for Eval-Exec pattern
+    this.reflectionController = new ReflectionController(
+      {
+        maxIterations: this.maxIterations,
+        confidenceThreshold: 0.8,
+        enableMetrics: true,
+        evaluateFirst: true, // Eval-Exec pattern: Evaluate → Execute
+        onEvent: (event: ReflectionEvent) => {
+          logger.debug({ event }, 'Reflection event');
+        },
+      },
+      [
+        TerminationConditions.maxIterations(this.maxIterations),
+        this.createFinalResultCondition(this.taskId),
+      ]
+    );
 
-      logger.info(
-        { taskId: this.taskId, chatId, iteration, maxIterations: this.maxIterations },
-        'Starting iteration'
+    // Create phase executors that wrap IterationBridge
+    const evaluatePhase = this.createEvaluatePhase();
+    const executePhase = this.createExecutePhase();
+
+    try {
+      // Run reflection cycle
+      const generator = this.reflectionController.run(
+        this.taskId,
+        executePhase,
+        evaluatePhase
       );
 
-      // Reset task done flag for this iteration
-      this.currentIterationTaskDone = false;
-
-      // Process iteration with REAL-TIME streaming
-      try {
-        for await (const msg of this.processIterationStreaming(iteration)) {
-          // Yield the message immediately to the user
-          yield msg;
-        }
-      } catch (error) {
-        logger.error(
-          { err: error, taskId: this.taskId, chatId, iteration },
-          'Error during iteration processing'
-        );
-        throw error;
+      // Yield all messages
+      let result = await generator.next();
+      while (!result.done) {
+        yield result.value;
+        result = await generator.next();
       }
 
-      // Check if task was completed during this iteration
-      if (this.currentIterationTaskDone) {
-        logger.info(
-          { taskId: this.taskId, chatId, iteration },
-          'Task completed during this iteration'
-        );
-        break;
-      }
+      // Check if task completed
+      this.taskComplete = await this.fileManager.hasFinalResult(this.taskId);
+      this.iterationCount = this.reflectionController.getMetrics().totalIterations;
 
-      logger.info(
-        { taskId: this.taskId, chatId, iteration },
-        'Iteration completed, task not yet done'
+    } catch (error) {
+      logger.error(
+        { err: error, taskId: this.taskId, chatId },
+        'Error during reflection cycle'
       );
+      throw error;
     }
 
     // Write final summary when task completes
-    if (this.currentIterationTaskDone) {
+    if (this.taskComplete) {
       await this.writeFinalSummary();
     }
 
     // Log warning if max iterations reached without task completion
-    if (iteration >= this.maxIterations && !this.currentIterationTaskDone) {
+    if (this.iterationCount >= this.maxIterations && !this.taskComplete) {
       logger.warn(
         {
           taskId: this.taskId,
           chatId,
-          iteration,
+          iteration: this.iterationCount,
           maxIterations: this.maxIterations,
         },
         'Task stopped after reaching maximum iterations without completion signal'
@@ -241,9 +245,49 @@ export class DialogueOrchestrator {
     }
 
     logger.info(
-      { taskId: this.taskId, chatId, totalIterations: iteration, completed: this.currentIterationTaskDone },
+      { taskId: this.taskId, chatId, totalIterations: this.iterationCount, completed: this.taskComplete },
       'Dialogue flow finished'
     );
+  }
+
+  /**
+   * Create the Evaluate phase executor.
+   *
+   * Uses IterationBridge to run the Evaluator.
+   */
+  private createEvaluatePhase() {
+    const self = this;
+    return async function* (context: ReflectionContext): AsyncGenerator<AgentMessage> {
+      const bridge = new IterationBridge({
+        evaluatorConfig: self.evaluatorConfig,
+        iteration: context.iteration,
+        taskId: context.taskId,
+        chatId: self.currentChatId,
+      });
+
+      // Run evaluator phase only (not the full iteration)
+      yield* bridge.runEvaluatorOnly();
+    };
+  }
+
+  /**
+   * Create the Execute phase executor.
+   *
+   * Uses IterationBridge to run the Executor.
+   */
+  private createExecutePhase() {
+    const self = this;
+    return async function* (context: ReflectionContext): AsyncGenerator<AgentMessage> {
+      const bridge = new IterationBridge({
+        evaluatorConfig: self.evaluatorConfig,
+        iteration: context.iteration,
+        taskId: context.taskId,
+        chatId: self.currentChatId,
+      });
+
+      // Run executor phase only
+      yield* bridge.runExecutorOnly();
+    };
   }
 
   /**
@@ -265,6 +309,7 @@ export class DialogueOrchestrator {
   private generateFinalSummary(): string {
     const timestamp = new Date().toISOString();
     const duration = this.iterationCount > 0 ? `${this.iterationCount} iterations` : 'Unknown';
+    const metrics = this.reflectionController?.getMetrics();
 
     return `# Final Summary: ${this.taskId}
 
@@ -280,6 +325,13 @@ Task completed successfully after ${this.iterationCount} iteration(s).
 ## Iteration History
 
 ${Array.from({ length: this.iterationCount }, (_, i) => `- Iteration ${i + 1}: Executed`).join('\n')}
+
+## Reflection Metrics
+
+- Total Iterations: ${metrics?.totalIterations ?? 'N/A'}
+- Successful: ${metrics?.successfulIterations ?? 'N/A'}
+- Failed: ${metrics?.failedIterations ?? 'N/A'}
+- Avg Duration: ${metrics?.avgIterationDurationMs?.toFixed(0) ?? 'N/A'}ms
 
 ## Final Results
 

--- a/src/task/iteration-bridge.ts
+++ b/src/task/iteration-bridge.ts
@@ -510,4 +510,161 @@ export class IterationBridge {
       return '';
     }
   }
+
+  // ============================================================================
+  // Separated Phase Methods (for ReflectionController integration - Issue #283)
+  // ============================================================================
+
+  /**
+   * Run only the Evaluator phase.
+   *
+   * This method is designed to be used with ReflectionController's
+   * evaluateFirst mode, where the Evaluator runs first to check
+   * task completion status.
+   *
+   * @yields AgentMessage from the Evaluator
+   */
+  async *runEvaluatorOnly(): AsyncIterable<AgentMessage> {
+    logger.info({
+      iteration: this.iteration,
+      taskId: this.taskId,
+    }, 'Running Evaluator phase only (for ReflectionController)');
+
+    this.initMetrics();
+    this.emitEvent('phase_start', { phase: 'evaluate' });
+    const evaluateStart = Date.now();
+    let evaluateMessageCount = 0;
+
+    const evaluator = new Evaluator(this.evaluatorConfig);
+
+    try {
+      // Evaluator writes evaluation.md
+      for await (const msg of evaluator.evaluate(this.taskId, this.iteration)) {
+        evaluateMessageCount++;
+        if (this.metrics) {
+          this.metrics.phases.evaluate.messageCount++;
+          this.metrics.totalMessages++;
+        }
+        yield msg;
+      }
+
+      const evaluateDuration = Date.now() - evaluateStart;
+      if (this.metrics) {
+        this.metrics.phases.evaluate.endTime = new Date();
+        this.metrics.phases.evaluate.durationMs = evaluateDuration;
+      }
+
+      this.emitEvent('phase_end', {
+        phase: 'evaluate',
+        durationMs: evaluateDuration,
+        messageCount: evaluateMessageCount,
+      });
+
+      logger.info({
+        iteration: this.iteration,
+        taskId: this.taskId,
+        durationMs: evaluateDuration,
+        messageCount: evaluateMessageCount,
+      }, 'Evaluator phase complete');
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      if (this.metrics) {
+        this.metrics.phases.evaluate.failed = true;
+        this.metrics.phases.evaluate.error = errorMsg;
+        this.metrics.phases.evaluate.endTime = new Date();
+        this.metrics.phases.evaluate.durationMs = Date.now() - evaluateStart;
+      }
+
+      this.emitEvent('error', { phase: 'evaluate', error: errorMsg });
+      logger.error({
+        err: error,
+        iteration: this.iteration,
+        taskId: this.taskId,
+      }, 'Evaluator phase failed');
+      throw error;
+    } finally {
+      evaluator.dispose();
+    }
+  }
+
+  /**
+   * Run only the Executor phase.
+   *
+   * This method is designed to be used with ReflectionController's
+   * evaluateFirst mode, where the Executor runs after the Evaluator
+   * determines that more work is needed.
+   *
+   * @yields AgentMessage from the Executor
+   */
+  async *runExecutorOnly(): AsyncIterable<AgentMessage> {
+    logger.info({
+      iteration: this.iteration,
+      taskId: this.taskId,
+    }, 'Running Executor phase only (for ReflectionController)');
+
+    // Initialize execute phase metrics if not already done
+    if (!this.metrics) {
+      this.initMetrics();
+    }
+
+    this.emitEvent('phase_start', { phase: 'execute' });
+    const executeStart = Date.now();
+
+    // Initialize execute phase metrics
+    if (this.metrics) {
+      this.metrics.phases.execute = {
+        phase: 'execute',
+        startTime: new Date(),
+        messageCount: 0,
+        failed: false,
+      };
+    }
+
+    let executeMessageCount = 0;
+    try {
+      for await (const msg of this.executeTask()) {
+        executeMessageCount++;
+        if (this.metrics && this.metrics.phases.execute) {
+          this.metrics.phases.execute.messageCount++;
+          this.metrics.totalMessages++;
+        }
+        yield msg;
+      }
+
+      const executeDuration = Date.now() - executeStart;
+      if (this.metrics && this.metrics.phases.execute) {
+        this.metrics.phases.execute.endTime = new Date();
+        this.metrics.phases.execute.durationMs = executeDuration;
+      }
+
+      this.emitEvent('phase_end', {
+        phase: 'execute',
+        durationMs: executeDuration,
+        messageCount: executeMessageCount,
+      });
+
+      logger.info({
+        iteration: this.iteration,
+        taskId: this.taskId,
+        durationMs: executeDuration,
+        messageCount: executeMessageCount,
+      }, 'Executor phase complete');
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      if (this.metrics && this.metrics.phases.execute) {
+        this.metrics.phases.execute.failed = true;
+        this.metrics.phases.execute.error = errorMsg;
+        this.metrics.phases.execute.endTime = new Date();
+        this.metrics.phases.execute.durationMs = Date.now() - executeStart;
+      }
+
+      this.emitEvent('error', { phase: 'execute', error: errorMsg });
+      logger.error({
+        err: error,
+        taskId: this.taskId,
+        iteration: this.iteration,
+      }, 'Executor phase failed');
+      throw error;
+    }
+  }
 }

--- a/src/task/reflection.ts
+++ b/src/task/reflection.ts
@@ -131,6 +131,12 @@ export interface ReflectionConfig {
   enableMetrics: boolean;
   /** Event handler for observability */
   onEvent?: (event: ReflectionEvent) => void;
+  /**
+   * Whether to run Evaluate phase before Execute phase (default: false).
+   * When true: Evaluate → Execute → Reflect (for Eval-Exec pattern)
+   * When false: Execute → Evaluate → Reflect (standard Reflection pattern)
+   */
+  evaluateFirst?: boolean;
 }
 
 /**
@@ -140,6 +146,7 @@ export const DEFAULT_REFLECTION_CONFIG: ReflectionConfig = {
   maxIterations: 10,
   confidenceThreshold: 0.8,
   enableMetrics: true,
+  evaluateFirst: false,
 };
 
 // ============================================================================
@@ -370,6 +377,9 @@ export class ReflectionController {
 
   /**
    * Run a single iteration of the reflection cycle.
+   *
+   * When evaluateFirst is true: Evaluate → Execute → Reflect
+   * When evaluateFirst is false: Execute → Evaluate → Reflect
    */
   private async *runIteration(
     taskId: string,
@@ -388,34 +398,7 @@ export class ReflectionController {
     this.emitEvent('iteration_start', taskId, iteration);
     const iterationStart = Date.now();
 
-    // Phase 1: Execute
-    this.emitEvent('phase_start', taskId, iteration, { phase: 'execute' });
-    const executeStart = Date.now();
     let executeFailed = false;
-
-    try {
-      for await (const msg of executePhase(context)) {
-        yield msg;
-      }
-    } catch (error) {
-      executeFailed = true;
-      logger.error({ err: error, taskId, iteration }, 'Execute phase failed');
-      yield {
-        content: `❌ Execute phase failed: ${error instanceof Error ? error.message : String(error)}`,
-        role: 'assistant',
-        messageType: 'error',
-      };
-    }
-
-    const executeDuration = Date.now() - executeStart;
-    if (this.config.enableMetrics) {
-      updatePhaseMetrics(this.metrics, 'execute', executeDuration, executeFailed);
-    }
-    this.emitEvent('phase_end', taskId, iteration, { phase: 'execute', durationMs: executeDuration });
-
-    // Phase 2: Evaluate
-    this.emitEvent('phase_start', taskId, iteration, { phase: 'evaluate' });
-    const evaluateStart = Date.now();
     let evaluateFailed = false;
     let evaluationResult: ReflectionEvaluationResult = {
       isComplete: false,
@@ -423,37 +406,23 @@ export class ReflectionController {
       reasoning: 'Evaluation not completed',
     };
 
-    try {
-      // Collect evaluation messages and determine result
-      for await (const msg of evaluatePhase(context)) {
-        yield msg;
-        // Note: In real implementation, the Evaluator writes evaluation.md
-        // and we would parse it to determine the result
+    if (this.config.evaluateFirst) {
+      // Eval-Exec Pattern: Evaluate → Execute → Reflect
+      // Phase 1: Evaluate
+      evaluationResult = yield* this.runEvaluatePhase(taskId, iteration, context, evaluatePhase);
+
+      // Phase 2: Execute (only if task not complete)
+      if (!evaluationResult.isComplete) {
+        executeFailed = yield* this.runExecutePhase(taskId, iteration, context, executePhase);
       }
+    } else {
+      // Standard Pattern: Execute → Evaluate → Reflect
+      // Phase 1: Execute
+      executeFailed = yield* this.runExecutePhase(taskId, iteration, context, executePhase);
 
-      // Default evaluation - task needs more work
-      // In real implementation, this would be determined by parsing evaluation.md
-      evaluationResult = {
-        isComplete: false,
-        confidence: 0.5,
-        reasoning: 'Evaluation completed, task needs more work',
-        nextActions: ['Continue execution'],
-      };
-    } catch (error) {
-      evaluateFailed = true;
-      logger.error({ err: error, taskId, iteration }, 'Evaluate phase failed');
-      yield {
-        content: `❌ Evaluate phase failed: ${error instanceof Error ? error.message : String(error)}`,
-        role: 'assistant',
-        messageType: 'error',
-      };
+      // Phase 2: Evaluate
+      evaluationResult = yield* this.runEvaluatePhase(taskId, iteration, context, evaluatePhase);
     }
-
-    const evaluateDuration = Date.now() - evaluateStart;
-    if (this.config.enableMetrics) {
-      updatePhaseMetrics(this.metrics, 'evaluate', evaluateDuration, evaluateFailed);
-    }
-    this.emitEvent('phase_end', taskId, iteration, { phase: 'evaluate', durationMs: evaluateDuration });
 
     // Phase 3: Reflect (optional)
     if (reflectPhase && !evaluationResult.isComplete) {
@@ -493,6 +462,96 @@ export class ReflectionController {
       durationMs: iterationDuration,
       evaluationResult,
     });
+
+    return evaluationResult;
+  }
+
+  /**
+   * Run the Execute phase.
+   * @returns Whether the phase failed
+   */
+  private async *runExecutePhase(
+    taskId: string,
+    iteration: number,
+    context: ReflectionContext,
+    executePhase: ExecutePhaseExecutor
+  ): AsyncGenerator<AgentMessage, boolean> {
+    this.emitEvent('phase_start', taskId, iteration, { phase: 'execute' });
+    const executeStart = Date.now();
+    let executeFailed = false;
+
+    try {
+      for await (const msg of executePhase(context)) {
+        yield msg;
+      }
+    } catch (error) {
+      executeFailed = true;
+      logger.error({ err: error, taskId, iteration }, 'Execute phase failed');
+      yield {
+        content: `❌ Execute phase failed: ${error instanceof Error ? error.message : String(error)}`,
+        role: 'assistant',
+        messageType: 'error',
+      };
+    }
+
+    const executeDuration = Date.now() - executeStart;
+    if (this.config.enableMetrics) {
+      updatePhaseMetrics(this.metrics, 'execute', executeDuration, executeFailed);
+    }
+    this.emitEvent('phase_end', taskId, iteration, { phase: 'execute', durationMs: executeDuration });
+
+    return executeFailed;
+  }
+
+  /**
+   * Run the Evaluate phase.
+   * @returns The evaluation result
+   */
+  private async *runEvaluatePhase(
+    taskId: string,
+    iteration: number,
+    context: ReflectionContext,
+    evaluatePhase: EvaluatePhaseExecutor
+  ): AsyncGenerator<AgentMessage, ReflectionEvaluationResult> {
+    this.emitEvent('phase_start', taskId, iteration, { phase: 'evaluate' });
+    const evaluateStart = Date.now();
+
+    let evaluationResult: ReflectionEvaluationResult = {
+      isComplete: false,
+      confidence: 0,
+      reasoning: 'Evaluation not completed',
+    };
+
+    try {
+      // Collect evaluation messages and determine result
+      for await (const msg of evaluatePhase(context)) {
+        yield msg;
+        // Note: In real implementation, the Evaluator writes evaluation.md
+        // and we would parse it to determine the result
+      }
+
+      // Default evaluation - task needs more work
+      // In real implementation, this would be determined by parsing evaluation.md
+      evaluationResult = {
+        isComplete: false,
+        confidence: 0.5,
+        reasoning: 'Evaluation completed, task needs more work',
+        nextActions: ['Continue execution'],
+      };
+    } catch (error) {
+      logger.error({ err: error, taskId, iteration }, 'Evaluate phase failed');
+      yield {
+        content: `❌ Evaluate phase failed: ${error instanceof Error ? error.message : String(error)}`,
+        role: 'assistant',
+        messageType: 'error',
+      };
+    }
+
+    const evaluateDuration = Date.now() - evaluateStart;
+    if (this.config.enableMetrics) {
+      updatePhaseMetrics(this.metrics, 'evaluate', evaluateDuration, false);
+    }
+    this.emitEvent('phase_end', taskId, iteration, { phase: 'evaluate', durationMs: evaluateDuration });
 
     return evaluationResult;
   }


### PR DESCRIPTION
## Summary

实现 #283 - 统一 Reflection 模式，简化迭代逻辑

将 DialogueOrchestrator 与 ReflectionController 集成，实现统一的迭代管理模式。

## Changes

### ReflectionController (reflection.ts)
- 添加 `evaluateFirst` 配置选项支持 Eval-Exec 模式
- 重构 `runIteration` 支持 Execute→Evaluate 和 Evaluate→Execute 两种顺序
- 提取 `runExecutePhase` 和 `runEvaluatePhase` 作为可复用方法

### IterationBridge (iteration-bridge.ts)
- 添加 `runEvaluatorOnly()` 方法用于分离的 Evaluator 阶段执行
- 添加 `runExecutorOnly()` 方法用于分离的 Executor 阶段执行
- 支持与 ReflectionController 的分阶段执行集成

### DialogueOrchestrator (dialogue-orchestrator.ts)
- 集成 ReflectionController 进行迭代管理
- 使用统一的终止条件 (maxIterations + final_result.md 检测)
- 通过 `getReflectionMetrics()` 利用统一的指标收集
- 添加 reflection event 日志用于可观测性

## Architecture

```
┌─────────────────────────────────────────────┐
│              Reflection Pattern              │
├─────────────────────────────────────────────┤
│  ┌─────────┐    ┌─────────┐    ┌─────────┐  │
│  │ Evaluate│ →  │ Execute │ →  │ Reflect │  │
│  └─────────┘    └─────────┘    └─────────┘  │
│       ↑                               │      │
│       └───────────────────────────────┘      │
│              (迭代直到满足条件)               │
└─────────────────────────────────────────────┘
```

## Test Results

```
Test Files  65 passed (65)
Tests       1146 passed | 8 skipped (1154)
```

## Verification

- ✅ 所有 1146 个单元测试通过
- ✅ 构建成功
- ✅ TypeScript 编译通过

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 运行构建 `npm run build`
- [x] 验证 ReflectionController 功能
- [x] 验证 IterationBridge 分离方法
- [x] 验证 DialogueOrchestrator 集成

Fixes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)