### PR TITLE
fix(feishu): control commands always handled locally regardless of @mentions

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -1,10 +1,13 @@
 /**
- * Tests for FeishuChannel command pass-through behavior when bot is mentioned.
+ * Tests for FeishuChannel command handling behavior when bot is mentioned.
  *
- * Issue #280: @bot 无法正确透传 /reset 指令给 agent
+ * Issue #387: /reset 命令在 @提及 时不生效
  *
- * When bot is mentioned (@bot), commands should be passed through to the agent
- * instead of being handled locally by the channel.
+ * Control commands (reset, status, help, restart, list-nodes, switch-node) should
+ * ALWAYS be handled locally through the control channel, regardless of @mentions.
+ * This ensures session/agent lifecycle commands work correctly.
+ *
+ * Non-control commands with @mention should be passed to the agent.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -92,7 +95,7 @@ vi.mock('../utils/task-tracker.js', () => ({
 
 import { FeishuChannel } from './feishu-channel.js';
 
-describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
+describe('FeishuChannel - Control Command Handling (Issue #387)', () => {
   let channel: FeishuChannel;
   let messageHandler: ReturnType<typeof vi.fn>;
   let controlHandler: ReturnType<typeof vi.fn>;
@@ -123,41 +126,41 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
     }
   });
 
-  describe('isBotMentioned helper (indirectly tested via command behavior)', () => {
-    /**
-     * Helper to simulate receiving a message.
-     * We access the private method via type casting for testing.
-     */
-    async function simulateMessageReceive(options: {
-      text: string;
-      mentions?: Array<{ key: string; id: { open_id: string }; name: string }>;
-    }): Promise<void> {
-      // Create a mock event that matches FeishuEventData structure
-      const mockEvent = {
-        message: {
-          message_id: 'test-msg-id',
-          chat_id: 'test-chat-id',
-          content: JSON.stringify({ text: options.text }),
-          message_type: 'text',
-          create_time: Date.now(),
-          mentions: options.mentions,
-        },
-        sender: {
-          sender_type: 'user',
-          sender_id: { open_id: 'user-open-id' },
-        },
-      };
+  /**
+   * Helper to simulate receiving a message.
+   * We access the private method via type casting for testing.
+   */
+  async function simulateMessageReceive(options: {
+    text: string;
+    mentions?: Array<{ key: string; id: { open_id: string }; name: string }>;
+  }): Promise<void> {
+    // Create a mock event that matches FeishuEventData structure
+    const mockEvent = {
+      message: {
+        message_id: 'test-msg-id',
+        chat_id: 'test-chat-id',
+        content: JSON.stringify({ text: options.text }),
+        message_type: 'text',
+        create_time: Date.now(),
+        mentions: options.mentions,
+      },
+      sender: {
+        sender_type: 'user',
+        sender_id: { open_id: 'user-open-id' },
+      },
+    };
 
-      // Access private method for testing
-      const handler = (channel as unknown as { handleMessageReceive: (data: unknown) => Promise<void> }).handleMessageReceive.bind(channel);
+    // Access private method for testing
+    const handler = (channel as unknown as { handleMessageReceive: (data: unknown) => Promise<void> }).handleMessageReceive.bind(channel);
 
-      // Start the channel first to set isRunning = true
-      await channel.start();
+    // Start the channel first to set isRunning = true
+    await channel.start();
 
-      await handler({ event: mockEvent });
-    }
+    await handler({ event: mockEvent });
+  }
 
-    it('should handle command locally when bot is NOT mentioned', async () => {
+  describe('Control commands should ALWAYS be handled locally (Issue #387)', () => {
+    it('should handle /reset locally when bot is NOT mentioned', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: undefined, // No mentions
@@ -175,7 +178,7 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should pass command to agent when bot IS mentioned', async () => {
+    it('should handle /reset locally even when bot IS mentioned (Issue #387 fix)', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: [
@@ -187,19 +190,19 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         ],
       });
 
-      // Control handler should NOT be called (command passed to agent)
-      expect(controlHandler).not.toHaveBeenCalled();
-
-      // Message should be passed to agent
-      expect(messageHandler).toHaveBeenCalledWith(
+      // Control handler SHOULD be called - control commands always handled locally
+      expect(controlHandler).toHaveBeenCalledWith(
         expect.objectContaining({
+          type: 'reset',
           chatId: 'test-chat-id',
-          content: '/reset',
         })
       );
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should pass command to agent when there are multiple mentions', async () => {
+    it('should handle /reset locally when there are multiple mentions', async () => {
       await simulateMessageReceive({
         text: '/reset',
         mentions: [
@@ -216,11 +219,80 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         ],
       });
 
-      // Command should be passed to agent
+      // Control command should be handled locally
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'reset',
+          chatId: 'test-chat-id',
+        })
+      );
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle /status locally when bot is mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/status',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should be called
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'status',
+        })
+      );
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle /help locally when bot is mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/help',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should be called
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'help',
+        })
+      );
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Non-control commands with @mention should be passed to agent', () => {
+    it('should pass unknown commands directly to agent when bot is mentioned', async () => {
+      await simulateMessageReceive({
+        text: '/unknown-command',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler should NOT be called for unknown commands with @mention
+      // (unknown commands with @mention are passed directly to agent)
       expect(controlHandler).not.toHaveBeenCalled();
+
+      // Message should be passed to agent
       expect(messageHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: '/reset',
+          content: '/unknown-command',
         })
       );
     });
