### PR TITLE
refactor(messaging): rename admin terminology to debug chat (Issue #454)

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -194,15 +194,16 @@ export interface ChannelsConfig {
 /**
  * Messaging routing configuration section.
  *
- * Controls how messages are routed between admin and user chats.
+ * Controls how messages are routed between debug and user chats.
  * @see Issue #266
+ * @see Issue #454
  */
 export interface MessagingConfig {
-  /** Admin chat configuration */
-  admin?: {
-    /** Admin chat ID (receives all messages including progress/debug) */
+  /** Debug chat configuration */
+  debug?: {
+    /** Debug chat ID (receives all messages including progress/debug) */
     chatId?: string;
-    /** Enable/disable admin chat routing */
+    /** Enable/disable debug chat routing */
     enabled?: boolean;
   };
   /** Message routing configuration */
@@ -222,8 +223,8 @@ export interface MessagingConfig {
     errors?: {
       /** Show stack traces to users */
       showStack?: boolean;
-      /** Who can see detailed errors: 'admin' | 'all' */
-      showDetails?: 'admin' | 'all';
+      /** Who can see detailed errors: 'debug' | 'all' */
+      showDetails?: 'debug' | 'all';
     };
   };
 }

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -4,7 +4,7 @@
  * This module implements Issue #266: Message Level Routing System
  *
  * Features:
- * - Routes execution progress to admin chats
+ * - Routes execution progress to debug chats
  * - Routes only key interactions to user chats
  * - Configurable message levels
  * - Throttling for progress messages
@@ -20,7 +20,7 @@
  *
  * // Create router
  * const config = createDefaultRouteConfig('user_chat_id');
- * config.adminChatId = 'admin_chat_id';
+ * config.debugChatId = 'debug_chat_id';
  *
  * const router = new MessageRouter({
  *   config,
@@ -35,6 +35,7 @@
  * ```
  *
  * @see Issue #266
+ * @see Issue #454
  */
 
 // Types

--- a/src/messaging/message-router.test.ts
+++ b/src/messaging/message-router.test.ts
@@ -100,50 +100,50 @@ describe('MessageRouter', () => {
     };
   });
 
-  describe('with admin chat configured', () => {
+  describe('with debug chat configured', () => {
     beforeEach(() => {
       const config: MessageRouteConfig = {
-        adminChatId: 'admin-chat-id',
+        debugChatId: 'debug-chat-id',
         userChatId: 'user-chat-id',
         userMessageLevels: DEFAULT_USER_LEVELS,
       };
       router = new MessageRouter({ config, sender: mockSender });
     });
 
-    it('should route DEBUG to admin only', async () => {
+    it('should route DEBUG to debug chat only', async () => {
       await router.route({ content: 'Debug message', level: MessageLevel.DEBUG });
       expect(mockSender.sendText).toHaveBeenCalledTimes(1);
-      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Debug message');
+      expect(mockSender.sendText).toHaveBeenCalledWith('debug-chat-id', 'Debug message');
     });
 
-    it('should route PROGRESS to admin only', async () => {
+    it('should route PROGRESS to debug chat only', async () => {
       await router.route({ content: 'Progress message', level: MessageLevel.PROGRESS });
       expect(mockSender.sendText).toHaveBeenCalledTimes(1);
-      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Progress message');
+      expect(mockSender.sendText).toHaveBeenCalledWith('debug-chat-id', 'Progress message');
     });
 
-    it('should route ERROR to both admin and user', async () => {
+    it('should route ERROR to both debug and user', async () => {
       await router.route({ content: 'Error message', level: MessageLevel.ERROR });
       expect(mockSender.sendText).toHaveBeenCalledTimes(2);
-      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Error message');
+      expect(mockSender.sendText).toHaveBeenCalledWith('debug-chat-id', 'Error message');
       expect(mockSender.sendText).toHaveBeenCalledWith('user-chat-id', 'Error message');
     });
 
-    it('should route RESULT to both admin and user', async () => {
+    it('should route RESULT to both debug and user', async () => {
       await router.route({ content: 'Result message', level: MessageLevel.RESULT });
       expect(mockSender.sendText).toHaveBeenCalledTimes(2);
     });
 
-    it('should route NOTICE to both admin and user', async () => {
+    it('should route NOTICE to both debug and user', async () => {
       await router.route({ content: 'Notice message', level: MessageLevel.NOTICE });
       expect(mockSender.sendText).toHaveBeenCalledTimes(2);
     });
 
     it('should get correct targets for each level', () => {
-      expect(router.getTargets(MessageLevel.DEBUG)).toEqual(['admin-chat-id']);
-      expect(router.getTargets(MessageLevel.PROGRESS)).toEqual(['admin-chat-id']);
-      expect(router.getTargets(MessageLevel.ERROR)).toEqual(['admin-chat-id', 'user-chat-id']);
-      expect(router.getTargets(MessageLevel.RESULT)).toEqual(['admin-chat-id', 'user-chat-id']);
+      expect(router.getTargets(MessageLevel.DEBUG)).toEqual(['debug-chat-id']);
+      expect(router.getTargets(MessageLevel.PROGRESS)).toEqual(['debug-chat-id']);
+      expect(router.getTargets(MessageLevel.ERROR)).toEqual(['debug-chat-id', 'user-chat-id']);
+      expect(router.getTargets(MessageLevel.RESULT)).toEqual(['debug-chat-id', 'user-chat-id']);
     });
 
     it('should check user visibility correctly', () => {
@@ -153,9 +153,9 @@ describe('MessageRouter', () => {
       expect(router.isUserVisible(MessageLevel.RESULT)).toBe(true);
     });
 
-    it('should have admin chat configured', () => {
-      expect(router.hasAdminChat()).toBe(true);
-      expect(router.getAdminChatId()).toBe('admin-chat-id');
+    it('should have debug chat configured', () => {
+      expect(router.hasDebugChat()).toBe(true);
+      expect(router.getDebugChatId()).toBe('debug-chat-id');
     });
 
     it('should return user chat ID', () => {
@@ -163,7 +163,7 @@ describe('MessageRouter', () => {
     });
   });
 
-  describe('without admin chat', () => {
+  describe('without debug chat', () => {
     beforeEach(() => {
       const config: MessageRouteConfig = {
         userChatId: 'user-chat-id',
@@ -177,21 +177,21 @@ describe('MessageRouter', () => {
       expect(mockSender.sendText).toHaveBeenCalledWith('user-chat-id', 'Result');
     });
 
-    it('should not route debug messages when no admin', async () => {
+    it('should not route debug messages when no debug chat', async () => {
       await router.route({ content: 'Debug', level: MessageLevel.DEBUG });
       expect(mockSender.sendText).not.toHaveBeenCalled();
     });
 
-    it('should not have admin chat', () => {
-      expect(router.hasAdminChat()).toBe(false);
-      expect(router.getAdminChatId()).toBeUndefined();
+    it('should not have debug chat', () => {
+      expect(router.hasDebugChat()).toBe(false);
+      expect(router.getDebugChatId()).toBeUndefined();
     });
   });
 
-  describe('with same admin and user chat', () => {
+  describe('with same debug and user chat', () => {
     beforeEach(() => {
       const config: MessageRouteConfig = {
-        adminChatId: 'same-chat-id',
+        debugChatId: 'same-chat-id',
         userChatId: 'same-chat-id',
         userMessageLevels: DEFAULT_USER_LEVELS,
       };
@@ -208,7 +208,7 @@ describe('MessageRouter', () => {
   describe('with custom user levels', () => {
     beforeEach(() => {
       const config: MessageRouteConfig = {
-        adminChatId: 'admin-chat-id',
+        debugChatId: 'debug-chat-id',
         userChatId: 'user-chat-id',
         userMessageLevels: [MessageLevel.ERROR, MessageLevel.RESULT], // Only errors and results
       };
@@ -218,7 +218,7 @@ describe('MessageRouter', () => {
     it('should not route NOTICE to user', async () => {
       await router.route({ content: 'Notice', level: MessageLevel.NOTICE });
       expect(mockSender.sendText).toHaveBeenCalledTimes(1);
-      expect(mockSender.sendText).toHaveBeenCalledWith('admin-chat-id', 'Notice');
+      expect(mockSender.sendText).toHaveBeenCalledWith('debug-chat-id', 'Notice');
     });
 
     it('should route ERROR to both', async () => {
@@ -239,18 +239,18 @@ describe('MessageRouter', () => {
       expect(router.isUserVisible(MessageLevel.RESULT)).toBe(false);
     });
 
-    it('should update admin chat ID', () => {
-      expect(router.hasAdminChat()).toBe(false);
-      router.setAdminChatId('new-admin-id');
-      expect(router.hasAdminChat()).toBe(true);
-      expect(router.getAdminChatId()).toBe('new-admin-id');
+    it('should update debug chat ID', () => {
+      expect(router.hasDebugChat()).toBe(false);
+      router.setDebugChatId('new-debug-id');
+      expect(router.hasDebugChat()).toBe(true);
+      expect(router.getDebugChatId()).toBe('new-debug-id');
     });
   });
 
   describe('error handling', () => {
     beforeEach(() => {
       const config: MessageRouteConfig = {
-        adminChatId: 'admin-chat-id',
+        debugChatId: 'debug-chat-id',
         userChatId: 'user-chat-id',
       };
       router = new MessageRouter({ config, sender: mockSender });
@@ -258,7 +258,7 @@ describe('MessageRouter', () => {
 
     it('should continue sending to other targets on error', async () => {
       mockSender.sendText = vi.fn()
-        .mockRejectedValueOnce(new Error('Failed to admin'))
+        .mockRejectedValueOnce(new Error('Failed to debug chat'))
         .mockResolvedValueOnce(undefined);
 
       await router.route({ content: 'Error', level: MessageLevel.ERROR });
@@ -290,7 +290,7 @@ describe('createDefaultRouteConfig', () => {
   it('should include default error settings', () => {
     const config = createDefaultRouteConfig('my-chat-id');
     expect(config.errors?.showStack).toBe(false);
-    expect(config.errors?.showDetails).toBe('admin');
+    expect(config.errors?.showDetails).toBe('debug');
   });
 });
 
@@ -330,7 +330,7 @@ describe('RoutedOutputAdapter', () => {
   });
 
   it('should not track if user not in targets', async () => {
-    mockRouter.getTargets.mockReturnValue(['admin-chat-id']);
+    mockRouter.getTargets.mockReturnValue(['debug-chat-id']);
     mockRouter.getUserChatId.mockReturnValue('user-chat-id');
 
     await adapter.write('Debug', 'tool_progress');

--- a/src/messaging/message-router.ts
+++ b/src/messaging/message-router.ts
@@ -1,11 +1,14 @@
 /**
  * Message router implementation for level-based message routing.
  *
- * Routes messages to appropriate chats based on their level:
- * - Admin chat receives all messages (progress, debug, etc.)
- * - User chat receives only key messages (results, errors, confirmations)
+ * Message routing rules:
+ * - Level >= user visibility threshold: Send to user (current chat)
+ * - Level < user visibility threshold: Send to debug chat (shared by all)
+ *
+ * The debug chat is created and managed by PrimaryNode, shared by all users.
  *
  * @see Issue #266
+ * @see Issue #454
  */
 
 /**
@@ -42,7 +45,7 @@ export interface MessageRouterOptions {
 /**
  * Message router implementation.
  *
- * Routes messages to admin and/or user chats based on message level.
+ * Routes messages to debug and/or user chats based on message level.
  */
 export class MessageRouter implements IMessageRouter {
   private readonly config: MessageRouteConfig;
@@ -103,15 +106,15 @@ export class MessageRouter implements IMessageRouter {
   getTargets(level: MessageLevel): string[] {
     const targets: string[] = [];
 
-    // Admin chat receives all messages (if configured)
-    if (this.config.adminChatId) {
-      targets.push(this.config.adminChatId);
+    // Debug chat receives all messages (if configured)
+    if (this.config.debugChatId) {
+      targets.push(this.config.debugChatId);
     }
 
     // User chat receives messages based on level
     if (this.config.userChatId && this.userLevels.has(level)) {
-      // Avoid duplicate if admin and user chat are the same
-      if (this.config.adminChatId !== this.config.userChatId) {
+      // Avoid duplicate if debug and user chat are the same
+      if (this.config.debugChatId !== this.config.userChatId) {
         targets.push(this.config.userChatId);
       }
     }
@@ -127,17 +130,17 @@ export class MessageRouter implements IMessageRouter {
   }
 
   /**
-   * Check if admin chat is configured.
+   * Check if debug chat is configured.
    */
-  hasAdminChat(): boolean {
-    return !!this.config.adminChatId;
+  hasDebugChat(): boolean {
+    return !!this.config.debugChatId;
   }
 
   /**
-   * Get the admin chat ID.
+   * Get the debug chat ID.
    */
-  getAdminChatId(): string | undefined {
-    return this.config.adminChatId;
+  getDebugChatId(): string | undefined {
+    return this.config.debugChatId;
   }
 
   /**
@@ -157,11 +160,11 @@ export class MessageRouter implements IMessageRouter {
   }
 
   /**
-   * Update the admin chat ID.
+   * Update the debug chat ID.
    */
-  setAdminChatId(chatId: string | undefined): void {
-    (this.config as { adminChatId?: string }).adminChatId = chatId;
-    this.logger?.info('MessageRouter: Updated admin chat ID', { chatId });
+  setDebugChatId(chatId: string | undefined): void {
+    (this.config as { debugChatId?: string }).debugChatId = chatId;
+    this.logger?.info('MessageRouter: Updated debug chat ID', { chatId });
   }
 }
 
@@ -179,7 +182,7 @@ export function createDefaultRouteConfig(userChatId: string): MessageRouteConfig
     },
     errors: {
       showStack: false,
-      showDetails: 'admin',
+      showDetails: 'debug',
     },
   };
 }

--- a/src/messaging/routed-output-adapter.ts
+++ b/src/messaging/routed-output-adapter.ts
@@ -17,7 +17,7 @@ import { mapAgentMessageTypeToLevel, type IMessageRouter, type RoutedMessageMeta
 export interface RoutedOutputAdapterOptions {
   /** Message router instance */
   router: IMessageRouter;
-  /** Default chat ID for messages (used when router has no admin configured) */
+  /** Default chat ID for messages (used when router has no debug chat configured) */
   defaultChatId?: string;
   /** Enable debug logging */
   debug?: boolean;
@@ -28,13 +28,13 @@ export interface RoutedOutputAdapterOptions {
  *
  * Features:
  * - Maps AgentMessageType to MessageLevel
- * - Routes to admin/user chats via MessageRouter
+ * - Routes to debug/user chats via MessageRouter
  * - Throttles progress messages
  * - Tracks if user-visible messages were sent
  */
 export class RoutedOutputAdapter implements OutputAdapter {
   private readonly router: IMessageRouter;
-  // Reserved for future use when router has no admin configured
+  // Reserved for future use when router has no debug chat configured
   private readonly defaultChatId?: string;
   // Reserved for debug logging
   private readonly debug: boolean;
@@ -154,7 +154,7 @@ export class RoutedOutputAdapter implements OutputAdapter {
 
 /**
  * Create a simple output adapter that only sends to user chat.
- * This is for backward compatibility when no admin chat is configured.
+ * This is for backward compatibility when no debug chat is configured.
  */
 export class SimpleUserOutputAdapter implements OutputAdapter {
   private readonly sendText: (chatId: string, text: string) => Promise<void>;

--- a/src/messaging/types.ts
+++ b/src/messaging/types.ts
@@ -1,11 +1,14 @@
 /**
  * Message routing types for implementing message level-based routing.
  *
- * This module defines the types for the message routing system that:
- * - Routes execution progress to admin chats
- * - Routes only key interactions to user chats
+ * Message routing rules:
+ * - Level >= user visibility threshold: Send to user (current chat)
+ * - Level < user visibility threshold: Send to debug chat (shared by all chats/users)
+ *
+ * The debug chat is created and managed by PrimaryNode, shared by all users.
  *
  * @see Issue #266
+ * @see Issue #454
  */
 
 import type { AgentMessageType } from '../types/agent.js';
@@ -13,13 +16,13 @@ import type { AgentMessageType } from '../types/agent.js';
 /**
  * Message level enum for routing decisions.
  *
- * - DEBUG: Debug information → Admin only
- * - PROGRESS: Execution progress → Admin only
- * - INFO: General information → Admin only
- * - NOTICE: Notification → User + Admin
- * - IMPORTANT: Important information → User + Admin (strong alert)
- * - ERROR: Error information → User + Admin
- * - RESULT: Final result → User + Admin
+ * - DEBUG: Debug information → Debug chat only
+ * - PROGRESS: Execution progress → Debug chat only
+ * - INFO: General information → Debug chat only
+ * - NOTICE: Notification → User + Debug chat
+ * - IMPORTANT: Important information → User + Debug chat (strong alert)
+ * - ERROR: Error information → User + Debug chat
+ * - RESULT: Final result → User + Debug chat
  */
 export enum MessageLevel {
   DEBUG = 'debug',
@@ -42,7 +45,7 @@ export const DEFAULT_USER_LEVELS: MessageLevel[] = [
 ];
 
 /**
- * All message levels (admin receives all).
+ * All message levels (debug chat receives all).
  */
 export const ALL_LEVELS: MessageLevel[] = [
   MessageLevel.DEBUG,
@@ -82,8 +85,8 @@ export interface RoutedMessageMetadata {
  * Configuration for message routing.
  */
 export interface MessageRouteConfig {
-  /** Admin chat ID (receives all messages) */
-  adminChatId?: string;
+  /** Debug chat ID (receives all messages including debug/progress) */
+  debugChatId?: string;
   /** User chat ID (receives filtered messages) */
   userChatId: string;
   /** Message levels visible to users */
@@ -98,8 +101,8 @@ export interface MessageRouteConfig {
   errors?: {
     /** Whether to show stack traces to users */
     showStack?: boolean;
-    /** Who can see detailed errors: 'admin' | 'all' */
-    showDetails?: 'admin' | 'all';
+    /** Who can see detailed errors: 'debug' | 'all' */
+    showDetails?: 'debug' | 'all';
   };
 }
 


### PR DESCRIPTION
## Summary

Refactors message routing terminology to use more accurate descriptions:
- "Admin" → "Debug Chat" / "调试群"
- The debug chat is a shared chat for all users, not an "admin" feature

## Problem

The current code uses "Admin" terminology to describe message routing targets, which is confusing. The actual routing logic is:
- **High level messages**: Sent directly to user (in current chat)
- **Low level messages**: Sent to debug chat (shared by all users)

## Solution

### Terminology Changes

| Old Term | New Term |
|----------|----------|
| adminChatId | debugChatId |
| hasAdminChat() | hasDebugChat() |
| getAdminChatId() | getDebugChatId() |
| setAdminChatId() | setDebugChatId() |
| showDetails: 'admin' | showDetails: 'debug' |
| MessagingConfig.admin | MessagingConfig.debug |

## Changes

| File | Description |
|------|-------------|
| src/messaging/types.ts | Rename adminChatId to debugChatId, update comments |
| src/messaging/message-router.ts | Update method names and routing logic comments |
| src/config/types.ts | Rename MessagingConfig.admin to MessagingConfig.debug |
| src/messaging/index.ts | Update example code and comments |
| src/messaging/routed-output-adapter.ts | Update comments |
| src/messaging/message-router.test.ts | Update test descriptions and values |

## Test Results

| Metric | Value |
|--------|-------|
| Tests | 1229 passed, 8 skipped |
| Type Check | Pass |

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)