### PR TITLE
feat(feedback): integrate ChatOps for group channel creation (Issue #402)

### DIFF
--- a/src/feedback/feedback-controller.test.ts
+++ b/src/feedback/feedback-controller.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for FeedbackController.
  *
- * @see Issue #411
+ * @see Issue #411 - FeedbackController design
+ * @see Issue #402 - ChatOps integration for group channel creation
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -14,6 +15,9 @@ const mockClient = {
     message: {
       create: vi.fn(),
     },
+    chat: {
+      create: vi.fn(),
+    },
   },
 } as unknown as lark.Client;
 
@@ -24,6 +28,9 @@ describe('FeedbackController', () => {
     vi.clearAllMocks();
     mockClient.im.message.create = vi.fn().mockResolvedValue({
       data: { message_id: 'test-message-id' },
+    });
+    mockClient.im.chat.create = vi.fn().mockResolvedValue({
+      data: { chat_id: 'oc_new_group_123' },
     });
     controller = new FeedbackController({
       client: mockClient,
@@ -51,10 +58,43 @@ describe('FeedbackController', () => {
       ).rejects.toThrow('chatId is required for existing channel type');
     });
 
-    it('should throw error for group type (not yet implemented)', async () => {
+    it('should create group chat using ChatOps', async () => {
+      const chatId = await controller.createChannel({
+        type: 'group',
+        name: 'Test Discussion',
+        members: ['ou_user1', 'ou_user2'],
+      });
+
+      expect(chatId).toBe('oc_new_group_123');
+      expect(mockClient.im.chat.create).toHaveBeenCalledWith({
+        data: {
+          name: 'Test Discussion',
+          chat_mode: 'group',
+          chat_type: 'group',
+          user_id_list: ['ou_user1', 'ou_user2'],
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+    });
+
+    it('should throw error when name is missing for group type', async () => {
+      await expect(
+        controller.createChannel({ type: 'group', members: ['ou_user1'] })
+      ).rejects.toThrow('name is required for group channel type');
+    });
+
+    it('should throw error when members is missing for group type', async () => {
       await expect(
         controller.createChannel({ type: 'group', name: 'Test Group' })
-      ).rejects.toThrow('Group channel creation requires ChatManager');
+      ).rejects.toThrow('members is required for group channel type');
+    });
+
+    it('should throw error when members array is empty for group type', async () => {
+      await expect(
+        controller.createChannel({ type: 'group', name: 'Test Group', members: [] })
+      ).rejects.toThrow('members is required for group channel type');
     });
 
     it('should throw error for private type (not yet implemented)', async () => {

--- a/src/feedback/feedback-controller.ts
+++ b/src/feedback/feedback-controller.ts
@@ -4,7 +4,8 @@
  * Simplifies the pattern of "create channel → send message → collect feedback → make decision".
  * Used by v0.4 features: #357 (smart recommendations), #347 (dynamic admin), #393 (PR scanner).
  *
- * @see Issue #411
+ * @see Issue #411 - FeedbackController design
+ * @see Issue #402 - ChatOps integration for group channel creation
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
@@ -12,6 +13,7 @@ import type { Logger } from 'pino';
 import { createLogger } from '../utils/logger.js';
 import { FeishuMessageSender } from '../platforms/feishu/feishu-message-sender.js';
 import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
+import { createDiscussionChat } from '../platforms/feishu/chat-ops.js';
 import {
   buildCard,
   buildDiv,
@@ -218,7 +220,7 @@ export class FeedbackController {
    *   chatId: 'oc_xxx'
    * });
    *
-   * // Create new group (requires ChatManager - PR #404)
+   * // Create new group (uses ChatOps)
    * const chatId = await controller.createChannel({
    *   type: 'group',
    *   name: 'PR #123 Discussion',
@@ -226,10 +228,6 @@ export class FeedbackController {
    * });
    */
   async createChannel(options: CreateChannelOptions): Promise<string> {
-    // Note: This method is async for API consistency, even though current implementations
-    // are synchronous. Future implementations (group/private) will require async operations.
-    await Promise.resolve(); // Satisfy require-await lint rule
-
     switch (options.type) {
       case 'existing':
         if (!options.chatId) {
@@ -239,11 +237,18 @@ export class FeedbackController {
         return options.chatId;
 
       case 'group':
-        // TODO: Integrate with ChatManager (PR #404) when merged
-        throw new Error(
-          'Group channel creation requires ChatManager (PR #404). ' +
-            'Use type: "existing" with a pre-created group chat ID for now.'
-        );
+        if (!options.name) {
+          throw new Error('name is required for group channel type');
+        }
+        if (!options.members || options.members.length === 0) {
+          throw new Error('members is required for group channel type');
+        }
+        const chatId = await createDiscussionChat(this.client, {
+          topic: options.name,
+          members: options.members,
+        });
+        this.logger.info({ chatId, name: options.name, memberCount: options.members.length }, 'Group channel created');
+        return chatId;
 
       case 'private':
         // TODO: Implement private channel creation

--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for ChatOps utility functions.
+ *
+ * @see Issue #402
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createDiscussionChat, dissolveChat, addMembers } from './chat-ops.js';
+
+// Mock lark client
+const mockClient = {
+  im: {
+    chat: {
+      create: vi.fn(),
+      delete: vi.fn(),
+    },
+    chatMembers: {
+      create: vi.fn(),
+    },
+  },
+} as unknown as lark.Client;
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+describe('ChatOps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createDiscussionChat', () => {
+    it('should create a group chat and return chat ID', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: { chat_id: 'oc_new_chat_123' },
+      });
+
+      const chatId = await createDiscussionChat(mockClient, {
+        topic: 'Test Discussion',
+        members: ['ou_user_1', 'ou_user_2'],
+      });
+
+      expect(chatId).toBe('oc_new_chat_123');
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: {
+          name: 'Test Discussion',
+          chat_mode: 'group',
+          chat_type: 'group',
+          user_id_list: ['ou_user_1', 'ou_user_2'],
+        },
+        params: {
+          user_id_type: 'open_id',
+        },
+      });
+    });
+
+    it('should throw error when chat_id is not returned', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({
+        data: {},
+      });
+
+      await expect(
+        createDiscussionChat(mockClient, {
+          topic: 'Test Discussion',
+          members: ['ou_user_1'],
+        })
+      ).rejects.toThrow('Failed to get chat_id from response');
+    });
+
+    it('should throw and log on API error', async () => {
+      const mockCreate = mockClient.im.chat.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('API error'));
+
+      await expect(
+        createDiscussionChat(mockClient, {
+          topic: 'Test Discussion',
+          members: ['ou_user_1'],
+        })
+      ).rejects.toThrow('API error');
+    });
+  });
+
+  describe('dissolveChat', () => {
+    it('should dissolve a chat successfully', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockResolvedValue({});
+
+      await dissolveChat(mockClient, 'oc_chat_123');
+
+      expect(mockDelete).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+      });
+    });
+
+    it('should throw on dissolve error', async () => {
+      const mockDelete = mockClient.im.chat.delete as ReturnType<typeof vi.fn>;
+      mockDelete.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(dissolveChat(mockClient, 'oc_chat_123')).rejects.toThrow(
+        'Permission denied'
+      );
+    });
+  });
+
+  describe('addMembers', () => {
+    it('should add members to a chat successfully', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockResolvedValue({});
+
+      await addMembers(mockClient, 'oc_chat_123', ['ou_user_1', 'ou_user_2']);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        data: { id_list: ['ou_user_1', 'ou_user_2'] },
+        params: { member_id_type: 'open_id' },
+      });
+    });
+
+    it('should throw on add members error', async () => {
+      const mockCreate = mockClient.im.chatMembers.create as ReturnType<typeof vi.fn>;
+      mockCreate.mockRejectedValue(new Error('User not found'));
+
+      await expect(
+        addMembers(mockClient, 'oc_chat_123', ['ou_invalid_user'])
+      ).rejects.toThrow('User not found');
+    });
+  });
+});