@@ -247,8 +319,10 @@ describe('FeishuChannel - Command Pass-through (Issue #280)', () => {
         })
       );
     });
+  });
 
-    it('should handle command without mentions normally', async () => {
+  describe('Commands without mentions', () => {
+    it('should handle /status without mentions', async () => {
       await simulateMessageReceive({
         text: '/status',
         mentions: undefined,

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -427,68 +427,80 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     );
 
     // Check for control commands
-    // When bot is mentioned (@bot), pass commands through to agent instead of handling locally
+    // Control commands should ALWAYS be handled through the control channel, regardless of mentions
+    // This ensures /reset, /status, etc. work correctly even when bot is @mentioned
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
-    if (trimmedText.startsWith('/') && !botMentioned) {
+    // Control commands that should always be handled locally through the control channel
+    // These commands affect session/agent lifecycle and should not be passed to the agent
+    const CONTROL_COMMANDS = ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node'];
+
+    if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
 
-      if (this.controlHandler) {
-        const response = await this.emitControl({
-          type: cmd as any,
-          chatId: chat_id,
-          data: { args, rawText: trimmedText },
-        });
+      // Handle control commands through the control channel
+      // Control commands are ALWAYS handled locally, regardless of @mentions
+      // Non-control commands with @mention are passed to agent
+      const isControlCommand = CONTROL_COMMANDS.includes(cmd);
 
-        // Only return if command was successfully handled
-        // Unknown commands (success: false) will fall through to normal message processing
-        if (response.success) {
-          if (response.message) {
-            await this.sendMessage({
-              chatId: chat_id,
-              type: 'text',
-              text: response.message,
-            });
+      if (isControlCommand || !botMentioned) {
+        if (this.controlHandler) {
+          const response = await this.emitControl({
+            type: cmd as any,
+            chatId: chat_id,
+            data: { args, rawText: trimmedText },
+          });
+
+          // Only return if command was successfully handled
+          // Unknown commands (success: false) will fall through to normal message processing
+          if (response.success) {
+            if (response.message) {
+              await this.sendMessage({
+                chatId: chat_id,
+                type: 'text',
+                text: response.message,
+              });
+            }
+            return;
           }
+          // Unknown command: fall through to emitMessage for Agent to handle
+        }
+
+        // Default command handling if no control handler registered
+        if (cmd === 'reset') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
+          });
           return;
         }
-        // Unknown command: fall through to emitMessage for Agent to handle
-      }
 
-      // Default command handling if no control handler registered
-      if (cmd === 'reset') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
-        });
-        return;
-      }
+        if (cmd === 'status') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
+          });
+          return;
+        }
 
-      if (cmd === 'status') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
-        });
-        return;
-      }
-
-      if (cmd === 'help') {
-        await this.sendMessage({
-          chatId: chat_id,
-          type: 'text',
-          text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
-        });
-        return;
+        if (cmd === 'help') {
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+          });
+          return;
+        }
       }
     }
 
-    // Log if bot is mentioned with a command (for debugging)
+    // Log if bot is mentioned with a non-control command (for debugging)
     if (botMentioned && trimmedText.startsWith('/')) {
-      logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with command, passing to agent');
+      logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
     }
 
     // Emit as incoming message


### PR DESCRIPTION
## Summary

Fixes #387 - `/reset` 命令在 @提及 时不生效

When user sends `@bot /reset`, the command now correctly executes the reset operation instead of being passed to the Agent as a message.

## Problem

The original code at `feishu-channel.ts` line 434:
```typescript
if (trimmedText.startsWith('/') && !botMentioned) {
  // Command handling - ONLY executed when NOT mentioned
}
```

This caused ALL commands with @mentions to be skipped and passed to agent, which is incorrect for control commands.

## Solution

Define a list of `CONTROL_COMMANDS` that should **ALWAYS** be handled locally through the control channel, regardless of @mentions:

- `reset` - Reset session
- `status` - Show status
- `help` - Show help
- `restart` - Restart service
- `list-nodes` - List execution nodes
- `switch-node` - Switch execution node

These commands affect session/agent lifecycle and must be executed immediately rather than passed to the agent.

## Architecture Alignment

This aligns with the owner's feedback on previous PRs (#389, #395):
- Control commands should be handled through the **control instruction channel**
- `/reset` should force create a new ChatAgent and deprecate the old context
- This requires systematic architecture (which is already in place via `emitControl`)

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| `/reset` (no mention) | Handled locally ✅ | Handled locally ✅ |
| `@bot /reset` | Passed to agent ❌ | Handled locally ✅ |
| `@bot /status` | Passed to agent ❌ | Handled locally ✅ |
| `@bot /unknown` | Passed to agent | Passed to agent ✅ |

## Tests

Updated `feishu-channel-mention.test.ts` to reflect correct behavior:
- 8 tests for control command handling
- All tests verify control commands are ALWAYS handled locally
- Non-control commands with @mention are correctly passed to agent
- **All 1150 tests pass**

## Related

- Fixes #387
- Supersedes closed PRs: #389, #395
- Updates behavior from Issue #280 (which had incorrect expectation)

## Test plan

- [x] Run `npm test` - all 1150 tests pass
- [x] Run `npm run type-check` - type check passes
- [x] Unit tests for control command behavior with/without mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)