### PR TITLE
feat(skills): add /save-skill command to create skills from chat history (Issue #448)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -434,7 +434,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     // Control commands that should always be handled locally through the control channel
     // These commands affect session/agent lifecycle and should not be passed to the agent
-    const CONTROL_COMMANDS = ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node'];
+    const CONTROL_COMMANDS = ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node', 'save-skill', 'list-skills', 'delete-skill'];
 
     if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -109,7 +109,7 @@ export interface OutgoingMessage {
 /**
  * Control command types.
  */
-export type ControlCommandType = 'reset' | 'restart' | 'status' | 'list-nodes' | 'switch-node';
+export type ControlCommandType = 'reset' | 'restart' | 'status' | 'list-nodes' | 'switch-node' | 'save-skill' | 'list-skills' | 'delete-skill';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -400,6 +400,75 @@ export class CommunicationNode extends EventEmitter {
         }
       }
 
+      case 'save-skill': {
+        // Dynamic import to avoid circular dependencies
+        const { createSkillFromChat } = await import('../skills/creator.js');
+        const args = (command.data?.args as string[] | undefined);
+        const skillName = args?.[0];
+
+        if (!skillName) {
+          return {
+            success: false,
+            error: '请指定技能名称。\n\n用法: `/save-skill <skill-name>`\n\n示例: `/save-skill my-code-style`',
+          };
+        }
+
+        const result = await createSkillFromChat({
+          name: skillName,
+          chatId: command.chatId,
+        });
+
+        if (result.success) {
+          return {
+            success: true,
+            message: `✅ **技能已创建**\n\n技能名称: \`${skillName}\`\n存储路径: \`${result.skillPath}\`\n\n你现在可以使用 \`/${skillName}\` 命令来调用这个技能。`,
+          };
+        } else {
+          return { success: false, error: `创建技能失败: ${result.error}` };
+        }
+      }
+
+      case 'list-skills': {
+        // Dynamic import to avoid circular dependencies
+        const { listUserSkills } = await import('../skills/creator.js');
+        const skills = await listUserSkills();
+
+        if (skills.length === 0) {
+          return {
+            success: true,
+            message: '📋 **用户技能列表**\n\n暂无用户创建的技能。\n\n使用 `/save-skill <name>` 从当前对话创建技能。',
+          };
+        }
+
+        const skillsList = skills.map(s => `- \`/${s}\``).join('\n');
+        return {
+          success: true,
+          message: `📋 **用户技能列表**\n\n${skillsList}\n\n使用 \`/save-skill <name>\` 创建新技能。`,
+        };
+      }
+
+      case 'delete-skill': {
+        // Dynamic import to avoid circular dependencies
+        const { deleteUserSkill } = await import('../skills/creator.js');
+        const args = (command.data?.args as string[] | undefined);
+        const skillName = args?.[0];
+
+        if (!skillName) {
+          return {
+            success: false,
+            error: '请指定要删除的技能名称。\n\n用法: `/delete-skill <skill-name>`',
+          };
+        }
+
+        const result = await deleteUserSkill(skillName);
+
+        if (result.success) {
+          return { success: true, message: `✅ **技能已删除**\n\n技能: \`${skillName}\`` };
+        } else {
+          return { success: false, error: `删除技能失败: ${result.error}` };
+        }
+      }
+
       default:
         return { success: false, error: `Unknown command: ${command.type}` };
     }

