### PR TITLE
fix: resolve TypeScript and ESLint errors from CI failure

### DIFF
--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -308,7 +308,7 @@ describe('SiteMiner Subagent Interface', () => {
       }
 
       expect(messages.length).toBe(1);
-      const content = messages[0].content;
+      const [{ content }] = messages;
       expect(typeof content).toBe('string');
       const result = JSON.parse(content as string);
       expect(result.success).toBe(false);

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -208,6 +208,8 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
         );
       }
     }
+
+    return Promise.resolve();
   }
 
   protected checkHealth(): boolean {

--- a/src/sdk/factory.test.ts
+++ b/src/sdk/factory.test.ts
@@ -158,7 +158,7 @@ describe('ClaudeSDKProvider', () => {
         name: 'test_tool',
         description: 'A test tool',
         parameters: z.object({ input: z.string() }),
-        handler: async () => 'result',
+        handler: () => Promise.resolve('result'),
       };
       const tool = provider.createInlineTool(toolDef);
       expect(tool).toBeDefined();


### PR DESCRIPTION
## Summary

修复 CI 自动测试失败的问题 (#382)

### 问题详情

1. **TypeScript 类型错误**: `rest-channel.ts:164` - `doSendMessage` 函数声明返回 `Promise<void>` 但缺少结尾的 return 语句
2. **ESLint prefer-destructuring 错误**: `site-miner.test.ts:311` - 应使用数组解构
3. **ESLint require-await 错误**: `factory.test.ts:161` - async 函数中没有 await 表达式

### 修复内容

- **rest-channel.ts**: 在 `doSendMessage` 函数末尾添加 `return Promise.resolve();`
- **site-miner.test.ts**: 将 `const { content } = messages[0]` 改为 `const [{ content }] = messages`
- **factory.test.ts**: 将 `async () => 'result'` 改为 `() => Promise.resolve('result')`

## Test plan

- [x] TypeScript 类型检查通过 (`npm run type-check`)
- [x] ESLint 检查通过 (0 errors, 62 warnings)
- [x] 单元测试全部通过 (1147 passed, 8 skipped)

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)