### PR TITLE
fix(lint): 修复大部分 ESLint 错误 (103 -> 13)

### DIFF
--- a/src/agents/evaluator.ts
+++ b/src/agents/evaluator.ts
@@ -24,7 +24,7 @@ import { Config } from '../config/index.js';
 import type { AgentMessage, AgentInput } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
-import type { SkillAgent, UserInput, SkillAgentConfig } from './types.js';
+import type { SkillAgent, UserInput } from './types.js';
 
 /**
  * Evaluator-specific allowed tools.
@@ -76,9 +76,9 @@ export class Evaluator extends BaseAgent implements SkillAgent {
    * Initialize the Evaluator agent.
    * No skill loading needed - allowedTools are defined directly in code.
    */
-  async initialize(): Promise<void> {
+  initialize(): Promise<void> {
     if (this.initialized) {
-      return;
+      return Promise.resolve();
     }
 
     this.initialized = true;
@@ -86,6 +86,7 @@ export class Evaluator extends BaseAgent implements SkillAgent {
       { toolCount: EVALUATOR_ALLOWED_TOOLS.length },
       'Evaluator initialized'
     );
+    return Promise.resolve();
   }
 
   /**

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -17,7 +17,7 @@ import * as fs from 'fs/promises';
 import type { ParsedSDKMessage, AgentMessage } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
-import type { SkillAgent, UserInput, SkillAgentConfig } from './types.js';
+import type { SkillAgent, UserInput } from './types.js';
 
 /**
  * Executor configuration.

--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentFactory } from './factory.js';
 import { Pilot } from './pilot.js';
-import { Config } from '../config/index.js';
 
 // Mock Config module
 vi.mock('../config/index.js', () => ({

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -27,13 +27,12 @@
  */
 
 import { Config } from '../config/index.js';
-import type { BaseAgentConfig, AgentProvider } from './types.js';
 import { Evaluator, type EvaluatorConfig } from './evaluator.js';
 import { Executor, type ExecutorConfig } from './executor.js';
 import { Reporter } from './reporter.js';
 import { Pilot, type PilotConfig, type PilotCallbacks } from './pilot.js';
 import { createSiteMiner, isPlaywrightAvailable } from './site-miner.js';
-import type { ChatAgent, SkillAgent, Subagent } from './types.js';
+import type { ChatAgent, SkillAgent, Subagent, BaseAgentConfig, AgentProvider } from './types.js';
 
 /**
  * Options for creating agents with custom configuration.

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -39,7 +39,7 @@ import type { StreamingUserMessage } from '../sdk/index.js';
 import { Config } from '../config/index.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
-import type { ChatAgent, UserInput, ChatAgentConfig } from './types.js';
+import type { ChatAgent, UserInput } from './types.js';
 import type { AgentMessage } from '../types/agent.js';
 import type { FileRef } from '../file-transfer/types.js';
 import { MessageChannel } from './message-channel.js';
@@ -162,8 +162,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
    *
    * @returns Promise that resolves when started
    */
-  async start(): Promise<void> {
+  start(): Promise<void> {
     this.logger.debug('Pilot start() called - sessions are created on-demand');
+    return Promise.resolve();
   }
 
   /**

--- a/src/agents/reporter.ts
+++ b/src/agents/reporter.ts
@@ -33,7 +33,7 @@
 import type { AgentMessage } from '../types/agent.js';
 import type { ReporterContext } from '../types/reporter.js';
 import type { TaskProgressEvent } from './executor.js';
-import type { SkillAgent, UserInput, SkillAgentConfig } from './types.js';
+import type { SkillAgent, UserInput } from './types.js';
 import { createFeishuSdkMcpServer } from '../mcp/feishu-context-mcp.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 
@@ -70,9 +70,9 @@ export class Reporter extends BaseAgent implements SkillAgent {
    * Initialize the Reporter agent.
    * No skill loading needed - allowedTools are defined directly in code.
    */
-  async initialize(): Promise<void> {
+  initialize(): Promise<void> {
     if (this.initialized) {
-      return;
+      return Promise.resolve();
     }
 
     this.initialized = true;
@@ -80,6 +80,7 @@ export class Reporter extends BaseAgent implements SkillAgent {
       { toolCount: REPORTER_ALLOWED_TOOLS.length },
       'Reporter initialized'
     );
+    return Promise.resolve();
   }
 
   /**

--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -250,7 +250,7 @@ The tool returns structured results with extracted information and confidence sc
         timeout: z.number().optional().default(60000).describe('Timeout in milliseconds'),
         takeScreenshot: z.boolean().optional().default(false).describe('Whether to take a screenshot for evidence'),
       }),
-      handler: async (params: SiteMinerOptions): Promise<SiteMinerResult> => {
+      handler: (params: SiteMinerOptions): Promise<SiteMinerResult> => {
         return this.runMining(params);
       },
     };
@@ -603,7 +603,7 @@ Begin mining now.`;
  * // [{ name: 'repo/name', stars: '1234', description: '...' }, ...]
  * ```
  */
-export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMinerResult> {
+export function runSiteMiner(options: SiteMinerOptions): Promise<SiteMinerResult> {
   const agentConfig = Config.getAgentConfig();
   const siteMiner = new SiteMiner({
     apiKey: agentConfig.apiKey,
@@ -619,7 +619,7 @@ export async function runSiteMiner(options: SiteMinerOptions): Promise<SiteMiner
  * Export a factory function for convenience.
  * @deprecated Use `new SiteMiner(config)` instead
  */
-export function createSiteMiner(config?: Partial<BaseAgentConfig>): typeof runSiteMiner {
+export function createSiteMiner(_config?: Partial<BaseAgentConfig>): typeof runSiteMiner {
   // SiteMiner uses global config, but this allows for future customization
   return runSiteMiner;
 }

--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -124,7 +124,7 @@ export const authToolDefinitions: InlineToolDefinition[] = [
       callbackUrl: z.string().describe('OAuth callback URL (must match the registered redirect URI)'),
       chatId: z.string().describe('Chat ID from the task context'),
     }),
-    handler: async ({ providerName, authUrl, tokenUrl, clientId, clientSecret, scopes, callbackUrl, chatId }) => {
+    handler: ({ providerName, authUrl, tokenUrl, clientId, clientSecret, scopes, callbackUrl, chatId }) => {
       try {
         const provider: OAuthProviderConfig = {
           name: providerName,
@@ -142,9 +142,9 @@ export const authToolDefinitions: InlineToolDefinition[] = [
         logger.info({ chatId, provider: providerName }, 'Authorization URL generated');
 
         return toolSuccess(
-          `Authorization URL generated:\n\n` +
+          'Authorization URL generated:\n\n' +
           `**URL:** ${result.url}\n\n` +
-          `Send this URL to the user so they can authorize. After authorization, the user should return and continue.`
+          'Send this URL to the user so they can authorize. After authorization, the user should return and continue.'
         );
       } catch (error) {
         return toolError(`Failed to generate authorization URL: ${error instanceof Error ? error.message : String(error)}`);
@@ -176,7 +176,7 @@ export const authToolDefinitions: InlineToolDefinition[] = [
           if (result.status === 401) {
             return toolError(
               `Authentication required for ${provider}. The user needs to authorize this service first. ` +
-              `Use auth_check to verify authorization status.`
+              'Use auth_check to verify authorization status.'
             );
           }
           return toolError(`API request failed (${result.status}): ${result.error}`);

--- a/src/auth/oauth-manager.test.ts
+++ b/src/auth/oauth-manager.test.ts
@@ -83,7 +83,7 @@ describe('OAuthManager', () => {
       // Mock fetch for token exchange
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({
+        json: () => ({
           access_token: 'test-access-token',
           token_type: 'Bearer',
           expires_in: 3600,
@@ -110,7 +110,7 @@ describe('OAuthManager', () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 400,
-        text: async () => 'Invalid grant',
+        text: () => 'Invalid grant',
       });
 
       const result = await manager.handleCallback('test-code', state);
@@ -205,7 +205,7 @@ describe('OAuthManager', () => {
         ok: true,
         status: 200,
         headers: new Headers({ 'content-type': 'application/json' }),
-        json: async () => ({ login: 'testuser' }),
+        json: () => ({ login: 'testuser' }),
       });
 
       const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {
@@ -242,7 +242,7 @@ describe('OAuthManager', () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 404,
-        text: async () => 'Not Found',
+        text: () => 'Not Found',
       });
 
       const result = await manager.makeAuthenticatedRequest('chat-1', 'github', {

--- a/src/auth/oauth-manager.ts
+++ b/src/auth/oauth-manager.ts
@@ -288,7 +288,7 @@ export class OAuthManager {
         body: config.body ? JSON.stringify(config.body) : undefined,
       });
 
-      const status = response.status;
+      const {status} = response;
 
       if (!response.ok) {
         const text = await response.text();
@@ -340,7 +340,7 @@ export class OAuthManager {
    * @param provider - Provider name
    * @returns true if token was deleted
    */
-  async revokeToken(chatId: string, provider: string): Promise<boolean> {
+  revokeToken(chatId: string, provider: string): Promise<boolean> {
     return this.tokenStore.deleteToken(chatId, provider);
   }
 
@@ -350,7 +350,7 @@ export class OAuthManager {
    * @param chatId - Chat identifier
    * @returns Array of provider names
    */
-  async listAuthorizations(chatId: string): Promise<string[]> {
+  listAuthorizations(chatId: string): Promise<string[]> {
     return this.tokenStore.listProviders(chatId);
   }
 
@@ -360,9 +360,9 @@ export class OAuthManager {
    * @param port - Port to listen on
    * @returns Server URL
    */
-  async startCallbackServer(port: number = 3000): Promise<string> {
+  startCallbackServer(port: number = 3000): Promise<string> {
     if (this.callbackServer) {
-      return `http://localhost:${port}`;
+      return Promise.resolve(`http://localhost:${port}`);
     }
 
     return new Promise((resolve, reject) => {

--- a/src/channels/base-channel.test.ts
+++ b/src/channels/base-channel.test.ts
@@ -39,17 +39,20 @@ class TestChannel extends BaseChannel<ChannelConfig> {
   public checkHealthResult = true;
   public lastMessage: OutgoingMessage | null = null;
 
-  protected async doStart(): Promise<void> {
+  protected doStart(): Promise<void> {
     this.doStartCalled = true;
+    return Promise.resolve();
   }
 
-  protected async doStop(): Promise<void> {
+  protected doStop(): Promise<void> {
     this.doStopCalled = true;
+    return Promise.resolve();
   }
 
-  protected async doSendMessage(message: OutgoingMessage): Promise<void> {
+  protected doSendMessage(message: OutgoingMessage): Promise<void> {
     this.doSendMessageCalled = true;
     this.lastMessage = message;
+    return Promise.resolve();
   }
 
   protected checkHealth(): boolean {
@@ -257,11 +260,11 @@ describe('BaseChannel', () => {
   describe('Error Handling', () => {
     it('should emit error event on start failure', async () => {
       class FailingChannel extends BaseChannel<ChannelConfig> {
-        protected async doStart(): Promise<void> {
-          throw new Error('Start failed');
+        protected doStart(): Promise<void> {
+          return Promise.reject(new Error('Start failed'));
         }
-        protected async doStop(): Promise<void> {}
-        protected async doSendMessage(): Promise<void> {}
+        protected doStop(): Promise<void> { return Promise.resolve(); }
+        protected doSendMessage(): Promise<void> { return Promise.resolve(); }
         protected checkHealth(): boolean { return true; }
       }
 
@@ -276,11 +279,11 @@ describe('BaseChannel', () => {
 
     it('should emit error event on stop failure', async () => {
       class FailingStopChannel extends BaseChannel<ChannelConfig> {
-        protected async doStart(): Promise<void> {}
-        protected async doStop(): Promise<void> {
-          throw new Error('Stop failed');
+        protected doStart(): Promise<void> { return Promise.resolve(); }
+        protected doStop(): Promise<void> {
+          return Promise.reject(new Error('Stop failed'));
         }
-        protected async doSendMessage(): Promise<void> {}
+        protected doSendMessage(): Promise<void> { return Promise.resolve(); }
         protected checkHealth(): boolean { return true; }
       }
 

--- a/src/channels/base-channel.ts
+++ b/src/channels/base-channel.ts
@@ -267,14 +267,14 @@ export abstract class BaseChannel<TConfig extends ChannelConfig = ChannelConfig>
    * @param command - Control command to emit
    * @returns Response from the control handler
    */
-  protected async emitControl(
+  protected emitControl(
     command: Parameters<ControlHandler>[0]
   ): Promise<ReturnType<ControlHandler>> {
     if (this.controlHandler) {
       return this.controlHandler(command);
     }
     logger.warn({ id: this.id, type: command.type }, 'No control handler registered');
-    return { success: false, error: 'No control handler registered' };
+    return Promise.resolve({ success: false, error: 'No control handler registered' });
   }
 
   // Abstract methods for subclasses to implement

--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -91,7 +91,6 @@ vi.mock('../utils/task-tracker.js', () => ({
 }));
 
 import { FeishuChannel } from './feishu-channel.js';
-import type { IncomingMessage } from './types.js';
 
 describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
   let channel: FeishuChannel;

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -139,7 +139,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     logger.info('FeishuChannel started');
   }
 
-  protected async doStop(): Promise<void> {
+  protected doStop(): Promise<void> {
     this.wsClient = undefined;
     this.client = undefined;
     this.messageSender = undefined;
@@ -151,6 +151,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     attachmentManager.cleanupOldAttachments();
 
     logger.info('FeishuChannel stopped');
+    return Promise.resolve();
   }
 
   protected async doSendMessage(message: OutgoingMessage): Promise<void> {
@@ -277,7 +278,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // In Feishu, when bot is mentioned, it appears in the mentions array
     // The bot's id type is typically 'app' or has a specific pattern
     // We check if any mention has an id that looks like a bot/app
-    return mentions.some((mention) => {
+    return mentions.some((_mention) => {
       // Bot mentions typically have open_id starting with 'ou_' or 'on_'
       // but we should check all mentions since user might @bot
       // The safest approach: if there's any mention, treat it as bot mention

--- a/src/channels/platforms/rest/rest-adapter.ts
+++ b/src/channels/platforms/rest/rest-adapter.ts
@@ -39,13 +39,14 @@ export class RestMessageSender implements IMessageSender {
     this.logger = config.logger;
   }
 
-  async sendText(chatId: string, text: string, threadId?: string): Promise<void> {
+  sendText(chatId: string, text: string, threadId?: string): Promise<void> {
     this.logger.debug({ chatId, text: text.substring(0, 50), threadId }, 'REST: Sending text message');
     // REST channel handles message routing internally
     // This is mainly for logging and future HTTP callback support
+    return Promise.resolve();
   }
 
-  async sendCard(
+  sendCard(
     chatId: string,
     card: Record<string, unknown>,
     description?: string,
@@ -53,16 +54,18 @@ export class RestMessageSender implements IMessageSender {
   ): Promise<void> {
     this.logger.debug({ chatId, description, threadId }, 'REST: Sending card message');
     // REST channel handles message routing internally
+    return Promise.resolve();
   }
 
-  async sendFile(chatId: string, filePath: string, threadId?: string): Promise<void> {
+  sendFile(chatId: string, filePath: string, threadId?: string): Promise<void> {
     this.logger.debug({ chatId, filePath, threadId }, 'REST: Sending file');
     // REST channel handles file transfer internally
+    return Promise.resolve();
   }
 
-  async addReaction?(messageId: string, emoji: string): Promise<boolean> {
+  addReaction?(messageId: string, emoji: string): Promise<boolean> {
     this.logger.debug({ messageId, emoji }, 'REST: Adding reaction (not supported)');
-    return false;
+    return Promise.resolve(false);
   }
 }
 

--- a/src/channels/rest-channel.test.ts
+++ b/src/channels/rest-channel.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { RestChannel, type RestChannelConfig } from './rest-channel.js';
+import { RestChannel } from './rest-channel.js';
 import http from 'node:http';
 
 // Mock logger
@@ -27,7 +27,7 @@ vi.mock('../utils/logger.js', () => ({
 /**
  * Helper to make HTTP requests to the test server.
  */
-async function makeRequest(
+function makeRequest(
   port: number,
   options: {
     method: string;
@@ -264,18 +264,18 @@ describe('RestChannel', () => {
     });
 
     it('should wait for done message in sync mode', async () => {
-      let receivedMessage: { messageId: string; chatId: string } | null = null;
+      let _receivedMessage: { messageId: string; chatId: string } | null = null;
 
-      channel.onMessage(async (msg) => {
-        receivedMessage = msg;
+      channel.onMessage((msg) => {
+        _receivedMessage = msg;
         // Simulate async processing and response
-        setTimeout(async () => {
-          await channel.sendMessage({
+        setTimeout(() => {
+          void channel.sendMessage({
             chatId: msg.chatId,
             type: 'text',
             text: 'Response from agent',
           });
-          await channel.sendMessage({
+          void channel.sendMessage({
             chatId: msg.chatId,
             type: 'done',
           });
@@ -500,7 +500,7 @@ describe('RestChannel', () => {
     });
 
     it('should handle message handler errors', async () => {
-      channel.onMessage(async () => {
+      channel.onMessage(() => {
         throw new Error('Handler failed');
       });
 

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -117,7 +117,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     logger.info({ id: this.id, port: this.port }, 'RestChannel created');
   }
 
-  protected async doStart(): Promise<void> {
+  protected doStart(): Promise<void> {
     this.server = http.createServer((req, res) => {
       this.handleRequest(req, res).catch((error) => {
         logger.error({ err: error }, 'Failed to handle request');
@@ -138,7 +138,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     });
   }
 
-  protected async doStop(): Promise<void> {
+  protected doStop(): Promise<void> {
     // Clear all pending responses
     for (const [_chatId, pending] of this.pendingResponses) {
       clearTimeout(pending.timeout);
@@ -161,7 +161,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     });
   }
 
-  protected async doSendMessage(message: OutgoingMessage): Promise<void> {
+  protected doSendMessage(message: OutgoingMessage): Promise<void> {
     const messageId = this.chatToMessage.get(message.chatId);
 
     // Handle 'done' type - task completion signal for sync mode
@@ -199,6 +199,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     // For streaming mode: this could be extended to use Server-Sent Events
     // Currently we just log the message
     logger.debug({ chatId: message.chatId, type: message.type }, 'Message sent through REST channel');
+    return Promise.resolve();
   }
 
   protected checkHealth(): boolean {

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -58,22 +58,19 @@ let parseGlobalArgs: ParseGlobalArgsFn;
  */
 async function loadDependencies(): Promise<void> {
   const configModule = await import('./config/index.js');
-  Config = configModule.Config;
+  ({ Config } = configModule);
 
   const loggerModule = await import('./utils/logger.js');
-  initLogger = loggerModule.initLogger;
-  flushLogger = loggerModule.flushLogger;
-  getRootLogger = loggerModule.getRootLogger;
+  ({ initLogger, flushLogger, getRootLogger } = loggerModule);
 
   const errorHandlerModule = await import('./utils/error-handler.js');
-  handleError = errorHandlerModule.handleError;
-  ErrorCategory = errorHandlerModule.ErrorCategory;
+  ({ handleError, ErrorCategory } = errorHandlerModule);
 
   const skillsModule = await import('./utils/skills-setup.js');
-  setupSkillsInWorkspace = skillsModule.setupSkillsInWorkspace;
+  ({ setupSkillsInWorkspace } = skillsModule);
 
   const cliArgsModule = await import('./utils/cli-args.js');
-  parseGlobalArgs = cliArgsModule.parseGlobalArgs;
+  ({ parseGlobalArgs } = cliArgsModule);
 }
 
 /**

--- a/src/conversation/conversation-orchestrator.ts
+++ b/src/conversation/conversation-orchestrator.ts
@@ -188,7 +188,7 @@ export class ConversationOrchestrator {
   /**
    * Cleanup resources on shutdown.
    */
-  async shutdown(): Promise<void> {
+  shutdown(): void {
     this.logger.info('Shutting down ConversationOrchestrator');
 
     // Close all sessions

--- a/src/file-transfer/inbound/attachment-manager.test.ts
+++ b/src/file-transfer/inbound/attachment-manager.test.ts
@@ -9,7 +9,7 @@
  * - Cleaning up old attachments
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { AttachmentManager } from './attachment-manager.js';
 import type { FileAttachment } from '../../channels/adapters/types.js';
 

--- a/src/file-transfer/inbound/feishu-downloader.test.ts
+++ b/src/file-transfer/inbound/feishu-downloader.test.ts
@@ -8,8 +8,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import {
   extractFileExtension,
   downloadFile,

--- a/src/file-transfer/node-transfer/file-client.test.ts
+++ b/src/file-transfer/node-transfer/file-client.test.ts
@@ -10,7 +10,6 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import { FileClient } from './file-client.js';
 import type { FileRef } from '../types.js';
 

--- a/src/file-transfer/node-transfer/file-storage.test.ts
+++ b/src/file-transfer/node-transfer/file-storage.test.ts
@@ -9,9 +9,8 @@
  * - Storage statistics
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import { FileStorageService } from './file-storage.js';
 
 // Mock fs/promises

--- a/src/file-transfer/node-transfer/file-storage.ts
+++ b/src/file-transfer/node-transfer/file-storage.ts
@@ -58,7 +58,7 @@ export class FileStorageService {
     fileName: string,
     mimeType?: string,
     source: 'user' | 'agent' = 'user',
-    chatId?: string
+    _chatId?: string
   ): Promise<FileRef> {
     const stats = await fs.stat(localPath);
 
@@ -99,7 +99,7 @@ export class FileStorageService {
     fileName: string,
     mimeType?: string,
     source: 'user' | 'agent' = 'agent',
-    chatId?: string
+    _chatId?: string
   ): Promise<FileRef> {
     const buffer = Buffer.from(content, 'base64');
 

--- a/src/file-transfer/outbound/feishu-uploader.test.ts
+++ b/src/file-transfer/outbound/feishu-uploader.test.ts
@@ -9,8 +9,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as fs from 'fs/promises';
-import * as fsStream from 'fs';
 import {
   detectFileType,
   uploadFile,

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -620,7 +620,7 @@ export async function update_card(params: {
       logger.info({ messageId, chatId }, 'CLI mode: Card update simulated');
       return {
         success: true,
-        message: `✅ Card updated (CLI mode)`,
+        message: '✅ Card updated (CLI mode)',
       };
     }
 
@@ -656,7 +656,7 @@ export async function update_card(params: {
 
     return {
       success: true,
-      message: `✅ Card updated successfully`,
+      message: '✅ Card updated successfully',
     };
 
   } catch (error) {
@@ -721,7 +721,7 @@ export async function wait_for_interaction(params: {
       logger.info({ messageId, chatId }, 'CLI mode: Simulating interaction response');
       return {
         success: true,
-        message: `✅ Interaction received (CLI mode - simulated)`,
+        message: '✅ Interaction received (CLI mode - simulated)',
         actionValue: 'simulated',
         actionType: 'button',
         userId: 'cli-user',

--- a/src/messaging/routed-output-adapter.ts
+++ b/src/messaging/routed-output-adapter.ts
@@ -9,8 +9,7 @@
 
 import type { AgentMessageType } from '../types/agent.js';
 import type { OutputAdapter, MessageMetadata } from '../utils/output-adapter.js';
-import type { IMessageRouter, RoutedMessageMetadata } from './types.js';
-import { MessageLevel, mapAgentMessageTypeToLevel } from './types.js';
+import { mapAgentMessageTypeToLevel, type IMessageRouter, type RoutedMessageMetadata } from './types.js';
 
 /**
  * Options for RoutedOutputAdapter.

--- a/src/nodes/communication-node.test.ts
+++ b/src/nodes/communication-node.test.ts
@@ -5,7 +5,7 @@
  * Issue #241: Refactored to use ExecNodeManager and ChannelManager
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WebSocket } from 'ws';
 
 // Mock the dependencies

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -19,7 +19,7 @@ import http from 'node:http';
 import { EventEmitter } from 'events';
 import { Config } from '../config/index.js';
 import { createLogger } from '../utils/logger.js';
-import type { IChannel, IncomingMessage, OutgoingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
+import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
 import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage } from '../types/websocket-messages.js';
@@ -380,7 +380,7 @@ export class CommunicationNode extends EventEmitter {
       }
 
       case 'switch-node': {
-        const targetNodeId = command.targetNodeId;
+        const {targetNodeId} = command;
         if (!targetNodeId) {
           // Show usage hint
           const nodes = this.execNodeManager.getStats();

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -34,7 +34,7 @@ import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, OutgoingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
-import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage, ExecNodeInfo as WsExecNodeInfo } from '../types/websocket-messages.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage } from '../types/websocket-messages.js';
 import type { FileRef } from '../file-transfer/types.js';
 import { FileStorageService, type FileStorageConfig } from '../file-transfer/node-transfer/file-storage.js';
 import { createFileTransferAPIHandler } from '../file-transfer/node-transfer/file-api.js';
@@ -805,7 +805,7 @@ export class PrimaryNode extends EventEmitter {
       }
 
       case 'switch-node': {
-        const targetNodeId = command.targetNodeId;
+        const {targetNodeId} = command;
         if (!targetNodeId) {
           const nodes = this.getExecNodes();
           const nodesList = nodes.map(n => `- \`${n.nodeId}\` (${n.name}${n.isLocal ? ', local' : ''})`).join('\n');

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -503,7 +503,7 @@ export class WorkerNode {
   /**
    * Stop the Worker Node.
    */
-  async stop(): Promise<void> {
+  stop(): void {
     if (!this.running) {return;}
 
     this.running = false;

--- a/src/platforms/feishu/card-builders/interactive-card-builder.test.ts
+++ b/src/platforms/feishu/card-builders/interactive-card-builder.test.ts
@@ -10,7 +10,6 @@ import {
   buildMarkdown,
   buildDivider,
   buildActionGroup,
-  buildNote,
   buildCard,
   buildConfirmCard,
   buildSelectionCard,

--- a/src/platforms/feishu/card-builders/interactive-card-builder.ts
+++ b/src/platforms/feishu/card-builders/interactive-card-builder.ts
@@ -313,16 +313,6 @@ export function buildColumnSet(columns: ColumnConfig[]): CardElement {
  * });
  */
 export function buildCard(config: CardConfig): Record<string, unknown> {
-  const card: Record<string, unknown> = {
-    type: 'template',
-    data: {
-      template_id: 'AAqkz9****', // Default template, can be customized
-      template_variable: {
-        elements: config.elements,
-      },
-    },
-  };
-
   // Build custom card structure without template
   const customCard: Record<string, unknown> = {
     config: {

--- a/src/platforms/feishu/feishu-message-sender.test.ts
+++ b/src/platforms/feishu/feishu-message-sender.test.ts
@@ -244,8 +244,6 @@ describe('FeishuMessageSender', () => {
       const mockUpload = uploadAndSendFile as ReturnType<typeof vi.fn>;
       mockUpload.mockResolvedValue(5120);
 
-      const { messageLogger } = await import('../../feishu/message-logger.js');
-
       await sender.sendFile('chat_456', '/path/to/document.pdf');
 
       expect(mockLogger.info).toHaveBeenCalledWith(

--- a/src/platforms/feishu/interaction-manager.test.ts
+++ b/src/platforms/feishu/interaction-manager.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { InteractionManager } from './interaction-manager.js';
-import type { FeishuCardActionEvent, InteractionContext } from '../../../types/platform.js';
+import type { FeishuCardActionEvent } from '../../../types/platform.js';
 
 describe('InteractionManager', () => {
   let manager: InteractionManager;

--- a/src/schedule/schedule-file-watcher.test.ts
+++ b/src/schedule/schedule-file-watcher.test.ts
@@ -24,7 +24,7 @@ const waitForCondition = async (
   const { timeout = 5000, interval = 100 } = options;
   const start = Date.now();
   while (Date.now() - start < timeout) {
-    if (condition()) return true;
+    if (condition()) {return true;}
     await waitFor(interval);
   }
   return false;
@@ -264,8 +264,8 @@ chatId: "oc_test"
 Prompt`;
 
       await fs.writeFile(filePath, content);
-      await fs.writeFile(filePath, content + '\n1');
-      await fs.writeFile(filePath, content + '\n2');
+      await fs.writeFile(filePath, `${content  }\n1`);
+      await fs.writeFile(filePath, `${content  }\n2`);
 
       const called = await waitForCondition(() => onFileAdded.mock.calls.length > 0);
       expect(called).toBe(true);

--- a/src/schedule/schedule-manager.test.ts
+++ b/src/schedule/schedule-manager.test.ts
@@ -424,7 +424,7 @@ Updated`;
       const expectedId = getTaskId('test-task');
 
       // Create second manager (simulating another process)
-      const manager2 = new ScheduleManager({ schedulesDir: testDir });
+      const _manager2 = new ScheduleManager({ schedulesDir: testDir });
 
       // Modify file directly (simulating update via another process)
       const filePath = path.join(testDir, 'test-task.md');

--- a/src/sdk/factory.test.ts
+++ b/src/sdk/factory.test.ts
@@ -158,7 +158,7 @@ describe('ClaudeSDKProvider', () => {
         name: 'test_tool',
         description: 'A test tool',
         parameters: z.object({ input: z.string() }),
-        handler: async () => 'result',
+        handler: () => 'result',
       };
       const tool = provider.createInlineTool(toolDef);
       expect(tool).toBeDefined();

--- a/src/sdk/providers/claude/message-adapter.ts
+++ b/src/sdk/providers/claude/message-adapter.ts
@@ -55,7 +55,7 @@ export function adaptSDKMessage(message: SDKMessage): AgentMessage {
 
       // 处理工具使用
       if (toolBlocks.length > 0) {
-        const block = toolBlocks[0]; // 取第一个工具使用
+        const [block] = toolBlocks; // 取第一个工具使用
         if ('name' in block && 'input' in block) {
           metadata.toolName = block.name as string;
           metadata.toolInput = block.input;
@@ -262,7 +262,7 @@ function formatToolInput(toolName: string, input: Record<string, unknown> | unde
     }
     case 'Grep': {
       const pattern = input.pattern as string | undefined;
-      return pattern ? `🔧 Searching for "${pattern}"` : `🔧 Searching`;
+      return pattern ? `🔧 Searching for "${pattern}"` : '🔧 Searching';
     }
     case 'Glob': {
       const globPattern = input.pattern as string | undefined;

--- a/src/task/iteration-bridge.ts
+++ b/src/task/iteration-bridge.ts
@@ -183,7 +183,7 @@ export class IterationBridge {
    * Initialize metrics tracking for this iteration.
    */
   private initMetrics(): void {
-    if (!this.enableMetrics) return;
+    if (!this.enableMetrics) {return;}
 
     this.metrics = {
       taskId: this.taskId,

--- a/src/task/task-file-watcher.test.ts
+++ b/src/task/task-file-watcher.test.ts
@@ -224,7 +224,7 @@ Test task description.
       await new Promise(resolve => setTimeout(resolve, 500));
 
       // Modify the file
-      await fs.promises.writeFile(taskFile, taskContent + '\n\nMore content', 'utf-8');
+      await fs.promises.writeFile(taskFile, `${taskContent  }\n\nMore content`, 'utf-8');
 
       // Wait briefly - modified file should not retrigger
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -276,7 +276,7 @@ Test task description.
     it('should continue processing after task failure', async () => {
       const executionOrder: string[] = [];
 
-      const failingCallback = vi.fn(async (_taskPath: string, messageId: string) => {
+      const failingCallback = vi.fn((_taskPath: string, messageId: string) => {
         if (messageId === 'msg_fail') {
           throw new Error('Task failed');
         }

--- a/src/task/task-file-watcher.ts
+++ b/src/task/task-file-watcher.ts
@@ -187,7 +187,7 @@ export class TaskFileWatcher {
    * Wait for a new task file to be created.
    * Uses fs.watch for efficiency.
    */
-  private async waitForNewTask(): Promise<void> {
+  private waitForNewTask(): Promise<void> {
     return new Promise<void>((resolve) => {
       this.waitResolver = resolve;
 


### PR DESCRIPTION
## Summary

修复主分支中的大部分 ESLint 错误，将错误数量从 103 个减少到 13 个。

## 修复内容

### 未使用的变量和导入
- 移除或添加 `_` 前缀到未使用的变量
- 合并重复的导入语句

### require-await 错误
- 移除没有 await 的 async 方法的 async 关键字
- 或改为返回 `Promise.resolve()` / `Promise.reject()`

### prefer-destructuring 错误
- 使用对象/数组解构赋值替代属性访问

### 其他
- 修复 prefer-template 和 quotes 错误
- 修复 no-unreachable 错误

## 剩余问题

还有 13 个 prefer-destructuring 错误在测试文件中，可以在后续 PR 中修复。

## Verification

- ✅ 所有 1146 个单元测试通过
- ✅ 构建成功
- ✅ ESLint 错误从 103 减少到 13

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 运行构建 `npm run build`
- [x] 验证 ESLint 错误减少

🤖 Generated with [Claude Code](https://claude.com/claude-code)