### PR TITLE
feat(skills): add simple skill discovery for Agent SDK (Issue #430)

### DIFF
--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -19,7 +19,23 @@ vi.mock('../config/index.js', () => ({
     getGlobalEnv: vi.fn(() => ({})),
     getMcpServersConfig: vi.fn(() => ({})), // No Playwright by default
     getLoggingConfig: vi.fn(() => ({ sdkDebug: false })),
+    getSkillsDir: vi.fn(() => '/tmp/test-skills'),
   },
+}));
+
+// Mock skills finder module
+vi.mock('../skills/index.js', () => ({
+  findSkill: vi.fn((name: string) => {
+    // Simulate finding evaluator and executor skills
+    if (name === 'evaluator') {
+      return Promise.resolve('/tmp/test-skills/evaluator/SKILL.md');
+    }
+    if (name === 'executor') {
+      return Promise.resolve('/tmp/test-skills/executor/SKILL.md');
+    }
+    // Unknown skill not found
+    return Promise.resolve(null);
+  }),
 }));
 
 describe('AgentFactory', () => {
@@ -57,37 +73,28 @@ describe('AgentFactory', () => {
   });
 
   describe('createSkillAgent', () => {
-    it('should create Evaluator when name is "evaluator"', () => {
-      const evaluator = AgentFactory.createSkillAgent('evaluator');
+    it('should create Evaluator when name is "evaluator"', async () => {
+      const evaluator = await AgentFactory.createSkillAgent('evaluator');
 
       expect(evaluator).toBeDefined();
       expect(evaluator.type).toBe('skill');
     });
 
-    it('should create Executor when name is "executor"', () => {
-      const executor = AgentFactory.createSkillAgent('executor');
+    it('should create Executor when name is "executor"', async () => {
+      const executor = await AgentFactory.createSkillAgent('executor');
 
       expect(executor).toBeDefined();
       expect(executor.type).toBe('skill');
     });
 
-    it('should pass subdirectory to Evaluator', () => {
-      const evaluator = AgentFactory.createSkillAgent('evaluator', {}, 'regular');
+    it('should pass options to agent', async () => {
+      const evaluator = await AgentFactory.createSkillAgent('evaluator', { model: 'custom-model' });
 
       expect(evaluator).toBeDefined();
     });
 
-    it('should pass abortSignal to Executor', () => {
-      const controller = new AbortController();
-      const executor = AgentFactory.createSkillAgent('executor', {}, controller.signal);
-
-      expect(executor).toBeDefined();
-    });
-
-    it('should throw error for unknown SkillAgent name', () => {
-      expect(() => {
-        AgentFactory.createSkillAgent('unknown');
-      }).toThrow('Unknown SkillAgent: unknown');
+    it('should throw error for unknown SkillAgent name', async () => {
+      await expect(AgentFactory.createSkillAgent('unknown')).rejects.toThrow('Skill not found: unknown');
     });
   });
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -9,15 +9,19 @@
  *
  * Uses unified configuration types from Issue #327.
  * Simplified with SkillAgent (Issue #413).
+ * Dynamic skill discovery (Issue #430).
  *
  * @example
  * ```typescript
  * // Create a Pilot (ChatAgent)
  * const pilot = AgentFactory.createChatAgent('pilot', callbacks);
  *
- * // Create skill agents
+ * // Create skill agents (built-in)
  * const evaluator = AgentFactory.createSkillAgent('evaluator');
  * const executor = AgentFactory.createSkillAgent('executor');
+ *
+ * // Create skill agents (custom skills)
+ * const customAgent = AgentFactory.createSkillAgent('my-custom-skill');
  *
  * // Create a subagent
  * const siteMiner = AgentFactory.createSubagent('site-miner');
@@ -27,6 +31,7 @@
  */
 
 import { Config } from '../config/index.js';
+import { findSkill } from '../skills/index.js';
 import { SkillAgent } from './skill-agent.js';
 import { Pilot, type PilotConfig, type PilotCallbacks } from './pilot.js';
 import { createSiteMiner, isPlaywrightAvailable } from './site-miner.js';
@@ -123,10 +128,15 @@ export class AgentFactory {
    * Uses the simplified SkillAgent architecture (Issue #413).
    * Skill agents are created with their corresponding skill files.
    *
-   * @param name - Agent name ('evaluator', 'executor')
+   * Dynamic skill discovery (Issue #430):
+   * - Searches for skills across project, workspace, and package domains
+   * - Supports both built-in skills (evaluator, executor) and custom skills
+   *
+   * @param name - Agent name (e.g., 'evaluator', 'executor', or custom skill name)
    * @param args - Additional arguments:
    *   - args[0]: AgentCreateOptions - Optional configuration overrides
    * @returns SkillAgent instance
+   * @throws Error if skill not found
    *
    * @example
    * ```typescript
@@ -135,21 +145,23 @@ export class AgentFactory {
    *
    * // Executor with custom config
    * const executor = AgentFactory.createSkillAgent('executor', { model: 'claude-3-opus' });
+   *
+   * // Custom skill
+   * const custom = AgentFactory.createSkillAgent('my-custom-skill');
    * ```
    */
-  static createSkillAgent(name: string, ...args: unknown[]): SkillAgentInterface {
+  static async createSkillAgent(name: string, ...args: unknown[]): Promise<SkillAgentInterface> {
     const options = (args[0] as AgentCreateOptions) || {};
     const baseConfig = this.getBaseConfig(options);
 
-    // Map agent names to skill files
-    const skillFileMap: Record<string, string> = {
-      evaluator: 'skills/evaluator/SKILL.md',
-      executor: 'skills/executor/SKILL.md',
-    };
+    // Use dynamic skill discovery (Issue #430)
+    const skillPath = await findSkill(name);
 
-    const skillPath = skillFileMap[name];
     if (!skillPath) {
-      throw new Error(`Unknown SkillAgent: ${name}`);
+      throw new Error(
+        `Skill not found: ${name}. ` +
+          'Searched in: .claude/skills/, workspace/.claude/skills/, and package skills/'
+      );
     }
 
     return new SkillAgent(baseConfig, skillPath);

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -529,7 +529,7 @@ export interface AgentFactoryInterface {
   /**
    * Create a SkillAgent instance.
    */
-  createSkillAgent(name: string, ...args: unknown[]): SkillAgent;
+  createSkillAgent(name: string, ...args: unknown[]): Promise<SkillAgent>;
 
   /**
    * Create a Subagent instance.

--- a/src/skills/finder.test.ts
+++ b/src/skills/finder.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for SkillFinder.
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  findSkill,
+  listSkills,
+  skillExists,
+  readSkillContent,
+  getDefaultSearchPaths,
+  type SkillSearchPath,
+} from './finder.js';
+
+// Mock Config module
+vi.mock('../config/index.js', () => ({
+  Config: {
+    getWorkspaceDir: vi.fn(() => '/tmp/test-workspace'),
+    getSkillsDir: vi.fn(() => '/tmp/test-skills'),
+  },
+}));
+
+describe('SkillFinder', () => {
+  let tempDir: string;
+  let projectSkillsDir: string;
+  let workspaceSkillsDir: string;
+  let packageSkillsDir: string;
+
+  beforeEach(async () => {
+    // Create temp directories
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skills-test-'));
+    projectSkillsDir = path.join(tempDir, 'project', '.claude', 'skills');
+    workspaceSkillsDir = path.join(tempDir, 'workspace', '.claude', 'skills');
+    packageSkillsDir = path.join(tempDir, 'package', 'skills');
+
+    await fs.mkdir(projectSkillsDir, { recursive: true });
+    await fs.mkdir(workspaceSkillsDir, { recursive: true });
+    await fs.mkdir(packageSkillsDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('getDefaultSearchPaths', () => {
+    it('should return search paths sorted by priority', () => {
+      const paths = getDefaultSearchPaths();
+
+      expect(paths).toHaveLength(3);
+      expect(paths[0].priority).toBeGreaterThanOrEqual(paths[1].priority);
+      expect(paths[1].priority).toBeGreaterThanOrEqual(paths[2].priority);
+    });
+
+    it('should include project, workspace, and package domains', () => {
+      const paths = getDefaultSearchPaths();
+      const domains = paths.map(p => p.domain);
+
+      expect(domains).toContain('project');
+      expect(domains).toContain('workspace');
+      expect(domains).toContain('package');
+    });
+  });
+
+  describe('findSkill', () => {
+    it('should find skill in highest priority domain', async () => {
+      // Create skill in package domain
+      const skillDir = path.join(packageSkillsDir, 'test-skill');
+      await fs.mkdir(skillDir);
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Test Skill');
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+        { path: workspaceSkillsDir, domain: 'workspace', priority: 2 },
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const result = await findSkill('test-skill', searchPaths);
+
+      expect(result).toBe(path.join(packageSkillsDir, 'test-skill', 'SKILL.md'));
+    });
+
+    it('should return project domain skill when exists in multiple domains', async () => {
+      // Create skill in all domains
+      for (const dir of [packageSkillsDir, workspaceSkillsDir, projectSkillsDir]) {
+        const skillDir = path.join(dir, 'common-skill');
+        await fs.mkdir(skillDir);
+        await fs.writeFile(path.join(skillDir, 'SKILL.md'), `# Skill from ${dir}`);
+      }
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+        { path: workspaceSkillsDir, domain: 'workspace', priority: 2 },
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const result = await findSkill('common-skill', searchPaths);
+
+      // Should return project domain (highest priority)
+      expect(result).toBe(path.join(projectSkillsDir, 'common-skill', 'SKILL.md'));
+    });
+
+    it('should return null when skill not found', async () => {
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+      ];
+
+      const result = await findSkill('nonexistent', searchPaths);
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip directories without SKILL.md', async () => {
+      // Create directory without SKILL.md
+      const noSkillDir = path.join(packageSkillsDir, 'no-skill');
+      await fs.mkdir(noSkillDir);
+      await fs.writeFile(path.join(noSkillDir, 'README.md'), 'No skill here');
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const result = await findSkill('no-skill', searchPaths);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listSkills', () => {
+    it('should list all skills across domains', async () => {
+      // Create skills in different domains
+      const skill1Dir = path.join(projectSkillsDir, 'project-skill');
+      await fs.mkdir(skill1Dir);
+      await fs.writeFile(path.join(skill1Dir, 'SKILL.md'), '# Project Skill');
+
+      const skill2Dir = path.join(packageSkillsDir, 'package-skill');
+      await fs.mkdir(skill2Dir);
+      await fs.writeFile(path.join(skill2Dir, 'SKILL.md'), '# Package Skill');
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const skills = await listSkills(searchPaths);
+
+      expect(skills).toHaveLength(2);
+      expect(skills.map(s => s.name)).toContain('project-skill');
+      expect(skills.map(s => s.name)).toContain('package-skill');
+    });
+
+    it('should deduplicate skills by priority', async () => {
+      // Create same skill in multiple domains
+      for (const dir of [packageSkillsDir, projectSkillsDir]) {
+        const skillDir = path.join(dir, 'shared-skill');
+        await fs.mkdir(skillDir);
+        await fs.writeFile(path.join(skillDir, 'SKILL.md'), `# Skill from ${dir}`);
+      }
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const skills = await listSkills(searchPaths);
+
+      // Should only return one entry (highest priority)
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe('shared-skill');
+      expect(skills[0].domain).toBe('project');
+    });
+
+    it('should return empty array when no skills found', async () => {
+      const searchPaths: SkillSearchPath[] = [
+        { path: projectSkillsDir, domain: 'project', priority: 3 },
+      ];
+
+      const skills = await listSkills(searchPaths);
+
+      expect(skills).toEqual([]);
+    });
+  });
+
+  describe('skillExists', () => {
+    it('should return true when skill exists', async () => {
+      const skillDir = path.join(packageSkillsDir, 'existing-skill');
+      await fs.mkdir(skillDir);
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Existing Skill');
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const exists = await skillExists('existing-skill', searchPaths);
+
+      expect(exists).toBe(true);
+    });
+
+    it('should return false when skill does not exist', async () => {
+      const searchPaths: SkillSearchPath[] = [
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const exists = await skillExists('nonexistent', searchPaths);
+
+      expect(exists).toBe(false);
+    });
+  });
+
+  describe('readSkillContent', () => {
+    it('should read skill file content', async () => {
+      const skillDir = path.join(packageSkillsDir, 'readable-skill');
+      await fs.mkdir(skillDir);
+      await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# Readable Skill\n\nContent here.');
+
+      const searchPaths: SkillSearchPath[] = [
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const content = await readSkillContent('readable-skill', searchPaths);
+
+      expect(content).toBe('# Readable Skill\n\nContent here.');
+    });
+
+    it('should return null when skill not found', async () => {
+      const searchPaths: SkillSearchPath[] = [
+        { path: packageSkillsDir, domain: 'package', priority: 1 },
+      ];
+
+      const content = await readSkillContent('nonexistent', searchPaths);
+
+      expect(content).toBeNull();
+    });
+  });
+});

--- a/src/skills/finder.ts
+++ b/src/skills/finder.ts
@@ -1,0 +1,242 @@
+/**
+ * Skill Finder - Simple skill file discovery for Agent SDK.
+ *
+ * This module provides a simple skill search mechanism as described in Issue #430:
+ * - Find skill files by name across multiple search paths
+ * - No YAML parsing - just return file paths
+ * - Support project, workspace, and package domains
+ *
+ * Design Principles:
+ * - Simple and minimal - no complex parsing
+ * - Just find and return file paths
+ * - Let SkillAgent read the markdown content
+ *
+ * @example
+ * ```typescript
+ * import { findSkill, listSkills } from './skills/finder.js';
+ *
+ * // Find a specific skill
+ * const skillPath = await findSkill('evaluator');
+ * // Returns: '/path/to/skills/evaluator/SKILL.md'
+ *
+ * // List all available skills
+ * const skills = await listSkills();
+ * // Returns: [{ name: 'evaluator', path: '...' }, ...]
+ * ```
+ *
+ * @module skills/finder
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Config } from '../config/index.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('SkillFinder');
+
+/**
+ * Represents a discovered skill.
+ */
+export interface DiscoveredSkill {
+  /** Skill name (derived from directory name) */
+  name: string;
+  /** Absolute path to the SKILL.md file */
+  path: string;
+  /** Domain where the skill was found */
+  domain: 'project' | 'workspace' | 'package';
+}
+
+/**
+ * Search path configuration for skill discovery.
+ */
+export interface SkillSearchPath {
+  /** Directory path to search */
+  path: string;
+  /** Domain identifier */
+  domain: 'project' | 'workspace' | 'package';
+  /** Priority (higher = searched first) */
+  priority: number;
+}
+
+/**
+ * Get the default search paths for skills.
+ *
+ * Search order (higher priority first):
+ * 1. Project domain: `.claude/skills/` in current working directory
+ * 2. Workspace domain: `.claude/skills/` in configured workspace
+ * 3. Package domain: `skills/` in package installation directory
+ *
+ * @returns Array of search paths sorted by priority
+ */
+export function getDefaultSearchPaths(): SkillSearchPath[] {
+  const cwd = process.cwd();
+  const workspaceDir = Config.getWorkspaceDir();
+  const packageDir = Config.getSkillsDir();
+
+  const paths: SkillSearchPath[] = [
+    // Project domain - highest priority (user's custom skills)
+    { path: path.join(cwd, '.claude', 'skills'), domain: 'project', priority: 3 },
+
+    // Workspace domain - medium priority
+    { path: path.join(workspaceDir, '.claude', 'skills'), domain: 'workspace', priority: 2 },
+
+    // Package domain - lowest priority (built-in skills)
+    { path: packageDir, domain: 'package', priority: 1 },
+  ];
+
+  return paths.sort((a, b) => b.priority - a.priority);
+}
+
+/**
+ * Find a skill by name across all search paths.
+ *
+ * Searches for `skills/<name>/SKILL.md` in each search path,
+ * returning the first match (highest priority).
+ *
+ * @param name - Skill name to find
+ * @param searchPaths - Optional custom search paths
+ * @returns Absolute path to the skill file, or null if not found
+ *
+ * @example
+ * ```typescript
+ * const path = await findSkill('evaluator');
+ * if (path) {
+ *   console.log(`Found at: ${path}`);
+ * }
+ * ```
+ */
+export async function findSkill(
+  name: string,
+  searchPaths?: SkillSearchPath[]
+): Promise<string | null> {
+  const paths = searchPaths || getDefaultSearchPaths();
+
+  for (const searchPath of paths) {
+    const skillFile = path.join(searchPath.path, name, 'SKILL.md');
+
+    try {
+      await fs.access(skillFile);
+      logger.debug({ name, path: skillFile, domain: searchPath.domain }, 'Found skill');
+      return skillFile;
+    } catch {
+      // Continue to next search path
+    }
+  }
+
+  logger.debug({ name, searchPaths: paths.map(p => p.path) }, 'Skill not found');
+  return null;
+}
+
+/**
+ * List all available skills across all search paths.
+ *
+ * Discovers all skills and returns them grouped by name.
+ * If the same skill exists in multiple domains, only the
+ * highest priority version is returned.
+ *
+ * @param searchPaths - Optional custom search paths
+ * @returns Array of discovered skills
+ *
+ * @example
+ * ```typescript
+ * const skills = await listSkills();
+ * for (const skill of skills) {
+ *   console.log(`${skill.name}: ${skill.path} (${skill.domain})`);
+ * }
+ * ```
+ */
+export async function listSkills(
+  searchPaths?: SkillSearchPath[]
+): Promise<DiscoveredSkill[]> {
+  const paths = searchPaths || getDefaultSearchPaths();
+  const found = new Map<string, DiscoveredSkill>();
+
+  for (const searchPath of paths) {
+    try {
+      const entries = await fs.readdir(searchPath.path, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+
+        const skillName = entry.name;
+        const skillFile = path.join(searchPath.path, skillName, 'SKILL.md');
+
+        try {
+          await fs.access(skillFile);
+
+          // Only add if not already found (higher priority wins)
+          if (!found.has(skillName)) {
+            found.set(skillName, {
+              name: skillName,
+              path: skillFile,
+              domain: searchPath.domain,
+            });
+          }
+        } catch {
+          // Directory doesn't contain SKILL.md, skip
+        }
+      }
+    } catch {
+      // Search path doesn't exist or not readable, skip
+    }
+  }
+
+  const skills = Array.from(found.values());
+  logger.debug({ count: skills.length, skills: skills.map(s => s.name) }, 'Listed skills');
+
+  return skills;
+}
+
+/**
+ * Check if a skill exists.
+ *
+ * @param name - Skill name to check
+ * @param searchPaths - Optional custom search paths
+ * @returns True if skill exists
+ */
+export async function skillExists(
+  name: string,
+  searchPaths?: SkillSearchPath[]
+): Promise<boolean> {
+  const skillPath = await findSkill(name, searchPaths);
+  return skillPath !== null;
+}
+
+/**
+ * Read skill content directly.
+ *
+ * This is a convenience function that finds and reads the skill file.
+ * Does not parse YAML - returns raw markdown content.
+ *
+ * @param name - Skill name to read
+ * @param searchPaths - Optional custom search paths
+ * @returns Raw markdown content, or null if not found
+ *
+ * @example
+ * ```typescript
+ * const content = await readSkillContent('evaluator');
+ * if (content) {
+ *   console.log(content);
+ * }
+ * ```
+ */
+export async function readSkillContent(
+  name: string,
+  searchPaths?: SkillSearchPath[]
+): Promise<string | null> {
+  const skillPath = await findSkill(name, searchPaths);
+
+  if (!skillPath) {
+    return null;
+  }
+
+  try {
+    const content = await fs.readFile(skillPath, 'utf-8');
+    return content;
+  } catch (error) {
+    logger.error({ error, skillPath }, 'Failed to read skill content');
+    return null;
+  }
+}

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Skills Module - Simple skill discovery for Agent SDK.
+ *
+ * This module provides a simple skill file discovery system as described in Issue #430:
+ *
+ * - Find skill markdown files across multiple search paths
+ * - No YAML parsing - just return file paths
+ * - Support project, workspace, and package domains
+ *
+ * Design Principles:
+ * - Simple and minimal - no complex parsing
+ * - Just find and return file paths
+ * - Let SkillAgent read the markdown content
+ *
+ * @example
+ * ```typescript
+ * import { findSkill, listSkills } from './skills/index.js';
+ *
+ * // Find a specific skill
+ * const skillPath = await findSkill('evaluator');
+ * // Returns: '/path/to/skills/evaluator/SKILL.md'
+ *
+ * // List all available skills
+ * const skills = await listSkills();
+ * // Returns: [{ name: 'evaluator', path: '...', domain: 'package' }, ...]
+ *
+ * // Read skill content
+ * const content = await readSkillContent('evaluator');
+ * ```
+ *
+ * @module skills
+ */
+
+export {
+  findSkill,
+  listSkills,
+  skillExists,
+  readSkillContent,
+  getDefaultSearchPaths,
+  type DiscoveredSkill,
+  type SkillSearchPath,
+} from './finder.js';


### PR DESCRIPTION
## Summary

Implements #430 - Provides a simple skill file discovery mechanism for the Agent SDK.

## Problem

- `AgentFactory.createSkillAgent()` only supported hardcoded 'evaluator' and 'executor'
- No skill search across multiple paths (project, workspace, package domains)
- Users couldn't use custom skills

## Solution

Created a minimal skill discovery module:

| File | Description |
|------|-------------|
| `src/skills/finder.ts` | Simple skill file discovery |
| `src/skills/index.ts` | Module exports |
| `src/skills/finder.test.ts` | Unit tests (13 tests) |

## Design Principles

Based on the feedback from closed PRs #431 and #433:
- ✅ **No YAML parsing** - Just find and return file paths
- ✅ **Simple and minimal** - Let SkillAgent read markdown content
- ✅ **Multi-path search** - Project → Workspace → Package domains

## Features

| Function | Description |
|----------|-------------|
| `findSkill(name)` | Find skill file across search paths |
| `listSkills()` | List all available skills |
| `skillExists(name)` | Check if skill exists |
| `readSkillContent(name)` | Read raw markdown content |

## Usage Example

```typescript
import { findSkill, listSkills } from './skills/index.js';

// Find a specific skill
const skillPath = await findSkill('my-custom-skill');
// Returns: '/project/.claude/skills/my-custom-skill/SKILL.md'

// List all available skills
const skills = await listSkills();
// Returns: [{ name: 'evaluator', path: '...', domain: 'package' }, ...]
```

## Changes to AgentFactory

- `createSkillAgent()` is now async (returns `Promise<SkillAgent>`)
- Uses dynamic skill discovery instead of hardcoded map
- Supports custom skills in `.claude/skills/`

```typescript
// Before (hardcoded)
const evaluator = AgentFactory.createSkillAgent('evaluator');

// After (dynamic)
const evaluator = await AgentFactory.createSkillAgent('evaluator');
const custom = await AgentFactory.createSkillAgent('my-custom-skill');
```

## Search Path Priority

1. **Project domain**: `.claude/skills/` (highest priority - user custom skills)
2. **Workspace domain**: `workspace/.claude/skills/`
3. **Package domain**: `skills/` (lowest priority - built-in skills)

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 13 |
| Total tests | 1222 passed |
| Type check | ✅ Pass |
| Lint | 0 errors |

## Related

- Issue #430: feat: 为 Agent SDK 提供通用 Skills 支持封装
- Closed PR #431: Too complex (had YAML parsing)
- Closed PR #433: Depended on #431

## Test plan

- [x] Unit tests for all finder functions
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes (0 errors)
- [ ] Manual test: Create custom skill in `.claude/skills/` and verify discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)