### PR TITLE
feat(feishu): add ChatOps utility for group chat management (Issue #402)

### DIFF
--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for ChatOps utility functions.
+ *
+ * @see Issue #402
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createDiscussionChat, dissolveChat, addMembers } from './chat-ops.js';
+
+// Mock lark client
+const mockClient = {
+  im: {
+    chat: {
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    chatMembers: {
+      create: vi.fn(),
+    },
+  },
+} as unknown as lark.Client;
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+describe('ChatOps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createDiscussionChat', () => {
+    it('should create a group chat and return chat ID', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { chat_id: 'oc_new_chat_123' },
+      });
+
+      const chatId = await createDiscussionChat(mockClient, {
+        topic: 'Test Discussion',
+        members: ['ou_user_1', 'ou_user_2'],
+      });
+
+      expect(chatId).toBe('oc_new_chat_123');
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: {
+          name: 'Test Discussion',
+          chat_mode: 'group',
+          chat_type: 'group',
+          user_id_list: ['ou_user_1', 'ou_user_2'],
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+    });
+
+    it('should throw error when chat_id is not returned', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: {},
+      });
+
+      await expect(
+        createDiscussionChat(mockClient, {
+          topic: 'Test Discussion',
+          members: ['ou_user_1'],
+        })
+      ).rejects.toThrow('Failed to get chat_id from response');
+    });
+
+    it('should throw and log on API error', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('API error'));
+
+      await expect(
+        createDiscussionChat(mockClient, {
+          topic: 'Test Discussion',
+          members: ['ou_user_1'],
+        })
+      ).rejects.toThrow('API error');
+    });
+  });
+
+  describe('dissolveChat', () => {
+    it('should dissolve a chat successfully', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockResolvedValue({});
+
+      await dissolveChat(mockClient, 'oc_chat_123');
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+      });
+    });
+
+    it('should throw on dissolve error', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(dissolveChat(mockClient, 'oc_chat_123')).rejects.toThrow(
+        'Permission denied'
+      );
+    });
+  });
+
+  describe('addMembers', () => {
+    it('should add members to a chat successfully', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({});
+
+      await addMembers(mockClient, 'oc_chat_123', ['ou_user_1', 'ou_user_2']);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: { id_list: ['ou_user_1', 'ou_user_2'] },
+        params: { member_id_type: 'open_id' },
+      });
+    });
+
+    it('should throw on add members error', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('User not found'));
+
+      await expect(
+        addMembers(mockClient, 'oc_chat_123', ['ou_invalid_user'])
+      ).rejects.toThrow('User not found');
+    });
+  });
+});

