### PR TITLE
feat(skills): add ClaudeCodeSkillProvider for Agent SDK (Issue #430 Phase 2-4)

### DIFF
--- a/src/agents/evaluator.ts
+++ b/src/agents/evaluator.ts
@@ -18,6 +18,10 @@
  * **Completion Detection**:
  * - Evaluator creates final_result.md when it determines the task is COMPLETE
  * - The system detects completion by checking for final_result.md presence
+ *
+ * **Skill Loading (Issue #430)**:
+ * - Skills are loaded from skill files via ClaudeCodeSkillProvider
+ * - Falls back to default tools if skill file not found
  */
 
 import { Config } from '../config/index.js';
@@ -25,12 +29,13 @@ import type { AgentMessage, AgentInput } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { SkillAgent, UserInput } from './types.js';
+import { ClaudeCodeSkillProvider, type LoadedSkills } from '../skills/index.js';
 
 /**
- * Evaluator-specific allowed tools.
- * Defined directly in code instead of loading from skill files.
+ * Default allowed tools for Evaluator.
+ * Used as fallback when skill file is not available.
  */
-const EVALUATOR_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'Write'];
+const DEFAULT_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'Write'];
 
 /**
  * Evaluator-specific configuration.
@@ -48,6 +53,7 @@ export interface EvaluatorConfig extends BaseAgentConfig {
  * - No JSON output - writes evaluation.md directly
  * - No structured result parsing
  * - File-driven workflow
+ * - Skill-based configuration (Issue #430)
  *
  * Extends BaseAgent to inherit:
  * - SDK configuration
@@ -62,10 +68,13 @@ export class Evaluator extends BaseAgent implements SkillAgent {
   readonly name = 'Evaluator';
 
   private fileManager: TaskFileManager;
+  private skillProvider: ClaudeCodeSkillProvider;
+  private loadedSkills: LoadedSkills | null = null;
 
   constructor(config: EvaluatorConfig) {
     super(config);
     this.fileManager = new TaskFileManager(Config.getWorkspaceDir(), config.subdirectory);
+    this.skillProvider = new ClaudeCodeSkillProvider();
   }
 
   protected getAgentName(): string {
@@ -74,19 +83,50 @@ export class Evaluator extends BaseAgent implements SkillAgent {
 
   /**
    * Initialize the Evaluator agent.
-   * No skill loading needed - allowedTools are defined directly in code.
+   * Loads skills from skill files (Issue #430).
    */
