### PR TITLE
feat(skills): add generic SkillLoader for Agent SDK (Issue #430 Phase 1)

### DIFF
--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Skills Module - Generic skill support for Agent SDK.
+ *
+ * This module provides a simple skill loading system as described in Issue #430:
+ *
+ * - Load skill markdown files from the file system
+ * - Parse YAML frontmatter for metadata
+ * - Search for skills across multiple paths
+ *
+ * Design Principles:
+ * - Simple and minimal - no complex parsing
+ * - Just read markdown files and extract basic metadata
+ * - Works with any Agent implementation
+ *
+ * @example
+ * ```typescript
+ * import { FileSystemSkillLoader } from './skills/index.js';
+ *
+ * const loader = new FileSystemSkillLoader();
+ *
+ * // Load a single skill
+ * const skill = await loader.loadSkill('skills/evaluator/SKILL.md');
+ * console.log(skill.name); // 'evaluator'
+ * console.log(skill.allowedTools); // ['Read', 'Grep', 'Glob', 'Write']
+ *
+ * // Search across multiple paths
+ * const skills = await loader.searchSkills([
+ *   { path: '.claude/skills', domain: 'project', priority: 3 },
+ *   { path: 'skills', domain: 'package', priority: 1 },
+ * ]);
+ * ```
+ *
+ * @module skills
+ */
+
+export { FileSystemSkillLoader } from './loader.js';
+export type {
+  Skill,
+  SkillLoader,
+  SkillSearchPath,
+  SkillFrontmatter,
+} from './types.js';

--- a/src/skills/loader.test.ts
+++ b/src/skills/loader.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for FileSystemSkillLoader.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FileSystemSkillLoader } from './loader.js';
+import type { SkillSearchPath } from './types.js';
+
+describe('FileSystemSkillLoader', () => {
+  let loader: FileSystemSkillLoader;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    loader = new FileSystemSkillLoader();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skills-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('loadSkill', () => {
+    it('should load a skill file with frontmatter', async () => {
+      const skillPath = path.join(tempDir, 'test-skill.md');
+      await fs.writeFile(
+        skillPath,
+        `---
+name: test-skill
+description: A test skill
+allowed-tools: [Read, Write]
+---
+
+# Test Skill
+
+This is the skill content.`
+      );
+
+      const skill = await loader.loadSkill(skillPath);
+
+      expect(skill.name).toBe('test-skill');
+      expect(skill.description).toBe('A test skill');
+      expect(skill.allowedTools).toEqual(['Read', 'Write']);
+      expect(skill.content).toContain('# Test Skill');
+      expect(skill.path).toBe(skillPath);
+    });
+
+    it('should load a skill file without frontmatter', async () => {
+      // Create a subdirectory for the skill to test directory name extraction
+      const skillDir = path.join(tempDir, 'simple-skill');
+      await fs.mkdir(skillDir);
+      const skillPath = path.join(skillDir, 'SKILL.md');
+      await fs.writeFile(
+        skillPath,
+        `# Simple Skill
+
+Just a simple skill without frontmatter.`
+      );
+
+      const skill = await loader.loadSkill(skillPath);
+
+      expect(skill.name).toBe('simple-skill'); // Falls back to directory name
+      expect(skill.description).toBeUndefined();
+      expect(skill.allowedTools).toBeUndefined();
+      expect(skill.content).toContain('Simple Skill');
+    });
+
+    it('should extract skill name from directory if not in frontmatter', async () => {
+      const skillDir = path.join(tempDir, 'my-skill');
+      await fs.mkdir(skillDir);
+      const skillPath = path.join(skillDir, 'SKILL.md');
+      await fs.writeFile(
+        skillPath,
+        `---
+description: Skill without name
+---
+
+# My Skill`
+      );
+
+      const skill = await loader.loadSkill(skillPath);
+
+      expect(skill.name).toBe('my-skill');
+    });
+
+    it('should throw error if file does not exist', async () => {
+      const skillPath = path.join(tempDir, 'nonexistent.md');
+
+      await expect(loader.loadSkill(skillPath)).rejects.toThrow();
+    });
+  });
+
+  describe('loadSkillsFromDirectory', () => {
+    it('should load all skills from subdirectories', async () => {
+      // Create skill directories
+      const evaluatorDir = path.join(tempDir, 'evaluator');
+      const executorDir = path.join(tempDir, 'executor');
+      await fs.mkdir(evaluatorDir);
+      await fs.mkdir(executorDir);
+
+      // Create skill files
+      await fs.writeFile(
+        path.join(evaluatorDir, 'SKILL.md'),
+        `---
+name: evaluator
+description: Evaluator skill
+allowed-tools: [Read, Write]
+---
+# Evaluator`
+      );
+      await fs.writeFile(
+        path.join(executorDir, 'SKILL.md'),
+        `---
+name: executor
+description: Executor skill
+---
+# Executor`
+      );
+
+      const skills = await loader.loadSkillsFromDirectory(tempDir);
+
+      expect(skills).toHaveLength(2);
+      expect(skills.map(s => s.name)).toContain('evaluator');
+      expect(skills.map(s => s.name)).toContain('executor');
+    });
+
+    it('should skip directories without SKILL.md', async () => {
+      const skillDir = path.join(tempDir, 'skill-with-file');
+      const emptyDir = path.join(tempDir, 'empty-dir');
+      await fs.mkdir(skillDir);
+      await fs.mkdir(emptyDir);
+
+      await fs.writeFile(
+        path.join(skillDir, 'SKILL.md'),
+        `---
+name: skill-with-file
+---
+# Skill`
+      );
+
+      const skills = await loader.loadSkillsFromDirectory(tempDir);
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe('skill-with-file');
+    });
+
+    it('should return empty array if directory does not exist', async () => {
+      const skills = await loader.loadSkillsFromDirectory('/nonexistent/path');
+
+      expect(skills).toEqual([]);
+    });
+
+    it('should skip non-directory entries', async () => {
+      // Create a file (not directory) in the skills directory
+      await fs.writeFile(path.join(tempDir, 'not-a-directory.md'), 'content');
+
+      const skills = await loader.loadSkillsFromDirectory(tempDir);
+
+      expect(skills).toEqual([]);
+    });
+  });
+
+  describe('searchSkills', () => {
+    it('should search skills across multiple paths', async () => {
+      // Create first path with one skill
+      const path1 = path.join(tempDir, 'path1');
+      const skill1Dir = path.join(path1, 'skill1');
+      await fs.mkdir(skill1Dir, { recursive: true });
+      await fs.writeFile(
+        path.join(skill1Dir, 'SKILL.md'),
+        `---
+name: skill1
+description: Skill from path1
+---
+# Skill 1`
+      );
+
+      // Create second path with another skill
+      const path2 = path.join(tempDir, 'path2');
+      const skill2Dir = path.join(path2, 'skill2');
+      await fs.mkdir(skill2Dir, { recursive: true });
+      await fs.writeFile(
+        path.join(skill2Dir, 'SKILL.md'),
+        `---
+name: skill2
+description: Skill from path2
+---
+# Skill 2`
+      );
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: path1, domain: 'first', priority: 1 },
+        { path: path2, domain: 'second', priority: 2 },
+      ];
+
+      const skills = await loader.searchSkills(searchPaths);
+
+      expect(skills).toHaveLength(2);
+      expect(skills.map(s => s.name)).toContain('skill1');
+      expect(skills.map(s => s.name)).toContain('skill2');
+    });
+
+    it('should respect priority when skills have same name', async () => {
+      // Create skill in first path
+      const path1 = path.join(tempDir, 'low-priority');
+      const skillDir1 = path.join(path1, 'common-skill');
+      await fs.mkdir(skillDir1, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir1, 'SKILL.md'),
+        `---
+name: common-skill
+description: Low priority version
+---
+# Low Priority`
+      );
+
+      // Create skill with same name in second path
+      const path2 = path.join(tempDir, 'high-priority');
+      const skillDir2 = path.join(path2, 'common-skill');
+      await fs.mkdir(skillDir2, { recursive: true });
+      await fs.writeFile(
+        path.join(skillDir2, 'SKILL.md'),
+        `---
+name: common-skill
+description: High priority version
+---
+# High Priority`
+      );
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: path1, domain: 'low', priority: 1 },
+        { path: path2, domain: 'high', priority: 2 },
+      ];
+
+      const skills = await loader.searchSkills(searchPaths);
+
+      // Should only have one skill (high priority wins)
+      expect(skills).toHaveLength(1);
+      expect(skills[0].description).toBe('High priority version');
+    });
+
+    it('should handle non-existent paths gracefully', async () => {
+      const searchPaths: SkillSearchPath[] = [
+        { path: '/nonexistent/path1', priority: 1 },
+        { path: '/nonexistent/path2', priority: 2 },
+      ];
+
+      const skills = await loader.searchSkills(searchPaths);
+
+      expect(skills).toEqual([]);
+    });
+  });
+
+  describe('frontmatter parsing', () => {
+    it('should parse allowed-tools with spaces', async () => {
+      const skillPath = path.join(tempDir, 'skill.md');
+      await fs.writeFile(
+        skillPath,
+        `---
+name: spaced-tools
+allowed-tools: [Read, Write, Glob]
+---
+# Skill`
+      );
+
+      const skill = await loader.loadSkill(skillPath);
+
+      expect(skill.allowedTools).toEqual(['Read', 'Write', 'Glob']);
+    });
+
+    it('should handle empty allowed-tools', async () => {
+      const skillPath = path.join(tempDir, 'skill.md');
+      await fs.writeFile(
+        skillPath,
+        `---
+name: empty-tools
+allowed-tools: []
+---
+# Skill`
+      );
+
+      const skill = await loader.loadSkill(skillPath);
+
+      // Empty arrays don't match the regex pattern, so they become undefined
+      expect(skill.allowedTools).toBeUndefined();
+    });
+  });
+});

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,0 +1,252 @@
+/**
+ * FileSystemSkillLoader - File system based skill loader implementation.
+ *
+ * Provides a minimal implementation for loading skills from the file system:
+ * - Load individual skill files
+ * - Discover skills in directories
+ * - Search across multiple paths
+ *
+ * Design Principles (from Issue #430):
+ * - Simple and minimal - no complex YAML parsing
+ * - Just read markdown files and extract basic metadata
+ * - No backward compatibility concerns
+ *
+ * @module skills/loader
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import type { Skill, SkillLoader, SkillSearchPath, SkillFrontmatter } from './types.js';
+
+/**
+ * Default skill file name to look for in subdirectories.
+ */
+const SKILL_FILE_NAME = 'SKILL.md';
+
+/**
+ * File system based implementation of SkillLoader.
+ *
+ * @example
+ * ```typescript
+ * const loader = new FileSystemSkillLoader();
+ *
+ * // Load a single skill
+ * const skill = await loader.loadSkill('/path/to/skills/evaluator/SKILL.md');
+ *
+ * // Load all skills from a directory
+ * const skills = await loader.loadSkillsFromDirectory('/path/to/skills');
+ *
+ * // Search across multiple paths
+ * const allSkills = await loader.searchSkills([
+ *   { path: '.claude/skills', domain: 'project', priority: 3 },
+ *   { path: 'workspace/.claude/skills', domain: 'workspace', priority: 2 },
+ *   { path: 'skills', domain: 'package', priority: 1 },
+ * ]);
+ * ```
+ */
+export class FileSystemSkillLoader implements SkillLoader {
+  private readonly logger = createLogger('SkillLoader');
+
+  /**
+   * Load a single skill from a file path.
+   *
+   * @param skillPath - Absolute or relative path to skill file
+   * @returns Loaded skill with metadata and content
+   * @throws Error if file cannot be read
+   */
+  async loadSkill(skillPath: string): Promise<Skill> {
+    this.logger.debug({ path: skillPath }, 'Loading skill');
+
+    const content = await fs.readFile(skillPath, 'utf-8');
+    const frontmatter = this.parseFrontmatter(content);
+    const name = this.extractSkillName(frontmatter, skillPath);
+
+    const skill: Skill = {
+      name,
+      description: frontmatter.description,
+      allowedTools: frontmatter['allowed-tools'],
+      content,
+      path: skillPath,
+    };
+
+    this.logger.debug(
+      {
+        name: skill.name,
+        description: skill.description,
+        allowedTools: skill.allowedTools,
+        path: skillPath,
+      },
+      'Skill loaded'
+    );
+
+    return skill;
+  }
+
+  /**
+   * Load all skills from a directory.
+   *
+   * Looks for SKILL.md files in subdirectories:
+   * ```
+   * skills/
+   * ├── evaluator/
+   * │   └── SKILL.md
+   * ├── executor/
+   * │   └── SKILL.md
+   * └── reporter/
+   *     └── SKILL.md
+   * ```
+   *
+   * @param dir - Directory path containing skill subdirectories
+   * @returns Array of loaded skills
+   */
+  async loadSkillsFromDirectory(dir: string): Promise<Skill[]> {
+    this.logger.debug({ dir }, 'Loading skills from directory');
+
+    const skills: Skill[] = [];
+
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+
+        const skillPath = path.join(dir, entry.name, SKILL_FILE_NAME);
+        try {
+          const skill = await this.loadSkill(skillPath);
+          skills.push(skill);
+        } catch (error) {
+          // Skip directories without SKILL.md
+          this.logger.debug(
+            { dir: entry.name, error: error instanceof Error ? error.message : String(error) },
+            'No SKILL.md found in directory, skipping'
+          );
+        }
+      }
+    } catch (error) {
+      // Directory doesn't exist, return empty array
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        this.logger.debug({ dir }, 'Directory does not exist, returning empty skills');
+        return [];
+      }
+      throw error;
+    }
+
+    this.logger.debug({ dir, count: skills.length }, 'Skills loaded from directory');
+    return skills;
+  }
+
+  /**
+   * Search for skills across multiple paths.
+   *
+   * Searches in priority order and deduplicates by skill name.
+   * Higher priority paths override lower priority ones.
+   *
+   * @param paths - Search paths with priority information
+   * @returns Array of loaded skills (deduplicated)
+   */
+  async searchSkills(paths: SkillSearchPath[]): Promise<Skill[]> {
+    this.logger.debug({ paths: paths.map(p => p.path) }, 'Searching for skills');
+
+    // Sort by priority (higher first)
+    const sortedPaths = [...paths].sort(
+      (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
+    );
+
+    const skillMap = new Map<string, Skill>();
+
+    for (const searchPath of sortedPaths) {
+      try {
+        const skills = await this.loadSkillsFromDirectory(searchPath.path);
+
+        for (const skill of skills) {
+          // Only add if not already present (higher priority wins)
+          if (!skillMap.has(skill.name)) {
+            skillMap.set(skill.name, skill);
+          } else {
+            this.logger.debug(
+              { name: skill.name, existingPath: skillMap.get(skill.name)?.path, newPath: skill.path },
+              'Skill already loaded from higher priority path, skipping'
+            );
+          }
+        }
+      } catch (error) {
+        this.logger.debug(
+          { path: searchPath.path, error: error instanceof Error ? error.message : String(error) },
+          'Failed to load skills from path'
+        );
+      }
+    }
+
+    const result = Array.from(skillMap.values());
+    this.logger.debug({ count: result.length }, 'Skills search completed');
+    return result;
+  }
+
+  /**
+   * Parse YAML frontmatter from skill markdown content.
+   *
+   * Uses simple regex parsing - no complex YAML library needed.
+   * Only extracts basic fields: name, description, allowed-tools.
+   *
+   * @param content - Raw markdown content with optional frontmatter
+   * @returns Parsed frontmatter object
+   */
+  private parseFrontmatter(content: string): SkillFrontmatter {
+    const frontmatter: SkillFrontmatter = {};
+
+    // Check for YAML frontmatter between --- markers
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) {
+      return frontmatter;
+    }
+
+    const [, yaml] = match;
+
+    // Parse name
+    const nameMatch = yaml.match(/^name:\s*(.+)$/m);
+    if (nameMatch) {
+      const [, name] = nameMatch;
+      frontmatter.name = name.trim();
+    }
+
+    // Parse description
+    const descMatch = yaml.match(/^description:\s*(.+)$/m);
+    if (descMatch) {
+      const [, desc] = descMatch;
+      frontmatter.description = desc.trim();
+    }
+
+    // Parse allowed-tools (can be array format: [Tool1, Tool2])
+    const toolsMatch = yaml.match(/^allowed-tools:\s*\[(.+)\]$/m);
+    if (toolsMatch) {
+      const [, toolsStr] = toolsMatch;
+      frontmatter['allowed-tools'] = toolsStr
+        .split(',')
+        .map(t => t.trim())
+        .filter(t => t.length > 0);
+    }
+
+    return frontmatter;
+  }
+
+  /**
+   * Extract skill name from frontmatter or file path.
+   *
+   * @param frontmatter - Parsed frontmatter
+   * @param skillPath - Path to skill file
+   * @returns Skill name
+   */
+  private extractSkillName(frontmatter: SkillFrontmatter, skillPath: string): string {
+    // Use frontmatter name if available
+    if (frontmatter.name) {
+      return frontmatter.name;
+    }
+
+    // Fall back to directory name
+    const dirName = path.basename(path.dirname(skillPath));
+    return dirName;
+  }
+}

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Skill Type Definitions - Generic skill support for Agent SDK.
+ *
+ * This module provides type definitions for the skill loading system as described in Issue #430:
+ *
+ * - SkillLoader: Interface for loading skills from files
+ * - Skill: Represents a loaded skill with metadata and content
+ * - SkillSearchPath: Defines where to search for skills
+ *
+ * Design Principles:
+ * - Simple and minimal - no complex parsing
+ * - Just read markdown files and extract metadata
+ * - Works with any Agent implementation
+ *
+ * @module skills/types
+ */
+
+/**
+ * Represents a loaded skill with metadata and content.
+ *
+ * A skill is a markdown file that defines:
+ * - Role and responsibilities (via content)
+ * - Available tools (via allowedTools)
+ * - Instructions for the agent
+ *
+ * @example
+ * ```typescript
+ * const skill: Skill = {
+ *   name: 'evaluator',
+ *   description: 'Task completion evaluation specialist',
+ *   allowedTools: ['Read', 'Grep', 'Glob', 'Write'],
+ *   content: '# Skill: Evaluator\n\n...',
+ *   path: '/path/to/skills/evaluator/SKILL.md',
+ * };
+ * ```
+ */
+export interface Skill {
+  /** Skill name (from YAML frontmatter or directory name) */
+  name: string;
+
+  /** Skill description (from YAML frontmatter) */
+  description?: string;
+
+  /** Allowed tools for this skill (from YAML frontmatter) */
+  allowedTools?: string[];
+
+  /** Raw markdown content (including frontmatter) */
+  content: string;
+
+  /** File path where the skill was loaded from */
+  path: string;
+}
+
+/**
+ * Search path configuration for skill discovery.
+ *
+ * @example
+ * ```typescript
+ * const searchPath: SkillSearchPath = {
+ *   path: '.claude/skills',
+ *   domain: 'project',
+ *   priority: 1,
+ * };
+ * ```
+ */
+export interface SkillSearchPath {
+  /** Directory path to search for skills */
+  path: string;
+
+  /** Domain identifier (e.g., 'project', 'workspace', 'package') */
+  domain?: string;
+
+  /** Priority for conflict resolution (higher = preferred) */
+  priority?: number;
+}
+
+/**
+ * Interface for loading and discovering skills.
+ *
+ * Implementations can provide different strategies for:
+ * - Loading individual skill files
+ * - Discovering skills in directories
+ * - Searching across multiple paths
+ *
+ * @example
+ * ```typescript
+ * class FileSystemSkillLoader implements SkillLoader {
+ *   async loadSkill(path: string): Promise<Skill> {
+ *     const content = await fs.readFile(path, 'utf-8');
+ *     return this.parseSkill(content, path);
+ *   }
+ *
+ *   async loadSkillsFromDirectory(dir: string): Promise<Skill[]> {
+ *     // Load all SKILL.md files from subdirectories
+ *   }
+ *
+ *   async searchSkills(paths: SkillSearchPath[]): Promise<Skill[]> {
+ *     // Search all paths and merge results
+ *   }
+ * }
+ * ```
+ */
+export interface SkillLoader {
+  /**
+   * Load a single skill from a file path.
+   *
+   * @param path - Absolute or relative path to skill file
+   * @returns Loaded skill with metadata and content
+   * @throws Error if file cannot be read
+   */
+  loadSkill(path: string): Promise<Skill>;
+
+  /**
+   * Load all skills from a directory.
+   *
+   * Looks for SKILL.md files in subdirectories:
+   * ```
+   * skills/
+   * ├── evaluator/
+   * │   └── SKILL.md
+   * ├── executor/
+   * │   └── SKILL.md
+   * └── reporter/
+   *     └── SKILL.md
+   * ```
+   *
+   * @param dir - Directory path containing skill subdirectories
+   * @returns Array of loaded skills
+   */
+  loadSkillsFromDirectory(dir: string): Promise<Skill[]>;
+
+  /**
+   * Search for skills across multiple paths.
+   *
+   * Searches in priority order and deduplicates by skill name.
+   * Higher priority paths override lower priority ones.
+   *
+   * @param paths - Search paths with priority information
+   * @returns Array of loaded skills (deduplicated)
+   */
+  searchSkills(paths: SkillSearchPath[]): Promise<Skill[]>;
+}
+
+/**
+ * Parsed YAML frontmatter from skill markdown.
+ */
+export interface SkillFrontmatter {
+  /** Skill name */
+  name?: string;
+
+  /** Skill description */
+  description?: string;
+
+  /** Allowed tools list */
+  'allowed-tools'?: string[];
+
+  /** Disable model invocation */
+  'disable-model-invocation'?: boolean;
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of Issue #430 - Creates a generic SkillLoader for Agent SDK.

## Problem

As described in Issue #430:
- Skills markdown files exist in `skills/` directory but are not actually loaded
- Evaluator/Executor classes hardcode configuration in TypeScript
- No generic mechanism for loading skills from files
- Skills are documentation-only, not used by the Agent system

## Solution

Created a minimal skill loading system with clear interfaces:

| File | Description |
|------|-------------|
| `src/skills/types.ts` | `Skill`, `SkillLoader`, `SkillSearchPath` interfaces |
| `src/skills/loader.ts` | `FileSystemSkillLoader` implementation |
| `src/skills/loader.test.ts` | Unit tests (13 tests) |
| `src/skills/index.ts` | Module exports |

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    Skill Loading System                      │
├─────────────────────────────────────────────────────────────┤
│                                                              │
│   FileSystemSkillLoader                                      │
│        │                                                     │
│        ├── loadSkill(path) → Skill                          │
│        │                                                     │
│        ├── loadSkillsFromDirectory(dir) → Skill[]           │
│        │                                                     │
│        └── searchSkills(paths[]) → Skill[] (with priority)  │
│                                                              │
│   Skill {                                                    │
│     name: string                                             │
│     description?: string                                     │
│     allowedTools?: string[]                                  │
│     content: string                                          │
│     path: string                                             │
│   }                                                          │
│                                                              │
└─────────────────────────────────────────────────────────────┘
```

## Features

1. **loadSkill(path)**: Load a single skill file with YAML frontmatter parsing
2. **loadSkillsFromDirectory(dir)**: Load all skills from subdirectories
3. **searchSkills(paths)**: Search across multiple paths with priority-based deduplication

## Design Principles (from Issue #430)

- ✅ **Simple and minimal** - no complex YAML parsing library
- ✅ **Just read markdown files** and extract basic metadata
- ✅ **Works with any Agent implementation** - generic interface
- ✅ **Priority-based discovery** - higher priority paths override lower ones

## Usage Example

```typescript
import { FileSystemSkillLoader } from './skills/index.js';

const loader = new FileSystemSkillLoader();

// Load a single skill
const skill = await loader.loadSkill('skills/evaluator/SKILL.md');
console.log(skill.name); // 'evaluator'
console.log(skill.allowedTools); // ['Read', 'Grep', 'Glob', 'Write']

// Search across multiple paths with priority
const skills = await loader.searchSkills([
  { path: '.claude/skills', domain: 'project', priority: 3 },
  { path: 'workspace/.claude/skills', domain: 'workspace', priority: 2 },
  { path: 'skills', domain: 'package', priority: 1 },
]);
```

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 13 |
| All tests | 1212 passed, 8 skipped |
| Type check | ✅ Pass |
| Lint | ✅ Pass |

## Future Phases (Issue #430)

- Phase 2: Claude Code Agent Skills implementation
- Phase 3: Skills injection mechanism
- Phase 4: Project domain support

This PR provides the foundation for these future enhancements.

## Related

- Issue #430: feat: 为 Agent SDK 提供通用 Skills 支持封装

## Test plan

- [x] Unit tests for FileSystemSkillLoader (13 tests)
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)