### PR TITLE
fix: 修复 ESLint 问题 (79 -> 59 问题)

### DIFF
--- a/src/feishu/task-flow-orchestrator.test.ts
+++ b/src/feishu/task-flow-orchestrator.test.ts
@@ -158,7 +158,7 @@ describe('TaskFlowOrchestrator', () => {
     it('should start dialogue phase with task path', async () => {
       const taskPath = '/test/workspace/tasks/msg_123/task.md';
 
-      orchestrator.executeDialoguePhase('chat-123', 'msg-001', taskPath);
+      void orchestrator.executeDialoguePhase('chat-123', 'msg-001', taskPath);
 
       // Wait a bit for async operations
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -169,7 +169,7 @@ describe('TaskFlowOrchestrator', () => {
     it('should handle chat ID correctly', async () => {
       const taskPath = '/test/workspace/tasks/msg_456/task.md';
 
-      orchestrator.executeDialoguePhase('test-chat-id', 'msg-002', taskPath);
+      void orchestrator.executeDialoguePhase('test-chat-id', 'msg-002', taskPath);
 
       await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -182,7 +182,7 @@ describe('TaskFlowOrchestrator', () => {
     it('should log dialogue phase start', async () => {
       const taskPath = '/test/workspace/tasks/msg_789/task.md';
 
-      orchestrator.executeDialoguePhase('chat-123', 'msg-003', taskPath);
+      void orchestrator.executeDialoguePhase('chat-123', 'msg-003', taskPath);
 
       await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -231,7 +231,7 @@ describe('TaskFlowOrchestrator', () => {
       );
 
       const taskPath = '/test/workspace/tasks/msg_err/task.md';
-      errorOrchestrator.executeDialoguePhase('chat-err', 'msg-err', taskPath);
+      void errorOrchestrator.executeDialoguePhase('chat-err', 'msg-err', taskPath);
 
       // Wait for async error handling
       await new Promise(resolve => setTimeout(resolve, 200));

--- a/src/file-transfer/node-transfer/file-api.test.ts
+++ b/src/file-transfer/node-transfer/file-api.test.ts
@@ -156,7 +156,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
       expect(response.error).toContain('Missing required fields');
@@ -172,7 +172,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
     });
@@ -197,7 +197,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
       expect(response.error).toContain('not found');
@@ -224,7 +224,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
       expect(response.error).toContain('not found');
@@ -250,7 +250,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
       expect(response.error).toContain('not found');
@@ -268,7 +268,7 @@ describe('createFileTransferAPIHandler', () => {
       const handled = await handler(req, res);
 
       expect(handled).toBe(true);
-      const endCall = (res.end as ReturnType<typeof vi.fn>).mock.calls[0];
+      const [endCall] = (res.end as ReturnType<typeof vi.fn>).mock.calls;
       const response = JSON.parse(endCall[0]);
       expect(response.success).toBe(false);
       expect(response.error).toContain('Storage error');

--- a/src/nodes/channel-manager.test.ts
+++ b/src/nodes/channel-manager.test.ts
@@ -201,7 +201,7 @@ describe('ChannelManager', () => {
   });
 
   describe('setupHandlers()', () => {
-    it('should set up message and control handlers', async () => {
+    it('should set up message and control handlers', () => {
       const channel = createMockChannel('feishu');
       manager.register(channel);
 
@@ -224,7 +224,7 @@ describe('ChannelManager', () => {
       manager.setupHandlers(channel, messageHandler, controlHandler);
 
       // Get the handler that was passed to onMessage
-      const registeredHandler = (channel.onMessage as any).mock.calls[0][0];
+      const [[registeredHandler]] = (channel.onMessage as any).mock.calls;
 
       // Call the handler with a message - should not throw
       const message: IncomingMessage = {

--- a/src/nodes/communication-node.test.ts
+++ b/src/nodes/communication-node.test.ts
@@ -138,7 +138,7 @@ describe('CommunicationNode Multi-Execution Node Support', () => {
         appId: undefined,
         appSecret: undefined,
       });
-      execNodeManager = (commNode as any).execNodeManager;
+      ({ execNodeManager } = commNode as any);
     });
 
     it('registerExecNode should add node to execNodes map', () => {

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -111,7 +111,7 @@ export class CommunicationNode extends EventEmitter {
       });
 
       // Initialize TaskFlowOrchestrator for Feishu channel
-      feishuChannel.initTaskFlowOrchestrator({
+      void feishuChannel.initTaskFlowOrchestrator({
         sendMessage: this.sendMessage.bind(this),
         sendCard: this.sendCard.bind(this),
         sendFile: this.sendFileToUser.bind(this),

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -137,7 +137,7 @@ export class PrimaryNode extends EventEmitter {
       });
 
       // Initialize TaskFlowOrchestrator for Feishu channel
-      feishuChannel.initTaskFlowOrchestrator({
+      void feishuChannel.initTaskFlowOrchestrator({
         sendMessage: this.sendMessage.bind(this),
         sendCard: this.sendCard.bind(this),
         sendFile: this.sendFileToUser.bind(this),
@@ -585,7 +585,7 @@ export class PrimaryNode extends EventEmitter {
   /**
    * Execute a prompt locally using the shared Pilot.
    */
-  private async executeLocally(message: PromptMessage): Promise<void> {
+  private executeLocally(message: PromptMessage): void {
     if (!this.sharedPilot) {
       throw new Error('Local execution not initialized');
     }

--- a/src/platforms/feishu/feishu-file-handler.test.ts
+++ b/src/platforms/feishu/feishu-file-handler.test.ts
@@ -173,7 +173,7 @@ describe('FeishuFileHandler', () => {
       const mockAdd = mockAttachmentManager.addAttachment as ReturnType<typeof vi.fn>;
       expect(mockAdd).toHaveBeenCalled();
 
-      const [chatId, attachment] = mockAdd.mock.calls[0];
+      const [[chatId, attachment]] = mockAdd.mock.calls;
       expect(chatId).toBe('chat-123');
       expect(attachment.fileKey).toBe('img_key');
       expect(attachment.messageId).toBe('msg-456');

--- a/src/schedule/schedule-file-scanner.test.ts
+++ b/src/schedule/schedule-file-scanner.test.ts
@@ -372,7 +372,7 @@ Prompt`;
       const tasks = await scanner.scanAll();
 
       expect(tasks).toHaveLength(1);
-      const readTask = tasks[0];
+      const [readTask] = tasks;
 
       expect(readTask.id).toBe(originalTask.id);
       expect(readTask.name).toBe(originalTask.name);

--- a/src/schedule/schedule-file-watcher.test.ts
+++ b/src/schedule/schedule-file-watcher.test.ts
@@ -184,7 +184,7 @@ Prompt`;
       const called = await waitForCondition(() => onFileRemoved.mock.calls.length > 0);
       expect(called).toBe(true);
 
-      const [taskId, removedFilePath] = onFileRemoved.mock.calls[0];
+      const [[taskId, removedFilePath]] = onFileRemoved.mock.calls;
       expect(taskId).toBe('schedule-remove-task');
       expect(removedFilePath).toBe(filePath);
     });

--- a/src/schedule/schedule-watcher.ts
+++ b/src/schedule/schedule-watcher.ts
@@ -442,7 +442,7 @@ export class ScheduleFileWatcher {
     // Debounce the event
     const timer = setTimeout(() => {
       this.debounceTimers.delete(filePath);
-      this.processFileEvent(eventType, filePath, filename);
+      void this.processFileEvent(eventType, filePath, filename);
     }, this.debounceMs);
 
     this.debounceTimers.set(filePath, timer);


### PR DESCRIPTION
## Summary

修复主分支中的 ESLint 问题，将问题数量从 79 个减少到 59 个（0 errors, 59 warnings）。

## 修复内容

### Errors 修复 (13 -> 0)

**prefer-destructuring (11个)**
- `file-api.test.ts`: 使用数组解构 `const [endCall] = ...mock.calls`
- `channel-manager.test.ts`: 使用嵌套解构 `const [[registeredHandler]] = ...mock.calls`
- `communication-node.test.ts`: 使用对象解构 `({ execNodeManager } = ...)`
- `feishu-file-handler.test.ts`: 使用嵌套解构
- `schedule-file-scanner.test.ts`: 使用数组解构 `const [readTask] = tasks`
- `schedule-file-watcher.test.ts`: 使用嵌套解构

**require-await (2个)**
- `channel-manager.test.ts`: 移除不需要的 `async` 关键字
- `primary-node.ts`: `executeLocally` 方法移除不需要的 `async`

### Warnings 修复 (66 -> 59)

**no-floating-promises (7个)**
- `task-flow-orchestrator.test.ts`: 使用 `void` 显式忽略 fire-and-forget Promise
- `communication-node.ts`: 使用 `void` 忽略 `initTaskFlowOrchestrator` 返回值
- `primary-node.ts`: 使用 `void` 忽略 `initTaskFlowOrchestrator` 返回值
- `schedule-watcher.ts`: 在 setTimeout 中使用 `void` 包装 async 调用

## 验证

- ✅ 所有 1146 个单元测试通过
- ✅ ESLint errors 从 13 减少到 0
- ✅ ESLint warnings 从 66 减少到 59

## 剩余 Warnings

剩余的 59 个 warnings 主要是：
- `@typescript-eslint/no-explicit-any` (~41个) - 测试代码中常见的类型绕过
- `@typescript-eslint/no-non-null-assertion` (~18个) - 测试代码中的非空断言

这些 warnings 在测试代码中是可以接受的，可以在后续 PR 中继续优化。

## Test plan

- [x] 运行单元测试 `npm test`
- [x] 运行 lint 检查 `npm run lint`
- [x] 验证错误数量减少

Fixes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)