### PR TITLE
feat(schedule): add PR scanner skill and example schedule (Issue #393)

### DIFF
--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -1,0 +1,88 @@
+---
+name: "PR 扫描器"
+cron: "*/30 * * * *"
+enabled: false
+blocking: true
+chatId: "REPLACE_WITH_ACTUAL_CHAT_ID"
+createdAt: "2026-03-01T00:00:00.000Z"
+---
+
+# PR 扫描任务
+
+每30分钟扫描 hs3180/disclaude 仓库的 open PR，发现新 PR 时发送通知。
+
+## 配置说明
+
+**重要**: 使用前请将 `chatId` 替换为实际的飞书 Chat ID，并将 `enabled` 设为 `true`。
+
+## 执行步骤
+
+### 1. 获取当前 open PR 列表
+
+```bash
+gh pr list --repo hs3180/disclaude --state open --json number,title,author,createdAt
+```
+
+### 2. 检查已处理的 PR
+
+读取 `workspace/data/processed-prs.json` 文件，获取已处理过的 PR 编号列表。
+如果文件不存在，创建一个空列表。
+
+### 3. 识别新 PR
+
+对比当前 open PR 列表和已处理 PR 列表，找出新 PR。
+
+### 4. 获取新 PR 详细信息
+
+对于每个新 PR：
+```bash
+gh pr view {number} --repo hs3180/disclaude --json title,body,author,additions,deletions,changedFiles,statusCheckRollup,url
+```
+
+### 5. 发送通知
+
+使用 `send_user_feedback` 发送格式化的 PR 信息到配置的 chatId。
+
+通知格式：
+```
+## 🔔 新 PR 检测到
+
+### PR #{number}: {title}
+
+- **作者**: {author}
+- **状态**: {CI状态}
+- **变更**: +{additions} -{deletions} ({changedFiles} files)
+- **链接**: {url}
+
+---
+
+**描述**:
+{body摘要}
+```
+
+### 6. 更新已处理 PR 列表
+
+将新处理的 PR 编号追加到 `workspace/data/processed-prs.json`。
+
+## 注意事项
+
+- 此任务**不会创建群聊**（ChatManager 功能待实现）
+- 通知发送到配置的 chatId
+- 如果没有新 PR，不发送通知
+- 如果发生错误，发送错误通知到 chatId
+
+## 错误处理
+
+1. 如果 `gh` 命令失败，重试一次
+2. 如果 `send_user_feedback` 失败，记录日志并继续
+3. 如果读取/写入 processed-prs.json 失败，创建新文件
+
+## 数据文件
+
+`workspace/data/processed-prs.json` 格式：
+```json
+{
+  "processedPrs": [123, 124, 125],
+  "lastUpdated": "2026-03-01T00:00:00.000Z"
+}
+```

--- a/skills/pr-scanner/SKILL.md
+++ b/skills/pr-scanner/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: pr-scanner
+description: PR scanning and notification specialist. Scans repository for open PRs and sends notifications to Feishu. Use for periodic PR monitoring and discussion facilitation.
+allowed-tools: Bash, Read, send_user_feedback
+---
+
+# PR Scanner
+
+Scan repository for open Pull Requests and send notifications.
+
+## Purpose
+
+This skill enables periodic PR monitoring:
+1. Scan repository for open PRs
+2. Get detailed PR information
+3. Send formatted notifications to Feishu
+
+## When to Use
+
+- Periodic PR status checks
+- PR review reminders
+- New PR detection
+
+## Workflow
+
+### 1. Scan Open PRs
+
+Use `gh` CLI to scan open PRs:
+
+```bash
+# Get all open PRs
+gh pr list --repo <owner/repo> --state open --json number,title,author,createdAt,headRefName
+
+# Get detailed PR info
+gh pr view <number> --repo <owner/repo> --json title,body,author,additions,deletions,changedFiles,statusCheckRollup
+```
+
+### 2. Format PR Information
+
+Create a formatted message with:
+- PR number and title
+- Author
+- Files changed / additions / deletions
+- CI status
+- Link to PR
+
+### 3. Send Notification
+
+Use `send_user_feedback` to send the formatted message to the designated chatId.
+
+## Output Format
+
+```markdown
+## PR #123: Fix authentication bug
+
+**Author:** @username
+**Status:** CI Passing
+**Changes:** +50 -10 (5 files)
+
+**Description:**
+Brief description of the PR...
+
+**Link:** https://github.com/owner/repo/pull/123
+```
+
+## Important Notes
+
+- This skill does NOT create group chats (ChatManager not available yet)
+- Notifications are sent to a pre-configured chatId
+- For group discussion features, wait for ChatManager implementation
+
+## Error Handling
+
+- If `gh` CLI fails, report error and retry once
+- If send_user_feedback fails, log error and report to system
+- If no open PRs found, send "No open PRs" message
+
+## Example Prompt for Schedule
+
+```markdown
+Scan the hs3180/disclaude repository for open PRs:
+1. Use `gh pr list` to get all open PRs
+2. For each PR, get detailed info with `gh pr view`
+3. Format the PR information
+4. Send a summary to the designated chatId using send_user_feedback
+```


### PR DESCRIPTION
## Summary

Implements #393 - PR scanning and notification as a scheduled task use case.

## Problem

Users need to be notified when new PRs are created in the repository, enabling timely review and discussion.

## Solution

Created a PR scanning skill and example schedule file:

| File | Description |
|------|-------------|
| `skills/pr-scanner/SKILL.md` | Skill definition for PR scanning |
| `examples/schedules/pr-scanner.example.md` | Example schedule file |

## Features

- **Scan repository for open PRs** using `gh` CLI
- **Detect new PRs** by tracking processed PRs in `workspace/data/processed-prs.json`
- **Send formatted notifications** to Feishu via `send_user_feedback`
- **Configurable cron schedule** (default: every 30 minutes)

## Usage

1. Copy `examples/schedules/pr-scanner.example.md` to `workspace/schedules/pr-scanner.md`
2. Replace `chatId` with actual Feishu chat ID
3. Set `enabled: true`
4. The scheduler will automatically pick up the new schedule

## Limitations

- **Group chat creation not supported** - ChatManager is pending redesign (PR #404 was closed)
- **Requires manual chatId configuration** - Users need to specify which chat to send notifications to
- **No interactive discussion** - Currently only sends notifications, doesn't create discussion threads

## Test Results

| Metric | Value |
|--------|-------|
| Type Check | ✅ Pass |
| Lint | ✅ 0 errors (62 warnings) |
| Unit Tests | ✅ 1224 passed |

## Future Enhancements

When ChatManager is implemented:
- Create group chats for each PR discussion
- Add interactive card with action buttons (merge, close, request changes)
- Support multi-user discussions

## Related

- Issue #393: feat: 定时扫描 PR 并创建讨论群聊
- Issue #402: v0.4 版本功能规划
- PR #404: ChatManager (closed, pending redesign)

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Unit tests pass
- [ ] Manual test: Copy schedule file and verify PR scanning works

🤖 Generated with [Claude Code](https://claude.com/claude-code)