### PR TITLE
fix(config): 配置优先级问题 - 基于 config file provider 验证

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -146,36 +146,69 @@ export class Config {
    * Validate required configuration fields.
    * Ensures all required fields are present before returning config.
    *
+   * Validation priority (config file takes precedence over environment variables):
+   * 1. If agent.provider is explicitly set, validate only that provider's config
+   * 2. If GLM is configured (apiKey in config file), validate GLM config
+   * 3. Otherwise, if Anthropic env var exists, validate Anthropic config
+   *
    * @throws Error if required configuration is missing
    */
   private static validateRequiredConfig(): void {
     const errors: ConfigValidationError[] = [];
 
-    // GLM configuration validation
-    if (this.GLM_API_KEY) {
+    // Get provider preference from config file
+    const provider = fileConfigOnly.agent?.provider;
+
+    // Determine which provider to validate based on config priority
+    if (provider === 'glm') {
+      // User explicitly chose GLM - only validate GLM config
+      if (!this.GLM_API_KEY) {
+        errors.push({
+          field: 'glm.apiKey',
+          message: 'glm.apiKey is required when agent.provider is "glm"',
+        });
+      }
+      if (!this.GLM_MODEL) {
+        errors.push({
+          field: 'glm.model',
+          message: 'glm.model is required when using GLM provider',
+        });
+      }
+    } else if (provider === 'anthropic') {
+      // User explicitly chose Anthropic - only validate Anthropic config
+      if (!this.ANTHROPIC_API_KEY) {
+        errors.push({
+          field: 'ANTHROPIC_API_KEY',
+          message: 'ANTHROPIC_API_KEY environment variable is required when agent.provider is "anthropic"',
+        });
+      }
+      if (!this.CLAUDE_MODEL) {
+        errors.push({
+          field: 'agent.model',
+          message: 'agent.model is required when using Anthropic provider',
+        });
+      }
+    } else if (this.GLM_API_KEY) {
+      // No explicit provider, but GLM is configured in config file - validate GLM
       if (!this.GLM_MODEL) {
         errors.push({
           field: 'glm.model',
           message: 'glm.model is required when GLM API key is configured',
         });
       }
-    }
-
-    // Anthropic configuration validation
-    if (this.ANTHROPIC_API_KEY) {
+    } else if (this.ANTHROPIC_API_KEY) {
+      // Fallback to Anthropic (from environment variable)
       if (!this.CLAUDE_MODEL) {
         errors.push({
           field: 'agent.model',
-          message: 'agent.model is required when ANTHROPIC_API_KEY is set',
+          message: 'agent.model is required when using Anthropic (ANTHROPIC_API_KEY is set)',
         });
       }
-    }
-
-    // At least one API key must be configured
-    if (!this.GLM_API_KEY && !this.ANTHROPIC_API_KEY) {
+    } else {
+      // No provider configured at all
       errors.push({
         field: 'apiKey',
-        message: 'No API key configured. Set glm.apiKey in disclaude.config.yaml',
+        message: 'No API key configured. Set glm.apiKey in disclaude.config.yaml or ANTHROPIC_API_KEY environment variable',
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes #394: 配置优先级问题 - agent.model 不应依赖环境变量

## Problem

当使用 GLM 提供者时，如果环境中设置了 `ANTHROPIC_API_KEY` 变量，配置验证会错误地要求 `agent.model` 字段，即使用户已经配置了 `glm.model`。

```yaml
# 这个配置应该正常工作
glm:
  apiKey: "your-glm-key"
  model: "glm-5"
agent:
  provider: "glm"
```

## Root Cause

验证逻辑将**环境变量**（`ANTHROPIC_API_KEY`）与**配置文件字段**（`agent.model`）混在一起检查，违反了"配置文件优先"的原则。

## Solution

重构 `validateRequiredConfig()` 方法，遵循明确的优先级：

1. 如果 `agent.provider` 明确设置，只验证该提供者的配置
2. 如果 GLM 配置了（配置文件中有 apiKey），验证 GLM 配置
3. 否则，如果 Anthropic 环境变量存在，验证 Anthropic 配置
4. 如果什么都没配置，显示适当的错误

## Changes

- 修改 `src/config/index.ts` 中的 `validateRequiredConfig()` 方法
- 配置文件中的 `agent.provider` 现在决定验证哪个提供者
- 环境变量只作为后备，不影响配置文件的优先级

## Test Results

- ✅ All 1147 tests pass
- ✅ Lint: 0 errors (62 existing warnings)
- ✅ Type check: Pass

## Test Plan

- [x] 单元测试通过
- [x] Lint 检查通过
- [x] 类型检查通过
- [ ] 在有 `ANTHROPIC_API_KEY` 环境变量的情况下测试 GLM 配置

🤖 Generated with [Claude Code](https://claude.com/claude-code)