### PR TITLE
fix(pilot): disable EnterPlanMode tool for Pilot agent

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -263,8 +263,10 @@ export class Pilot extends BaseAgent implements ChatAgent {
     }
 
     // Build SDK options using BaseAgent's createSdkOptions
+    // Note: EnterPlanMode is disabled for Pilot as it's a task dispatch agent
+    // that should not proactively enter plan mode (Issue #403)
     const sdkOptions = this.createSdkOptions({
-      disallowedTools: ['AskUserQuestion'],
+      disallowedTools: ['AskUserQuestion', 'EnterPlanMode'],
       mcpServers,
     });
 
@@ -384,8 +386,10 @@ export class Pilot extends BaseAgent implements ChatAgent {
     }
 
     // Build SDK options using BaseAgent's createSdkOptions
+    // Note: EnterPlanMode is disabled for Pilot as it's a task dispatch agent
+    // that should not proactively enter plan mode (Issue #403)
     const sdkOptions = this.createSdkOptions({
-      disallowedTools: ['AskUserQuestion'],
+      disallowedTools: ['AskUserQuestion', 'EnterPlanMode'],
       mcpServers,
     });
 


### PR DESCRIPTION
## Summary

- Disables `EnterPlanMode` tool for Pilot agent to prevent unnecessary plan mode triggers
- Pilot is a task dispatch agent that should not proactively enter plan mode
- Adds `EnterPlanMode` to `disallowedTools` in both `executeOnce()` (CLI mode) and `startAgentLoop()` (streaming mode)

## Background

As described in Issue #403, Pilot Agent was able to access `EnterPlanMode` tool from Claude Agent SDK, causing it to unnecessarily enter plan mode when executing simple tasks. This increased user interaction cost and was not appropriate for Pilot's role as a task dispatch agent.

## Changes

- Modified `src/agents/pilot.ts`:
  - Added `'EnterPlanMode'` to `disallowedTools` array in `executeOnce()` method
  - Added `'EnterPlanMode'` to `disallowedTools` array in `startAgentLoop()` method
  - Added explanatory comments referencing Issue #403

## Test Results

- All 1147 tests pass
- Type check passes
- No breaking changes

Fixes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)