### PR TITLE
feat(feishu): export ChatOps functions for FeedbackController integration (Issue #402)

### DIFF
--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -13,3 +13,12 @@ export { FeishuFileHandler, type FeishuFileHandlerConfig } from './feishu-file-h
 
 // Card Builders
 export { buildTextContent } from './card-builders/index.js';
+
+// Chat Operations (for FeedbackController integration)
+export {
+  createDiscussionChat,
+  dissolveChat,
+  addMembers,
+  type CreateDiscussionOptions,
+  type ChatOpsConfig,
+} from './chat-ops.js';


### PR DESCRIPTION
## Summary

Exports the ChatOps utility functions from the feishu platform module, enabling FeedbackController (PR #412) to use them for group channel creation.

## Problem

ChatOps was implemented in PR #423 but wasn't exported from the feishu platform module index. This prevents FeedbackController from importing and using these functions for `createChannel({ type: 'group' })` support.

## Solution

Added exports to `src/platforms/feishu/index.ts`:
- `createDiscussionChat` - Create group chats
- `dissolveChat` - Delete group chats
- `addMembers` - Add members to chats
- `CreateDiscussionOptions` - Type for chat creation options
- `ChatOpsConfig` - Type for ChatOps configuration

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/index.ts` | Export ChatOps functions and types |

## Test Results

| Metric | Value |
|--------|-------|
| Unit Tests | ✅ 1229 passed, 8 skipped |
| Type Check | ✅ Pass |

## Related

- Issue #402: v0.4 版本功能规划 - 群聊管理与控制通道
- PR #423: ChatOps implementation (merged)
- PR #412: FeedbackController (will benefit from this export)

## Test plan

- [x] All existing tests pass
- [x] Type check passes
- [x] ChatOps functions are now importable from `@/platforms/feishu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)