--- a/src/platforms/feishu/chat-ops.ts
+++ b/src/platforms/feishu/chat-ops.ts
@@ -1,0 +1,118 @@
+/**
+ * ChatOps - Simple chat operations for FeedbackController.
+ *
+ * A lightweight wrapper for Feishu chat operations, designed to be used
+ * as internal utility functions rather than a standalone complex service.
+ *
+ * @see Issue #402 - ChatManager simplified to ~50 lines
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import type { Logger } from 'pino';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('ChatOps');
+
+/**
+ * Options for creating a discussion chat.
+ */
+export interface CreateDiscussionOptions {
+  /** Chat topic/name */
+  topic: string;
+  /** Initial member open_ids */
+  members: string[];
+}
+
+/**
+ * ChatOps configuration.
+ */
+export interface ChatOpsConfig {
+  /** Feishu API client */
+  client: lark.Client;
+  /** Optional logger */
+  logger?: Logger;
+}
+
+/**
+ * Create a discussion group chat.
+ *
+ * @param client - Feishu API client
+ * @param options - Chat creation options
+ * @returns The created chat ID
+ * @throws Error if chat creation fails
+ */
+export async function createDiscussionChat(
+  client: lark.Client,
+  options: CreateDiscussionOptions
+): Promise<string> {
+  const { topic, members } = options;
+  const log = logger;
+
+  try {
+    const response = await client.im.chat.create({
+      data: {
+        name: topic,
+        chat_mode: 'group',
+        chat_type: 'group',
+        user_id_list: members,
+      },
+      params: {
+        user_id_type: 'open_id',
+      },
+    });
+
+    const chatId = response?.data?.chat_id;
+    if (!chatId) {
+      throw new Error('Failed to get chat_id from response');
+    }
+
+    log.info({ chatId, topic, memberCount: members.length }, 'Discussion chat created');
+    return chatId;
+  } catch (error) {
+    log.error({ err: error, topic }, 'Failed to create discussion chat');
+    throw error;
+  }
+}
+
+/**
+ * Dissolve (delete) a group chat.
+ *
+ * @param client - Feishu API client
+ * @param chatId - Chat ID to dissolve
+ */
+export async function dissolveChat(client: lark.Client, chatId: string): Promise<void> {
+  try {
+    await client.im.chat.delete({
+      path: { chat_id: chatId },
+    });
+    logger.info({ chatId }, 'Chat dissolved');
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'Failed to dissolve chat');
+    throw error;
+  }
+}
+
+/**
+ * Add members to a chat.
+ *
+ * @param client - Feishu API client
+ * @param chatId - Target chat ID
+ * @param members - Member open_ids to add
+ */
+export async function addMembers(
+  client: lark.Client,
+  chatId: string,
+  members: string[]
+): Promise<void> {
+  try {
+    await client.im.chatMembers.create({
+      path: { chat_id: chatId },
+      data: { id_list: members },
+      params: { member_id_type: 'open_id' },
+    });
+    logger.info({ chatId, memberCount: members.length }, 'Members added');
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'Failed to add members');
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Implements simplified ChatOps utility functions for group chat management, as requested in Issue #402's updated design direction.

## Problem

PR #404's ChatManager (280+ lines) was closed as too complex. Issue #402's latest comment specifies:
- ChatManager should be simplified to ~50 lines
- Should be internal utility functions for FeedbackController
- Not a standalone complex service

## Solution

Created a lightweight ChatOps module with three core functions:

| Function | Description |
|----------|-------------|
| `createDiscussionChat()` | Create group chats for discussions |
| `dissolveChat()` | Delete/dissolve group chats |
| `addMembers()` | Add members to existing chats |

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/chat-ops.ts` | ChatOps utility functions (~100 lines) |
| `src/platforms/feishu/chat-ops.test.ts` | Unit tests (7 tests) |

## Design Principles

- ✅ Simple utility functions (not a class)
- ✅ ~100 lines total (vs 280+ for original ChatManager)
- ✅ Designed to be used by FeedbackController
- ✅ No complex abstractions

## Usage Example

```typescript
import { createDiscussionChat, addMembers } from './chat-ops.js';

// Create a discussion group
const chatId = await createDiscussionChat(client, {
  topic: 'PR #123 Discussion',
  members: ['ou_user_1', 'ou_user_2'],
});

// Add more members later
await addMembers(client, chatId, ['ou_user_3']);
```

## Integration with FeedbackController

When PR #412 (FeedbackController) is merged, these functions can be used to implement `createChannel({ type: 'group' })`:

```typescript
// In FeedbackController
async createChannel(options: { type: 'group', name, members }) {
  return createDiscussionChat(this.client, {
    topic: options.name,
    members: options.members,
  });
}
```

## Test Results

| Metric | Value |
|--------|-------|
| Unit Tests | ✅ 7 passed |
| Type Check | ✅ Pass |
| Lint | ✅ 0 errors (62 warnings) |
| All Tests | ✅ 1231 passed |

## Related

- Issue #402: v0.4 功能规划 - ChatOps requirement
- Issue #411: FeedbackController - will use these functions
- PR #404: Original ChatManager (closed as too complex)

## Test plan

- [x] Unit tests for all ChatOps functions
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes
- [ ] Integration with FeedbackController (after PR #412 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)