--- a/src/platforms/feishu/chat-ops.ts
+++ b/src/platforms/feishu/chat-ops.ts
@@ -1,0 +1,118 @@
+/**
+ * ChatOps - Simple chat operations for FeedbackController.
+ *
+ * A lightweight wrapper for Feishu chat operations, designed to be used
+ * as internal utility functions rather than a standalone complex service.
+ *
+ * @see Issue #402 - ChatManager simplified to ~50 lines
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import type { Logger } from 'pino';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('ChatOps');
+
+/**
+ * Options for creating a discussion chat.
+ */
+export interface CreateDiscussionOptions {
+  /** Chat topic/name */
+  topic: string;
+  /** Initial member open_ids */
+  members: string[];
+}
+
+/**
+ * ChatOps configuration.
+ */
+export interface ChatOpsConfig {
+  /** Feishu API client */
+  client: lark.Client;
+  /** Optional logger */
+  logger?: Logger;
+}
+
+/**
+ * Create a discussion group chat.
+ *
+ * @param client - Feishu API client
+ * @param options - Chat creation options
+ * @returns The created chat ID
+ * @throws Error if chat creation fails
+ */
+export async function createDiscussionChat(
+  client: lark.Client,
+  options: CreateDiscussionOptions
+): Promise<string> {
+  const { topic, members } = options;
+  const log = logger;
+
+  try {
+    const response = await client.im.chat.create({
+      data: {
+        name: topic,
+        chat_mode: 'group',
+        chat_type: 'group',
+        user_id_list: members,
+      },
+      params: {
+        user_id_type: 'open_id',
+      },
+    });
+
+    const chatId = response?.data?.chat_id;
+    if (!chatId) {
+      throw new Error('Failed to get chat_id from response');
+    }
+
+    log.info({ chatId, topic, memberCount: members.length }, 'Discussion chat created');
+    return chatId;
+  } catch (error) {
+    log.error({ err: error, topic }, 'Failed to create discussion chat');
+    throw error;
+  }
+}
+
+/**
+ * Dissolve (delete) a group chat.
+ *
+ * @param client - Feishu API client
+ * @param chatId - Chat ID to dissolve
+ */
+export async function dissolveChat(client: lark.Client, chatId: string): Promise<void> {
+  try {
+    await client.im.chat.delete({
+      path: { chat_id: chatId },
+    });
+    logger.info({ chatId }, 'Chat dissolved');
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'Failed to dissolve chat');
+    throw error;
+  }
+}
+
+/**
+ * Add members to a chat.
+ *
+ * @param client - Feishu API client
+ * @param chatId - Target chat ID
+ * @param members - Member open_ids to add
+ */
+export async function addMembers(
+  client: lark.Client,
+  chatId: string,
+  members: string[]
+): Promise<void> {
+  try {
+    await client.im.chatMembers.create({
+      path: { chat_id: chatId },
+      data: { id_list: members },
+      params: { member_id_type: 'open_id' },
+    });
+    logger.info({ chatId, memberCount: members.length }, 'Members added');
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'Failed to add members');
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Integrates ChatOps into FeedbackController's `createChannel` method, enabling the `'group'` channel type for creating discussion groups programmatically.

## Problem

Previously, `FeedbackController.createChannel()` threw an error for `'group'` type:
```
'Group channel creation requires ChatManager (PR #404). ' +
  'Use type: "existing" with a pre-created group chat ID for now.'
```

This required users to manually create group chats before using FeedbackController with groups.

## Solution

- Import `createDiscussionChat` from `chat-ops.ts` (simplified ChatManager from Issue #402)
- Implement `'group'` channel type in `createChannel()` using ChatOps
- Add validation for required `name` and `members` fields
- Update tests for new group channel functionality

## Changes

| File | Description |
|------|-------------|
| `src/feedback/feedback-controller.ts` | Integrate ChatOps for group creation |
| `src/feedback/feedback-controller.test.ts` | Add 4 tests for group channel |
| `src/platforms/feishu/chat-ops.ts` | Add file from main branch |
| `src/platforms/feishu/chat-ops.test.ts` | Add test file from main branch |

## Usage Example

```typescript
const controller = new FeedbackController({ client });

// Create new group chat dynamically
const chatId = await controller.createChannel({
  type: 'group',
  name: 'PR #123 Discussion',
  members: ['ou_user1', 'ou_user2']
});

await controller.sendMessage(chatId, {
  title: 'Review Required',
  body: 'Please review this PR',
  buttons: [
    { text: 'Approve', value: 'approve', style: 'primary' },
    { text: 'Request Changes', value: 'reject' }
  ]
});
```

## Test Results

| Metric | Value |
|--------|-------|
| Total tests | 1248 passed, 8 skipped |
| Type check | ✅ Pass |
| Lint | ✅ 0 errors (70 warnings) |

## Architecture Alignment

This PR follows the design revision from Issue #402:

```
FeedbackController
  ├── FeishuMessageSender (send messages)
  └── ChatOps (create groups) ← NEW
```

ChatOps is intentionally designed as a lightweight (~50 lines) utility function, not a standalone complex service, serving as FeedbackController's underlying support.

## Related

- Issue #402: v0.4 版本功能规划
- Issue #411: FeedbackController design
- PR #412: Original FeedbackController implementation (base branch)

## Test plan

- [x] Group channel creation with valid options
- [x] Error when name is missing
- [x] Error when members is missing
- [x] Error when members array is empty
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)