-  initialize(): Promise<void> {
+  async initialize(): Promise<void> {
     if (this.initialized) {
-      return Promise.resolve();
+      return;
     }
+
+    // Load skills from skill files
+    this.loadedSkills = await this.skillProvider.loadSkillsForAgent('evaluator');
+
+    // Use loaded tools or fall back to defaults
+    const allowedTools = this.getAllowedTools();
 
     this.initialized = true;
     this.logger.debug(
-      { toolCount: EVALUATOR_ALLOWED_TOOLS.length },
+      {
+        toolCount: allowedTools.length,
+        tools: allowedTools,
+        skillLoaded: this.loadedSkills.skills.length > 0,
+      },
       'Evaluator initialized'
     );
-    return Promise.resolve();
+  }
+
+  /**
+   * Get allowed tools for this agent.
+   * Returns loaded tools from skill file, or defaults if not loaded.
+   */
+  private getAllowedTools(): string[] {
+    if (this.loadedSkills && this.loadedSkills.allowedTools.length > 0) {
+      return this.loadedSkills.allowedTools;
+    }
+    return DEFAULT_ALLOWED_TOOLS;
+  }
+
+  /**
+   * Get skill system prompt content.
+   * Returns empty string if no skill loaded.
+   */
+  private getSkillPrompt(): string {
+    if (this.loadedSkills && this.loadedSkills.systemPromptContent) {
+      return this.loadedSkills.systemPromptContent;
+    }
+    return '';
   }
 
   /**
@@ -100,9 +140,11 @@ export class Evaluator extends BaseAgent implements SkillAgent {
       await this.initialize();
     }
 
+    const allowedTools = this.getAllowedTools();
+
     // Note: send_user_feedback, send_file_to_feishu are intentionally NOT included (Reporter's job)
     const sdkOptions = this.createSdkOptions({
-      allowedTools: EVALUATOR_ALLOWED_TOOLS,
+      allowedTools,
       // No MCP servers needed - Evaluator only uses file reading/writing tools
     });
 
@@ -166,7 +208,11 @@ export class Evaluator extends BaseAgent implements SkillAgent {
       previousExecutionPath = this.fileManager.getExecutionPath(taskId, iteration - 1);
     }
 
-    let prompt = `# Evaluator Task
+    // Include skill content if available
+    const skillPrompt = this.getSkillPrompt();
+    const skillSection = skillPrompt ? `\n${skillPrompt}\n` : '';
+
+    let prompt = `${skillSection}# Evaluator Task
 
 ## Context
 - Task ID: ${taskId}

--- a/src/agents/executor.ts
+++ b/src/agents/executor.ts
@@ -6,6 +6,7 @@
  * - Direct task execution based on Evaluator's evaluation.md
  * - Outputs execution.md only (final_result.md is created by Evaluator)
  * - Yields progress events for real-time reporting
+ * - Skill-based configuration (Issue #430)
  *
  * Extends BaseAgent to inherit:
  * - SDK configuration building
@@ -18,6 +19,13 @@ import type { ParsedSDKMessage, AgentMessage } from '../types/agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { SkillAgent, UserInput } from './types.js';
+import { ClaudeCodeSkillProvider, type LoadedSkills } from '../skills/index.js';
+
+/**
+ * Default allowed tools for Executor.
+ * Used as fallback when skill file is not available.
+ */
+const DEFAULT_ALLOWED_TOOLS = ['Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep'];
 
 /**
  * Executor configuration.
@@ -89,11 +97,14 @@ export class Executor extends BaseAgent implements SkillAgent {
 
   private readonly config: ExecutorConfig;
   private fileManager: TaskFileManager;
+  private skillProvider: ClaudeCodeSkillProvider;
+  private loadedSkills: LoadedSkills | null = null;
 
   constructor(config: ExecutorConfig) {
     super(config);
     this.config = config;
     this.fileManager = new TaskFileManager();
+    this.skillProvider = new ClaudeCodeSkillProvider();
 
     this.logger.debug(
       {
@@ -106,6 +117,54 @@ export class Executor extends BaseAgent implements SkillAgent {
 
   protected getAgentName(): string {
     return 'Executor';
+  }
+
+  /**
+   * Initialize the Executor agent.
+   * Loads skills from skill files (Issue #430).
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    // Load skills from skill files
+    this.loadedSkills = await this.skillProvider.loadSkillsForAgent('executor');
+
+    // Use loaded tools or fall back to defaults
+    const allowedTools = this.getAllowedTools();
+
+    this.initialized = true;
+    this.logger.debug(
+      {
+        toolCount: allowedTools.length,
+        tools: allowedTools,
+        skillLoaded: this.loadedSkills.skills.length > 0,
+      },
+      'Executor skills loaded'
+    );
+  }
+
+  /**
+   * Get allowed tools for this agent.
+   * Returns loaded tools from skill file, or defaults if not loaded.
+   */
+  private getAllowedTools(): string[] {
+    if (this.loadedSkills && this.loadedSkills.allowedTools.length > 0) {
+      return this.loadedSkills.allowedTools;
+    }
+    return DEFAULT_ALLOWED_TOOLS;
+  }
+
+  /**
+   * Get skill system prompt content.
+   * Returns empty string if no skill loaded.
+   */
+  private getSkillPrompt(): string {
+    if (this.loadedSkills && this.loadedSkills.systemPromptContent) {
+      return this.loadedSkills.systemPromptContent;
+    }
+    return '';
   }
 
   /**
@@ -129,6 +188,11 @@ export class Executor extends BaseAgent implements SkillAgent {
     // Check for cancellation
     if (this.config?.abortSignal?.aborted) {
       throw new Error('AbortError');
+    }
+
+    // Initialize if needed (loads skills)
+    if (!this.initialized) {
+      await this.initialize();
     }
 
     await fs.mkdir(workspaceDir, { recursive: true });
@@ -165,6 +229,7 @@ export class Executor extends BaseAgent implements SkillAgent {
     // Prepare SDK options using BaseAgent's createSdkOptions
     const sdkOptions = this.createSdkOptions({
       cwd: workspaceDir,
+      allowedTools: this.getAllowedTools(),
     });
 
     let output = '';
@@ -260,6 +325,15 @@ export class Executor extends BaseAgent implements SkillAgent {
     const executionPath = this.fileManager.getExecutionPath(taskId, iteration);
 
     const parts: string[] = [];
+
+    // Include skill content if available (Issue #430)
+    const skillPrompt = this.getSkillPrompt();
+    if (skillPrompt) {
+      parts.push(skillPrompt);
+      parts.push('');
+      parts.push('---');
+      parts.push('');
+    }
 
     parts.push('# Task Execution');
     parts.push('');
@@ -366,12 +440,19 @@ ${error ? `## Error\n\n${error}\n` : ''}
    * @yields AgentMessage responses
    */
   async *execute(input: string | UserInput[]): AsyncGenerator<AgentMessage> {
+    // Initialize if needed (loads skills)
+    if (!this.initialized) {
+      await this.initialize();
+    }
+
     // Convert UserInput[] to string if needed
     const prompt: string = typeof input === 'string'
       ? input
       : input.map(u => u.content).join('\n');
 
-    const sdkOptions = this.createSdkOptions({});
+    const sdkOptions = this.createSdkOptions({
+      allowedTools: this.getAllowedTools(),
+    });
 
     try {
       for await (const { parsed } of this.queryOnce(prompt, sdkOptions)) {

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -6,6 +6,7 @@
  * - Load skill markdown files from the file system
  * - Parse YAML frontmatter for metadata
  * - Search for skills across multiple paths
+ * - Inject skills into Agent system prompts
  *
  * Design Principles:
  * - Simple and minimal - no complex parsing
@@ -14,29 +15,34 @@
  *
  * @example
  * ```typescript
- * import { FileSystemSkillLoader } from './skills/index.js';
+ * import { FileSystemSkillLoader, ClaudeCodeSkillProvider } from './skills/index.js';
  *
+ * // Using the loader directly
  * const loader = new FileSystemSkillLoader();
- *
- * // Load a single skill
  * const skill = await loader.loadSkill('skills/evaluator/SKILL.md');
  * console.log(skill.name); // 'evaluator'
  * console.log(skill.allowedTools); // ['Read', 'Grep', 'Glob', 'Write']
  *
- * // Search across multiple paths
- * const skills = await loader.searchSkills([
- *   { path: '.claude/skills', domain: 'project', priority: 3 },
- *   { path: 'skills', domain: 'package', priority: 1 },
- * ]);
+ * // Using the provider for Agent integration
+ * const provider = new ClaudeCodeSkillProvider();
+ * const result = await provider.loadSkillsForAgent('evaluator');
+ * console.log(result.allowedTools); // ['Read', 'Grep', 'Glob', 'Write']
+ * console.log(result.systemPromptContent); // Skill content for system prompt
  * ```
  *
  * @module skills
  */
 
 export { FileSystemSkillLoader } from './loader.js';
+export { ClaudeCodeSkillProvider } from './provider.js';
 export type {
   Skill,
   SkillLoader,
   SkillSearchPath,
   SkillFrontmatter,
 } from './types.js';
+export type {
+  SkillLoadContext,
+  SkillProviderOptions,
+  LoadedSkills,
+} from './provider.js';

--- a/src/skills/provider.test.ts
+++ b/src/skills/provider.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Tests for ClaudeCodeSkillProvider.
+ *
+ * Tests Phase 2-4 of Issue #430:
+ * - Phase 2: Claude Code Agent Skills implementation
+ * - Phase 3: Skills injection mechanism
+ * - Phase 4: Project domain support
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { ClaudeCodeSkillProvider } from './provider.js';
+import { FileSystemSkillLoader } from './loader.js';
+
+describe('ClaudeCodeSkillProvider', () => {
+  let tempDir: string;
+  let provider: ClaudeCodeSkillProvider;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-provider-test-'));
+    provider = new ClaudeCodeSkillProvider({
+      context: {
+        workspaceDir: tempDir,
+        packageDir: tempDir,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getDefaultSearchPaths', () => {
+    it('should return paths in correct priority order', () => {
+      const paths = provider.getDefaultSearchPaths();
+
+      expect(paths).toHaveLength(3);
+
+      // Check priority order (highest first)
+      expect(paths[0].domain).toBe('project');
+      expect(paths[0].priority).toBe(3);
+
+      expect(paths[1].domain).toBe('workspace');
+      expect(paths[1].priority).toBe(2);
+
+      expect(paths[2].domain).toBe('package');
+      expect(paths[2].priority).toBe(1);
+    });
+
+    it('should include additional paths when provided', () => {
+      const providerWithExtra = new ClaudeCodeSkillProvider({
+        context: {
+          workspaceDir: tempDir,
+          packageDir: tempDir,
+          additionalPaths: [
+            { path: '/custom/skills', domain: 'custom', priority: 4 },
+          ],
+        },
+      });
+
+      const paths = providerWithExtra.getDefaultSearchPaths();
+
+      expect(paths).toHaveLength(4);
+      expect(paths.some(p => p.domain === 'custom')).toBe(true);
+    });
+  });
+
+  describe('loadSkillsForAgent', () => {
+    it('should load skill for specific agent', async () => {
+      // Create package skills directory
+      const skillsDir = path.join(tempDir, 'skills', 'evaluator');
+      await fs.mkdir(skillsDir, { recursive: true });
+
+      const skillContent = `---
+name: evaluator
+description: Test evaluator
+allowed-tools: [Read, Write]
+---
+
+# Evaluator Skill
+
+Test content for evaluator.
+`;
+
+      await fs.writeFile(path.join(skillsDir, 'SKILL.md'), skillContent);
+
+      const result = await provider.loadSkillsForAgent('evaluator');
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].name).toBe('evaluator');
+      expect(result.allowedTools).toEqual(['Read', 'Write']);
+      expect(result.systemPromptContent).toContain('Evaluator Skill');
+      expect(result.systemPromptContent).toContain('Test content for evaluator');
+    });
+
+    it('should prefer higher priority paths', async () => {
+      // Create skill in package domain
+      const packageDir = path.join(tempDir, 'skills', 'test-skill');
+      await fs.mkdir(packageDir, { recursive: true });
+      await fs.writeFile(
+        path.join(packageDir, 'SKILL.md'),
+        `---
+name: test-skill
+allowed-tools: [Read]
+---
+# Package Skill
+`
+      );
+
+      // Create skill in project domain (higher priority)
+      const projectDir = path.join(tempDir, '.claude', 'skills', 'test-skill');
+      await fs.mkdir(projectDir, { recursive: true });
+      await fs.writeFile(
+        path.join(projectDir, 'SKILL.md'),
+        `---
+name: test-skill
+allowed-tools: [Read, Write, Bash]
+---
+# Project Skill (Override)
+`
+      );
+
+      const result = await provider.loadSkillsForAgent('test-skill');
+
+      expect(result.skills).toHaveLength(1);
+      expect(result.skills[0].allowedTools).toEqual(['Read', 'Write', 'Bash']);
+      expect(result.systemPromptContent).toContain('Project Skill (Override)');
+    });
+
+    it('should return empty result when skill not found', async () => {
+      const result = await provider.loadSkillsForAgent('nonexistent');
+
+      expect(result.skills).toHaveLength(0);
+      expect(result.allowedTools).toHaveLength(0);
+      expect(result.systemPromptContent).toBe('');
+    });
+
+    it('should cache loaded skills', async () => {
+      // Create skill
+      const skillsDir = path.join(tempDir, 'skills', 'cached-skill');
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        `---
+name: cached-skill
+---
+# Cached
+`
+      );
+
+      // First load
+      const result1 = await provider.loadSkillsForAgent('cached-skill');
+      expect(result1.skills).toHaveLength(1);
+
+      // Delete the skill file
+      await fs.rm(skillsDir, { recursive: true, force: true });
+
+      // Second load should return cached result
+      const result2 = await provider.loadSkillsForAgent('cached-skill');
+      expect(result2.skills).toHaveLength(1);
+    });
+
+    it('should clear cache when requested', async () => {
+      // Create skill
+      const skillsDir = path.join(tempDir, 'skills', 'clear-cache-skill');
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        `---
+name: clear-cache-skill
+---
+# Original
+`
+      );
+
+      // Load and cache
+      await provider.loadSkillsForAgent('clear-cache-skill');
+
+      // Clear cache
+      provider.clearCache();
+
+      // Modify skill
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        `---
+name: clear-cache-skill
+---
+# Modified
+`
+      );
+
+      // Should load new content
+      const result = await provider.loadSkillsForAgent('clear-cache-skill');
+      expect(result.systemPromptContent).toContain('Modified');
+    });
+  });
+
+  describe('loadAllSkills', () => {
+    it('should load all skills from all paths', async () => {
+      // Create multiple skills
+      const evaluatorDir = path.join(tempDir, 'skills', 'evaluator');
+      await fs.mkdir(evaluatorDir, { recursive: true });
+      await fs.writeFile(
+        path.join(evaluatorDir, 'SKILL.md'),
+        `---
+name: evaluator
+allowed-tools: [Read, Write]
+---
+# Evaluator
+`
+      );
+
+      const executorDir = path.join(tempDir, 'skills', 'executor');
+      await fs.mkdir(executorDir, { recursive: true });
+      await fs.writeFile(
+        path.join(executorDir, 'SKILL.md'),
+        `---
+name: executor
+allowed-tools: [Read, Write, Bash]
+---
+# Executor
+`
+      );
+
+      const result = await provider.loadAllSkills();
+
+      expect(result.skills.length).toBeGreaterThanOrEqual(2);
+      expect(result.allowedTools).toContain('Read');
+      expect(result.allowedTools).toContain('Write');
+      expect(result.allowedTools).toContain('Bash');
+    });
+  });
+
+  describe('systemPromptContent', () => {
+    it('should extract content without frontmatter', async () => {
+      const skillsDir = path.join(tempDir, 'skills', 'prompt-skill');
+      await fs.mkdir(skillsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir, 'SKILL.md'),
+        `---
+name: prompt-skill
+description: Test description
+---
+
+# Main Content
+
+This is the actual skill content.
+
+## Section 1
+Details here.
+`
+      );
+
+      const result = await provider.loadSkillsForAgent('prompt-skill');
+
+      // Should not contain frontmatter
+      expect(result.systemPromptContent).not.toContain('---');
+      expect(result.systemPromptContent).not.toContain('description:');
+
+      // Should contain actual content
+      expect(result.systemPromptContent).toContain('Main Content');
+      expect(result.systemPromptContent).toContain('Section 1');
+    });
+
+    it('should format multiple skills with headers', async () => {
+      // Create provider with skills
+      const providerWithLoader = new ClaudeCodeSkillProvider({
+        loader: new FileSystemSkillLoader(),
+        context: {
+          workspaceDir: tempDir,
+          packageDir: tempDir,
+        },
+      });
+
+      // Create two skills
+      const skill1Dir = path.join(tempDir, 'skills', 'skill1');
+      await fs.mkdir(skill1Dir, { recursive: true });
+      await fs.writeFile(
+        path.join(skill1Dir, 'SKILL.md'),
+        `---
+name: skill1
+---
+# Skill 1 Content
+`
+      );
+
+      const skill2Dir = path.join(tempDir, 'skills', 'skill2');
+      await fs.mkdir(skill2Dir, { recursive: true });
+      await fs.writeFile(
+        path.join(skill2Dir, 'SKILL.md'),
+        `---
+name: skill2
+---
+# Skill 2 Content
+`
+      );
+
+      const result = await providerWithLoader.loadAllSkills();
+
+      if (result.skills.length >= 2) {
+        expect(result.systemPromptContent).toContain('# Skills');
+        expect(result.systemPromptContent).toContain('## Skill: skill1');
+        expect(result.systemPromptContent).toContain('## Skill: skill2');
+      }
+    });
+
+    it('should return empty string when no skills loaded', async () => {
+      const result = await provider.loadAllSkills();
+
+      expect(result.systemPromptContent).toBe('');
+    });
+  });
+});

