### PR TITLE
feat(agents): add GenericSkillAgent for simplified skill execution (Issue #413)

### DIFF
--- a/skills/evaluator/SKILL.md
+++ b/skills/evaluator/SKILL.md
@@ -7,6 +7,15 @@ allowed-tools: [Read, Grep, Glob, Write]
 
 # Skill: Evaluator
 
+## Execution Context
+
+- **Task ID**: {{taskId}}
+- **Iteration**: {{iteration}}
+- **Task Spec**: `{{taskMdPath}}`
+- **Evaluation Output**: `{{evaluationPath}}`
+- **Final Result Output**: `{{finalResultPath}}`
+- **Previous Execution**: `{{previousExecutionPath}}`
+
 ## Role
 
 Task completion evaluation specialist.

--- a/skills/executor/SKILL.md
+++ b/skills/executor/SKILL.md
@@ -6,6 +6,22 @@ allowed-tools: [Read, Write, Edit, Bash, Glob, Grep]
 
 # Executor Agent
 
+## Execution Context
+
+- **Task ID**: {{taskId}}
+- **Iteration**: {{iteration}}
+- **Task Spec**: `{{taskMdPath}}`
+- **Execution Output**: `{{executionPath}}`
+- **Workspace**: `{{workspaceDir}}`
+
+## Evaluation Guidance
+
+{{evaluationContent}}
+
+---
+
+# Executor Agent
+
 You are a task execution specialist. Your job is to implement features, fix bugs, and complete tasks based on Task.md requirements and Evaluator guidance.
 
 ## Single Responsibility

--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -57,37 +57,22 @@ describe('AgentFactory', () => {
   });
 
   describe('createSkillAgent', () => {
-    it('should create Evaluator when name is "evaluator"', () => {
-      const evaluator = AgentFactory.createSkillAgent('evaluator');
-
-      expect(evaluator).toBeDefined();
-      expect(evaluator.type).toBe('skill');
+    it('should throw deprecation error for "evaluator"', () => {
+      expect(() => {
+        AgentFactory.createSkillAgent('evaluator');
+      }).toThrow("'evaluator' is deprecated. Use GenericSkillAgent directly instead");
     });
 
-    it('should create Executor when name is "executor"', () => {
-      const executor = AgentFactory.createSkillAgent('executor');
-
-      expect(executor).toBeDefined();
-      expect(executor.type).toBe('skill');
-    });
-
-    it('should pass subdirectory to Evaluator', () => {
-      const evaluator = AgentFactory.createSkillAgent('evaluator', {}, 'regular');
-
-      expect(evaluator).toBeDefined();
-    });
-
-    it('should pass abortSignal to Executor', () => {
-      const controller = new AbortController();
-      const executor = AgentFactory.createSkillAgent('executor', {}, controller.signal);
-
-      expect(executor).toBeDefined();
+    it('should throw deprecation error for "executor"', () => {
+      expect(() => {
+        AgentFactory.createSkillAgent('executor');
+      }).toThrow("'executor' is deprecated. Use GenericSkillAgent directly instead");
     });
 
     it('should throw error for unknown SkillAgent name', () => {
       expect(() => {
         AgentFactory.createSkillAgent('unknown');
-      }).toThrow('Unknown SkillAgent: unknown');
+      }).toThrow('Unknown SkillAgent: unknown. Use GenericSkillAgent directly.');
     });
   });
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -4,20 +4,23 @@
  * Implements AgentFactoryInterface from #282 Phase 3 for unified agent creation.
  * All agent creation goes through the type-specific methods:
  * - createChatAgent: Create chat agents (pilot)
- * - createSkillAgent: Create skill agents (evaluator, executor, reporter)
+ * - createSkillAgent: Create skill agents (deprecated, use GenericSkillAgent directly)
  * - createSubagent: Create subagents (site-miner)
  *
  * Uses unified configuration types from Issue #327.
+ *
+ * Refactored (Issue #413): Evaluator and Executor replaced by GenericSkillAgent.
  *
  * @example
  * ```typescript
  * // Create a Pilot (ChatAgent)
  * const pilot = AgentFactory.createChatAgent('pilot', callbacks);
  *
- * // Create skill agents
- * const evaluator = AgentFactory.createSkillAgent('evaluator');
- * const executor = AgentFactory.createSkillAgent('executor', {}, abortSignal);
- * const reporter = AgentFactory.createSkillAgent('reporter');
+ * // Create skill agents (use GenericSkillAgent directly instead)
+ * const skillAgent = new GenericSkillAgent(config);
+ * for await (const msg of skillAgent.executeSkill('skills/evaluator/SKILL.md', context)) {
+ *   console.log(msg.content);
+ * }
  *
  * // Create a subagent
  * const siteMiner = AgentFactory.createSubagent('site-miner');
@@ -27,11 +30,9 @@
  */
 
 import { Config } from '../config/index.js';
-import { Evaluator, type EvaluatorConfig } from './evaluator.js';
-import { Executor, type ExecutorConfig } from './executor.js';
 import { Pilot, type PilotConfig, type PilotCallbacks } from './pilot.js';
 import { createSiteMiner, isPlaywrightAvailable } from './site-miner.js';
-import type { ChatAgent, SkillAgent, Subagent, BaseAgentConfig, AgentProvider } from './types.js';
+import type { ChatAgent, Subagent, BaseAgentConfig, AgentProvider } from './types.js';
 
 /**
  * Options for creating agents with custom configuration.
@@ -121,57 +122,20 @@ export class AgentFactory {
   /**
    * Create a SkillAgent instance by name.
    *
-   * @param name - Agent name ('evaluator', 'executor', 'reporter')
-   * @param args - Additional arguments:
-   *   - For 'evaluator':
-   *     - args[0]: AgentCreateOptions - Optional configuration overrides
-   *     - args[1]: string - Optional subdirectory for task files
-   *   - For 'executor':
-   *     - args[0]: AgentCreateOptions - Optional configuration overrides
-   *     - args[1]: AbortSignal - Optional abort signal for cancellation
-   *   - For 'reporter':
-   *     - args[0]: AgentCreateOptions - Optional configuration overrides
-   * @returns SkillAgent instance
+   * @deprecated Use GenericSkillAgent directly instead. Issue #413.
    *
-   * @example
-   * ```typescript
-   * // Evaluator with default config
-   * const evaluator = AgentFactory.createSkillAgent('evaluator');
-   *
-   * // Evaluator with subdirectory
-   * const evaluator = AgentFactory.createSkillAgent('evaluator', {}, 'regular');
-   *
-   * // Executor with abort signal
-   * const controller = new AbortController();
-   * const executor = AgentFactory.createSkillAgent('executor', {}, controller.signal);
-   *
-   * // Reporter
-   * const reporter = AgentFactory.createSkillAgent('reporter');
-   * ```
+   * @param name - Agent name
+   * @throws Error for 'evaluator' and 'executor' - use GenericSkillAgent directly
+   * @returns SkillAgent instance (only for backwards compatibility)
    */
-  static createSkillAgent(name: string, ...args: unknown[]): SkillAgent {
-    const options = (args[0] as AgentCreateOptions) || {};
-
-    switch (name) {
-      case 'evaluator': {
-        const subdirectory = args[1] as string | undefined;
-        const config: EvaluatorConfig = {
-          ...this.getBaseConfig(options),
-          subdirectory,
-        };
-        return new Evaluator(config) as unknown as SkillAgent;
-      }
-      case 'executor': {
-        const abortSignal = args[1] as AbortSignal | undefined;
-        const config: ExecutorConfig = {
-          ...this.getBaseConfig(options),
-          abortSignal,
-        };
-        return new Executor(config) as unknown as SkillAgent;
-      }
-      default:
-        throw new Error(`Unknown SkillAgent: ${name}`);
+  static createSkillAgent(name: string, ..._args: unknown[]): never {
+    if (name === 'evaluator' || name === 'executor') {
+      throw new Error(
+        `'${name}' is deprecated. Use GenericSkillAgent directly instead. ` +
+        `Example: new GenericSkillAgent(config).executeSkill('skills/${name}/SKILL.md', context)`
+      );
     }
+    throw new Error(`Unknown SkillAgent: ${name}. Use GenericSkillAgent directly.`);
   }
 
   /**

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -3,23 +3,25 @@
  *
  * Provides:
  * - BaseAgent: Abstract base class for all agents
- * - Evaluator: Task completion evaluation specialist
- * - Executor: Task execution specialist
- * - Reporter: Communication and instruction generation specialist
+ * - GenericSkillAgent: Generic skill execution agent (Issue #413)
  * - Pilot: Platform-agnostic direct chat with streaming input
  * - SessionManager: Pilot session lifecycle management
  * - ConversationContext: Pilot conversation context tracking
  *
  * Agent Type Classification (Issue #282):
  * - ChatAgent: Continuous conversation agents (Pilot)
- * - SkillAgent: Single-shot task agents (Evaluator, Executor, Reporter)
+ * - SkillAgent: Single-shot task agents (GenericSkillAgent)
  * - Subagent: SkillAgent that can be used as a tool (SiteMiner)
  *
  * Unified Configuration Types (Issue #327):
  * - BaseAgentConfig: Base configuration for all agents
  * - ChatAgentConfig: Configuration for ChatAgent (Pilot)
- * - SkillAgentConfig: Configuration for SkillAgent (Evaluator, Executor, Reporter)
+ * - SkillAgentConfig: Configuration for SkillAgent
  * - SubagentConfig: Configuration for Subagent (SiteMiner)
+ *
+ * Refactored (Issue #413):
+ * - GenericSkillAgent replaces Evaluator and Executor for skill execution
+ * - Use GenericSkillAgent.executeSkill('skills/evaluator/SKILL.md', context) instead
  */
 
 // Type definitions
@@ -52,7 +54,11 @@ export {
   type QueryStreamResult,
 } from './base-agent.js';
 
-// Task agents
+// Skill-based agent (Issue #413)
+export { GenericSkillAgent, type SkillContext } from './skill-agent.js';
+
+// Legacy task agents (deprecated, use GenericSkillAgent instead)
+// These are kept for backward compatibility but will be removed in a future version
 export { Evaluator, type EvaluatorConfig } from './evaluator.js';
 export { Executor, type ExecutorConfig, type TaskProgressEvent, type TaskResult } from './executor.js';
 

--- a/src/agents/skill-agent.test.ts
+++ b/src/agents/skill-agent.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for GenericSkillAgent
+ *
+ * GenericSkillAgent is the simplified skill execution agent from Issue #413.
+ * It reads skill markdown files, replaces template variables, and executes via SDK.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import { GenericSkillAgent, type SkillContext } from './skill-agent.js';
+import type { BaseAgentConfig } from './types.js';
+
+// Mock fs/promises
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+// Mock Config
+vi.mock('../config/index.js', () => ({
+  Config: {
+    getWorkspaceDir: () => '/test/workspace',
+    getAgentConfig: () => ({
+      apiKey: 'test-key',
+      model: 'test-model',
+      provider: 'anthropic',
+    }),
+    getLoggingConfig: () => ({
+      sdkDebug: false,
+    }),
+    getGlobalEnv: () => ({}),
+  },
+}));
+
+// Mock SDK provider
+vi.mock('../sdk/index.js', () => ({
+  getProvider: () => ({
+    queryOnce: vi.fn().mockImplementation(function* (input: string) {
+      yield {
+        type: 'text',
+        content: `Response to: ${input.substring(0, 50)}...`,
+        metadata: {},
+      };
+    }),
+  }),
+}));
+
+// Mock logger
+vi.mock('../utils/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+describe('GenericSkillAgent', () => {
+  let agent: GenericSkillAgent;
+  const config: BaseAgentConfig = {
+    apiKey: 'test-api-key',
+    model: 'test-model',
+    provider: 'anthropic',
+    permissionMode: 'bypassPermissions',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agent = new GenericSkillAgent(config);
+  });
+
+  afterEach(() => {
+    agent.dispose();
+  });
+
+  describe('constructor', () => {
+    it('should create instance with correct properties', () => {
+      expect(agent.type).toBe('skill');
+      expect(agent.name).toBe('GenericSkillAgent');
+    });
+  });
+
+  describe('executeSkill', () => {
+    it('should read skill file and execute with template variables', async () => {
+      const skillContent = `# Test Skill
+Task ID: {{taskId}}
+Iteration: {{iteration}}
+Path: {{taskMdPath}}`;
+
+      vi.mocked(fs.readFile).mockResolvedValueOnce(skillContent);
+
+      const context: SkillContext = {
+        taskId: 'task-123',
+        iteration: 1,
+        taskMdPath: '/test/workspace/tasks/task-123/Task.md',
+      };
+
+      const messages = [];
+      for await (const msg of agent.executeSkill('skills/test/SKILL.md', context)) {
+        messages.push(msg);
+      }
+
+      expect(fs.readFile).toHaveBeenCalled();
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('should replace multiple template variables', async () => {
+      const skillContent = 'Task: {{taskId}}, Iter: {{iteration}}, Path: {{taskMdPath}}';
+      vi.mocked(fs.readFile).mockResolvedValueOnce(skillContent);
+
+      const context: SkillContext = {
+        taskId: 'my-task',
+        iteration: 5,
+        taskMdPath: '/path/to/Task.md',
+      };
+
+      const messages = [];
+      for await (const msg of agent.executeSkill('skills/test/SKILL.md', context)) {
+        messages.push(msg);
+      }
+
+      expect(fs.readFile).toHaveBeenCalled();
+    });
+
+    it('should replace undefined variables with empty string', async () => {
+      const skillContent = 'Task: {{taskId}}, Missing: {{undefinedVar}}';
+      vi.mocked(fs.readFile).mockResolvedValueOnce(skillContent);
+
+      const context: SkillContext = {
+        taskId: 'task-123',
+      };
+
+      const messages = [];
+      for await (const msg of agent.executeSkill('skills/test/SKILL.md', context)) {
+        messages.push(msg);
+      }
+
+      expect(fs.readFile).toHaveBeenCalled();
+    });
+
+    it('should handle null variable values', async () => {
+      const skillContent = 'Previous: {{previousExecutionPath}}';
+      vi.mocked(fs.readFile).mockResolvedValueOnce(skillContent);
+
+      const context: SkillContext = {
+        taskId: 'task-123',
+        previousExecutionPath: null,
+      };
+
+      const messages = [];
+      for await (const msg of agent.executeSkill('skills/test/SKILL.md', context)) {
+        messages.push(msg);
+      }
+
+      expect(fs.readFile).toHaveBeenCalled();
+    });
+
+    it('should throw error when skill file cannot be read', async () => {
+      vi.mocked(fs.readFile).mockRejectedValueOnce(new Error('File not found'));
+
+      const context: SkillContext = { taskId: 'task-123' };
+
+      await expect(async () => {
+        for await (const _ of agent.executeSkill('skills/missing/SKILL.md', context)) {
+          // Should not reach here
+        }
+      }).rejects.toThrow('Failed to read skill file');
+    });
+
+    it('should resolve relative paths correctly', async () => {
+      vi.mocked(fs.readFile).mockResolvedValueOnce('skill content');
+
+      const context: SkillContext = { taskId: 'task-123' };
+
+      for await (const _ of agent.executeSkill('skills/test/SKILL.md', context)) {
+        break;
+      }
+
+      // eslint-disable-next-line prefer-destructuring
+      const calledPath = vi.mocked(fs.readFile).mock.calls[0][0];
+      expect(calledPath).toContain('skills/test/SKILL.md');
+    });
+
+    it('should use absolute paths as-is', async () => {
+      vi.mocked(fs.readFile).mockResolvedValueOnce('skill content');
+
+      const context: SkillContext = { taskId: 'task-123' };
+      const absolutePath = '/absolute/path/to/SKILL.md';
+
+      for await (const _ of agent.executeSkill(absolutePath, context)) {
+        break;
+      }
+
+      expect(fs.readFile).toHaveBeenCalledWith(absolutePath, 'utf-8');
+    });
+  });
+
+  describe('execute (SkillAgent interface)', () => {
+    it('should execute string input directly', async () => {
+      const messages = [];
+      for await (const msg of agent.execute('test prompt')) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('should execute UserInput array', async () => {
+      const messages = [];
+      for await (const msg of agent.execute([
+        { role: 'user', content: 'hello' },
+        { role: 'user', content: 'world' },
+      ])) {
+        messages.push(msg);
+      }
+
+      expect(messages.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should be idempotent', () => {
+      agent.dispose();
+      agent.dispose(); // Should not throw
+    });
+  });
+
+  describe('SkillContext', () => {
+    it('should support all expected fields', () => {
+      const context: SkillContext = {
+        taskId: 'task-123',
+        iteration: 1,
+        workspaceDir: '/workspace',
+        taskMdPath: '/path/to/Task.md',
+        evaluationPath: '/path/to/evaluation.md',
+        executionPath: '/path/to/execution.md',
+        previousExecutionPath: '/path/to/prev.md',
+        finalResultPath: '/path/to/final.md',
+        evaluationContent: 'evaluation text',
+        customField: 'custom value',
+      };
+
+      expect(context.taskId).toBe('task-123');
+      expect(context.customField).toBe('custom value');
+    });
+  });
+});

--- a/src/agents/skill-agent.ts
+++ b/src/agents/skill-agent.ts
@@ -1,0 +1,207 @@
+/**
+ * GenericSkillAgent - Minimal skill execution agent.
+ *
+ * Reads a skill markdown file, replaces template variables, and executes via SDK.
+ * This is the simplified architecture from Issue #413.
+ *
+ * Design principles:
+ * - Minimal wrapper (~50 lines)
+ * - No YAML frontmatter parsing
+ * - No allowedTools configuration (SDK handles tool restrictions)
+ * - Template variable replacement for context injection
+ *
+ * @example
+ * ```typescript
+ * const agent = new GenericSkillAgent(config);
+ *
+ * // Execute a skill with context
+ * for await (const msg of agent.executeSkill('skills/evaluator/SKILL.md', {
+ *   taskId: 'task-123',
+ *   iteration: 1,
+ * })) {
+ *   console.log(msg.content);
+ * }
+ * ```
+ *
+ * @module agents/skill-agent
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
+import type { SkillAgent as SkillAgentInterface, UserInput } from './types.js';
+import type { AgentMessage } from '../types/agent.js';
+import { Config } from '../config/index.js';
+
+/**
+ * Context object for skill execution.
+ * These values are available as template variables in skill files.
+ */
+export interface SkillContext {
+  /** Task identifier */
+  taskId?: string;
+  /** Current iteration number */
+  iteration?: number;
+  /** Workspace directory */
+  workspaceDir?: string;
+  /** Task specification file path */
+  taskMdPath?: string;
+  /** Evaluation output file path */
+  evaluationPath?: string;
+  /** Execution output file path */
+  executionPath?: string;
+  /** Previous execution file path */
+  previousExecutionPath?: string | null;
+  /** Final result file path */
+  finalResultPath?: string;
+  /** Evaluation content for executor guidance */
+  evaluationContent?: string;
+  /** Additional context values */
+  [key: string]: string | number | undefined | null;
+}
+
+/**
+ * GenericSkillAgent - Minimal skill execution agent.
+ *
+ * Implements Issue #413's simplified architecture:
+ * - Read skill markdown file
+ * - Replace template variables (e.g., {{taskId}})
+ * - Pass to SDK as prompt
+ */
+export class GenericSkillAgent extends BaseAgent implements SkillAgentInterface {
+  /** Agent type identifier */
+  readonly type = 'skill' as const;
+
+  /** Agent name for logging */
+  readonly name = 'GenericSkillAgent';
+
+  constructor(config: BaseAgentConfig) {
+    super(config);
+  }
+
+  protected getAgentName(): string {
+    return 'GenericSkillAgent';
+  }
+
+  /**
+   * Execute a skill file with context.
+   *
+   * @param skillPath - Path to the skill markdown file
+   * @param context - Context values for template replacement
+   * @yields AgentMessage responses
+   */
+  async *executeSkill(
+    skillPath: string,
+    context: SkillContext = {}
+  ): AsyncGenerator<AgentMessage> {
+    // Resolve skill path relative to workspace
+    const resolvedPath = this.resolveSkillPath(skillPath);
+
+    // Read skill file
+    const skillContent = await this.readSkillFile(resolvedPath);
+
+    // Replace template variables
+    const prompt = this.replaceTemplateVariables(skillContent, context);
+
+    this.logger.debug(
+      {
+        skillPath: resolvedPath,
+        contextKeys: Object.keys(context),
+        promptLength: prompt.length,
+      },
+      'Executing skill'
+    );
+
+    // Execute via SDK
+    const sdkOptions = this.createSdkOptions({});
+
+    try {
+      for await (const { parsed } of this.queryOnce(prompt, sdkOptions)) {
+        yield this.formatMessage(parsed);
+      }
+    } catch (error) {
+      yield this.handleIteratorError(error, 'executeSkill');
+    }
+  }
+
+  /**
+   * Resolve skill path to absolute path.
+   */
+  private resolveSkillPath(skillPath: string): string {
+    // If already absolute, use as-is
+    if (path.isAbsolute(skillPath)) {
+      return skillPath;
+    }
+
+    // Resolve relative to workspace directory
+    const workspaceDir = Config.getWorkspaceDir();
+    return path.resolve(workspaceDir, '..', skillPath);
+  }
+
+  /**
+   * Read skill file content.
+   */
+  private async readSkillFile(skillPath: string): Promise<string> {
+    try {
+      return await fs.readFile(skillPath, 'utf-8');
+    } catch (error) {
+      this.logger.error({ skillPath, error }, 'Failed to read skill file');
+      throw new Error(`Failed to read skill file: ${skillPath}`);
+    }
+  }
+
+  /**
+   * Replace template variables in content.
+   *
+   * Supports {{variableName}} syntax.
+   * Undefined variables are replaced with empty string.
+   */
+  private replaceTemplateVariables(
+    content: string,
+    context: SkillContext
+  ): string {
+    // Add derived paths if taskId and iteration are provided
+    const enrichedContext = { ...context };
+
+    if (context.taskId && context.workspaceDir) {
+      const taskDir = path.join(context.workspaceDir, 'tasks', context.taskId);
+
+      if (!enrichedContext.taskMdPath) {
+        enrichedContext.taskMdPath = path.join(taskDir, 'Task.md');
+      }
+    }
+
+    // Replace all {{variableName}} patterns
+    return content.replace(/\{\{(\w+)\}\}/g, (_, key: string) => {
+      const value = enrichedContext[key];
+      if (value === undefined || value === null) {
+        return '';
+      }
+      return String(value);
+    });
+  }
+
+  /**
+   * Execute a single task and yield results.
+   * Implements SkillAgent interface.
+   *
+   * @param input - Task input as string or structured data
+   * @yields AgentMessage responses
+   */
+  async *execute(input: string | UserInput[]): AsyncGenerator<AgentMessage> {
+    // For direct string input, use as prompt directly
+    const prompt: string = typeof input === 'string'
+      ? input
+      : input.map(u => u.content).join('\n');
+
+    const sdkOptions = this.createSdkOptions({});
+
+    try {
+      for await (const { parsed } of this.queryOnce(prompt, sdkOptions)) {
+        yield this.formatMessage(parsed);
+      }
+    } catch (error) {
+      yield this.handleIteratorError(error, 'execute');
+    }
+  }
+}

--- a/src/feishu/task-flow-orchestrator.ts
+++ b/src/feishu/task-flow-orchestrator.ts
@@ -18,6 +18,7 @@
  *
  * Refactored (Issue #283): Uses ReflectionController instead of DialogueOrchestrator.
  * Refactored (Issue #417): Removed Reporter, using message level system instead.
+ * Refactored (Issue #413): Uses SkillAgent instead of Evaluator/Executor classes.
  */
 
 import * as path from 'path';
@@ -34,71 +35,121 @@ import { handleError, ErrorCategory } from '../utils/error-handler.js';
 import type { Logger } from 'pino';
 import type { AgentMessage } from '../types/agent.js';
 import type { ReflectionContext } from '../task/reflection.js';
-import { Evaluator } from '../agents/evaluator.js';
-import { Executor, type TaskProgressEvent } from '../agents/executor.js';
+import { GenericSkillAgent, type SkillContext } from '../agents/skill-agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { DIALOGUE } from '../config/constants.js';
 import { MessageLevel, mapAgentMessageTypeToLevel } from '../messaging/types.js';
+import type { BaseAgentConfig } from '../agents/types.js';
 
 /**
- * Process executor events and yield agent messages.
+ * Run evaluation phase using SkillAgent.
  *
- * Replaces the Reporter class with a simpler message level-based approach (Issue #417).
- * Maps executor events to appropriate message levels for routing.
- *
- * @param event - Executor progress event
- * @param taskId - Task identifier
- * @param iteration - Current iteration number
- * @yields AgentMessage - Processed messages
+ * @param context - Reflection context with taskId and iteration
+ * @param agentConfig - Agent configuration
+ * @yields AgentMessage responses
  */
-function* processExecutorEvent(
-  event: TaskProgressEvent,
-  taskId: string,
-  iteration: number
-): Generator<AgentMessage> {
-  switch (event.type) {
-    case 'start':
-      yield {
-        content: `⚡ 开始: ${event.title}`,
-        role: 'assistant',
-        messageType: 'status',
-        metadata: { level: MessageLevel.INFO, taskId, iteration },
-      };
-      break;
+async function* runEvaluationPhase(
+  context: ReflectionContext,
+  agentConfig: BaseAgentConfig
+): AsyncGenerator<AgentMessage> {
+  const fileManager = new TaskFileManager();
+  const agent = new GenericSkillAgent(agentConfig);
 
-    case 'output':
-      // Map the message type to a level for routing decisions
-      const level = mapAgentMessageTypeToLevel(event.messageType as any, event.content);
-      yield {
-        content: event.content,
-        role: 'assistant',
-        messageType: event.messageType as AgentMessage['messageType'],
-        metadata: { level, taskId, iteration, ...event.metadata },
-      };
-      break;
+  // Ensure iteration directory exists
+  await fileManager.createIteration(context.taskId, context.iteration);
 
-    case 'complete':
-      yield {
-        content: `✅ 完成: ${event.summaryFile}`,
-        role: 'assistant',
-        messageType: 'task_completion',
-        metadata: {
-          level: MessageLevel.RESULT,
-          taskId,
-          iteration,
-          files: event.files,
-        },
-      };
-      break;
+  // Build context for template variables
+  const skillContext: SkillContext = {
+    taskId: context.taskId,
+    iteration: context.iteration,
+    workspaceDir: Config.getWorkspaceDir(),
+    taskMdPath: fileManager.getTaskSpecPath(context.taskId),
+    evaluationPath: fileManager.getEvaluationPath(context.taskId, context.iteration),
+    finalResultPath: fileManager.getFinalResultPath(context.taskId),
+    previousExecutionPath: context.iteration > 1
+      ? fileManager.getExecutionPath(context.taskId, context.iteration - 1)
+      : null,
+  };
 
-    case 'error':
+  try {
+    yield* agent.executeSkill('skills/evaluator/SKILL.md', skillContext);
+  } finally {
+    agent.dispose();
+  }
+}
+
+/**
+ * Run execution phase using SkillAgent.
+ *
+ * @param context - Reflection context with taskId and iteration
+ * @param agentConfig - Agent configuration
+ * @yields AgentMessage responses with progress events
+ */
+async function* runExecutionPhase(
+  context: ReflectionContext,
+  agentConfig: BaseAgentConfig
+): AsyncGenerator<AgentMessage> {
+  const fileManager = new TaskFileManager();
+  const workspaceDir = Config.getWorkspaceDir();
+
+  // Yield start event
+  yield {
+    content: '⚡ **Executing Task**',
+    role: 'assistant',
+    messageType: 'status',
+    metadata: { level: MessageLevel.INFO, taskId: context.taskId, iteration: context.iteration },
+  };
+
+  // Read evaluation content for guidance
+  let evaluationContent = '';
+  try {
+    evaluationContent = await fileManager.readEvaluation(context.taskId, context.iteration);
+  } catch {
+    // No evaluation found, proceed without guidance
+  }
+
+  const agent = new GenericSkillAgent(agentConfig);
+
+  // Build context for template variables
+  const skillContext: SkillContext = {
+    taskId: context.taskId,
+    iteration: context.iteration,
+    workspaceDir,
+    taskMdPath: fileManager.getTaskSpecPath(context.taskId),
+    executionPath: fileManager.getExecutionPath(context.taskId, context.iteration),
+    evaluationContent: evaluationContent || '(No evaluation guidance available)',
+  };
+
+  try {
+    for await (const msg of agent.executeSkill('skills/executor/SKILL.md', skillContext)) {
+      // Map message type to level for routing
+      const level = mapAgentMessageTypeToLevel(msg.messageType as any, typeof msg.content === 'string' ? msg.content : '');
       yield {
-        content: `❌ 错误: ${event.error}`,
-        role: 'assistant',
-        messageType: 'error',
-        metadata: { level: MessageLevel.ERROR, taskId, iteration },
+        ...msg,
+        metadata: { level, taskId: context.taskId, iteration: context.iteration, ...msg.metadata },
       };
-      break;
+    }
+
+    // Yield completion event
+    yield {
+      content: `✅ 完成: ${fileManager.getExecutionPath(context.taskId, context.iteration)}`,
+      role: 'assistant',
+      messageType: 'task_completion',
+      metadata: {
+        level: MessageLevel.RESULT,
+        taskId: context.taskId,
+        iteration: context.iteration,
+      },
+    };
+  } catch (error) {
+    yield {
+      content: `❌ 错误: ${error instanceof Error ? error.message : String(error)}`,
+      role: 'assistant',
+      messageType: 'error',
+      metadata: { level: MessageLevel.ERROR, taskId: context.taskId, iteration: context.iteration },
+    };
+  } finally {
+    agent.dispose();
   }
 }
 
@@ -185,9 +236,10 @@ export class TaskFlowOrchestrator {
   }
 
   /**
-   * Run the dialogue phase using ReflectionController (Evaluator → Executor → Reporter).
+   * Run the dialogue phase using ReflectionController (Evaluator → Executor).
    *
    * Refactored (Issue #283): Uses ReflectionController instead of DialogueOrchestrator.
+   * Refactored (Issue #413): Uses SkillAgent instead of Evaluator/Executor classes.
    */
   private async runDialogue(
     chatId: string,
@@ -244,23 +296,20 @@ export class TaskFlowOrchestrator {
       ]
     );
 
-    // Create execute phase: runs Evaluator
-    const executePhase = async function* (context: ReflectionContext): AsyncGenerator<AgentMessage> {
-      const evaluator = new Evaluator({
-        apiKey: agentConfig.apiKey,
-        model: agentConfig.model,
-        apiBaseUrl: agentConfig.apiBaseUrl,
-        permissionMode: 'bypassPermissions',
-      });
-
-      try {
-        yield* evaluator.evaluate(context.taskId, context.iteration);
-      } finally {
-        evaluator.dispose();
-      }
+    // Skill agent configuration
+    const skillAgentConfig: BaseAgentConfig = {
+      apiKey: agentConfig.apiKey,
+      model: agentConfig.model,
+      apiBaseUrl: agentConfig.apiBaseUrl,
+      permissionMode: 'bypassPermissions',
     };
 
-    // Create evaluate phase: runs Executor (after Evaluator)
+    // Create execute phase: runs evaluation using SkillAgent
+    const executePhase = async function* (context: ReflectionContext): AsyncGenerator<AgentMessage> {
+      yield* runEvaluationPhase(context, skillAgentConfig);
+    };
+
+    // Create evaluate phase: runs execution using SkillAgent
     const evaluatePhase = async function* (context: ReflectionContext): AsyncGenerator<AgentMessage> {
       // Check if task is already complete
       const hasFinalResult = await fileManager.hasFinalResult(context.taskId);
@@ -274,37 +323,7 @@ export class TaskFlowOrchestrator {
         return;
       }
 
-      yield {
-        content: '⚡ **Executing Task**',
-        role: 'assistant',
-        messageType: 'status',
-      };
-
-      const executor = new Executor({
-        apiKey: agentConfig.apiKey,
-        model: agentConfig.model,
-        apiBaseUrl: agentConfig.apiBaseUrl,
-        permissionMode: 'bypassPermissions',
-      });
-
-      try {
-        const executorStream = executor.executeTask(
-          context.taskId,
-          context.iteration,
-          Config.getWorkspaceDir()
-        );
-
-        // Process executor events directly using message level system (Issue #417)
-        for await (const event of executorStream) {
-          yield* processExecutorEvent(event, context.taskId, context.iteration);
-        }
-      } catch (error) {
-        yield {
-          content: `❌ **Task execution failed**: ${error instanceof Error ? error.message : String(error)}`,
-          role: 'assistant',
-          messageType: 'error',
-        };
-      }
+      yield* runExecutionPhase(context, skillAgentConfig);
     };
 
     try {


### PR DESCRIPTION
## Summary

Implements Issue #413 - Creates a minimal GenericSkillAgent that reads skill markdown files, replaces template variables, and executes via SDK.

## Problem

The existing Evaluator and Executor classes are complex TypeScript classes (~274 and ~385 lines) that:
- Build prompts programmatically
- Hardcode allowedTools in code
- Don't leverage existing skill markdown files

## Solution

Created GenericSkillAgent with minimal implementation (~160 lines):
- Reads skill markdown files directly
- Supports template variable replacement ({{taskId}}, {{iteration}}, etc.)
- Passes content to SDK as prompt
- No YAML parsing, no allowedTools configuration

## Changes

| File | Description |
|------|-------------|
| `src/agents/skill-agent.ts` | New GenericSkillAgent class |
| `src/agents/skill-agent.test.ts` | Unit tests (12 tests) |
| `src/agents/factory.ts` | Deprecate evaluator/executor in createSkillAgent |
| `src/agents/index.ts` | Export GenericSkillAgent |
| `src/feishu/task-flow-orchestrator.ts` | Use GenericSkillAgent for evaluation/execution |
| `skills/evaluator/SKILL.md` | Add Execution Context section with template vars |
| `skills/executor/SKILL.md` | Add Execution Context section with template vars |

## Architecture

### Before
```
TaskFlowOrchestrator
  └── new Evaluator(config)
        └── buildEvaluationPrompt() // hardcoded
  └── new Executor(config)
        └── buildTaskPrompt() // hardcoded
```

### After
```
TaskFlowOrchestrator
  └── runEvaluationPhase()
        └── new GenericSkillAgent(config)
              └── executeSkill('skills/evaluator/SKILL.md', context)
  └── runExecutionPhase()
        └── new GenericSkillAgent(config)
              └── executeSkill('skills/executor/SKILL.md', context)
```

## Test Results

| Metric | Value |
|--------|-------|
| Unit Tests | ✅ 1209 passed, 8 skipped |
| Type Check | ✅ Pass |
| Lint | ✅ 0 errors (63 warnings) |

## Deprecation Notice

- `AgentFactory.createSkillAgent('evaluator')` - throws deprecation error
- `AgentFactory.createSkillAgent('executor')` - throws deprecation error
- Use `new GenericSkillAgent(config).executeSkill('skills/evaluator/SKILL.md', context)` instead

## Related

- Fixes #413
- Replaces: PR #414 (closed as too complex)
- Replaces: PR #418 (closed as superseded)

## Test plan

- [x] Unit tests for GenericSkillAgent (12 tests)
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)