### PR TITLE
feat(feishu): add ChatManager for group chat management (Issue #402 Phase 1)

### DIFF
--- a/src/feishu/chat-manager.test.ts
+++ b/src/feishu/chat-manager.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Tests for ChatManager.
+ *
+ * Tests the group chat management functionality for Feishu platform:
+ * - Creating group chats
+ * - Dissolving group chats
+ * - Adding/removing members
+ * - Getting chat info
+ * - Getting chat members
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChatManager } from './chat-manager.js';
+import type { Logger } from 'pino';
+
+// Mock lark client
+const mockClient = {
+  im: {
+    chat: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      get: vi.fn(),
+      update: vi.fn(),
+    },
+    chatMembers: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      get: vi.fn(),
+    },
+  },
+};
+
+// Mock logger
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+};
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn(() => mockClient),
+}));
+
+describe('ChatManager', () => {
+  let chatManager: ChatManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    chatManager = new ChatManager({
+      client: mockClient as any,
+      logger: mockLogger as unknown as Logger,
+    });
+  });
+
+  describe('createGroup', () => {
+    it('should create a group chat successfully', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { chat_id: 'oc_new_chat_123' },
+      });
+
+      const chatId = await chatManager.createGroup({
+        name: 'Test Group',
+        ownerId: 'ou_owner_123',
+        initialMembers: ['ou_member_456'],
+      });
+
+      expect(chatId).toBe('oc_new_chat_123');
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: {
+          name: 'Test Group',
+          chat_mode: 'group',
+          chat_type: 'group',
+          user_id_list: expect.arrayContaining(['ou_owner_123', 'ou_member_456']),
+          owner_id: 'ou_owner_123',
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+    });
+
+    it('should include owner in member list even if not in initialMembers', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { chat_id: 'oc_new_chat_456' },
+      });
+
+      await chatManager.createGroup({
+        name: 'Test Group',
+        ownerId: 'ou_owner_789',
+        initialMembers: ['ou_member_1', 'ou_member_2'],
+      });
+
+      const callData = mockCreate.mock.calls[0][0].data;
+      expect(callData.user_id_list).toContain('ou_owner_789');
+      expect(callData.user_id_list).toContain('ou_member_1');
+      expect(callData.user_id_list).toContain('ou_member_2');
+    });
+
+    it('should work with no initial members (only owner)', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { chat_id: 'oc_new_chat_789' },
+      });
+
+      const chatId = await chatManager.createGroup({
+        name: 'Owner Only Group',
+        ownerId: 'ou_owner_123',
+      });
+
+      expect(chatId).toBe('oc_new_chat_789');
+      const callData = mockCreate.mock.calls[0][0].data;
+      expect(callData.user_id_list).toEqual(['ou_owner_123']);
+    });
+
+    it('should throw error when chat_id is not returned', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: {},
+      });
+
+      await expect(
+        chatManager.createGroup({
+          name: 'Test Group',
+          ownerId: 'ou_owner_123',
+        })
+      ).rejects.toThrow('Failed to get chat_id from response');
+    });
+
+    it('should throw and log on API error', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      const apiError = new Error('API error');
+      mockCreate.mockRejectedValue(apiError);
+
+      await expect(
+        chatManager.createGroup({
+          name: 'Test Group',
+          ownerId: 'ou_owner_123',
+        })
+      ).rejects.toThrow('API error');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('dissolveGroup', () => {
+    it('should dissolve a group chat successfully', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockResolvedValue({});
+
+      await chatManager.dissolveGroup('oc_chat_123');
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { chatId: 'oc_chat_123' },
+        'Group chat dissolved'
+      );
+    });
+
+    it('should throw and log on dissolve error', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      const apiError = new Error('Permission denied');
+      mockDelete.mockRejectedValue(apiError);
+
+      await expect(chatManager.dissolveGroup('oc_chat_123')).rejects.toThrow(
+        'Permission denied'
+      );
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('addMembers', () => {
+    it('should add members to a group chat successfully', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({});
+
+      await chatManager.addMembers('oc_chat_123', ['ou_user_1', 'ou_user_2']);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: {
+          id_list: ['ou_user_1', 'ou_user_2'],
+        },
+        params: {
+          member_id_type: 'open_id',
+        },
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { chatId: 'oc_chat_123', memberCount: 2 },
+        'Members added to group chat'
+      );
+    });
+
+    it('should throw and log on add members error', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      const apiError = new Error('User not found');
+      mockCreate.mockRejectedValue(apiError);
+
+      await expect(
+        chatManager.addMembers('oc_chat_123', ['ou_invalid_user'])
+      ).rejects.toThrow('User not found');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('removeMembers', () => {
+    it('should remove members from a group chat successfully', async () => {
+      const mockDelete = mockClient.im.chatMembers.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockResolvedValue({});
+
+      await chatManager.removeMembers('oc_chat_123', ['ou_user_1']);
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: {
+          id_list: ['ou_user_1'],
+        },
+        params: {
+          member_id_type: 'open_id',
+        },
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { chatId: 'oc_chat_123', memberCount: 1 },
+        'Members removed from group chat'
+      );
+    });
+
+    it('should throw and log on remove members error', async () => {
+      const mockDelete = mockClient.im.chatMembers.delete as ReturnType<typeof vi.fn>;
+      const apiError = new Error('Cannot remove owner');
+      mockDelete.mockRejectedValue(apiError);
+
+      await expect(
+        chatManager.removeMembers('oc_chat_123', ['ou_owner'])
+      ).rejects.toThrow('Cannot remove owner');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('getChatInfo', () => {
+    it('should get chat info successfully', async () => {
+      const mockGet = mockClient.im.chat.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: {
+          name: 'Test Group',
+          owner_id: 'ou_owner_123',
+          user_count: '5',
+          description: 'A test group',
+        },
+      });
+
+      const chatInfo = await chatManager.getChatInfo('oc_chat_123');
+
+      expect(chatInfo).toEqual({
+        chatId: 'oc_chat_123',
+        name: 'Test Group',
+        ownerId: 'ou_owner_123',
+        memberCount: 5,
+        description: 'A test group',
+      });
+      expect(mockGet).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+    });
+
+    it('should handle missing optional fields', async () => {
+      const mockGet = mockClient.im.chat.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: {
+          // name and description missing
+        },
+      });
+
+      const chatInfo = await chatManager.getChatInfo('oc_chat_456');
+
+      expect(chatInfo).toEqual({
+        chatId: 'oc_chat_456',
+        name: '',
+        ownerId: '',
+        memberCount: 0,
+        description: undefined,
+      });
+    });
+
+    it('should parse user_count string to number', async () => {
+      const mockGet = mockClient.im.chat.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: {
+          name: 'Test Group',
+          user_count: '10',
+        },
+      });
+
+      const chatInfo = await chatManager.getChatInfo('oc_chat_123');
+
+      expect(chatInfo.memberCount).toBe(10);
+    });
+
+    it('should throw error when response data is missing', async () => {
+      const mockGet = mockClient.im.chat.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({});
+
+      await expect(chatManager.getChatInfo('oc_chat_123')).rejects.toThrow(
+        'Failed to get chat info from response'
+      );
+    });
+
+    it('should throw and log on get chat info error', async () => {
+      const mockGet = mockClient.im.chat.get as ReturnType<typeof vi.fn>;
+      const apiError = new Error('Chat not found');
+      mockGet.mockRejectedValue(apiError);
+
+      await expect(chatManager.getChatInfo('oc_invalid_chat')).rejects.toThrow(
+        'Chat not found'
+      );
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('getMembers', () => {
+    it('should get chat members successfully', async () => {
+      const mockGet = mockClient.im.chatMembers.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: {
+          items: [
+            { member_id: 'ou_user_1' },
+            { member_id: 'ou_user_2' },
+            { member_id: 'ou_user_3' },
+          ],
+        },
+      });
+
+      const members = await chatManager.getMembers('oc_chat_123');
+
+      expect(members).toEqual(['ou_user_1', 'ou_user_2', 'ou_user_3']);
+      expect(mockGet).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        params: {
+          member_id_type: 'open_id',
+          page_size: 100,
+        },
+      });
+    });
+
+    it('should return empty array when no members', async () => {
+      const mockGet = mockClient.im.chatMembers.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: { items: [] },
+      });
+
+      const members = await chatManager.getMembers('oc_chat_123');
+
+      expect(members).toEqual([]);
+    });
+
+    it('should filter out undefined member_ids', async () => {
+      const mockGet = mockClient.im.chatMembers.get as ReturnType<typeof vi.fn>;
+      mockGet.mockResolvedValue({
+        data: {
+          items: [
+            { member_id: 'ou_user_1' },
+            { member_id: undefined },
+            { member_id: 'ou_user_2' },
+          ],
+        },
+      });
+
+      const members = await chatManager.getMembers('oc_chat_123');
+
+      expect(members).toEqual(['ou_user_1', 'ou_user_2']);
+    });
+
+    it('should throw and log on get members error', async () => {
+      const mockGet = mockClient.im.chatMembers.get as ReturnType<typeof vi.fn>;
+      const apiError = new Error('Access denied');
+      mockGet.mockRejectedValue(apiError);
+
+      await expect(chatManager.getMembers('oc_chat_123')).rejects.toThrow('Access denied');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateChatInfo', () => {
+    it('should update chat name successfully', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      mockUpdate.mockResolvedValue({});
+
+      await chatManager.updateChatInfo('oc_chat_123', { name: 'New Group Name' });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: {
+          name: 'New Group Name',
+          description: undefined,
+        },
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        { chatId: 'oc_chat_123', updates: { name: 'New Group Name' } },
+        'Chat info updated'
+      );
+    });
+
+    it('should update chat description successfully', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      mockUpdate.mockResolvedValue({});
+
+      await chatManager.updateChatInfo('oc_chat_123', {
+        description: 'New description',
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: {
+          name: undefined,
+          description: 'New description',
+        },
+      });
+    });
+
+    it('should update both name and description', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      mockUpdate.mockResolvedValue({});
+
+      await chatManager.updateChatInfo('oc_chat_123', {
+        name: 'New Name',
+        description: 'New Description',
+      });
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: {
+          name: 'New Name',
+          description: 'New Description',
+        },
+      });
+    });
+
+    it('should throw and log on update error', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      const apiError = new Error('Update failed');
+      mockUpdate.mockRejectedValue(apiError);
+
+      await expect(
+        chatManager.updateChatInfo('oc_chat_123', { name: 'New Name' })
+      ).rejects.toThrow('Update failed');
+
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/feishu/chat-manager.ts
+++ b/src/feishu/chat-manager.ts
@@ -1,0 +1,280 @@
+/**
+ * ChatManager - Feishu Group Chat Management Service.
+ *
+ * This module implements the ChatManager service as defined in Issue #402:
+ * - Create group chats
+ * - Dissolve group chats
+ * - Add members to chats
+ * - Get chat information
+ *
+ * @module feishu/chat-manager
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import type { Logger } from 'pino';
+
+/**
+ * ChatManager configuration.
+ */
+export interface ChatManagerConfig {
+  /** Feishu API client */
+  client: lark.Client;
+  /** Logger instance */
+  logger: Logger;
+}
+
+/**
+ * Options for creating a group chat.
+ */
+export interface CreateGroupOptions {
+  /** Group chat name */
+  name: string;
+  /** Owner user ID (open_id format) */
+  ownerId: string;
+  /** Initial member user IDs (open_id format) */
+  initialMembers?: string[];
+}
+
+/**
+ * Chat information.
+ */
+export interface ChatInfo {
+  /** Chat ID */
+  chatId: string;
+  /** Chat name */
+  name: string;
+  /** Owner user ID */
+  ownerId: string;
+  /** Member count */
+  memberCount: number;
+  /** Chat description */
+  description?: string;
+}
+
+/**
+ * ChatManager - Manages Feishu group chats.
+ *
+ * Provides methods for creating, managing, and querying group chats.
+ */
+export class ChatManager {
+  private client: lark.Client;
+  private logger: Logger;
+
+  constructor(config: ChatManagerConfig) {
+    this.client = config.client;
+    this.logger = config.logger;
+  }
+
+  /**
+   * Create a new group chat.
+   *
+   * @param options - Group creation options
+   * @returns The created chat ID
+   */
+  async createGroup(options: CreateGroupOptions): Promise<string> {
+    const { name, ownerId, initialMembers = [] } = options;
+
+    try {
+      // Ensure owner is in the member list
+      const members = new Set(initialMembers);
+      members.add(ownerId);
+
+      const response = await this.client.im.chat.create({
+        data: {
+          name,
+          chat_mode: 'group',
+          chat_type: 'group',
+          user_id_list: Array.from(members),
+          owner_id: ownerId,
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+
+      const chatId = response?.data?.chat_id;
+      if (!chatId) {
+        throw new Error('Failed to get chat_id from response');
+      }
+
+      this.logger.info({ chatId, name, ownerId, memberCount: members.size }, 'Group chat created');
+      return chatId;
+    } catch (error) {
+      this.logger.error({ err: error, name, ownerId }, 'Failed to create group chat');
+      throw error;
+    }
+  }
+
+  /**
+   * Dissolve (delete) a group chat.
+   *
+   * Note: This requires the bot to be the chat owner or have admin permissions.
+   *
+   * @param chatId - The chat ID to dissolve
+   */
+  async dissolveGroup(chatId: string): Promise<void> {
+    try {
+      await this.client.im.chat.delete({
+        path: {
+          chat_id: chatId,
+        },
+      });
+
+      this.logger.info({ chatId }, 'Group chat dissolved');
+    } catch (error) {
+      this.logger.error({ err: error, chatId }, 'Failed to dissolve group chat');
+      throw error;
+    }
+  }
+
+  /**
+   * Add members to a group chat.
+   *
+   * @param chatId - The chat ID
+   * @param userIds - User IDs to add (open_id format)
+   */
+  async addMembers(chatId: string, userIds: string[]): Promise<void> {
+    try {
+      await this.client.im.chatMembers.create({
+        path: {
+          chat_id: chatId,
+        },
+        data: {
+          id_list: userIds,
+        },
+        params: {
+          member_id_type: 'open_id',
+        },
+      });
+
+      this.logger.info({ chatId, memberCount: userIds.length }, 'Members added to group chat');
+    } catch (error) {
+      this.logger.error({ err: error, chatId, userIds }, 'Failed to add members to group chat');
+      throw error;
+    }
+  }
+
+  /**
+   * Remove members from a group chat.
+   *
+   * @param chatId - The chat ID
+   * @param userIds - User IDs to remove (open_id format)
+   */
+  async removeMembers(chatId: string, userIds: string[]): Promise<void> {
+    try {
+      await this.client.im.chatMembers.delete({
+        path: {
+          chat_id: chatId,
+        },
+        data: {
+          id_list: userIds,
+        },
+        params: {
+          member_id_type: 'open_id',
+        },
+      });
+
+      this.logger.info({ chatId, memberCount: userIds.length }, 'Members removed from group chat');
+    } catch (error) {
+      this.logger.error({ err: error, chatId, userIds }, 'Failed to remove members from group chat');
+      throw error;
+    }
+  }
+
+  /**
+   * Get chat information.
+   *
+   * @param chatId - The chat ID
+   * @returns Chat information
+   */
+  async getChatInfo(chatId: string): Promise<ChatInfo> {
+    try {
+      const response = await this.client.im.chat.get({
+        path: {
+          chat_id: chatId,
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+
+      const data = response?.data;
+      if (!data) {
+        throw new Error('Failed to get chat info from response');
+      }
+
+      // user_count is returned as string from API
+      const memberCount = data.user_count ? parseInt(data.user_count, 10) : 0;
+
+      const chatInfo: ChatInfo = {
+        chatId,
+        name: data.name || '',
+        ownerId: data.owner_id || '',
+        memberCount,
+        description: data.description,
+      };
+
+      this.logger.debug({ chatId, chatInfo }, 'Retrieved chat info');
+      return chatInfo;
+    } catch (error) {
+      this.logger.error({ err: error, chatId }, 'Failed to get chat info');
+      throw error;
+    }
+  }
+
+  /**
+   * Get members of a group chat.
+   *
+   * @param chatId - The chat ID
+   * @returns List of member user IDs (open_id format)
+   */
+  async getMembers(chatId: string): Promise<string[]> {
+    try {
+      const response = await this.client.im.chatMembers.get({
+        path: {
+          chat_id: chatId,
+        },
+        params: {
+          member_id_type: 'open_id',
+          page_size: 100,
+        },
+      });
+
+      const members = response?.data?.items?.map((item: { member_id?: string }) => item.member_id).filter(Boolean) || [];
+
+      this.logger.debug({ chatId, memberCount: members.length }, 'Retrieved chat members');
+      return members as string[];
+    } catch (error) {
+      this.logger.error({ err: error, chatId }, 'Failed to get chat members');
+      throw error;
+    }
+  }
+
+  /**
+   * Update chat information.
+   *
+   * @param chatId - The chat ID
+   * @param updates - Fields to update
+   */
+  async updateChatInfo(
+    chatId: string,
+    updates: { name?: string; description?: string }
+  ): Promise<void> {
+    try {
+      await this.client.im.chat.update({
+        path: {
+          chat_id: chatId,
+        },
+        data: {
+          name: updates.name,
+          description: updates.description,
+        },
+      });
+
+      this.logger.info({ chatId, updates }, 'Chat info updated');
+    } catch (error) {
+      this.logger.error({ err: error, chatId, updates }, 'Failed to update chat info');
+      throw error;
+    }
+  }
+}

--- a/src/feishu/index.ts
+++ b/src/feishu/index.ts
@@ -9,3 +9,5 @@
 // Re-export commonly used components
 export { TaskFlowOrchestrator } from './task-flow-orchestrator.js';
 export { messageLogger } from './message-logger.js';
+export { ChatManager } from './chat-manager.js';
+export type { ChatManagerConfig, CreateGroupOptions, ChatInfo } from './chat-manager.js';


### PR DESCRIPTION
## Summary

Implements the ChatManager service as defined in Issue #402 v0.4 roadmap. This is Phase 1 of the v0.4 群聊管理与控制通道 feature.

## Features

| Method | Description |
|--------|-------------|
| `createGroup` | Create new group chats with owner and initial members |
| `dissolveGroup` | Delete/dissolve existing group chats |
| `addMembers` | Add users to a group chat |
| `removeMembers` | Remove users from a group chat |
| `getChatInfo` | Get chat metadata (name, owner, member count, description) |
| `getMembers` | List all members of a group chat |
| `updateChatInfo` | Update chat name and description |

## Implementation Details

- Uses `@larksuiteoapi/node-sdk` for Feishu API calls
- Proper error handling with logging
- Full TypeScript type definitions
- 24 unit tests with 100% coverage

## API Design

```typescript
export interface CreateGroupOptions {
  name: string;
  ownerId: string;
  initialMembers?: string[];
}

export interface ChatInfo {
  chatId: string;
  name: string;
  ownerId: string;
  memberCount: number;
  description?: string;
}

export class ChatManager {
  async createGroup(options: CreateGroupOptions): Promise<string>;
  async dissolveGroup(chatId: string): Promise<void>;
  async addMembers(chatId: string, userIds: string[]): Promise<void>;
  async removeMembers(chatId: string, userIds: string[]): Promise<void>;
  async getChatInfo(chatId: string): Promise<ChatInfo>;
  async getMembers(chatId: string): Promise<string[]>;
  async updateChatInfo(chatId: string, updates: { name?: string; description?: string }): Promise<void>;
}
```

## Test Results

- 24 tests for ChatManager
- All 1171 tests pass
- Type check: Pass
- Lint: 0 errors (63 warnings in existing code)

## Related

- Part of Issue #402 (v0.4 版本功能规划 - 群聊管理与控制通道)
- Prerequisite for Issue #393 (定时扫描 PR 并创建讨论群聊)
- Prerequisite for Issue #347 (动态管理员设置与自动创建日志群)

## Test plan

- [x] Unit tests for all ChatManager methods
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)