### PR TITLE
fix(feishu): control commands now always handled locally regardless of mentions

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -1,10 +1,12 @@
 /**
- * Tests for FeishuChannel command pass-through behavior when bot is mentioned.
+ * Tests for FeishuChannel command handling behavior.
  *
- * Issue #280: @bot 无法正确透传 /reset 指令给 agent
+ * Issue #280: @bot 无法正确透传 /reset 指令给 agent (original behavior)
+ * Issue #387: /reset 命令在 @提及 时不生效 (fix: control commands always handled locally)
  *
- * When bot is mentioned (@bot), commands should be passed through to the agent
- * instead of being handled locally by the channel.
+ * Control commands (reset, status, help) should ALWAYS be handled locally,
+ * regardless of mentions. Only non-control commands with @mention are passed
+ * to agent for context-aware handling.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -92,7 +94,7 @@ vi.mock('../utils/task-tracker.js', () => ({
 
 import { FeishuChannel } from './feishu-channel.js';
 
-describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
+describe('FeishuChannel - Command Handling (Issue #387)', () => {
   let channel: FeishuChannel;
   let messageHandler: ReturnType<typeof vi.fn>;
   let controlHandler: ReturnType<typeof vi.fn>;
@@ -123,7 +125,7 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
     }
   });
 
-  describe('isBotMentioned helper (indirectly tested via command behavior)', () => {
+  describe('Control commands should ALWAYS be handled locally (Issue #387)', () => {
     /**
      * Helper to simulate receiving a message.
      * We access the private method via type casting for testing.
@@ -157,7 +159,7 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
       await handler({ event: mockEvent });
     }
 
-    it('should handle command locally when bot is NOT mentioned', async () => {
+    it('should handle /reset locally when bot is NOT mentioned', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: undefined, // No mentions
@@ -175,7 +177,7 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should pass command to agent when bot IS mentioned', async () => {
+    it('should handle /reset locally EVEN WHEN bot IS mentioned (Issue #387 fix)', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: [
@@ -187,40 +189,98 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         ],
       });
 
-      // Control handler should NOT be called (command passed to agent)
-      expect(controlHandler).not.toHaveBeenCalled();
-
-      // Message should be passed to agent
-      expect(messageHandler).toHaveBeenCalledWith(
+      // Control handler SHOULD be called (local handling) - this is the fix for Issue #387
+      expect(controlHandler).toHaveBeenCalledWith(
         expect.objectContaining({
+          type: 'reset',
           chatId: 'test-chat-id',
-          content: '/reset',
         })
       );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should pass command to agent when there are multiple mentions', async () => {
+    it('should handle /status locally when bot IS mentioned', async () => {
       await simulateMessageReceive({
-        text: '/reset',
+        text: '/status',
         mentions: [
           {
-            key: '@_user1',
-            id: { open_id: 'user1-open-id' },
-            name: 'User1',
-          },
-          {
-            key: '@_user2',
-            id: { open_id: 'user2-open-id' },
-            name: 'User2',
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
           },
         ],
       });
 
-      // Command should be passed to agent
+      // Control handler should be called (local handling)
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'status',
+        })
+      );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle /help locally when bot IS mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/help',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should be called (local handling)
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'help',
+        })
+      );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should pass NON-CONTROL command to agent when bot IS mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/custom-command',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should NOT be called for non-control commands with mention
       expect(controlHandler).not.toHaveBeenCalled();
+
+      // Message should be passed to agent for context-aware handling
       expect(messageHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: '/reset',
+          chatId: 'test-chat-id',
+          content: '/custom-command',
+        })
+      );
+    });
+
+    it('should try control handler for unknown commands WITHOUT mention', async () => {
+      await simulateMessageReceive({
+        text: '/unknown-cmd',
+        mentions: undefined,
+      });
+
+      // Control handler should be tried (will return success: false for unknown)
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'unknown-cmd',
         })
       );
     });
@@ -248,18 +308,32 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
       );
     });
 
-    it('should handle command without mentions normally', async () => {
+    it('should handle command with multiple mentions', async () => {
       await simulateMessageReceive({
-        text: '/status',
-        mentions: undefined,
+        text: '/reset',
+        mentions: [
+          {
+            key: '@_user1',
+            id: { open_id: 'user1-open-id' },
+            name: 'User1',
+          },
+          {
+            key: '@_user2',
+            id: { open_id: 'user2-open-id' },
+            name: 'User2',
+          },
+        ],
       });
 
-      // Control handler should be called
+      // Control command should STILL be handled locally
       expect(controlHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'status',
+          type: 'reset',
         })
       );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -427,68 +427,95 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     );
 
     // Check for control commands
-    // When bot is mentioned (@bot), pass commands through to agent instead of handling locally
+    // Control commands (reset, status, help) should ALWAYS be handled locally, regardless of mentions
+    // Other commands with @mention are passed to agent for context-aware handling
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
-    if (trimmedText.startsWith('/') && !botMentioned) {
+    if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
 
-      if (this.controlHandler) {
-        const response = await this.emitControl({
-          type: cmd as any,
-          chatId: chat_id,
-          data: { args, rawText: trimmedText },
-        });
+      // Control commands that should always be executed locally
+      const controlCommands = ['reset', 'status', 'help'];
+      const isControlCommand = controlCommands.includes(cmd);
 
-        // Only return if command was successfully handled
-        // Unknown commands (success: false) will fall through to normal message processing
-        if (response.success) {
-          if (response.message) {
-            await this.sendMessage({
-              chatId: chat_id,
-              type: 'text',
-              text: response.message,
-            });
+      // Handle control commands locally, regardless of mentions
+      if (isControlCommand) {
+        if (this.controlHandler) {
+          const response = await this.emitControl({
+            type: cmd as any,
+            chatId: chat_id,
+            data: { args, rawText: trimmedText },
+          });
+
+          if (response.success) {
+            if (response.message) {
+              await this.sendMessage({
+                chatId: chat_id,
+                type: 'text',
+                text: response.message,
+              });
+            }
+            return;
           }
+        }
+
+        // Default command handling if no control handler registered
+        if (cmd === 'reset') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
+          });
           return;
         }
-        // Unknown command: fall through to emitMessage for Agent to handle
+
+        if (cmd === 'status') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
+          });
+          return;
+        }
+
+        if (cmd === 'help') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+          });
+          return;
+        }
       }
 
-      // Default command handling if no control handler registered
-      if (cmd === 'reset') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
-        });
-        return;
-      }
+      // For non-control commands with @mention, pass to agent for context-aware handling
+      if (botMentioned) {
+        logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
+        // Fall through to emitMessage
+      } else {
+        // Non-control command without @mention - try control handler for unknown commands
+        if (this.controlHandler) {
+          const response = await this.emitControl({
+            type: cmd as any,
+            chatId: chat_id,
+            data: { args, rawText: trimmedText },
+          });
 
-      if (cmd === 'status') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
-        });
-        return;
+          if (response.success) {
+            if (response.message) {
+              await this.sendMessage({
+                chatId: chat_id,
+                type: 'text',
+                text: response.message,
+              });
+            }
+            return;
+          }
+        }
+        // Unknown command without @mention: fall through to emitMessage for Agent to handle
       }
-
-      if (cmd === 'help') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
-        });
-        return;
-      }
-    }
-
-    // Log if bot is mentioned with a command (for debugging)
-    if (botMentioned && trimmedText.startsWith('/')) {
-      logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with command, passing to agent');
     }
 
     // Emit as incoming message


### PR DESCRIPTION
## Summary
Fixes #387 - Control commands (`/reset`, `/status`, `/help`) are now always handled locally, regardless of @mentions.

## Problem
When users send `/reset` with @mention (e.g., `@bot /reset`), the command was passed to the Agent instead of being executed locally, resulting in the reset operation not actually being performed.

## Root Cause
```typescript
if (trimmedText.startsWith('/') && !botMentioned) {
  // Command handling - ONLY executed when NOT mentioned
}
```
This meant ALL commands with @mention were skipped and passed to Agent.

## Solution
- Control commands (reset, status, help) are now always handled locally
- Non-control commands with @mention are still passed to agent for context-aware handling

## Changes
- Modified `feishu-channel.ts` command handling logic
- Updated `feishu-channel-mention.test.ts` to reflect new expected behavior

## Test Results
✅ All 1150 tests passed (65 test files)
✅ 8 tests specifically for this fix

## Test Plan
- [ ] Test `/reset` without @mention → should reset locally
- [ ] Test `/reset` with @mention → should reset locally (this is the fix!)
- [ ] Test `/status` with @mention → should show status locally
- [ ] Test `/help` with @mention → should show help locally
- [ ] Test `/custom-command` with @mention → should pass to agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)