### PR TITLE
feat(feishu): add LogChatService for unified log chat support (Issue #347)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -38,6 +38,7 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getWorkspaceDir: vi.fn(() => '/tmp/test-workspace'),
   },
 }));
 

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -14,6 +14,7 @@ import { messageLogger } from '../feishu/message-logger.js';
 import { FeishuFileHandler } from '../platforms/feishu/feishu-file-handler.js';
 import { FeishuMessageSender } from '../platforms/feishu/feishu-message-sender.js';
 import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
+import { LogChatService } from '../platforms/feishu/log-chat-service.js';
 import { resolvePendingInteraction } from '../mcp/feishu-context-mcp.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
@@ -62,6 +63,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   private taskTracker: TaskTracker;
   private taskFlowOrchestrator?: TaskFlowOrchestrator;
   private interactionManager: InteractionManager;
+  private logChatService?: LogChatService;
 
   private readonly MAX_MESSAGE_AGE = DEDUPLICATION.MAX_MESSAGE_AGE;
 
@@ -98,6 +100,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   protected async doStart(): Promise<void> {
     // Initialize message logger
     await messageLogger.init();
+
+    // Initialize LogChatService for log chat support
+    this.logChatService = new LogChatService();
+    const hasLogChat = await this.logChatService.hasLogChat();
+    if (hasLogChat) {
+      const logChatId = await this.logChatService.getLogChatId();
+      logger.info({ logChatId }, 'Log chat configured');
+    }
 
     // Create event dispatcher
     this.eventDispatcher = new lark.EventDispatcher({}).register({
@@ -167,6 +177,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     switch (message.type) {
       case 'text':
         await sender.sendText(message.chatId, message.text || '', message.threadId);
+        // Also send to log chat (if configured and not already sending to log chat)
+        await this.sendToLogChat(message);
         break;
       case 'card':
         await sender.sendCard(
@@ -175,10 +187,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           message.description,
           message.threadId
         );
+        // Also send to log chat (if configured and not already sending to log chat)
+        await this.sendToLogChat(message);
         break;
       case 'file':
         // TODO: Pass threadId when Issue #68 is implemented
         await sender.sendFile(message.chatId, message.filePath || '');
+        // Also send to log chat (if configured and not already sending to log chat)
+        await this.sendToLogChat(message);
         break;
       case 'done':
         // Task completion signal, no actual message to send
@@ -187,6 +203,47 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
         break;
       default:
         throw new Error(`Unsupported message type: ${(message as { type: string }).type}`);
+    }
+  }
+
+  /**
+   * Send a copy of the message to the log chat (if configured).
+   * This enables administrators to monitor all bot activity.
+   *
+   * @param message - The original message to copy to log chat
+   */
+  private async sendToLogChat(message: OutgoingMessage): Promise<void> {
+    if (!this.logChatService || !this.messageSender) {
+      return;
+    }
+
+    const logChatId = await this.logChatService.getLogChatId();
+    if (!logChatId) {
+      return; // Log chat not configured
+    }
+
+    // Don't send to log chat if this IS the log chat (prevent loops)
+    if (message.chatId === logChatId) {
+      return;
+    }
+
+    try {
+      // Send a copy to log chat (without threadId, as it's a different chat)
+      switch (message.type) {
+        case 'text':
+          await this.messageSender.sendText(logChatId, message.text || '');
+          break;
+        case 'card':
+          await this.messageSender.sendCard(logChatId, message.card || {}, message.description);
+          break;
+        case 'file':
+          await this.messageSender.sendFile(logChatId, message.filePath || '');
+          break;
+      }
+      logger.debug({ logChatId, type: message.type }, 'Message copied to log chat');
+    } catch (error) {
+      // Log error but don't fail the original send
+      logger.error({ err: error, logChatId }, 'Failed to send message to log chat');
     }
   }
 
@@ -321,6 +378,15 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     if (sender?.sender_type === 'app') {
       logger.debug('Skipped bot message');
       return;
+    }
+
+    // Skip messages from log chat (bot only sends, doesn't respond)
+    if (this.logChatService) {
+      const logChatId = await this.logChatService.getLogChatId();
+      if (logChatId && chat_id === logChatId) {
+        logger.debug({ chatId: chat_id }, 'Skipped message from log chat');
+        return;
+      }
     }
 
     // Check message age

--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -11,5 +11,11 @@ export { FeishuPlatformAdapter, type FeishuPlatformAdapterConfig } from './feish
 export { FeishuMessageSender, type FeishuMessageSenderConfig } from './feishu-message-sender.js';
 export { FeishuFileHandler, type FeishuFileHandlerConfig } from './feishu-file-handler.js';
 
+// Log Chat Service
+export { LogChatService, type LogChatServiceConfig } from './log-chat-service.js';
+
+// ChatOps
+export { createDiscussionChat, dissolveChat, addMembers, type CreateDiscussionOptions, type ChatOpsConfig } from './chat-ops.js';
+
 // Card Builders
 export { buildTextContent } from './card-builders/index.js';

--- a/src/platforms/feishu/log-chat-service.test.ts
+++ b/src/platforms/feishu/log-chat-service.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for LogChatService.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { LogChatService } from './log-chat-service.js';
+
+describe('LogChatService', () => {
+  let tempDir: string;
+  let service: LogChatService;
+
+  beforeEach(() => {
+    // Create a unique temp directory for each test
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-chat-test-'));
+    service = new LogChatService({ workspaceDir: tempDir });
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getLogChatId', () => {
+    it('returns undefined when no log chat is set', async () => {
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBeUndefined();
+    });
+
+    it('returns the chat ID after setting it', async () => {
+      await service.setLogChatId('oc_test123', 'Test Log');
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBe('oc_test123');
+    });
+  });
+
+  describe('setLogChatId', () => {
+    it('saves the chat ID to file', async () => {
+      await service.setLogChatId('oc_test456', 'My Log Chat');
+
+      // Verify file was created
+      const statePath = path.join(tempDir, 'log-chat.json');
+      expect(fs.existsSync(statePath)).toBe(true);
+
+      // Verify content
+      const content = JSON.parse(fs.readFileSync(statePath, 'utf-8'));
+      expect(content.chatId).toBe('oc_test456');
+      expect(content.topic).toBe('My Log Chat');
+      expect(content.createdAt).toBeDefined();
+    });
+
+    it('updates existing chat ID', async () => {
+      await service.setLogChatId('oc_old', 'Old');
+      await service.setLogChatId('oc_new', 'New');
+
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBe('oc_new');
+    });
+  });
+
+  describe('hasLogChat', () => {
+    it('returns false when no log chat is set', async () => {
+      const hasLogChat = await service.hasLogChat();
+      expect(hasLogChat).toBe(false);
+    });
+
+    it('returns true after setting log chat', async () => {
+      await service.setLogChatId('oc_test');
+      const hasLogChat = await service.hasLogChat();
+      expect(hasLogChat).toBe(true);
+    });
+  });
+
+  describe('clearLogChat', () => {
+    it('removes the log chat configuration', async () => {
+      await service.setLogChatId('oc_test');
+      await service.clearLogChat();
+
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBeUndefined();
+    });
+
+    it('does not throw when no log chat is set', async () => {
+      await expect(service.clearLogChat()).resolves.not.toThrow();
+    });
+  });
+
+  describe('caching', () => {
+    it('caches the state after first load', async () => {
+      await service.setLogChatId('oc_cached');
+
+      // First load (from file)
+      const chatId1 = await service.getLogChatId();
+      expect(chatId1).toBe('oc_cached');
+
+      // Modify file directly
+      const statePath = path.join(tempDir, 'log-chat.json');
+      fs.writeFileSync(statePath, JSON.stringify({ chatId: 'oc_modified', createdAt: new Date().toISOString() }));
+
+      // Should still return cached value
+      const chatId2 = await service.getLogChatId();
+      expect(chatId2).toBe('oc_cached');
+    });
+
+    it('updates cache when setting new chat ID', async () => {
+      await service.setLogChatId('oc_first');
+      await service.setLogChatId('oc_second');
+
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBe('oc_second');
+    });
+  });
+
+  describe('workspace directory creation', () => {
+    it('creates workspace directory if it does not exist', async () => {
+      const nestedDir = path.join(tempDir, 'nested', 'dir');
+      const nestedService = new LogChatService({ workspaceDir: nestedDir });
+
+      await nestedService.setLogChatId('oc_test');
+
+      expect(fs.existsSync(nestedDir)).toBe(true);
+    });
+  });
+});

--- a/src/platforms/feishu/log-chat-service.ts
+++ b/src/platforms/feishu/log-chat-service.ts
@@ -1,0 +1,194 @@
+/**
+ * LogChatService - Manages the unified log chat for monitoring all bot messages.
+ *
+ * This service stores the log chat ID in the workspace directory (not in config file)
+ * following the "minimum configuration" principle.
+ *
+ * Features:
+ * - Stores log chat ID in workspace/log-chat.json
+ * - Provides methods to get/set log chat ID
+ * - Optional auto-creation of log chat via ChatOps
+ *
+ * @see Issue #347 - Dynamic admin mode setup and auto-create log chat
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Config } from '../../config/index.js';
+import { createLogger } from '../../utils/logger.js';
+import { createDiscussionChat } from './chat-ops.js';
+import type * as lark from '@larksuiteoapi/node-sdk';
+
+const logger = createLogger('LogChatService');
+
+/**
+ * Log chat state stored in workspace.
+ */
+interface LogChatState {
+  /** Log chat ID */
+  chatId: string;
+  /** When the log chat was created/set */
+  createdAt: string;
+  /** Topic/name of the log chat */
+  topic?: string;
+}
+
+/**
+ * Configuration for LogChatService.
+ */
+export interface LogChatServiceConfig {
+  /** Feishu API client (required for auto-create) */
+  client?: lark.Client;
+  /** Custom workspace directory (defaults to Config.getWorkspaceDir()) */
+  workspaceDir?: string;
+}
+
+/**
+ * LogChatService - Manages the unified log chat for message monitoring.
+ *
+ * Usage:
+ * ```typescript
+ * const logChatService = new LogChatService({ client });
+ *
+ * // Get existing log chat ID
+ * const chatId = await logChatService.getLogChatId();
+ *
+ * // Set log chat ID (when user configures it)
+ * await logChatService.setLogChatId('oc_xxxx');
+ *
+ * // Or create a new log chat
+ * const newChatId = await logChatService.createLogChat(['ou_user1']);
+ * ```
+ */
+export class LogChatService {
+  private readonly client?: lark.Client;
+  private readonly workspaceDir: string;
+  private readonly stateFilePath: string;
+  private cachedState?: LogChatState;
+
+  constructor(config: LogChatServiceConfig = {}) {
+    this.client = config.client;
+    this.workspaceDir = config.workspaceDir || Config.getWorkspaceDir();
+    this.stateFilePath = path.join(this.workspaceDir, 'log-chat.json');
+  }
+
+  /**
+   * Get the log chat ID.
+   *
+   * @returns The log chat ID, or undefined if not set
+   */
+  async getLogChatId(): Promise<string | undefined> {
+    const state = await this.loadState();
+    return state?.chatId;
+  }
+
+  /**
+   * Set the log chat ID.
+   *
+   * This is used when the user manually configures an existing chat as log chat.
+   *
+   * @param chatId - The chat ID to use as log chat
+   * @param topic - Optional topic/name for the log chat
+   */
+  async setLogChatId(chatId: string, topic?: string): Promise<void> {
+    const state: LogChatState = {
+      chatId,
+      createdAt: new Date().toISOString(),
+      topic,
+    };
+
+    await this.saveState(state);
+    logger.info({ chatId, topic }, 'Log chat ID set');
+  }
+
+  /**
+   * Create a new log chat and set it as the log chat.
+   *
+   * This requires the Feishu client to be configured.
+   *
+   * @param members - Initial members to add to the chat (open_ids)
+   * @param topic - Optional topic for the chat (default: "Pilot Log")
+   * @returns The created chat ID
+   */
+  async createLogChat(members: string[], topic = 'Pilot Log'): Promise<string> {
+    if (!this.client) {
+      throw new Error('Feishu client is required to create log chat');
+    }
+
+    const chatId = await createDiscussionChat(this.client, {
+      topic,
+      members,
+    });
+
+    await this.setLogChatId(chatId, topic);
+    logger.info({ chatId, topic, memberCount: members.length }, 'Log chat created');
+
+    return chatId;
+  }
+
+  /**
+   * Check if log chat is configured.
+   */
+  async hasLogChat(): Promise<boolean> {
+    const chatId = await this.getLogChatId();
+    return chatId !== undefined;
+  }
+
+  /**
+   * Clear the log chat configuration.
+   */
+  async clearLogChat(): Promise<void> {
+    if (fs.existsSync(this.stateFilePath)) {
+      await fs.promises.unlink(this.stateFilePath);
+      this.cachedState = undefined;
+      logger.info('Log chat configuration cleared');
+    }
+  }
+
+  /**
+   * Load state from file.
+   */
+  private async loadState(): Promise<LogChatState | undefined> {
+    // Return cached state if available
+    if (this.cachedState) {
+      return this.cachedState;
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(this.stateFilePath)) {
+      return undefined;
+    }
+
+    try {
+      const content = await fs.promises.readFile(this.stateFilePath, 'utf-8');
+      const state = JSON.parse(content) as LogChatState;
+      this.cachedState = state;
+      return state;
+    } catch (error) {
+      logger.error({ err: error, path: this.stateFilePath }, 'Failed to load log chat state');
+      return undefined;
+    }
+  }
+
+  /**
+   * Save state to file.
+   */
+  private async saveState(state: LogChatState): Promise<void> {
+    // Ensure workspace directory exists
+    if (!fs.existsSync(this.workspaceDir)) {
+      await fs.promises.mkdir(this.workspaceDir, { recursive: true });
+    }
+
+    try {
+      await fs.promises.writeFile(
+        this.stateFilePath,
+        JSON.stringify(state, null, 2),
+        'utf-8'
+      );
+      this.cachedState = state;
+    } catch (error) {
+      logger.error({ err: error, path: this.stateFilePath }, 'Failed to save log chat state');
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements #347 - Adds a unified log chat service that stores the chat ID in the workspace directory (not in config file) following the "minimum configuration" principle.

## Problem

Users need a way to monitor all bot activity in one place. Previous PR #436 was closed because it required configuration in config file, but the correct approach is to store the chat ID in workspace directory.

## Solution

| Component | Description |
|-----------|-------------|
| `LogChatService` | Stores log chat ID in workspace/log-chat.json |
| `FeishuChannel.doSendMessage` | Sends message copy to log chat |
| `FeishuChannel.handleMessageReceive` | Skips messages from log chat |

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/log-chat-service.ts` | New service for managing log chat |
| `src/platforms/feishu/log-chat-service.test.ts` | 11 unit tests |
| `src/channels/feishu-channel.ts` | Add log chat support |
| `src/platforms/feishu/index.ts` | Export LogChatService |

## Features

- **Log chat ID storage**: Stored in `workspace/log-chat.json`
- **Auto-copy messages**: All outgoing messages are copied to log chat
- **Skip log chat messages**: Bot doesn't respond to messages from log chat
- **No config required**: Chat ID is stored dynamically, not in config file

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 11 |
| Total tests | 1240 passed, 8 skipped |
| Type check | Pass |
| Lint | 0 errors |

## Related

- Issue #347

## Test plan

- [x] LogChatService stores chat ID in workspace file
- [x] FeishuChannel sends message copy to log chat
- [x] FeishuChannel skips messages from log chat
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)