--- a/src/skills/creator.test.ts
+++ b/src/skills/creator.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for Skill Creator.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { createSkillFromChat, listUserSkills, deleteUserSkill } from './creator.js';
+
+// Mock the messageLogger
+vi.mock('../feishu/message-logger.js', () => ({
+  messageLogger: {
+    getChatHistory: vi.fn(),
+  },
+}));
+
+// Mock Config
+vi.mock('../config/index.js', () => ({
+  Config: {
+    getWorkspaceDir: vi.fn(),
+  },
+}));
+
+import { messageLogger } from '../feishu/message-logger.js';
+import { Config } from '../config/index.js';
+
+describe('SkillCreator', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create temp directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-creator-test-'));
+    vi.mocked(Config.getWorkspaceDir).mockReturnValue(tempDir);
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('createSkillFromChat', () => {
+    it('should create a skill from chat history', async () => {
+      const mockHistory = `
+# Chat Message Log: test-chat-id
+
+---
+
+## [2024-01-01T00:00:00.000Z] 📥 User
+
+**Sender**: user123
+**Type**: text
+
+以后所有代码都用 TypeScript 写
+
+---
+
+## [2024-01-01T00:01:00.000Z] 📤 Bot
+
+**Sender**: bot
+**Type**: text
+
+好的，我会记住这个偏好。
+
+---
+`;
+
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue(mockHistory);
+
+      const result = await createSkillFromChat({
+        name: 'my-code-style',
+        chatId: 'test-chat-id',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skillPath).toContain('my-code-style');
+      expect(result.skillPath).toContain('SKILL.md');
+
+      // Verify file was created
+      const content = await fs.readFile(result.skillPath!, 'utf-8');
+      expect(content).toContain('name: my-code-style');
+      expect(content).toContain('user-invocable: true');
+    });
+
+    it('should fail when name is empty', async () => {
+      const result = await createSkillFromChat({
+        name: '',
+        chatId: 'test-chat-id',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('required');
+    });
+
+    it('should fail when no chat history exists', async () => {
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue('');
+
+      const result = await createSkillFromChat({
+        name: 'test-skill',
+        chatId: 'empty-chat-id',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No chat history');
+    });
+
+    it('should fail when skill already exists', async () => {
+      const mockHistory = 'Some chat content';
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue(mockHistory);
+
+      // Create skill first time
+      const result1 = await createSkillFromChat({
+        name: 'existing-skill',
+        chatId: 'test-chat-id',
+      });
+      expect(result1.success).toBe(true);
+
+      // Try to create same skill again
+      const result2 = await createSkillFromChat({
+        name: 'existing-skill',
+        chatId: 'test-chat-id',
+      });
+      expect(result2.success).toBe(false);
+      expect(result2.error).toContain('already exists');
+    });
+
+    it('should sanitize skill name', async () => {
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue('Some content');
+
+      const result = await createSkillFromChat({
+        name: 'My Cool Skill!!!',
+        chatId: 'test-chat-id',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skillPath).toContain('my-cool-skill');
+    });
+
+    it('should use custom description if provided', async () => {
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue('Some content');
+
+      const result = await createSkillFromChat({
+        name: 'custom-desc-skill',
+        chatId: 'test-chat-id',
+        description: 'Custom skill description',
+      });
+
+      expect(result.success).toBe(true);
+      const content = await fs.readFile(result.skillPath!, 'utf-8');
+      expect(content).toContain('description: Custom skill description');
+    });
+  });
+
+  describe('listUserSkills', () => {
+    it('should return empty array when no skills exist', async () => {
+      const skills = await listUserSkills();
+      expect(skills).toEqual([]);
+    });
+
+    it('should list created skills', async () => {
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue('Content');
+
+      await createSkillFromChat({ name: 'skill-one', chatId: 'chat-1' });
+      await createSkillFromChat({ name: 'skill-two', chatId: 'chat-2' });
+
+      const skills = await listUserSkills();
+      expect(skills).toContain('skill-one');
+      expect(skills).toContain('skill-two');
+    });
+  });
+
+  describe('deleteUserSkill', () => {
+    it('should delete an existing skill', async () => {
+      vi.mocked(messageLogger.getChatHistory).mockResolvedValue('Content');
+
+      await createSkillFromChat({ name: 'to-delete', chatId: 'chat-1' });
+
+      const result = await deleteUserSkill('to-delete');
+      expect(result.success).toBe(true);
+
+      const skills = await listUserSkills();
+      expect(skills).not.toContain('to-delete');
+    });
+
+    it('should fail when skill does not exist', async () => {
+      const result = await deleteUserSkill('non-existent');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not found');
+    });
+  });
+});

--- a/src/skills/creator.ts
+++ b/src/skills/creator.ts
@@ -1,0 +1,283 @@
+/**
+ * Skill Creator - Create skills from chat history.
+ *
+ * This module implements Issue #448: 利用聊天记录快速学会用户指令技能
+ * - Create skills from conversation learning moments
+ * - Parse chat history to extract learning content
+ * - Generate SKILL.md files in workspace
+ *
+ * @module skills/creator
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { Config } from '../config/index.js';
+import { createLogger } from '../utils/logger.js';
+import { messageLogger } from '../feishu/message-logger.js';
+
+const logger = createLogger('SkillCreator');
+
+/**
+ * Options for creating a skill.
+ */
+export interface CreateSkillOptions {
+  /** Skill name (used for directory name) */
+  name: string;
+  /** Chat ID to extract history from */
+  chatId: string;
+  /** Optional description (auto-generated if not provided) */
+  description?: string;
+  /** Optional skill content (auto-extracted if not provided) */
+  content?: string;
+}
+
+/**
+ * Result of skill creation.
+ */
+export interface CreateSkillResult {
+  /** Whether creation was successful */
+  success: boolean;
+  /** Path to created SKILL.md file */
+  skillPath?: string;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Sanitize skill name for use as directory name.
+ *
+ * @param name - Raw skill name
+ * @returns Sanitized name (lowercase, alphanumeric with hyphens)
+ */
+function sanitizeSkillName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .substring(0, 64); // Max 64 characters
+}
+
+/**
+ * Generate a skill description from chat history.
+ *
+ * @param chatHistory - Raw chat history markdown
+ * @returns Generated description
+ */
+function generateDescription(chatHistory: string): string {
+  // Extract key learning patterns from chat history
+  const lines = chatHistory.split('\n');
+
+  // Look for patterns like "以后就这样做", "记住这个", etc.
+  const learningPatterns = [
+    /以后.*这样做/,
+    /记住/,
+    /记住这个/,
+    /下次/,
+    /按照这个/,
+    /遵循/,
+    /按照以下/,
+    /使用这个/,
+  ];
+
+  let detectedPattern = '';
+  for (const line of lines) {
+    for (const pattern of learningPatterns) {
+      if (pattern.test(line)) {
+        detectedPattern = line.trim().substring(0, 100);
+        break;
+      }
+    }
+    if (detectedPattern) {
+      break;
+    }
+  }
+
+  if (detectedPattern) {
+    return `User-defined skill: ${detectedPattern}`;
+  }
+
+  return 'Custom skill created from conversation';
+}
+
+/**
+ * Extract learning content from chat history.
+ *
+ * @param chatHistory - Raw chat history markdown
+ * @returns Extracted learning content
+ */
+function extractLearningContent(chatHistory: string): string {
+  const sections = chatHistory.split('---');
+  const recentMessages = sections.slice(-10); // Last 10 message blocks
+
+  // Extract user messages (📥 User)
+  const userMessages: string[] = [];
+  for (const section of recentMessages) {
+    if (section.includes('📥 User')) {
+      // Extract content after the header
+      const lines = section.split('\n');
+      let inContent = false;
+      let content = '';
+
+      for (const line of lines) {
+        if (inContent && line.trim()) {
+          content = `${content}${line}\n`;
+        }
+        if (line.startsWith('**Type**:')) {
+          inContent = true;
+        }
+      }
+
+      if (content.trim()) {
+        userMessages.push(content.trim());
+      }
+    }
+  }
+
+  // Combine user messages to form the skill content
+  if (userMessages.length > 0) {
+    return `# Instructions\n\nBased on user guidance from conversation:\n\n${userMessages.map((m, i) => `${i + 1}. ${m}`).join('\n\n')}`;
+  }
+
+  return '# Instructions\n\nCustom skill content from conversation.';
+}
+
+/**
+ * Create a skill from chat history.
+ *
+ * @param options - Skill creation options
+ * @returns Creation result
+ */
+export async function createSkillFromChat(options: CreateSkillOptions): Promise<CreateSkillResult> {
+  const { name, chatId, description, content } = options;
+
+  try {
+    // Validate name
+    if (!name || name.trim().length === 0) {
+      return { success: false, error: 'Skill name is required' };
+    }
+
+    const sanitizedName = sanitizeSkillName(name);
+    if (sanitizedName.length < 2) {
+      return { success: false, error: 'Skill name too short (min 2 characters after sanitization)' };
+    }
+
+    // Get chat history
+    const chatHistory = await messageLogger.getChatHistory(chatId);
+
+    if (!chatHistory || chatHistory.trim().length === 0) {
+      return { success: false, error: 'No chat history found for this conversation' };
+    }
+
+    // Generate skill content
+    const skillDescription = description || generateDescription(chatHistory);
+    const skillContent = content || extractLearningContent(chatHistory);
+
+    // Determine skill directory path (workspace/.claude/skills/)
+    const workspaceDir = Config.getWorkspaceDir();
+    const skillDir = path.join(workspaceDir, '.claude', 'skills', sanitizedName);
+    const skillFilePath = path.join(skillDir, 'SKILL.md');
+
+    // Check if skill already exists
+    try {
+      await fs.access(skillFilePath);
+      return { success: false, error: `Skill "${sanitizedName}" already exists. Use a different name or delete the existing skill first.` };
+    } catch {
+      // File doesn't exist, proceed
+    }
+
+    // Create skill directory
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // Generate SKILL.md content
+    const skillMd = `---
+name: ${sanitizedName}
+description: ${skillDescription}
+user-invocable: true
+---
+
+${skillContent}
+
+---
+*Created from chat ${chatId} on ${new Date().toISOString()}*
+`;
+
+    // Write SKILL.md file
+    await fs.writeFile(skillFilePath, skillMd, 'utf-8');
+
+    logger.info({ skillPath: skillFilePath, chatId, name: sanitizedName }, 'Skill created from chat history');
+
+    return {
+      success: true,
+      skillPath: skillFilePath,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error({ error, chatId, name }, 'Failed to create skill from chat');
+    return { success: false, error: errorMessage };
+  }
+}
+
+/**
+ * List user-created skills in workspace.
+ *
+ * @returns Array of skill names
+ */
+export async function listUserSkills(): Promise<string[]> {
+  const workspaceDir = Config.getWorkspaceDir();
+  const skillsDir = path.join(workspaceDir, '.claude', 'skills');
+
+  try {
+    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+    const skills: string[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const skillFile = path.join(skillsDir, entry.name, 'SKILL.md');
+        try {
+          await fs.access(skillFile);
+          skills.push(entry.name);
+        } catch {
+          // No SKILL.md, skip
+        }
+      }
+    }
+
+    return skills;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Delete a user-created skill.
+ *
+ * @param name - Skill name to delete
+ * @returns Deletion result
+ */
+export async function deleteUserSkill(name: string): Promise<CreateSkillResult> {
+  const sanitizedName = sanitizeSkillName(name);
+  const workspaceDir = Config.getWorkspaceDir();
+  const skillDir = path.join(workspaceDir, '.claude', 'skills', sanitizedName);
+
+  try {
+    // Check if skill exists
+    const skillFilePath = path.join(skillDir, 'SKILL.md');
+    try {
+      await fs.access(skillFilePath);
+    } catch {
+      return { success: false, error: `Skill "${sanitizedName}" not found` };
+    }
+
+    // Delete the skill directory
+    await fs.rm(skillDir, { recursive: true, force: true });
+
+    logger.info({ skillDir, name: sanitizedName }, 'User skill deleted');
+
+    return { success: true, skillPath: skillFilePath };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error({ error, name: sanitizedName }, 'Failed to delete user skill');
+    return { success: false, error: errorMessage };
+  }
+}

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -40,3 +40,11 @@ export {
   type DiscoveredSkill,
   type SkillSearchPath,
 } from './finder.js';
+
+export {
+  createSkillFromChat,
+  listUserSkills,
+  deleteUserSkill,
+  type CreateSkillOptions,
+  type CreateSkillResult,
+} from './creator.js';


### PR DESCRIPTION
## Summary

Implements #448 - Allows users to create reusable skills from conversation learning moments.

在对话过程中，用户经常会"教会" Agent 一些新的技能或工作方式。本 PR 实现了将这些"教学"快速转化为可复用 Skill 的功能。

## Changes

### New Files
- `src/skills/creator.ts` - Skill creation service
- `src/skills/creator.test.ts` - 10 unit tests

### Modified Files
- `src/channels/types.ts` - Added new command types
- `src/channels/feishu-channel.ts` - Added new commands
- `src/nodes/communication-node.ts` - Added command handlers
- `src/skills/index.ts` - Export new creator functions

## Features

### /save-skill <name>
Creates a skill from current conversation

### /list-skills
Lists all user-created skills

### /delete-skill <name>
Deletes a user-created skill

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 10 |
| Total tests | 1239 passed, 8 skipped |
| Type check | Pass |
| Lint | Pass |

Fixes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)