### PR TITLE
test(integration): 提取公共测试环境并实现 Use Case 2/3 集成测试

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,6 +2,40 @@
 
 This directory contains integration tests for the Disclaude project.
 
+## Test Framework Architecture
+
+The integration tests use a shared test environment library:
+
+```
+tests/integration/
+├── test-env.sh                    # Common test environment library
+├── rest-channel-test.sh           # REST Channel API tests
+├── use-case-2-task-execution.sh   # Use Case 2: Task execution tests
+└── use-case-3-multi-turn.sh       # Use Case 3: Multi-turn conversation tests
+```
+
+### Common Test Environment (`test-env.sh`)
+
+The `test-env.sh` script provides common functions for all integration tests:
+
+- **Server Management**: `start_server`, `stop_server`, `ensure_server_running`
+- **HTTP Helpers**: `make_request`, `send_chat_message`, `wait_for_reply`
+- **Logging**: `log_info`, `log_pass`, `log_fail`, `log_skip`, `log_section`
+- **Utilities**: `generate_chat_id`, `check_prerequisites`, `print_summary`
+
+To use it in a new test script:
+
+```bash
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test-env.sh"
+
+# Parse common arguments
+parse_common_args "$@"
+
+# Your test functions here...
+```
+
 ## Test Environment Setup
 
 ### 1. Build the Project
@@ -10,30 +44,51 @@ This directory contains integration tests for the Disclaude project.
 npm run build
 ```
 
-### 2. Start the Test Server
+### 2. Run Tests
 
-Start the Primary Node with REST Channel:
-
-```bash
-node dist/cli-entry.js start --mode primary --rest-port 3099 --host 127.0.0.1
-```
-
-With a custom config file:
+Tests will automatically start the server if needed:
 
 ```bash
-node dist/cli-entry.js start --mode primary --rest-port 3099 --config ./path/to/disclaude.config.yaml
-```
-
-### 3. Run Integration Tests
-
-```bash
+# REST Channel tests
 ./tests/integration/rest-channel-test.sh
+
+# Use Case 2: Task execution
+./tests/integration/use-case-2-task-execution.sh
+
+# Use Case 3: Multi-turn conversation
+./tests/integration/use-case-3-multi-turn.sh
 ```
 
 Or use npm script:
 
 ```bash
 npm run test:integration
+```
+
+## Command Line Options
+
+All test scripts support common options:
+
+| Option | Description |
+|--------|-------------|
+| `--verbose, -v` | Enable verbose output |
+| `--timeout, -t SECS` | Request timeout (default: 30) |
+| `--port, -p PORT` | REST API port (default: 3099) |
+| `--config, -c PATH` | Config file path |
+| `--dry-run` | Show configuration without running |
+| `--help, -h` | Show help |
+
+Examples:
+
+```bash
+# Verbose mode
+./tests/integration/use-case-2-task-execution.sh --verbose
+
+# Custom port and timeout
+./tests/integration/use-case-3-multi-turn.sh --port 3001 --timeout 120
+
+# With config file
+./tests/integration/rest-channel-test.sh --config ./test-config.yaml
 ```
 
 ## Configuration
@@ -45,18 +100,13 @@ Integration tests are configured via **environment variables**:
 | `DISCLAUDE_CONFIG` | (auto-detect) | Path to config file (passed to --config) |
 | `REST_PORT` | 3099 | REST API port for testing |
 | `HOST` | 127.0.0.1 | Test server host |
-| `TIMEOUT` | 10 | Request timeout in seconds |
+| `TIMEOUT` | 30 | Request timeout in seconds |
+| `VERBOSE` | false | Enable verbose output |
 
 Example:
 
 ```bash
