### PR TITLE
feat(feishu): add ChatRegistry and ProactiveMessenger for Issue #357

### DIFF
--- a/src/feishu/chat-registry.test.ts
+++ b/src/feishu/chat-registry.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for ChatRegistry.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { ChatRegistry } from './chat-registry.js';
+import { Config } from '../config/index.js';
+
+describe('ChatRegistry', () => {
+  let registry: ChatRegistry;
+  let testRegistryPath: string;
+
+  beforeEach(async () => {
+    // Create a fresh registry instance for each test
+    registry = new ChatRegistry();
+    testRegistryPath = path.join(Config.getWorkspaceDir(), 'chat-registry.json');
+
+    // Clean up any existing registry file
+    try {
+      await fs.unlink(testRegistryPath);
+    } catch {
+      // File doesn't exist, that's fine
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up after each test
+    try {
+      await fs.unlink(testRegistryPath);
+    } catch {
+      // File doesn't exist, that's fine
+    }
+  });
+
+  describe('init', () => {
+    it('should initialize with empty registry when no file exists', async () => {
+      await registry.init();
+      const chats = await registry.getAll();
+      expect(chats).toEqual([]);
+    });
+
+    it('should load existing chats from file', async () => {
+      // Create a registry file manually
+      const existingChats = [
+        {
+          chatId: 'oc_test1',
+          userId: 'ou_user1',
+          chatName: 'Test Chat 1',
+          firstSeenAt: '2024-01-01T00:00:00Z',
+          lastSeenAt: '2024-01-02T00:00:00Z',
+          enabled: true,
+        },
+      ];
+      await fs.mkdir(path.dirname(testRegistryPath), { recursive: true });
+      await fs.writeFile(testRegistryPath, JSON.stringify(existingChats, null, 2));
+
+      await registry.init();
+      const chats = await registry.getAll();
+
+      expect(chats).toHaveLength(1);
+      expect(chats[0].chatId).toBe('oc_test1');
+      expect(chats[0].userId).toBe('ou_user1');
+    });
+  });
+
+  describe('register', () => {
+    it('should register a new chat', async () => {
+      const chatInfo = await registry.register('oc_new', {
+        userId: 'ou_user',
+        chatName: 'New Chat',
+      });
+
+      expect(chatInfo.chatId).toBe('oc_new');
+      expect(chatInfo.userId).toBe('ou_user');
+      expect(chatInfo.chatName).toBe('New Chat');
+      expect(chatInfo.enabled).toBe(true);
+      expect(chatInfo.firstSeenAt).toBeDefined();
+      expect(chatInfo.lastSeenAt).toBeDefined();
+    });
+
+    it('should update existing chat while preserving firstSeenAt', async () => {
+      // Register first time
+      const first = await registry.register('oc_update', { chatName: 'Original' });
+
+      // Wait a bit to ensure timestamp difference
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Update the chat
+      const updated = await registry.register('oc_update', { chatName: 'Updated' });
+
+      expect(updated.chatName).toBe('Updated');
+      expect(updated.firstSeenAt).toBe(first.firstSeenAt);
+      expect(updated.lastSeenAt).not.toBe(first.lastSeenAt);
+    });
+  });
+
+  describe('get', () => {
+    it('should return undefined for non-existent chat', async () => {
+      const chat = await registry.get('oc_nonexistent');
+      expect(chat).toBeUndefined();
+    });
+
+    it('should return chat info for existing chat', async () => {
+      await registry.register('oc_exists', { chatName: 'Exists' });
+      const chat = await registry.get('oc_exists');
+
+      expect(chat).toBeDefined();
+      expect(chat?.chatName).toBe('Exists');
+    });
+  });
+
+  describe('getEnabledChats', () => {
+    it('should return only enabled chats', async () => {
+      await registry.register('oc_enabled1', { enabled: true });
+      await registry.register('oc_enabled2', { enabled: true });
+      await registry.register('oc_disabled', { enabled: false });
+
+      const enabled = await registry.getEnabledChats();
+
+      expect(enabled).toHaveLength(2);
+      expect(enabled.map((c) => c.chatId).sort()).toEqual(['oc_enabled1', 'oc_enabled2']);
+    });
+  });
+
+  describe('setEnabled', () => {
+    it('should enable/disable a chat', async () => {
+      await registry.register('oc_toggle', { enabled: true });
+
+      const result = await registry.setEnabled('oc_toggle', false);
+      expect(result).toBe(true);
+
+      const chat = await registry.get('oc_toggle');
+      expect(chat?.enabled).toBe(false);
+    });
+
+    it('should return false for non-existent chat', async () => {
+      const result = await registry.setEnabled('oc_nonexistent', true);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an existing chat', async () => {
+      await registry.register('oc_remove', {});
+      const result = await registry.remove('oc_remove');
+
+      expect(result).toBe(true);
+
+      const chat = await registry.get('oc_remove');
+      expect(chat).toBeUndefined();
+    });
+
+    it('should return false for non-existent chat', async () => {
+      const result = await registry.remove('oc_nonexistent');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('has', () => {
+    it('should return true for existing chat', async () => {
+      await registry.register('oc_has', {});
+      const result = await registry.has('oc_has');
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-existent chat', async () => {
+      const result = await registry.has('oc_nonexistent');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('persistence', () => {
+    it('should persist data to file', async () => {
+      await registry.register('oc_persist', { chatName: 'Persistent' });
+
+      // Create a new registry instance to test persistence
+      const newRegistry = new ChatRegistry();
+      await newRegistry.init();
+
+      const chat = await newRegistry.get('oc_persist');
+      expect(chat?.chatName).toBe('Persistent');
+    });
+  });
+});

--- a/src/feishu/chat-registry.ts
+++ b/src/feishu/chat-registry.ts
@@ -1,0 +1,214 @@
+/**
+ * Chat Registry - Manages chatId storage and lookup.
+ *
+ * Stores mappings of chatId to user metadata for proactive messaging.
+ * Persists data to a JSON file in the workspace directory.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { Config } from '../config/index.js';
+
+/**
+ * Chat metadata stored in the registry.
+ */
+export interface ChatInfo {
+  /** Feishu chat ID */
+  chatId: string;
+  /** User ID who interacted with the bot */
+  userId?: string;
+  /** Chat name (if available) */
+  chatName?: string;
+  /** First interaction timestamp */
+  firstSeenAt: string;
+  /** Last interaction timestamp */
+  lastSeenAt: string;
+  /** Whether this chat is enabled for proactive messaging */
+  enabled: boolean;
+}
+
+/**
+ * Chat Registry - Manages registered chats for proactive messaging.
+ *
+ * Usage:
+ * ```typescript
+ * const registry = new ChatRegistry();
+ * await registry.init();
+ *
+ * // Register a chat
+ * await registry.register('oc_xxx', { userId: 'ou_xxx', chatName: 'My Chat' });
+ *
+ * // Get all enabled chats
+ * const chats = await registry.getEnabledChats();
+ *
+ * // Check if chat exists
+ * const info = await registry.get('oc_xxx');
+ * ```
+ */
+export class ChatRegistry {
+  private registryPath: string;
+  private chats: Map<string, ChatInfo> = new Map();
+  private initialized = false;
+
+  constructor() {
+    const workspaceDir = Config.getWorkspaceDir();
+    this.registryPath = path.join(workspaceDir, 'chat-registry.json');
+  }
+
+  /**
+   * Initialize the registry by loading from file.
+   */
+  async init(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    try {
+      const data = await fs.readFile(this.registryPath, 'utf-8');
+      const parsed = JSON.parse(data) as ChatInfo[];
+      for (const chat of parsed) {
+        this.chats.set(chat.chatId, chat);
+      }
+      console.log(`[ChatRegistry] Loaded ${this.chats.size} chats from registry`);
+    } catch {
+      // File doesn't exist or is invalid, start fresh
+      console.log('[ChatRegistry] No existing registry found, starting fresh');
+    }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Save the registry to file.
+   */
+  private async save(): Promise<void> {
+    try {
+      // Ensure directory exists
+      const dir = path.dirname(this.registryPath);
+      await fs.mkdir(dir, { recursive: true });
+
+      const data = JSON.stringify(Array.from(this.chats.values()), null, 2);
+      await fs.writeFile(this.registryPath, data, 'utf-8');
+    } catch (error) {
+      console.error('[ChatRegistry] Failed to save registry:', error);
+    }
+  }
+
+  /**
+   * Register or update a chat.
+   *
+   * @param chatId - Feishu chat ID
+   * @param options - Optional metadata
+   */
+  async register(
+    chatId: string,
+    options?: { userId?: string; chatName?: string; enabled?: boolean }
+  ): Promise<ChatInfo> {
+    await this.init();
+
+    const now = new Date().toISOString();
+    const existing = this.chats.get(chatId);
+
+    const chatInfo: ChatInfo = {
+      chatId,
+      userId: options?.userId ?? existing?.userId,
+      chatName: options?.chatName ?? existing?.chatName,
+      firstSeenAt: existing?.firstSeenAt ?? now,
+      lastSeenAt: now,
+      enabled: options?.enabled ?? existing?.enabled ?? true,
+    };
+
+    this.chats.set(chatId, chatInfo);
+    await this.save();
+
+    return chatInfo;
+  }
+
+  /**
+   * Get chat info by ID.
+   *
+   * @param chatId - Feishu chat ID
+   * @returns Chat info or undefined if not found
+   */
+  async get(chatId: string): Promise<ChatInfo | undefined> {
+    await this.init();
+    return this.chats.get(chatId);
+  }
+
+  /**
+   * Get all registered chats.
+   *
+   * @returns Array of all chat info
+   */
+  async getAll(): Promise<ChatInfo[]> {
+    await this.init();
+    return Array.from(this.chats.values());
+  }
+
+  /**
+   * Get all chats enabled for proactive messaging.
+   *
+   * @returns Array of enabled chat info
+   */
+  async getEnabledChats(): Promise<ChatInfo[]> {
+    await this.init();
+    return Array.from(this.chats.values()).filter((chat) => chat.enabled);
+  }
+
+  /**
+   * Enable or disable a chat for proactive messaging.
+   *
+   * @param chatId - Feishu chat ID
+   * @param enabled - Whether to enable or disable
+   */
+  async setEnabled(chatId: string, enabled: boolean): Promise<boolean> {
+    await this.init();
+
+    const chat = this.chats.get(chatId);
+    if (!chat) {
+      return false;
+    }
+
+    chat.enabled = enabled;
+    await this.save();
+    return true;
+  }
+
+  /**
+   * Remove a chat from the registry.
+   *
+   * @param chatId - Feishu chat ID
+   * @returns true if chat was removed, false if not found
+   */
+  async remove(chatId: string): Promise<boolean> {
+    await this.init();
+
+    const existed = this.chats.delete(chatId);
+    if (existed) {
+      await this.save();
+    }
+    return existed;
+  }
+
+  /**
+   * Check if a chat is registered.
+   *
+   * @param chatId - Feishu chat ID
+   * @returns true if chat is registered
+   */
+  async has(chatId: string): Promise<boolean> {
+    await this.init();
+    return this.chats.has(chatId);
+  }
+
+  /**
+   * Clear the registry (useful for testing).
+   */
+  async clear(): Promise<void> {
+    this.chats.clear();
+    await this.save();
+  }
+}
+
+// Singleton instance
+export const chatRegistry = new ChatRegistry();

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -9,3 +9,10 @@
 // Re-export commonly used components
 export { TaskFlowOrchestrator } from './task-flow-orchestrator.js';
 export { messageLogger } from './message-logger.js';
+export { ChatRegistry, chatRegistry, type ChatInfo } from './chat-registry.js';
+export {
+  ProactiveMessenger,
+  createProactiveMessenger,
+  type Recommendation,
+  type ProactiveMessengerConfig,
+} from './proactive-messenger.js';

--- a/src/feishu/proactive-messenger.test.ts
+++ b/src/feishu/proactive-messenger.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for ProactiveMessenger.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { ProactiveMessenger, createProactiveMessenger } from './proactive-messenger.js';
+import { chatRegistry } from './chat-registry.js';
+import fs from 'fs/promises';
+import path from 'path';
+import { Config } from '../config/index.js';
+
+// Mock the lark client
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn(),
+}));
+
+describe('ProactiveMessenger', () => {
+  let messenger: ProactiveMessenger;
+  let mockClient: { im: { message: { create: ReturnType<typeof vi.fn> } } };
+  let testRegistryPath: string;
+
+  beforeEach(async () => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Create mock client
+    mockClient = {
+      im: {
+        message: {
+          create: vi.fn().mockResolvedValue({ data: { message_id: 'msg_123' } }),
+        },
+      },
+    };
+
+    messenger = new ProactiveMessenger({
+      client: mockClient as unknown as lark.Client,
+    });
+
+    // Clean up registry
+    testRegistryPath = path.join(Config.getWorkspaceDir(), 'chat-registry.json');
+    try {
+      await fs.unlink(testRegistryPath);
+    } catch {
+      // File doesn't exist
+    }
+
+    // Clear the registry singleton
+    await chatRegistry.clear();
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.unlink(testRegistryPath);
+    } catch {
+      // File doesn't exist
+    }
+  });
+
+  describe('sendMessage', () => {
+    it('should send a text message to a chat', async () => {
+      const result = await messenger.sendMessage('oc_test', 'Hello!');
+
+      expect(result).toBe(true);
+      expect(mockClient.im.message.create).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: 'oc_test',
+          msg_type: 'text',
+          content: expect.stringContaining('Hello!'),
+        },
+      });
+    });
+
+    it('should return false when send fails', async () => {
+      mockClient.im.message.create.mockRejectedValue(new Error('API error'));
+
+      const result = await messenger.sendMessage('oc_test', 'Hello!');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('sendRecommendation', () => {
+    it('should send a recommendation card', async () => {
+      const recommendation = {
+        taskType: 'GitHub Issues',
+        pattern: 'User checks issues daily at 9am',
+        suggestedCron: '0 9 * * *',
+        confidence: 'High' as const,
+        occurrenceCount: 5,
+        suggestedPrompt: 'Check for new GitHub issues',
+      };
+
+      const result = await messenger.sendRecommendation('oc_test', recommendation);
+
+      expect(result).toBe(true);
+      expect(mockClient.im.message.create).toHaveBeenCalledWith({
+        params: { receive_id_type: 'chat_id' },
+        data: {
+          receive_id: 'oc_test',
+          msg_type: 'interactive',
+          content: expect.any(String),
+        },
+      });
+
+      // Verify the card contains the task type
+      const [call] = mockClient.im.message.create.mock.calls;
+      const cardContent = JSON.stringify(call[0]);
+      expect(JSON.stringify(cardContent)).toContain('GitHub Issues');
+    });
+
+    it('should return false when send fails', async () => {
+      mockClient.im.message.create.mockRejectedValue(new Error('API error'));
+
+      const recommendation = {
+        taskType: 'Test',
+        pattern: 'Test pattern',
+        suggestedCron: '0 * * * *',
+        confidence: 'Low' as const,
+        occurrenceCount: 1,
+        suggestedPrompt: 'Test prompt',
+      };
+
+      const result = await messenger.sendRecommendation('oc_test', recommendation);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('broadcast', () => {
+    it('should send message to all enabled chats', async () => {
+      // Register some chats
+      await chatRegistry.register('oc_chat1', { enabled: true });
+      await chatRegistry.register('oc_chat2', { enabled: true });
+      await chatRegistry.register('oc_chat3', { enabled: false });
+
+      const count = await messenger.broadcast('Broadcast message');
+
+      expect(count).toBe(2);
+      expect(mockClient.im.message.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return 0 when no enabled chats', async () => {
+      const count = await messenger.broadcast('No one to hear');
+
+      expect(count).toBe(0);
+      expect(mockClient.im.message.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getEnabledChats', () => {
+    it('should return enabled chats from registry', async () => {
+      await chatRegistry.register('oc_enabled', { enabled: true, chatName: 'Enabled Chat' });
+
+      const chats = await messenger.getEnabledChats();
+
+      expect(chats).toHaveLength(1);
+      expect(chats[0].chatId).toBe('oc_enabled');
+    });
+  });
+
+  describe('registerChat', () => {
+    it('should register a chat for proactive messaging', async () => {
+      await messenger.registerChat('oc_new', { userId: 'ou_user', chatName: 'New Chat' });
+
+      const chat = await chatRegistry.get('oc_new');
+      expect(chat).toBeDefined();
+      expect(chat?.userId).toBe('ou_user');
+      expect(chat?.chatName).toBe('New Chat');
+    });
+  });
+
+  describe('createProactiveMessenger', () => {
+    it('should create a ProactiveMessenger instance', () => {
+      const instance = createProactiveMessenger(mockClient as unknown as lark.Client);
+
+      expect(instance).toBeInstanceOf(ProactiveMessenger);
+    });
+  });
+});

--- a/src/feishu/proactive-messenger.ts
+++ b/src/feishu/proactive-messenger.ts
@@ -1,0 +1,245 @@
+/**
+ * Proactive Messenger - Send messages without user trigger.
+ *
+ * Enables the bot to send messages to registered chats without
+ * receiving a message first. Used by scheduled tasks and other
+ * automated processes.
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import type { Logger } from 'pino';
+import { chatRegistry, type ChatInfo } from './chat-registry.js';
+import { createLogger } from '../utils/logger.js';
+import { buildTextContent } from '../platforms/feishu/card-builders/content-builder.js';
+
+const logger = createLogger('ProactiveMessenger');
+
+/**
+ * Recommendation for scheduled task.
+ */
+export interface Recommendation {
+  /** Task type */
+  taskType: string;
+  /** Detected pattern description */
+  pattern: string;
+  /** Recommended cron expression */
+  suggestedCron: string;
+  /** Confidence level */
+  confidence: 'High' | 'Medium' | 'Low';
+  /** Number of occurrences */
+  occurrenceCount: number;
+  /** Suggested prompt for the scheduled task */
+  suggestedPrompt: string;
+}
+
+/**
+ * Proactive Messenger Configuration.
+ */
+export interface ProactiveMessengerConfig {
+  /** Feishu API client */
+  client: lark.Client;
+  /** Logger instance (optional) */
+  logger?: Logger;
+}
+
+/**
+ * Proactive Messenger - Send messages without user trigger.
+ *
+ * Usage:
+ * ```typescript
+ * const messenger = new ProactiveMessenger({ client });
+ *
+ * // Send a text message to a specific chat
+ * await messenger.sendMessage('oc_xxx', 'Hello from scheduled task!');
+ *
+ * // Send a recommendation card
+ * await messenger.sendRecommendation('oc_xxx', recommendation);
+ *
+ * // Broadcast to all enabled chats
+ * await messenger.broadcast('Daily report: ...');
+ * ```
+ */
+export class ProactiveMessenger {
+  private client: lark.Client;
+
+  constructor(config: ProactiveMessengerConfig) {
+    this.client = config.client;
+  }
+
+  /**
+   * Send a text message to a specific chat.
+   *
+   * @param chatId - Target chat ID
+   * @param content - Text content to send
+   * @returns true if message was sent successfully
+   */
+  async sendMessage(chatId: string, content: string): Promise<boolean> {
+    try {
+      await this.client.im.message.create({
+        params: {
+          receive_id_type: 'chat_id',
+        },
+        data: {
+          receive_id: chatId,
+          msg_type: 'text',
+          content: buildTextContent(content),
+        },
+      });
+
+      logger.info({ chatId }, 'Proactive message sent');
+      return true;
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to send proactive message');
+      return false;
+    }
+  }
+
+  /**
+   * Send a recommendation card to a specific chat.
+   *
+   * @param chatId - Target chat ID
+   * @param recommendation - Recommendation details
+   * @returns true if card was sent successfully
+   */
+  async sendRecommendation(chatId: string, recommendation: Recommendation): Promise<boolean> {
+    try {
+      const card = this.buildRecommendationCard(recommendation);
+
+      await this.client.im.message.create({
+        params: {
+          receive_id_type: 'chat_id',
+        },
+        data: {
+          receive_id: chatId,
+          msg_type: 'interactive',
+          content: JSON.stringify(card),
+        },
+      });
+
+      logger.info({ chatId, taskType: recommendation.taskType }, 'Recommendation card sent');
+      return true;
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to send recommendation card');
+      return false;
+    }
+  }
+
+  /**
+   * Broadcast a message to all enabled chats.
+   *
+   * @param content - Text content to broadcast
+   * @returns Number of successful sends
+   */
+  async broadcast(content: string): Promise<number> {
+    const chats = await chatRegistry.getEnabledChats();
+    let successCount = 0;
+
+    for (const chat of chats) {
+      const success = await this.sendMessage(chat.chatId, content);
+      if (success) {
+        successCount++;
+      }
+    }
+
+    logger.info({ total: chats.length, success: successCount }, 'Broadcast completed');
+    return successCount;
+  }
+
+  /**
+   * Build an interactive card for a recommendation.
+   *
+   * @param recommendation - Recommendation details
+   * @returns Interactive card object
+   */
+  private buildRecommendationCard(recommendation: Recommendation): Record<string, unknown> {
+    const confidenceEmoji = {
+      High: '🟢',
+      Medium: '🟡',
+      Low: '🔴',
+    };
+
+    return {
+      config: {
+        wide_screen_mode: true,
+      },
+      elements: [
+        {
+          tag: 'div',
+          text: {
+            tag: 'lark_md',
+            content: `## 💡 定时任务推荐\n\n**任务类型**: ${recommendation.taskType}\n**检测到的模式**: ${recommendation.pattern}\n**建议时间**: ${recommendation.suggestedCron}\n**置信度**: ${confidenceEmoji[recommendation.confidence]} ${recommendation.confidence}\n**出现次数**: ${recommendation.occurrenceCount}`,
+          },
+        },
+        {
+          tag: 'div',
+          text: {
+            tag: 'lark_md',
+            content: `**建议的定时任务内容**:\n\`\`\`\n${recommendation.suggestedPrompt}\n\`\`\``,
+          },
+        },
+        {
+          tag: 'action',
+          actions: [
+            {
+              tag: 'button',
+              text: {
+                tag: 'plain_text',
+                content: '✅ 创建定时任务',
+              },
+              type: 'primary',
+              value: {
+                action: 'create_schedule',
+                prompt: recommendation.suggestedPrompt,
+                cron: recommendation.suggestedCron,
+              },
+            },
+            {
+              tag: 'button',
+              text: {
+                tag: 'plain_text',
+                content: '❌ 忽略',
+              },
+              type: 'default',
+              value: {
+                action: 'ignore',
+              },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  /**
+   * Get all enabled chats for proactive messaging.
+   *
+   * @returns Array of enabled chat info
+   */
+  getEnabledChats(): Promise<ChatInfo[]> {
+    return chatRegistry.getEnabledChats();
+  }
+
+  /**
+   * Register a chat for proactive messaging.
+   *
+   * @param chatId - Chat ID to register
+   * @param options - Optional metadata
+   */
+  async registerChat(
+    chatId: string,
+    options?: { userId?: string; chatName?: string }
+  ): Promise<void> {
+    await chatRegistry.register(chatId, options);
+    logger.info({ chatId }, 'Chat registered for proactive messaging');
+  }
+}
+
+/**
+ * Create a ProactiveMessenger instance.
+ *
+ * @param client - Feishu API client
+ * @returns ProactiveMessenger instance
+ */
+export function createProactiveMessenger(client: lark.Client): ProactiveMessenger {
+  return new ProactiveMessenger({ client });
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the proactive messaging infrastructure for Issue #357 (智能定时任务推荐系统).

## Problem

The intelligent scheduled task recommendation system needs the ability to send messages to users without a user trigger (proactive messaging). This requires:
1. A registry to store and manage chat IDs
2. A messenger to send messages to registered chats

## Solution

### ChatRegistry (`src/feishu/chat-registry.ts`)
- Stores `chatId → metadata` mappings for proactive messaging
- Provides methods: `register`, `get`, `getAll`, `getEnabledChats`, `setEnabled`, `remove`, `has`
- Persists data to `workspace/chat-registry.json`
- Singleton instance for easy access

### ProactiveMessenger (`src/feishu/proactive-messenger.ts`)
- Sends messages to chats without user trigger
- Methods:
  - `sendMessage(chatId, content)` - Send text message
  - `sendRecommendation(chatId, recommendation)` - Send interactive recommendation card
  - `broadcast(content)` - Send to all enabled chats
- Builds interactive cards with action buttons for schedule creation

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    ProactiveMessenger                        │
├─────────────────────────────────────────────────────────────┤
│  sendMessage()  │  sendRecommendation()  │  broadcast()     │
└─────────────────────────────────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│                      ChatRegistry                            │
├─────────────────────────────────────────────────────────────┤
│  register()  │  get()  │  getEnabledChats()  │  setEnabled()│
└─────────────────────────────────────────────────────────────┘
                           │
                           ▼
┌─────────────────────────────────────────────────────────────┐
│              workspace/chat-registry.json                    │
└─────────────────────────────────────────────────────────────┘
```

## Test Coverage

- 14 tests for ChatRegistry
- 9 tests for ProactiveMessenger
- All 1170 tests pass
- Lint: 0 errors (62 warnings in existing code)
- Type check: Pass

## Related

- Fixes #357 (Phase 1)
- Related closed PR: #381 (closed due to wrong approach - hardcoded analysis logic)

## Next Steps

Phase 2 (future PR):
- Create `schedules/recommend-analysis.md` scheduled task
- Use the schedule-recommend skill with proactive messaging

## Test Plan

- [x] Unit tests for ChatRegistry
- [x] Unit tests for ProactiveMessenger
- [x] All existing tests pass
- [x] Lint check passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)