### PR TITLE
fix(feishu): correct card action event type (Issue #450)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -108,7 +108,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           logger.error({ err: error }, 'Failed to handle message receive');
         }
       },
-      'im.message.action_v1': async (data: unknown) => {
+      'card.action.trigger': async (data: unknown) => {
         try {
           await this.handleCardAction(data as FeishuCardActionEventData);
         } catch (error) {


### PR DESCRIPTION
## Summary

修复飞书卡片按钮点击事件未正确处理的问题。

## Problem

用户点击飞书卡片按钮时，事件未被正确处理，日志中出现警告：
```
[warn]: [ 'no card.action.trigger handle' ]
```

## Root Cause

在 `src/channels/feishu-channel.ts` 中注册的事件处理器使用了错误的事件类型：
- **错误**: `im.message.action_v1`
- **正确**: `card.action.trigger`

飞书卡片交互事件的正确类型是 `card.action.trigger`（参考：[飞书文档](https://open.feishu.cn/document/client-docs/bot-v3/events/card-action-trigger)）

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | 修改事件类型从 `im.message.action_v1` 为 `card.action.trigger` |

## Test Results

| Metric | Value |
|--------|-------|
| Tests | ✅ 1229 passed, 8 skipped |
| Type Check | ✅ Pass |
| Lint | ✅ 0 errors (62 warnings) |

Fixes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)