--- a/src/skills/provider.ts
+++ b/src/skills/provider.ts
@@ -1,0 +1,348 @@
+/**
+ * ClaudeCodeSkillProvider - Skill provider for Claude Code Agent SDK.
+ *
+ * This module implements Phase 2-4 of Issue #430:
+ * - Phase 2: Claude Code Agent Skills implementation
+ * - Phase 3: Skills injection mechanism
+ * - Phase 4: Project domain support
+ *
+ * The provider loads skills from multiple search paths and provides:
+ * - allowedTools configuration for SDK
+ * - skill content for system prompt injection
+ *
+ * @module skills/provider
+ */
+
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import { FileSystemSkillLoader } from './loader.js';
+import type { Skill, SkillSearchPath } from './types.js';
+
+/**
+ * Context for skill loading.
+ */
+export interface SkillLoadContext {
+  /** Workspace directory (usually process.cwd()) */
+  workspaceDir?: string;
+  /** Package directory (where skills/ is located) */
+  packageDir?: string;
+  /** Additional search paths */
+  additionalPaths?: SkillSearchPath[];
+}
+
+/**
+ * Skill provider options.
+ */
+export interface SkillProviderOptions {
+  /** Skill loader instance (defaults to FileSystemSkillLoader) */
+  loader?: FileSystemSkillLoader;
+  /** Context for skill loading */
+  context?: SkillLoadContext;
+}
+
+/**
+ * Loaded skills result with metadata.
+ */
+export interface LoadedSkills {
+  /** Array of loaded skills */
+  skills: Skill[];
+  /** Combined allowed tools from all skills */
+  allowedTools: string[];
+  /** System prompt content from all skills */
+  systemPromptContent: string;
+  /** Loading errors (non-fatal) */
+  errors: Array<{ path: string; error: Error }>;
+}
+
+/**
+ * ClaudeCodeSkillProvider - Provides skills for Claude Code Agent SDK.
+ *
+ * This class implements the skill loading and injection mechanism for the
+ * Agent system. It loads skills from multiple paths with priority-based
+ * deduplication and provides both allowedTools and system prompt content.
+ *
+ * Search Path Priority (highest to lowest):
+ * 1. Project domain: `.claude/skills/` (user-defined, highest priority)
+ * 2. Workspace domain: `workspace/.claude/skills/` (shared workspace skills)
+ * 3. Package domain: `skills/` (built-in skills, lowest priority)
+ *
+ * @example
+ * ```typescript
+ * const provider = new ClaudeCodeSkillProvider();
+ *
+ * // Load skills for evaluator agent
+ * const result = await provider.loadSkillsForAgent('evaluator');
+ *
+ * // Use allowedTools in SDK options
+ * const sdkOptions = {
+ *   allowedTools: result.allowedTools,
+ * };
+ *
+ * // Use systemPromptContent in system prompt
+ * const systemPrompt = basePrompt + '\n\n' + result.systemPromptContent;
+ * ```
+ */
+export class ClaudeCodeSkillProvider {
+  private readonly logger = createLogger('SkillProvider');
+  private readonly loader: FileSystemSkillLoader;
+  private readonly context: SkillLoadContext;
+
+  /** Cache for loaded skills */
+  private skillsCache: Map<string, LoadedSkills> = new Map();
+
+  constructor(options: SkillProviderOptions = {}) {
+    this.loader = options.loader ?? new FileSystemSkillLoader();
+    this.context = options.context ?? {};
+  }
+
+  /**
+   * Get default search paths for skill discovery.
+   *
+   * Returns paths in priority order (highest first):
+   * 1. Project domain: .claude/skills (priority 3)
+   * 2. Workspace domain: workspace/.claude/skills (priority 2)
+   * 3. Package domain: skills (priority 1)
+   *
+   * @returns Array of search paths with priorities
+   */
+  getDefaultSearchPaths(): SkillSearchPath[] {
+    const workspaceDir = this.context.workspaceDir ?? process.cwd();
+    const packageDir = this.context.packageDir ?? this.findPackageDir();
+
+    const paths: SkillSearchPath[] = [
+      // Project domain - user-defined skills (highest priority)
+      {
+        path: path.join(workspaceDir, '.claude', 'skills'),
+        domain: 'project',
+        priority: 3,
+      },
+      // Workspace domain - shared workspace skills
+      {
+        path: path.join(workspaceDir, 'workspace', '.claude', 'skills'),
+        domain: 'workspace',
+        priority: 2,
+      },
+      // Package domain - built-in skills (lowest priority)
+      {
+        path: path.join(packageDir, 'skills'),
+        domain: 'package',
+        priority: 1,
+      },
+    ];
+
+    // Add additional paths if provided
+    if (this.context.additionalPaths) {
+      paths.push(...this.context.additionalPaths);
+    }
+
+    return paths;
+  }
+
+  /**
+   * Load all available skills from search paths.
+   *
+   * @returns Loaded skills with metadata
+   */
+  async loadAllSkills(): Promise<LoadedSkills> {
+    const cacheKey = '__all__';
+    if (this.skillsCache.has(cacheKey)) {
+      return this.skillsCache.get(cacheKey)!;
+    }
+
+    const searchPaths = this.getDefaultSearchPaths();
+    const result = await this.loadSkillsFromPaths(searchPaths);
+
+    this.skillsCache.set(cacheKey, result);
+    return result;
+  }
+
+  /**
+   * Load skills for a specific agent by name.
+   *
+   * This method loads the skill file for the named agent and returns
+   * the allowedTools and systemPromptContent for that specific skill.
+   *
+   * @param agentName - Name of the agent (e.g., 'evaluator', 'executor')
+   * @returns Loaded skill data for the agent
+   */
+  async loadSkillsForAgent(agentName: string): Promise<LoadedSkills> {
+    // Check cache first
+    if (this.skillsCache.has(agentName)) {
+      return this.skillsCache.get(agentName)!;
+    }
+
+    const searchPaths = this.getDefaultSearchPaths();
+    const errors: Array<{ path: string; error: Error }> = [];
+
+    // Sort by priority (highest first)
+    const sortedPaths = [...searchPaths].sort(
+      (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
+    );
+
+    // Try to find the specific skill
+    for (const searchPath of sortedPaths) {
+      const skillPath = path.join(searchPath.path, agentName, 'SKILL.md');
+
+      try {
+        const skill = await this.loader.loadSkill(skillPath);
+
+        const result: LoadedSkills = {
+          skills: [skill],
+          allowedTools: skill.allowedTools ?? [],
+          systemPromptContent: this.buildSystemPromptContent([skill]),
+          errors: [],
+        };
+
+        this.skillsCache.set(agentName, result);
+        this.logger.debug(
+          { agentName, skillPath, allowedTools: result.allowedTools },
+          'Skill loaded for agent'
+        );
+
+        return result;
+      } catch (error) {
+        // Skill not found in this path, try next
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          errors.push({
+            path: skillPath,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+        }
+      }
+    }
+
+    // No skill found, return empty result
+    this.logger.debug(
+      { agentName, errors },
+      'No skill file found for agent, using defaults'
+    );
+
+    const result: LoadedSkills = {
+      skills: [],
+      allowedTools: [],
+      systemPromptContent: '',
+      errors,
+    };
+
+    this.skillsCache.set(agentName, result);
+    return result;
+  }
+
+  /**
+   * Load skills from specific paths.
+   *
+   * @param paths - Search paths to load from
+   * @returns Loaded skills with metadata
+   */
+  async loadSkillsFromPaths(paths: SkillSearchPath[]): Promise<LoadedSkills> {
+    const skills = await this.loader.searchSkills(paths);
+    const errors: Array<{ path: string; error: Error }> = [];
+
+    // Collect all allowedTools
+    const allowedToolsSet = new Set<string>();
+    for (const skill of skills) {
+      if (skill.allowedTools) {
+        for (const tool of skill.allowedTools) {
+          allowedToolsSet.add(tool);
+        }
+      }
+    }
+
+    const result: LoadedSkills = {
+      skills,
+      allowedTools: Array.from(allowedToolsSet),
+      systemPromptContent: this.buildSystemPromptContent(skills),
+      errors,
+    };
+
+    this.logger.debug(
+      { skillCount: skills.length, allowedToolsCount: result.allowedTools.length },
+      'Skills loaded from paths'
+    );
+
+    return result;
+  }
+
+  /**
+   * Build system prompt content from loaded skills.
+   *
+   * @param skills - Array of loaded skills
+   * @returns Combined system prompt content
+   */
+  private buildSystemPromptContent(skills: Skill[]): string {
+    if (skills.length === 0) {
+      return '';
+    }
+
+    const sections: string[] = [];
+
+    for (const skill of skills) {
+      // Extract content after frontmatter
+      const content = this.extractContentWithoutFrontmatter(skill.content);
+
+      if (content.trim()) {
+        sections.push(`## Skill: ${skill.name}\n\n${content}`);
+      }
+    }
+
+    if (sections.length === 0) {
+      return '';
+    }
+
+    return `# Skills\n\n${sections.join('\n\n---\n\n')}`;
+  }
+
+  /**
+   * Extract content without YAML frontmatter.
+   *
+   * @param content - Raw markdown content with optional frontmatter
+   * @returns Content without frontmatter
+   */
+  private extractContentWithoutFrontmatter(content: string): string {
+    // Match and remove YAML frontmatter
+    const frontmatterMatch = content.match(/^---\n[\s\S]*?\n---\n?/);
+    if (frontmatterMatch) {
+      return content.slice(frontmatterMatch[0].length);
+    }
+    return content;
+  }
+
+  /**
+   * Find the package directory (where skills/ is located).
+   *
+   * @returns Package directory path
+   */
+  private findPackageDir(): string {
+    // Try to find package directory from various sources
+    // 1. Check if dist/skills exists (compiled TypeScript)
+    // 2. Check if src/skills exists (source TypeScript)
+    // 3. Fall back to current directory
+
+    const possibleDirs = [
+      path.resolve(__dirname, '..'), // src/ directory
+      path.resolve(__dirname, '..', '..'), // package root
+    ];
+
+    for (const dir of possibleDirs) {
+      const skillsDir = path.join(dir, 'skills');
+      try {
+        require('fs').existsSync(skillsDir);
+        return dir;
+      } catch {
+        // Continue to next
+      }
+    }
+
+    return process.cwd();
+  }
+
+  /**
+   * Clear the skills cache.
+   *
+   * Useful when skills files have been modified and need to be reloaded.
+   */
+  clearCache(): void {
+    this.skillsCache.clear();
+    this.logger.debug('Skills cache cleared');
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2-4 of Issue #430:
- Phase 2: Claude Code Agent Skills implementation
- Phase 3: Skills injection mechanism  
- Phase 4: Project domain support

## Problem

As described in Issue #430:
- Skills markdown files exist in `skills/` directory but are not actually loaded by Agents
- Evaluator/Executor classes hardcode configuration in TypeScript
- No mechanism for injecting skill content into Agent system prompts
- No support for user-defined project-level skills

## Solution

Created `ClaudeCodeSkillProvider` to bridge skills files and Agent SDK:

| File | Description |
|------|-------------|
| `src/skills/provider.ts` | ClaudeCodeSkillProvider class (new) |
| `src/skills/provider.test.ts` | Unit tests for provider (11 tests) |
| `src/skills/index.ts` | Export new types and classes |
| `src/agents/evaluator.ts` | Use skill provider for configuration |
| `src/agents/executor.ts` | Use skill provider for configuration |

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                    Skill Loading System                      │
├─────────────────────────────────────────────────────────────┤
│                                                              │
│   ClaudeCodeSkillProvider                                    │
│        │                                                     │
│        ├── loadSkillsForAgent(name) → LoadedSkills          │
│        │       └── allowedTools, systemPromptContent        │
│        │                                                     │
│        ├── loadAllSkills() → LoadedSkills                   │
│        │                                                     │
│        └── getDefaultSearchPaths() → SkillSearchPath[]      │
│                ├── .claude/skills (priority 3)              │
│                ├── workspace/.claude/skills (priority 2)    │
│                └── skills (priority 1)                      │
│                                                              │
│   LoadedSkills {                                             │
│     skills: Skill[]                                          │
│     allowedTools: string[]                                   │
│     systemPromptContent: string                              │
│     errors: Array<{ path, error }>                           │
│   }                                                          │
│                                                              │
└─────────────────────────────────────────────────────────────┘
```

## Features

1. **ClaudeCodeSkillProvider**: Loads skills from multiple search paths
   - `loadSkillsForAgent(name)`: Load skill for specific agent
   - `loadAllSkills()`: Load all available skills
   - Automatic caching with `clearCache()` for reload

2. **Search Path Priority** (highest to lowest):
   - Project domain: `.claude/skills/` (user-defined)
   - Workspace domain: `workspace/.claude/skills/`
   - Package domain: `skills/` (built-in)

3. **Skills Injection**:
   - `allowedTools` extracted from skill frontmatter
   - `systemPromptContent` from skill markdown content
   - Falls back to defaults if skill not found

## Integration

Evaluator and Executor now:
- Load skills from skill files on initialization
- Use loaded `allowedTools` for SDK configuration
- Include skill content in system prompts
- Fall back to hardcoded defaults if skill not found

## Usage Example

```typescript
import { ClaudeCodeSkillProvider } from './skills/index.js';

const provider = new ClaudeCodeSkillProvider();

// Load skill for specific agent
const result = await provider.loadSkillsForAgent('evaluator');
console.log(result.allowedTools); // ['Read', 'Grep', 'Glob', 'Write']
console.log(result.systemPromptContent); // Skill content for system prompt

// Use in Agent configuration
const sdkOptions = {
  allowedTools: result.allowedTools,
};

const systemPrompt = basePrompt + '\n\n' + result.systemPromptContent;
```

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 11 |
| All tests | 1223 passed, 8 skipped |
| Type check | ✅ Pass |
| Lint | ✅ 0 errors (65 warnings) |

## Design Principles (from Issue #430)

- ✅ **Simple and minimal** - no complex abstractions
- ✅ **Works with any Agent implementation** - generic interface
- ✅ **Priority-based discovery** - higher priority paths override lower ones
- ✅ **Backward compatible** - falls back to defaults if skill not found

## Related

- Issue #430: feat: 为 Agent SDK 提供通用 Skills 支持封装
- Builds on PR #431 (Phase 1: SkillLoader)

## Test plan

- [x] Unit tests for ClaudeCodeSkillProvider (11 tests)
- [x] Evaluator tests pass (14 tests)
- [x] Executor tests pass (10 tests)
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)