-REST_PORT=3099 HOST=127.0.0.1 ./tests/integration/rest-channel-test.sh
-```
-
-With custom config:
-
-```bash
-DISCLAUDE_CONFIG=./test-config.yaml ./tests/integration/rest-channel-test.sh
+REST_PORT=3099 HOST=127.0.0.1 TIMEOUT=60 ./tests/integration/use-case-2-task-execution.sh
 ```
 
 ## Available Tests
@@ -72,10 +122,52 @@ Tests the REST Channel functionality:
 - **Custom ChatId**: Tests custom chat ID preservation
 - **Unknown Routes**: Tests 404 responses
 
+### Use Case 2: Task Execution (`use-case-2-task-execution.sh`)
+
+Tests task execution scenario - user sends a task, agent executes and returns result:
+
+- **Calculation Task**: Agent performs mathematical calculation
+- **File System Task**: Agent lists directory contents
+- **Analysis Task**: Agent analyzes and summarizes text
+
+**Acceptance Criteria** (Issue #330):
+- [x] Use REST Channel to send task
+- [x] Agent correctly parses task intent
+- [x] Agent executes task (calls tools)
+- [x] Result returned via REST Channel
+- [x] Does not depend on vitest framework
+
+### Use Case 3: Multi-turn Conversation (`use-case-3-multi-turn.sh`)
+
+Tests multi-turn conversation with context preservation:
+
+- **Number Context**: Set favorite number, recall it, use in calculation
+- **Name Context**: Introduce name and interests, ask about each
+- **Context Isolation**: Verify different chatIds have isolated contexts
+
+**Acceptance Criteria** (Issue #331):
+- [x] Use REST Channel for multi-turn conversation
+- [x] Agent can reference first turn's info in second turn
+- [x] Context is correctly passed
+- [x] Does not depend on vitest framework
+
 ## Adding New Tests
 
 To add a new integration test:
 
 1. Create a new test script in `tests/integration/`
-2. Follow the existing pattern with helper functions
-3. Update this README
+2. Source the common test environment:
+   ```bash
+   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   source "${SCRIPT_DIR}/test-env.sh"
+   parse_common_args "$@"
+   ```
+3. Use the provided helper functions
+4. Update this README
+
+## Prerequisites
+
+- Node.js installed
+- Project built (`npm run build`)
+- Valid `disclaude.config.yaml` with AI provider configured
+- Environment variable set (`ANTHROPIC_API_KEY` or `OPENAI_API_KEY`)

--- a/tests/integration/rest-channel-test.sh
+++ b/tests/integration/rest-channel-test.sh
@@ -10,161 +10,23 @@
 # - CORS support
 #
 # Usage:
-#   ./tests/integration/rest-channel-test.sh
+#   ./tests/integration/rest-channel-test.sh [options]
 #
-# Environment variables:
-#   DISCLAUDE_CONFIG - Path to config file (passed to --config)
-#   REST_PORT        - REST API port (default: 3099)
-#   HOST             - Test server host (default: 127.0.0.1)
-#   TIMEOUT          - Request timeout in seconds (default: 10)
-#
-# Exit codes:
-#   0 - All tests passed
-#   1 - One or more tests failed
+# Options:
+#   --verbose, -v       Enable verbose output
+#   --timeout, -t SECS  Request timeout (default: 30)
+#   --port, -p PORT     REST API port (default: 3099)
+#   --config, -c PATH   Config file path
+#   --dry-run           Show configuration without running
+#   --help, -h          Show help
 #
 
-set -e
-
-# =============================================================================
-# Configuration
-# =============================================================================
+# Source common test environment
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-REST_PORT="${REST_PORT:-3099}"
-HOST="${HOST:-127.0.0.1}"
-API_URL="http://${HOST}:${REST_PORT}"
-TIMEOUT=10
-CONFIG_PATH="${DISCLAUDE_CONFIG:-}"
-SERVER_PID=""
+source "${SCRIPT_DIR}/test-env.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Test counters
-TESTS_PASSED=0
-TESTS_FAILED=0
-
-# =============================================================================
-# Helper Functions
-# =============================================================================
-
-log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
-
-log_pass() {
-    echo -e "${GREEN}[PASS]${NC} $1"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-}
-
-log_fail() {
-    echo -e "${RED}[FAIL]${NC} $1"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-}
-
-log_skip() {
-    echo -e "${YELLOW}[SKIP]${NC} $1"
-}
-
-# Start the test server
-start_server() {
-    log_info "Starting test server..."
-
-    cd "$PROJECT_ROOT"
-
-    # Build config argument if provided
-    local config_arg=""
-    if [ -n "$CONFIG_PATH" ]; then
-        config_arg="--config ${CONFIG_PATH}"
-        log_info "Using config file: ${CONFIG_PATH}"
-    fi
-
-    # Start server in background
-    node dist/cli-entry.js start --mode primary --rest-port ${REST_PORT} --host ${HOST} ${config_arg} > /tmp/disclaude-test-server.log 2>&1 &
-    SERVER_PID=$!
-
-    # Wait for server to be ready
-    log_info "Waiting for server to be ready..."
-    local max_retries=30
-    local retry=0
-    while [ $retry -lt $max_retries ]; do
-        if curl -s "${API_URL}/api/health" > /dev/null 2>&1; then
-            log_info "Server is ready (PID: ${SERVER_PID})"
-            return 0
-        fi
-        sleep 1
-        retry=$((retry + 1))
-    done
-
-    log_fail "Server failed to start within ${max_retries} seconds"
-    show_server_logs
-    return 1
-}
-
-# Stop the test server
-stop_server() {
-    if [ -n "$SERVER_PID" ]; then
-        log_info "Stopping test server (PID: ${SERVER_PID})..."
-        kill $SERVER_PID 2>/dev/null || true
-        wait $SERVER_PID 2>/dev/null || true
-        SERVER_PID=""
-    fi
-}
-
-# Show server logs for debugging
-show_server_logs() {
-    if [ -f /tmp/disclaude-test-server.log ]; then
-        echo ""
-        echo "Server logs:"
-        echo "----------------------------------------"
-        tail -50 /tmp/disclaude-test-server.log
-        echo "----------------------------------------"
-    fi
-}
-
-# Cleanup on exit
-cleanup() {
-    stop_server
-}
-
-# Register cleanup handler
-trap cleanup EXIT
-
-# Make HTTP request and return status code and body
-make_request() {
-    local method="$1"
-    local path="$2"
-    local body="${3:-}"
-    local headers="${4:-}"
-
-    local response
-    local status
-
-    if [ -n "$body" ]; then
-        response=$(curl -s -w "\n%{http_code}" \
-            -X "$method" \
-            "${API_URL}${path}" \
-            -H "Content-Type: application/json" \
-            ${headers:+-H "$headers"} \
-            -d "$body" \
-            --max-time "$TIMEOUT" 2>&1)
-    else
-        response=$(curl -s -w "\n%{http_code}" \
-            -X "$method" \
-            "${API_URL}${path}" \
-            ${headers:+-H "$headers"} \
-            --max-time "$TIMEOUT" 2>&1)
-    fi
-
-    status=$(echo "$response" | tail -n 1)
-    body=$(echo "$response" | sed '$d')
-
-    echo "$status|$body"
-}
+# Parse command line arguments
+parse_common_args "$@"
 
 # =============================================================================
 # Test Functions
@@ -371,11 +233,8 @@ test_empty_body() {
 # =============================================================================
 
 main() {
-    echo ""
-    echo "=============================================="
-    echo "  REST Channel Integration Tests"
-    echo "=============================================="
-    echo ""
+    log_section "REST Channel Integration Tests"
+
     echo "API URL: ${API_URL}"
     echo "Timeout: ${TIMEOUT}s"
     if [ -n "$CONFIG_PATH" ]; then
@@ -383,17 +242,15 @@ main() {
     fi
     echo ""
 
-    # Start server if not already running
-    log_info "Checking if REST server is running..."
-    if curl -s "${API_URL}/api/health" > /dev/null 2>&1; then
-        log_info "Server is already running"
-    else
-        log_info "Server not running, starting automatically..."
-        if ! start_server; then
-            exit 1
-        fi
+    # Check prerequisites
+    if ! check_prerequisites; then
+        exit 1
     fi
-    echo ""
+
+    # Ensure server is running
+    if ! ensure_server_running; then
+        exit 1
+    fi
 
     # Run tests
     echo "Running tests..."
@@ -411,21 +268,7 @@ main() {
     test_empty_body
 
     # Summary
-    echo ""
-    echo "=============================================="
-    echo "  Test Summary"
-    echo "=============================================="
-    echo ""
-    echo -e "  ${GREEN}Passed: ${TESTS_PASSED}${NC}"
-    echo -e "  ${RED}Failed: ${TESTS_FAILED}${NC}"
-    echo ""
-
-    if [ "$TESTS_FAILED" -gt 0 ]; then
-        show_server_logs
-        exit 1
-    fi
-
-    exit 0
+    print_summary "REST Channel Test Summary"
 }
 
 main "$@"

--- a/tests/integration/test-env.sh
+++ b/tests/integration/test-env.sh
@@ -1,0 +1,394 @@
+#!/bin/bash
+#
+# Integration Test Environment - Common Functions Library
+#
+# This script provides common functions for integration tests:
+# - Server lifecycle management (start/stop)
+# - HTTP request helpers
+# - Logging utilities
+# - Test result tracking
+#
+# Usage:
+#   source tests/integration/test-env.sh
+#
+# Environment variables (can be overridden):
+#   DISCLAUDE_CONFIG - Path to config file
+#   REST_PORT        - REST API port (default: 3099)
+#   HOST             - Test server host (default: 127.0.0.1)
+#   TIMEOUT          - Request timeout in seconds (default: 30)
+#   VERBOSE          - Enable verbose output (default: false)
+#
+# After sourcing, you can use:
+#   start_server     - Start the test server
+#   stop_server      - Stop the test server
+#   make_request     - Make HTTP request
+#   log_info/pass/fail/skip - Logging functions
+#   wait_for_reply   - Wait for agent reply (for chat tests)
+#
+
+# =============================================================================
+# Configuration
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REST_PORT="${REST_PORT:-3099}"
+HOST="${HOST:-127.0.0.1}"
+API_URL="http://${HOST}:${REST_PORT}"
+TIMEOUT="${TIMEOUT:-30}"
+CONFIG_PATH="${DISCLAUDE_CONFIG:-}"
+VERBOSE="${VERBOSE:-false}"
+SERVER_PID=""
+SERVER_LOG="/tmp/disclaude-test-server-$$.log"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_PASSED=0
+TESTS_FAILED=0
+TESTS_SKIPPED=0
+
+# =============================================================================
+# Logging Functions
+# =============================================================================
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_debug() {
+    if [ "$VERBOSE" = "true" ]; then
+        echo -e "${CYAN}[DEBUG]${NC} $1"
+    fi
+}
+
+log_pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+log_fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+}
+
+log_skip() {
+    echo -e "${YELLOW}[SKIP]${NC} $1"
+    TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
+}
+
+log_section() {
+    echo ""
+    echo -e "${BLUE}==============================================${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}==============================================${NC}"
+    echo ""
+}
+
+# =============================================================================
+# Server Management Functions
+# =============================================================================
+
+# Start the test server
+# Returns: 0 on success, 1 on failure
+start_server() {
+    log_info "Starting test server..."
+
+    cd "$PROJECT_ROOT"
+
+    # Build config argument if provided
+    local config_arg=""
+    if [ -n "$CONFIG_PATH" ]; then
+        config_arg="--config ${CONFIG_PATH}"
+        log_info "Using config file: ${CONFIG_PATH}"
+    fi
+
+    # Start server in background
+    node dist/cli-entry.js start --mode primary --rest-port ${REST_PORT} --host ${HOST} ${config_arg} > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+
+    # Wait for server to be ready
+    log_info "Waiting for server to be ready (PID: ${SERVER_PID})..."
+    local max_retries=30
+    local retry=0
+    while [ $retry -lt $max_retries ]; do
+        if curl -s "${API_URL}/api/health" > /dev/null 2>&1; then
+            log_info "Server is ready"
+            return 0
+        fi
+        sleep 1
+        retry=$((retry + 1))
+        log_debug "Waiting... ($retry/$max_retries)"
+    done
+
+    log_fail "Server failed to start within ${max_retries} seconds"
+    show_server_logs
+    return 1
+}
+
+# Stop the test server
+stop_server() {
+    if [ -n "$SERVER_PID" ]; then
+        log_info "Stopping test server (PID: ${SERVER_PID})..."
+        kill $SERVER_PID 2>/dev/null || true
+        wait $SERVER_PID 2>/dev/null || true
+        SERVER_PID=""
+    fi
+}
+
+# Check if server is running
+is_server_running() {
+    if [ -n "$SERVER_PID" ] && kill -0 $SERVER_PID 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+# Ensure server is running (start if not)
+ensure_server_running() {
+    log_info "Checking if REST server is running..."
+    if curl -s "${API_URL}/api/health" > /dev/null 2>&1; then
+        log_info "Server is already running"
+        return 0
+    else
+        log_info "Server not running, starting automatically..."
+        start_server
+        return $?
+    fi
+}
+
+# Show server logs for debugging
+show_server_logs() {
+    if [ -f "$SERVER_LOG" ] && [ -s "$SERVER_LOG" ]; then
+        echo ""
+        echo "Server logs (last 50 lines):"
+        echo "----------------------------------------"
+        tail -50 "$SERVER_LOG"
+        echo "----------------------------------------"
+    fi
+}
+
+# Cleanup function to be called on exit
+cleanup() {
+    stop_server
+    # Remove server log if tests passed
+    if [ "$TESTS_FAILED" -eq 0 ] && [ -f "$SERVER_LOG" ]; then
+        rm -f "$SERVER_LOG"
+    fi
+}
+
+# Register cleanup handler
+trap cleanup EXIT
+
+# =============================================================================
+# HTTP Request Helpers
+# =============================================================================
+
+# Make HTTP request and return status code and body
+# Usage: make_request METHOD PATH [BODY] [EXTRA_HEADERS]
+# Returns: "STATUS|BODY"
+make_request() {
+    local method="$1"
+    local path="$2"
+    local body="${3:-}"
+    local headers="${4:-}"
+
+    local response
+    local status
+
+    if [ -n "$body" ]; then
+        response=$(curl -s -w "\n%{http_code}" \
+            -X "$method" \
+            "${API_URL}${path}" \
+            -H "Content-Type: application/json" \
+            ${headers:+-H "$headers"} \
+            -d "$body" \
+            --max-time "$TIMEOUT" 2>&1)
+    else
+        response=$(curl -s -w "\n%{http_code}" \
+            -X "$method" \
+            "${API_URL}${path}" \
+            ${headers:+-H "$headers"} \
+            --max-time "$TIMEOUT" 2>&1)
+    fi
+
+    status=$(echo "$response" | tail -n 1)
+    body=$(echo "$response" | sed '$d')
+
+    echo "$status|$body"
+}
+
+# Send chat message and return messageId
+# Usage: send_chat_message MESSAGE [CHATID]
+# Returns: messageId or empty on failure
+send_chat_message() {
+    local message="$1"
+    local chatId="${2:-test-chat-$$}"
+
+    local result
+    result=$(make_request "POST" "/api/chat" "{\"message\":\"${message}\",\"chatId\":\"${chatId}\"}")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" = "200" ]; then
+        # Extract messageId from response
+        echo "$body" | grep -o '"messageId":"[^"]*"' | cut -d'"' -f4
+    else
+        return 1
+    fi
+}
+
+# Wait for agent reply
+# Usage: wait_for_reply CHATID [TIMEOUT_SECS]
+# Returns: reply message or empty on timeout
+wait_for_reply() {
+    local chatId="$1"
+    local wait_timeout="${2:-60}"
+    local interval=2
+    local elapsed=0
+
+    log_debug "Waiting for reply on chatId: $chatId (timeout: ${wait_timeout}s)"
+
+    while [ $elapsed -lt $wait_timeout ]; do
+        local result
+        result=$(make_request "GET" "/api/chat/${chatId}/messages")
+
+        local status="${result%%|*}"
+        local body="${result#*|}"
+
+        if [ "$status" = "200" ]; then
+            # Check if there are messages from agent (role: assistant)
+            local agent_reply
+            agent_reply=$(echo "$body" | grep -o '"role":"assistant"[^}]*"content":"[^"]*"' | head -1)
+            if [ -n "$agent_reply" ]; then
+                # Extract content
+                echo "$agent_reply" | grep -o '"content":"[^"]*"' | cut -d'"' -f4
+                return 0
+            fi
+        fi
+
+        sleep $interval
+        elapsed=$((elapsed + interval))
+        log_debug "Waiting for reply... (${elapsed}s/${wait_timeout}s)"
+    done
+
+    log_fail "Timeout waiting for agent reply"
+    return 1
+}
+
+# =============================================================================
+# Test Summary Functions
+# =============================================================================
+
+# Print test summary
+print_summary() {
+    local title="${1:-Test Summary}"
+
+    echo ""
+    log_section "$title"
+    echo -e "  ${GREEN}Passed: ${TESTS_PASSED}${NC}"
+    echo -e "  ${RED}Failed: ${TESTS_FAILED}${NC}"
+    echo -e "  ${YELLOW}Skipped: ${TESTS_SKIPPED}${NC}"
+    echo ""
+
+    if [ "$TESTS_FAILED" -gt 0 ]; then
+        show_server_logs
+        return 1
+    fi
+
+    return 0
+}
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+# Generate unique chatId for testing
+generate_chat_id() {
+    echo "test-chat-$$-$(date +%s)"
+}
+
+# Check if a command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Validate prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+
+    # Check Node.js
+    if ! command_exists node; then
+        log_fail "Node.js is not installed"
+        return 1
+    fi
+
+    # Check curl
+    if ! command_exists curl; then
+        log_fail "curl is not installed"
+        return 1
+    fi
+
+    # Check if project is built
+    if [ ! -d "$PROJECT_ROOT/dist" ]; then
+        log_fail "Project not built. Run 'npm run build' first."
+        return 1
+    fi
+
+    log_info "Prerequisites OK"
+    return 0
+}
+
+# Parse common command line arguments
+# Sets: VERBOSE, TIMEOUT, REST_PORT, CONFIG_PATH
+parse_common_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --verbose|-v)
+                VERBOSE="true"
+                shift
+                ;;
+            --timeout|-t)
+                TIMEOUT="$2"
+                shift 2
+                ;;
+            --port|-p)
+                REST_PORT="$2"
+                API_URL="http://${HOST}:${REST_PORT}"
+                shift 2
+                ;;
+            --config|-c)
+                CONFIG_PATH="$2"
+                shift 2
+                ;;
+            --dry-run)
+                echo "Dry run mode - would execute tests with:"
+                echo "  API_URL: $API_URL"
+                echo "  TIMEOUT: $TIMEOUT"
+                echo "  CONFIG: ${CONFIG_PATH:-none}"
+                exit 0
+                ;;
+            --help|-h)
+                echo "Usage: $0 [options]"
+                echo ""
+                echo "Options:"
+                echo "  --verbose, -v       Enable verbose output"
+                echo "  --timeout, -t SECS  Request timeout (default: 30)"
+                echo "  --port, -p PORT     REST API port (default: 3099)"
+                echo "  --config, -c PATH   Config file path"
+                echo "  --dry-run           Show configuration without running"
+                echo "  --help, -h          Show this help"
+                exit 0
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+}

--- a/tests/integration/use-case-2-task-execution.sh
+++ b/tests/integration/use-case-2-task-execution.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+#
+# Integration Test: Use Case 2 - Task Execution
+#
+# This script tests the task execution scenario:
+# User sends a task request, Agent executes it and returns the result.
+#
+# Test Scenarios:
+# 1. Health check - Verify server is running
+# 2. Calculation task - Agent performs a calculation
+# 3. File system task - Agent lists directory contents
+# 4. Analysis task - Agent analyzes and summarizes text
+#
+# Usage:
+#   ./tests/integration/use-case-2-task-execution.sh [options]
+#
+# Options:
+#   --verbose, -v       Enable verbose output
+#   --timeout, -t SECS  Request timeout (default: 60)
+#   --port, -p PORT     REST API port (default: 3099)
+#   --config, -c PATH   Config file path
+#   --dry-run           Show configuration without running
+#   --help, -h          Show help
+#
+# Acceptance Criteria (from Issue #330):
+# - [x] Use REST Channel to send task
+# - [x] Agent correctly parses task intent
+# - [x] Agent executes task (calls tools)
+# - [x] Result returned via REST Channel
+# - [x] Does not depend on vitest framework
+#
+
+# Source common test environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test-env.sh"
+
+# Override timeout for agent responses
+TIMEOUT="${TIMEOUT:-60}"
+
+# Parse command line arguments
+parse_common_args "$@"
+
+# =============================================================================
+# Test Functions
+# =============================================================================
+
+# Test 1: Health Check
+test_health_check() {
+    log_info "Testing: Health check before task execution"
+
+    local result
+    result=$(make_request "GET" "/api/health")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" = "200" ]; then
+        if echo "$body" | grep -q '"status":"ok"'; then
+            log_pass "Server is healthy and ready"
+        else
+            log_fail "Health check returned 200 but body invalid"
+        fi
+    else
+        log_fail "Health check returned status $status (expected 200)"
+    fi
+}
+
+# Test 2: Calculation Task
+test_calculation_task() {
+    log_info "Testing: Calculation task (25 * 17)"
+
+    local chatId=$(generate_chat_id)
+    local message="What is 25 multiplied by 17? Please calculate and give me the result."
+
+    log_debug "Sending message to chatId: $chatId"
+
+    # Send the task
+    local result
+    result=$(make_request "POST" "/api/chat" "{\"message\":\"${message}\",\"chatId\":\"${chatId}\"}")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" != "200" ]; then
+        log_fail "Failed to send calculation task (status: $status)"
+        return
+    fi
+
+    log_info "Task sent, waiting for agent response..."
+
+    # Wait for agent reply
+    local reply
+    reply=$(wait_for_reply "$chatId" 90)
+
+    if [ -z "$reply" ]; then
+        log_fail "No response received for calculation task"
+        return
+    fi
+
+    log_debug "Agent reply: $reply"
+
+    # Check if the reply contains the expected result (425)
+    if echo "$reply" | grep -qi "425"; then
+        log_pass "Agent correctly calculated 25 * 17 = 425"
+    else
+        log_fail "Agent did not return correct calculation result (expected 425)"
+        log_info "Agent response: $reply"
+    fi
+}
+
+# Test 3: File System Task
+test_file_system_task() {
+    log_info "Testing: File system task (list files)"
+
+    local chatId=$(generate_chat_id)
+    local message="Please list the files in the current directory and tell me what you see."
+
+    log_debug "Sending message to chatId: $chatId"
+
+    # Send the task
+    local result
+    result=$(make_request "POST" "/api/chat" "{\"message\":\"${message}\",\"chatId\":\"${chatId}\"}")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" != "200" ]; then
+        log_fail "Failed to send file system task (status: $status)"
+        return
+    fi
+
+    log_info "Task sent, waiting for agent response..."
+
+    # Wait for agent reply
+    local reply
+    reply=$(wait_for_reply "$chatId" 90)
+
+    if [ -z "$reply" ]; then
+        log_fail "No response received for file system task"
+        return
+    fi
+
+    log_debug "Agent reply: $reply"
+
+    # Check if the reply contains some file-related content
+    # The agent should mention files or directories
+    if echo "$reply" | grep -qiE "(file|directory|folder|\.\w+|package\.json|src|dist)"; then
+        log_pass "Agent successfully executed file listing task"
+    else
+        log_fail "Agent response doesn't indicate file system task execution"
+        log_info "Agent response: $reply"
+    fi
+}
+
+# Test 4: Analysis Task
+test_analysis_task() {
+    log_info "Testing: Analysis task (summarize text)"
+
+    local chatId=$(generate_chat_id)
+    local message="Please analyze this text and give me a one-sentence summary: 'The quick brown fox jumps over the lazy dog. This sentence contains every letter of the English alphabet and is commonly used for testing fonts and keyboards.'"
+
+    log_debug "Sending message to chatId: $chatId"
+
+    # Send the task
+    local result
+    result=$(make_request "POST" "/api/chat" "{\"message\":\"${message}\",\"chatId\":\"${chatId}\"}")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" != "200" ]; then
+        log_fail "Failed to send analysis task (status: $status)"
+        return
+    fi
+
+    log_info "Task sent, waiting for agent response..."
+
+    # Wait for agent reply
+    local reply
+    reply=$(wait_for_reply "$chatId" 90)
+
+    if [ -z "$reply" ]; then
+        log_fail "No response received for analysis task"
+        return
+    fi
+
+    log_debug "Agent reply: $reply"
+
+    # Check if the reply contains a summary
+    # The agent should mention pangram, alphabet, or testing
+    if echo "$reply" | grep -qiE "(pangram|alphabet|sentence|letter|test|fox|dog)"; then
+        log_pass "Agent successfully analyzed and summarized the text"
+    else
+        log_fail "Agent response doesn't indicate analysis task completion"
+        log_info "Agent response: $reply"
+    fi
+}
+
+# =============================================================================
+# Main Test Runner
+# =============================================================================
+
+main() {
+    log_section "Use Case 2: Task Execution Tests"
+
+    echo "API URL: ${API_URL}"
+    echo "Timeout: ${TIMEOUT}s"
+    if [ -n "$CONFIG_PATH" ]; then
+        echo "Config: ${CONFIG_PATH}"
+    fi
+    echo ""
+
+    # Check prerequisites
+    if ! check_prerequisites; then
+        exit 1
+    fi
+
+    # Ensure server is running
+    if ! ensure_server_running; then
+        exit 1
+    fi
+
+    # Run tests
+    echo "Running tests..."
+    echo ""
+
+    test_health_check
+    test_calculation_task
+    test_file_system_task
+    test_analysis_task
+
+    # Summary
+    print_summary "Use Case 2 Test Summary"
+}
+
+main "$@"

--- a/tests/integration/use-case-3-multi-turn.sh
+++ b/tests/integration/use-case-3-multi-turn.sh
@@ -1,0 +1,301 @@
+#!/bin/bash
+#
+# Integration Test: Use Case 3 - Multi-turn Conversation with Context
+#
+# This script tests the multi-turn conversation scenario:
+# Agent can maintain context across multiple turns of dialogue.
+#
+# Test Scenarios:
+# 1. Health check - Verify server is running
+# 2. Number context - Set favorite number, ask about it, then calculate
+# 3. Name context - Introduce name and interests, ask about each
+# 4. Separate chats - Verify different chatIds have isolated contexts
+#
+# Usage:
+#   ./tests/integration/use-case-3-multi-turn.sh [options]
+#
+# Options:
+#   --verbose, -v       Enable verbose output
+#   --timeout, -t SECS  Request timeout (default: 60)
+#   --port, -p PORT     REST API port (default: 3099)
+#   --config, -c PATH   Config file path
+#   --dry-run           Show configuration without running
+#   --help, -h          Show help
+#
+# Acceptance Criteria (from Issue #331):
+# - [x] Use REST Channel for multi-turn conversation
+# - [x] Agent can reference first turn's info in second turn
+# - [x] Context is correctly passed
+# - [x] Does not depend on vitest framework
+#
+
+# Source common test environment
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/test-env.sh"
+
+# Override timeout for agent responses
+TIMEOUT="${TIMEOUT:-60}"
+
+# Parse command line arguments
+parse_common_args "$@"
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+# Send message and wait for reply
+# Returns: reply content or empty on failure
+send_and_wait() {
+    local chatId="$1"
+    local message="$2"
+    local wait_timeout="${3:-90}"
+
+    log_debug "Sending to $chatId: $message"
+
+    local result
+    result=$(make_request "POST" "/api/chat" "{\"message\":\"${message}\",\"chatId\":\"${chatId}\"}")
+
+    local status="${result%%|*}"
+
+    if [ "$status" != "200" ]; then
+        log_fail "Failed to send message (status: $status)"
+        return 1
+    fi
+
+    local reply
+    reply=$(wait_for_reply "$chatId" "$wait_timeout")
+
+    if [ -z "$reply" ]; then
+        log_fail "No response received"
+        return 1
+    fi
+
+    log_debug "Reply: $reply"
+    echo "$reply"
+    return 0
+}
+
+# =============================================================================
+# Test Functions
+# =============================================================================
+
+# Test 1: Health Check
+test_health_check() {
+    log_info "Testing: Health check before multi-turn tests"
+
+    local result
+    result=$(make_request "GET" "/api/health")
+
+    local status="${result%%|*}"
+    local body="${result#*|}"
+
+    if [ "$status" = "200" ]; then
+        if echo "$body" | grep -q '"status":"ok"'; then
+            log_pass "Server is healthy and ready"
+        else
+            log_fail "Health check returned 200 but body invalid"
+        fi
+    else
+        log_fail "Health check returned status $status (expected 200)"
+    fi
+}
+
+# Test 2: Number Context
+test_number_context() {
+    log_info "Testing: Number context (set favorite number, recall, calculate)"
+
+    local chatId="test-number-context-$$"
+
+    # Turn 1: Set favorite number
+    log_info "Turn 1: Setting favorite number"
+    local reply1
+    reply1=$(send_and_wait "$chatId" "My favorite number is 42. Please remember this.")
+    if [ -z "$reply1" ]; then
+        log_fail "Failed at Turn 1: setting favorite number"
+        return
+    fi
+
+    # Turn 2: Ask about the number
+    log_info "Turn 2: Asking about favorite number"
+    local reply2
+    reply2=$(send_and_wait "$chatId" "What is my favorite number?")
+    if [ -z "$reply2" ]; then
+        log_fail "Failed at Turn 2: asking about favorite number"
+        return
+    fi
+
+    # Verify context is maintained - should mention 42
+    if echo "$reply2" | grep -q "42"; then
+        log_pass "Agent correctly recalled favorite number (42)"
+    else
+        log_fail "Agent did not recall favorite number correctly"
+        log_info "Agent response: $reply2"
+        return
+    fi
+
+    # Turn 3: Use the number in calculation
+    log_info "Turn 3: Using favorite number in calculation"
+    local reply3
+    reply3=$(send_and_wait "$chatId" "Multiply my favorite number by 2 and tell me the result.")
+    if [ -z "$reply3" ]; then
+        log_fail "Failed at Turn 3: calculation with favorite number"
+        return
+    fi
+
+    # Verify calculation - should mention 84
+    if echo "$reply3" | grep -q "84"; then
+        log_pass "Agent correctly used context (42 * 2 = 84)"
+    else
+        log_fail "Agent did not calculate correctly with context"
+        log_info "Agent response: $reply3"
+    fi
+}
+
+# Test 3: Name Context
+test_name_context() {
+    log_info "Testing: Name context (introduce name and interests)"
+
+    local chatId="test-name-context-$$"
+
+    # Turn 1: Introduce name
+    log_info "Turn 1: Introducing name"
+    local reply1
+    reply1=$(send_and_wait "$chatId" "Hi, my name is Alice and I like programming.")
+    if [ -z "$reply1" ]; then
+        log_fail "Failed at Turn 1: introducing name"
+        return
+    fi
+
+    # Turn 2: Ask about name
+    log_info "Turn 2: Asking about name"
+    local reply2
+    reply2=$(send_and_wait "$chatId" "What is my name?")
+    if [ -z "$reply2" ]; then
+        log_fail "Failed at Turn 2: asking about name"
+        return
+    fi
+
+    # Verify context - should mention Alice
+    if echo "$reply2" | grep -qi "Alice"; then
+        log_pass "Agent correctly recalled name (Alice)"
+    else
+        log_fail "Agent did not recall name correctly"
+        log_info "Agent response: $reply2"
+        return
+    fi
+
+    # Turn 3: Ask about interest
+    log_info "Turn 3: Asking about interest"
+    local reply3
+    reply3=$(send_and_wait "$chatId" "What do I like to do?")
+    if [ -z "$reply3" ]; then
+        log_fail "Failed at Turn 3: asking about interest"
+        return
+    fi
+
+    # Verify context - should mention programming
+    if echo "$reply3" | grep -qi "programming"; then
+        log_pass "Agent correctly recalled interest (programming)"
+    else
+        log_fail "Agent did not recall interest correctly"
+        log_info "Agent response: $reply3"
+    fi
+}
+
+# Test 4: Separate Chat Context Isolation
+test_context_isolation() {
+    log_info "Testing: Context isolation between different chats"
+
+    local chatId1="test-isolation-1-$$"
+    local chatId2="test-isolation-2-$$"
+
+    # Chat 1: Set name to Bob
+    log_info "Chat 1: Setting name to Bob"
+    local reply1
+    reply1=$(send_and_wait "$chatId1" "My name is Bob.")
+    if [ -z "$reply1" ]; then
+        log_fail "Failed to set name in Chat 1"
+        return
+    fi
+
+    # Chat 2: Set name to Carol
+    log_info "Chat 2: Setting name to Carol"
+    local reply2
+    reply2=$(send_and_wait "$chatId2" "My name is Carol.")
+    if [ -z "$reply2" ]; then
+        log_fail "Failed to set name in Chat 2"
+        return
+    fi
+
+    # Chat 1: Ask about name - should be Bob
+    log_info "Chat 1: Asking about name (should be Bob)"
+    local reply3
+    reply3=$(send_and_wait "$chatId1" "What is my name?")
+    if [ -z "$reply3" ]; then
+        log_fail "Failed to ask name in Chat 1"
+        return
+    fi
+
+    if echo "$reply3" | grep -qi "Bob" && ! echo "$reply3" | grep -qi "Carol"; then
+        log_pass "Chat 1 correctly maintained its own context (Bob)"
+    else
+        log_fail "Chat 1 context was corrupted"
+        log_info "Agent response: $reply3"
+        return
+    fi
+
+    # Chat 2: Ask about name - should be Carol
+    log_info "Chat 2: Asking about name (should be Carol)"
+    local reply4
+    reply4=$(send_and_wait "$chatId2" "What is my name?")
+    if [ -z "$reply4" ]; then
+        log_fail "Failed to ask name in Chat 2"
+        return
+    fi
+
+    if echo "$reply4" | grep -qi "Carol" && ! echo "$reply4" | grep -qi "Bob"; then
+        log_pass "Chat 2 correctly maintained its own context (Carol)"
+    else
+        log_fail "Chat 2 context was corrupted"
+        log_info "Agent response: $reply4"
+    fi
+}
+
+# =============================================================================
+# Main Test Runner
+# =============================================================================
+
+main() {
+    log_section "Use Case 3: Multi-turn Conversation Tests"
+
+    echo "API URL: ${API_URL}"
+    echo "Timeout: ${TIMEOUT}s"
+    if [ -n "$CONFIG_PATH" ]; then
+        echo "Config: ${CONFIG_PATH}"
+    fi
+    echo ""
+
+    # Check prerequisites
+    if ! check_prerequisites; then
+        exit 1
+    fi
+
+    # Ensure server is running
+    if ! ensure_server_running; then
+        exit 1
+    fi
+
+    # Run tests
+    echo "Running tests..."
+    echo ""
+
+    test_health_check
+    test_number_context
+    test_name_context
+    test_context_isolation
+
+    # Summary
+    print_summary "Use Case 3 Test Summary"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

实现 #330 和 #331 - 提取公共测试环境脚本，并实现任务执行和多轮对话的集成测试

根据之前被关闭的 PR #359 和 #360 的反馈，本 PR 首先提取了公共测试环境脚本，然后再实现 Use Case 2 和 Use Case 3 的测试。

## Changes

### 公共测试环境 (test-env.sh)
- 提取服务器启动/停止逻辑
- 提取 HTTP 请求辅助函数
- 提取日志和测试结果统计函数
- 支持命令行参数解析 (--verbose, --timeout, --port, --config, --dry-run)
- 添加 wait_for_reply 函数用于等待 Agent 响应

### 重构 rest-channel-test.sh
- 使用公共 test-env.sh 脚本
- 减少代码重复

### Use Case 2: 任务执行测试 (use-case-2-task-execution.sh)
- 健康检查测试
- 数学计算任务测试 (25 * 17)
- 文件系统任务测试 (列出目录)
- 文本分析任务测试 (总结文本)

### Use Case 3: 多轮对话测试 (use-case-3-multi-turn.sh)
- 数字上下文测试 (设置/回忆/计算)
- 姓名上下文测试 (介绍/询问)
- 上下文隔离测试 (不同 chatId)

### 文档更新 (README.md)
- 更新测试框架架构说明
- 添加命令行选项说明
- 添加各测试脚本的详细描述

## 验收标准

### #330 Use Case 2
- [x] 使用 REST Channel 发送任务
- [x] Agent 正确解析任务意图
- [x] Agent 执行任务（调用工具）
- [x] 结果通过 REST Channel 返回
- [x] 不依赖 vitest 框架

### #331 Use Case 3
- [x] 使用 REST Channel 进行多轮对话
- [x] Agent 在第二轮能引用第一轮的信息
- [x] 上下文正确传递
- [x] 不依赖 vitest 框架

## Verification

- ✅ 所有 1146 个单元测试通过
- ✅ 脚本语法检查通过
- ✅ 构建成功
- ✅ Dry-run 测试通过

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 验证脚本语法 `bash -n`
- [x] 构建项目成功
- [x] Dry-run 测试验证配置
- [ ] 手动测试：配置环境后运行集成测试脚本

Fixes #330
Fixes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)