### PR TITLE
feat(feishu): add group management control commands (Issue #460)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -434,7 +434,20 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     // Control commands that should always be handled locally through the control channel
     // These commands affect session/agent lifecycle and should not be passed to the agent
-    const CONTROL_COMMANDS = ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node'];
+    const CONTROL_COMMANDS = [
+      'reset',
+      'status',
+      'help',
+      'restart',
+      'list-nodes',
+      'switch-node',
+      // Group management commands
+      'add-broadcast',
+      'remove-broadcast',
+      'list-broadcast',
+      'set-log-chat',
+      'clear-log-chat',
+    ];
 
     if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);
@@ -491,7 +504,19 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           await this.sendMessage({
             chatId: chat_id,
             type: 'text',
-            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+            text: `📖 **帮助**
+
+**基本命令:**
+- /reset - 重置对话
+- /status - 查看状态
+- /help - 显示帮助
+
+**群管理命令:**
+- /add-broadcast <chatId> <name> [description] - 添加广播群
+- /remove-broadcast <chatId> - 移除广播群
+- /list-broadcast - 列出所有广播群
+- /set-log-chat <chatId> - 设置日志群
+- /clear-log-chat - 清除日志群`,
           });
           return;
         }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -109,7 +109,17 @@ export interface OutgoingMessage {
 /**
  * Control command types.
  */
-export type ControlCommandType = 'reset' | 'restart' | 'status' | 'list-nodes' | 'switch-node';
+export type ControlCommandType =
+  | 'reset'
+  | 'restart'
+  | 'status'
+  | 'list-nodes'
+  | 'switch-node'
+  | 'add-broadcast'
+  | 'remove-broadcast'
+  | 'list-broadcast'
+  | 'set-log-chat'
+  | 'clear-log-chat';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -22,6 +22,7 @@ import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
+import { broadcastChatService, LogChatService } from '../platforms/feishu/index.js';
 import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage } from '../types/websocket-messages.js';
 import type { FileRef } from '../file-transfer/types.js';
 import { FileStorageService, type FileStorageConfig, createFileTransferAPIHandler } from '../file-transfer/node-transfer/index.js';
@@ -398,6 +399,79 @@ export class CommunicationNode extends EventEmitter {
         } else {
           return { success: false, error: `切换失败，节点 \`${targetNodeId}\` 不可用` };
         }
+      }
+
+      // ===== Group Management Commands =====
+
+      case 'add-broadcast': {
+        const args = command.data?.args as string[] | undefined;
+        if (!args || args.length < 2) {
+          return {
+            success: false,
+            error: '用法: /add-broadcast <chatId> <name> [description]',
+          };
+        }
+        const [chatId, name, ...descParts] = args;
+        const description = descParts.length > 0 ? descParts.join(' ') : undefined;
+
+        const added = broadcastChatService.addBroadcastChat(chatId, name, description);
+        if (added) {
+          return { success: true, message: `✅ **广播群已添加**\n\n- **Chat ID**: \`${chatId}\`\n- **名称**: ${name}${description ? `\n- **描述**: ${description}` : ''}` };
+        } else {
+          return { success: false, error: `该群已在广播群列表中: \`${chatId}\`` };
+        }
+      }
+
+      case 'remove-broadcast': {
+        const args = command.data?.args as string[] | undefined;
+        if (!args || args.length < 1) {
+          return {
+            success: false,
+            error: '用法: /remove-broadcast <chatId>',
+          };
+        }
+        const [chatId] = args;
+
+        const removed = broadcastChatService.removeBroadcastChat(chatId);
+        if (removed) {
+          return { success: true, message: `✅ **广播群已移除**\n\n- **Chat ID**: \`${chatId}\`` };
+        } else {
+          return { success: false, error: `未找到该广播群: \`${chatId}\`` };
+        }
+      }
+
+      case 'list-broadcast': {
+        const chats = broadcastChatService.loadBroadcastChats();
+        if (chats.length === 0) {
+          return { success: true, message: '📋 **广播群列表**\n\n暂无广播群' };
+        }
+        const list = chats.map(chat => {
+          const desc = chat.description ? ` - ${chat.description}` : '';
+          return `- **${chat.name}**: \`${chat.chatId}\`${desc}`;
+        }).join('\n');
+        return { success: true, message: `📋 **广播群列表**\n\n${list}` };
+      }
+
+      case 'set-log-chat': {
+        const args = command.data?.args as string[] | undefined;
+        if (!args || args.length < 1) {
+          return {
+            success: false,
+            error: '用法: /set-log-chat <chatId> [topic]',
+          };
+        }
+        const [chatId, ...topicParts] = args;
+        const topic = topicParts.length > 0 ? topicParts.join(' ') : undefined;
+
+        const logChatService = new LogChatService();
+        await logChatService.setLogChatId(chatId, topic);
+        return { success: true, message: `✅ **日志群已设置**\n\n- **Chat ID**: \`${chatId}\`${topic ? `\n- **主题**: ${topic}` : ''}` };
+      }
+
+      case 'clear-log-chat': {
+        const logChatService = new LogChatService();
+        await logChatService.clearLogChat();
+        return { success: true, message: '✅ **日志群已清除**' };
       }
 
       default:

--- a/src/platforms/feishu/broadcast-chat-service.test.ts
+++ b/src/platforms/feishu/broadcast-chat-service.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { BroadcastChatService } from './broadcast-chat-service.js';
+
+describe('BroadcastChatService', () => {
+  let tempDir: string;
+  let service: BroadcastChatService;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'broadcast-test-'));
+    service = new BroadcastChatService({ workspaceDir: tempDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('loadBroadcastChats', () => {
+    it('should return empty array when file does not exist', () => {
+      const chats = service.loadBroadcastChats();
+      expect(chats).toEqual([]);
+    });
+
+    it('should load chats from MD file', () => {
+      const mdContent = `# 广播群配置
+
+此文件由 disclaude 自动管理。
+
+## 广播群列表
+
+<!-- BROADCAST_LIST_START -->
+### Test Chat
+- **Chat ID**: \`oc_test123\`
+- **描述**: A test chat
+- **添加时间**: 2024-01-01T00:00:00Z
+<!-- BROADCAST_LIST_END -->
+`;
+      fs.writeFileSync(path.join(tempDir, 'broadcast-chats.md'), mdContent);
+
+      const chats = service.loadBroadcastChats();
+      expect(chats).toHaveLength(1);
+      expect(chats[0].chatId).toBe('oc_test123');
+      expect(chats[0].name).toBe('Test Chat');
+      expect(chats[0].description).toBe('A test chat');
+    });
+
+    it('should use cache for subsequent loads', () => {
+      const chats1 = service.loadBroadcastChats();
+      const chats2 = service.loadBroadcastChats();
+      expect(chats1).toBe(chats2); // Same reference due to cache
+    });
+  });
+
+  describe('isBroadcastChat', () => {
+    it('should return false for non-broadcast chat', () => {
+      expect(service.isBroadcastChat('oc_unknown')).toBe(false);
+    });
+
+    it('should return true for broadcast chat', () => {
+      service.addBroadcastChat('oc_test', 'Test Chat');
+      expect(service.isBroadcastChat('oc_test')).toBe(true);
+    });
+  });
+
+  describe('addBroadcastChat', () => {
+    it('should add a new broadcast chat', () => {
+      const result = service.addBroadcastChat('oc_new', 'New Chat', 'Description');
+      expect(result).toBe(true);
+
+      const chats = service.loadBroadcastChats();
+      expect(chats).toHaveLength(1);
+      expect(chats[0].chatId).toBe('oc_new');
+      expect(chats[0].name).toBe('New Chat');
+      expect(chats[0].description).toBe('Description');
+    });
+
+    it('should return false if chat already exists', () => {
+      service.addBroadcastChat('oc_existing', 'Existing Chat');
+      const result = service.addBroadcastChat('oc_existing', 'Another Name');
+      expect(result).toBe(false);
+    });
+
+    it('should create MD file with correct format', () => {
+      service.addBroadcastChat('oc_test', 'Test Chat', 'Test description');
+
+      const filePath = path.join(tempDir, 'broadcast-chats.md');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('# 广播群配置');
+      expect(content).toContain('oc_test');
+      expect(content).toContain('Test Chat');
+    });
+  });
+
+  describe('removeBroadcastChat', () => {
+    it('should remove an existing broadcast chat', () => {
+      service.addBroadcastChat('oc_to_remove', 'To Remove');
+      const result = service.removeBroadcastChat('oc_to_remove');
+      expect(result).toBe(true);
+      expect(service.isBroadcastChat('oc_to_remove')).toBe(false);
+    });
+
+    it('should return false if chat does not exist', () => {
+      const result = service.removeBroadcastChat('oc_nonexistent');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear the cache', () => {
+      service.addBroadcastChat('oc_test', 'Test');
+      service.loadBroadcastChats();
+      service.clearCache();
+
+      // After clearing cache, should reload from file
+      const chats = service.loadBroadcastChats();
+      expect(chats).toHaveLength(1);
+    });
+  });
+
+  describe('MD file format', () => {
+    it('should handle multiple chats', () => {
+      service.addBroadcastChat('oc_chat1', 'Chat 1', 'First chat');
+      service.addBroadcastChat('oc_chat2', 'Chat 2', 'Second chat');
+
+      const chats = service.loadBroadcastChats();
+      expect(chats).toHaveLength(2);
+    });
+
+    it('should handle chat without description', () => {
+      service.addBroadcastChat('oc_no_desc', 'No Description');
+
+      const chats = service.loadBroadcastChats();
+      expect(chats[0].description).toBeUndefined();
+    });
+  });
+});

--- a/src/platforms/feishu/broadcast-chat-service.ts
+++ b/src/platforms/feishu/broadcast-chat-service.ts
@@ -1,0 +1,256 @@
+/**
+ * Broadcast Chat Service.
+ *
+ * Manages broadcast chat configurations using MD file format.
+ * Broadcast chats are chats where the bot only sends messages but does not respond to user messages.
+ *
+ * Features:
+ * - MD file format for easy reading and editing
+ * - Dynamic add/remove broadcast chats
+ * - Cached loading for performance
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { Config } from '../../config/index.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('BroadcastChatService');
+
+/**
+ * Broadcast chat configuration.
+ */
+export interface BroadcastChat {
+  /** Chat ID (e.g., oc_xxx) */
+  chatId: string;
+  /** Human-readable name */
+  name: string;
+  /** Description of the broadcast chat's purpose */
+  description?: string;
+  /** When this chat was added as a broadcast chat */
+  addedAt: string;
+}
+
+/**
+ * Broadcast Chat Service Configuration.
+ */
+export interface BroadcastChatServiceConfig {
+  /** Workspace directory for storing the MD file */
+  workspaceDir?: string;
+}
+
+/**
+ * Broadcast Chat Service.
+ *
+ * Manages broadcast chat configurations stored in MD file format.
+ * The file is stored in the workspace directory.
+ */
+export class BroadcastChatService {
+  private readonly filePath: string;
+  private cache: BroadcastChat[] | null = null;
+  private lastLoadTime: number = 0;
+  private readonly CACHE_TTL = 5000; // 5 seconds cache
+
+  constructor(config: BroadcastChatServiceConfig = {}) {
+    const workspaceDir = config.workspaceDir || Config.getWorkspaceDir();
+    this.filePath = path.join(workspaceDir, 'broadcast-chats.md');
+    logger.debug({ filePath: this.filePath }, 'BroadcastChatService initialized');
+  }
+
+  /**
+   * Load broadcast chats from the MD file.
+   * Uses caching to avoid frequent file reads.
+   */
+  loadBroadcastChats(): BroadcastChat[] {
+    const now = Date.now();
+
+    // Return cached data if still valid
+    if (this.cache !== null && (now - this.lastLoadTime) < this.CACHE_TTL) {
+      return this.cache;
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(this.filePath)) {
+      logger.debug('Broadcast chats file not found, returning empty list');
+      this.cache = [];
+      this.lastLoadTime = now;
+      return this.cache;
+    }
+
+    try {
+      const content = fs.readFileSync(this.filePath, 'utf-8');
+      this.cache = this.parseMdContent(content);
+      this.lastLoadTime = now;
+      logger.debug({ count: this.cache.length }, 'Loaded broadcast chats');
+      return this.cache;
+    } catch (error) {
+      logger.error({ err: error, filePath: this.filePath }, 'Failed to load broadcast chats');
+      return [];
+    }
+  }
+
+  /**
+   * Check if a chat is a broadcast chat.
+   * @param chatId - The chat ID to check
+   */
+  isBroadcastChat(chatId: string): boolean {
+    const chats = this.loadBroadcastChats();
+    return chats.some(chat => chat.chatId === chatId);
+  }
+
+  /**
+   * Add a chat to the broadcast list.
+   * @param chatId - The chat ID to add
+   * @param name - Human-readable name for the chat
+   * @param description - Optional description
+   */
+  addBroadcastChat(chatId: string, name: string, description?: string): boolean {
+    const chats = this.loadBroadcastChats();
+
+    // Check if already exists
+    if (chats.some(chat => chat.chatId === chatId)) {
+      logger.debug({ chatId }, 'Chat already in broadcast list');
+      return false;
+    }
+
+    const newChat: BroadcastChat = {
+      chatId,
+      name,
+      description,
+      addedAt: new Date().toISOString(),
+    };
+
+    chats.push(newChat);
+    this.saveBroadcastChats(chats);
+    logger.info({ chatId, name }, 'Added broadcast chat');
+    return true;
+  }
+
+  /**
+   * Remove a chat from the broadcast list.
+   * @param chatId - The chat ID to remove
+   */
+  removeBroadcastChat(chatId: string): boolean {
+    const chats = this.loadBroadcastChats();
+    const index = chats.findIndex(chat => chat.chatId === chatId);
+
+    if (index === -1) {
+      logger.debug({ chatId }, 'Chat not found in broadcast list');
+      return false;
+    }
+
+    chats.splice(index, 1);
+    this.saveBroadcastChats(chats);
+    logger.info({ chatId }, 'Removed broadcast chat');
+    return true;
+  }
+
+  /**
+   * Parse MD content to extract broadcast chats.
+   */
+  private parseMdContent(content: string): BroadcastChat[] {
+    const chats: BroadcastChat[] = [];
+
+    // Find the broadcast list section between markers
+    const listMatch = content.match(/<!-- BROADCAST_LIST_START -->([\s\S]*?)<!-- BROADCAST_LIST_END -->/);
+    if (!listMatch) {
+      return chats;
+    }
+
+    const [, listContent] = listMatch;
+
+    // Parse each chat entry
+    // Format:
+    // ### Name
+    // - **Chat ID**: `oc_xxx`
+    // - **描述**: description
+    // - **添加时间**: timestamp
+    const chatRegex = /### (.+?)\n- \*\*Chat ID\*\*: `([^`]+)`(?:\n- \*\*描述\*\*: (.+?))?\n- \*\*添加时间\*\*: (.+?)(?=\n\n### |\n*$)/g;
+
+    let match;
+    while ((match = chatRegex.exec(listContent)) !== null) {
+      chats.push({
+        name: match[1].trim(),
+        chatId: match[2].trim(),
+        description: match[3]?.trim() || undefined,
+        addedAt: match[4].trim(),
+      });
+    }
+
+    return chats;
+  }
+
+  /**
+   * Save broadcast chats to the MD file.
+   */
+  private saveBroadcastChats(chats: BroadcastChat[]): void {
+    const content = this.generateMdContent(chats);
+
+    // Ensure workspace directory exists
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    fs.writeFileSync(this.filePath, content, 'utf-8');
+    this.cache = chats;
+    this.lastLoadTime = Date.now();
+    logger.debug({ filePath: this.filePath, count: chats.length }, 'Saved broadcast chats');
+  }
+
+  /**
+   * Generate MD content from broadcast chats.
+   */
+  private generateMdContent(chats: BroadcastChat[]): string {
+    const lines: string[] = [
+      '# 广播群配置',
+      '',
+      '此文件由 disclaude 自动管理。广播群中的用户消息将被忽略，只发送不处理。',
+      '',
+      '## 广播群列表',
+      '',
+      '<!-- BROADCAST_LIST_START -->',
+    ];
+
+    if (chats.length === 0) {
+      lines.push('（暂无广播群）');
+    } else {
+      for (const chat of chats) {
+        lines.push(`### ${chat.name}`);
+        lines.push(`- **Chat ID**: \`${chat.chatId}\``);
+        if (chat.description) {
+          lines.push(`- **描述**: ${chat.description}`);
+        }
+        lines.push(`- **添加时间**: ${chat.addedAt}`);
+        lines.push('');
+      }
+    }
+
+    lines.push('<!-- BROADCAST_LIST_END -->');
+    lines.push('');
+    lines.push('## 如何添加广播群');
+    lines.push('');
+    lines.push('使用以下命令添加广播群：');
+    lines.push('```');
+    lines.push('/add-broadcast <chatId> <name> [description]');
+    lines.push('```');
+    lines.push('');
+    lines.push('使用以下命令移除广播群：');
+    lines.push('```');
+    lines.push('/remove-broadcast <chatId>');
+    lines.push('```');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Clear the cache to force reload.
+   */
+  clearCache(): void {
+    this.cache = null;
+    this.lastLoadTime = 0;
+  }
+}
+
+// Export singleton instance (uses default Config.getWorkspaceDir())
+export const broadcastChatService = new BroadcastChatService();

--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -22,3 +22,17 @@ export {
   type CreateDiscussionOptions,
   type ChatOpsConfig,
 } from './chat-ops.js';
+
+// Broadcast Chat Service
+export {
+  BroadcastChatService,
+  broadcastChatService,
+  type BroadcastChat,
+  type BroadcastChatServiceConfig,
+} from './broadcast-chat-service.js';
+
+// Log Chat Service
+export {
+  LogChatService,
+  type LogChatServiceConfig,
+} from './log-chat-service.js';

--- a/src/platforms/feishu/log-chat-service.test.ts
+++ b/src/platforms/feishu/log-chat-service.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { LogChatService } from './log-chat-service.js';
+
+describe('LogChatService', () => {
+  let tempDir: string;
+  let service: LogChatService;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'log-chat-test-'));
+    service = new LogChatService({ workspaceDir: tempDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getLogChatId', () => {
+    it('should return undefined when no log chat is set', async () => {
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBeUndefined();
+    });
+
+    it('should return the log chat ID after setting', async () => {
+      await service.setLogChatId('oc_log123', 'Test Log');
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBe('oc_log123');
+    });
+  });
+
+  describe('setLogChatId', () => {
+    it('should save log chat ID to file', async () => {
+      await service.setLogChatId('oc_new_log', 'My Log Chat');
+
+      const filePath = path.join(tempDir, 'log-chat.json');
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const state = JSON.parse(content);
+      expect(state.chatId).toBe('oc_new_log');
+      expect(state.topic).toBe('My Log Chat');
+      expect(state.createdAt).toBeDefined();
+    });
+
+    it('should work without topic', async () => {
+      await service.setLogChatId('oc_log_no_topic');
+
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBe('oc_log_no_topic');
+    });
+
+    it('should create workspace directory if it does not exist', async () => {
+      const newDir = path.join(tempDir, 'nested', 'dir');
+      const nestedService = new LogChatService({ workspaceDir: newDir });
+
+      await nestedService.setLogChatId('oc_test');
+      expect(fs.existsSync(newDir)).toBe(true);
+    });
+  });
+
+  describe('hasLogChat', () => {
+    it('should return false when no log chat is set', async () => {
+      const hasLog = await service.hasLogChat();
+      expect(hasLog).toBe(false);
+    });
+
+    it('should return true after setting log chat', async () => {
+      await service.setLogChatId('oc_has_log');
+      const hasLog = await service.hasLogChat();
+      expect(hasLog).toBe(true);
+    });
+  });
+
+  describe('clearLogChat', () => {
+    it('should clear the log chat configuration', async () => {
+      await service.setLogChatId('oc_to_clear');
+      await service.clearLogChat();
+
+      const chatId = await service.getLogChatId();
+      expect(chatId).toBeUndefined();
+    });
+
+    it('should remove the state file', async () => {
+      await service.setLogChatId('oc_to_remove');
+      await service.clearLogChat();
+
+      const filePath = path.join(tempDir, 'log-chat.json');
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it('should not throw if no log chat is set', async () => {
+      await expect(service.clearLogChat()).resolves.not.toThrow();
+    });
+  });
+
+  describe('caching', () => {
+    it('should cache the state after first load', async () => {
+      await service.setLogChatId('oc_cached');
+
+      // First load
+      const chatId1 = await service.getLogChatId();
+      // Second load should use cache
+      const chatId2 = await service.getLogChatId();
+
+      expect(chatId1).toBe(chatId2);
+    });
+  });
+});

--- a/src/platforms/feishu/log-chat-service.ts
+++ b/src/platforms/feishu/log-chat-service.ts
@@ -1,0 +1,194 @@
+/**
+ * LogChatService - Manages the unified log chat for monitoring all bot messages.
+ *
+ * This service stores the log chat ID in the workspace directory (not in config file)
+ * following the "minimum configuration" principle.
+ *
+ * Features:
+ * - Stores log chat ID in workspace/log-chat.json
+ * - Provides methods to get/set log chat ID
+ * - Optional auto-creation of log chat via ChatOps
+ *
+ * @see Issue #347 - Dynamic admin mode setup and auto-create log chat
+ */
+
+import fs from 'fs';
+import path from 'path';
+import * as lark from '@larksuiteoapi/node-sdk';
+import { Config } from '../../config/index.js';
+import { createLogger } from '../../utils/logger.js';
+import { createDiscussionChat } from './chat-ops.js';
+
+const logger = createLogger('LogChatService');
+
+/**
+ * Log chat state stored in workspace.
+ */
+interface LogChatState {
+  /** Log chat ID */
+  chatId: string;
+  /** When the log chat was created/set */
+  createdAt: string;
+  /** Topic/name of the log chat */
+  topic?: string;
+}
+
+/**
+ * Configuration for LogChatService.
+ */
+export interface LogChatServiceConfig {
+  /** Feishu API client (required for auto-create) */
+  client?: lark.Client;
+  /** Custom workspace directory (defaults to Config.getWorkspaceDir()) */
+  workspaceDir?: string;
+}
+
+/**
+ * LogChatService - Manages the unified log chat for message monitoring.
+ *
+ * Usage:
+ * ```typescript
+ * const logChatService = new LogChatService({ client });
+ *
+ * // Get existing log chat ID
+ * const chatId = await logChatService.getLogChatId();
+ *
+ * // Set log chat ID (when user configures it)
+ * await logChatService.setLogChatId('oc_xxxx');
+ *
+ * // Or create a new log chat
+ * const newChatId = await logChatService.createLogChat(['ou_user1']);
+ * ```
+ */
+export class LogChatService {
+  private readonly client?: lark.Client;
+  private readonly workspaceDir: string;
+  private readonly stateFilePath: string;
+  private cachedState?: LogChatState;
+
+  constructor(config: LogChatServiceConfig = {}) {
+    this.client = config.client;
+    this.workspaceDir = config.workspaceDir || Config.getWorkspaceDir();
+    this.stateFilePath = path.join(this.workspaceDir, 'log-chat.json');
+  }
+
+  /**
+   * Get the log chat ID.
+   *
+   * @returns The log chat ID, or undefined if not set
+   */
+  async getLogChatId(): Promise<string | undefined> {
+    const state = await this.loadState();
+    return state?.chatId;
+  }
+
+  /**
+   * Set the log chat ID.
+   *
+   * This is used when the user manually configures an existing chat as log chat.
+   *
+   * @param chatId - The chat ID to use as log chat
+   * @param topic - Optional topic/name for the log chat
+   */
+  async setLogChatId(chatId: string, topic?: string): Promise<void> {
+    const state: LogChatState = {
+      chatId,
+      createdAt: new Date().toISOString(),
+      topic,
+    };
+
+    await this.saveState(state);
+    logger.info({ chatId, topic }, 'Log chat ID set');
+  }
+
+  /**
+   * Create a new log chat and set it as the log chat.
+   *
+   * This requires the Feishu client to be configured.
+   *
+   * @param members - Initial members to add to the chat (open_ids)
+   * @param topic - Optional topic for the chat (default: "Pilot Log")
+   * @returns The created chat ID
+   */
+  async createLogChat(members: string[], topic = 'Pilot Log'): Promise<string> {
+    if (!this.client) {
+      throw new Error('Feishu client is required to create log chat');
+    }
+
+    const chatId = await createDiscussionChat(this.client, {
+      topic,
+      members,
+    });
+
+    await this.setLogChatId(chatId, topic);
+    logger.info({ chatId, topic, memberCount: members.length }, 'Log chat created');
+
+    return chatId;
+  }
+
+  /**
+   * Check if log chat is configured.
+   */
+  async hasLogChat(): Promise<boolean> {
+    const chatId = await this.getLogChatId();
+    return chatId !== undefined;
+  }
+
+  /**
+   * Clear the log chat configuration.
+   */
+  async clearLogChat(): Promise<void> {
+    if (fs.existsSync(this.stateFilePath)) {
+      await fs.promises.unlink(this.stateFilePath);
+      this.cachedState = undefined;
+      logger.info('Log chat configuration cleared');
+    }
+  }
+
+  /**
+   * Load state from file.
+   */
+  private async loadState(): Promise<LogChatState | undefined> {
+    // Return cached state if available
+    if (this.cachedState) {
+      return this.cachedState;
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(this.stateFilePath)) {
+      return undefined;
+    }
+
+    try {
+      const content = await fs.promises.readFile(this.stateFilePath, 'utf-8');
+      const state = JSON.parse(content) as LogChatState;
+      this.cachedState = state;
+      return state;
+    } catch (error) {
+      logger.error({ err: error, path: this.stateFilePath }, 'Failed to load log chat state');
+      return undefined;
+    }
+  }
+
+  /**
+   * Save state to file.
+   */
+  private async saveState(state: LogChatState): Promise<void> {
+    // Ensure workspace directory exists
+    if (!fs.existsSync(this.workspaceDir)) {
+      await fs.promises.mkdir(this.workspaceDir, { recursive: true });
+    }
+
+    try {
+      await fs.promises.writeFile(
+        this.stateFilePath,
+        JSON.stringify(state, null, 2),
+        'utf-8'
+      );
+      this.cachedState = state;
+    } catch (error) {
+      logger.error({ err: error, path: this.stateFilePath }, 'Failed to save log chat state');
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements #460 - Adds group management control commands for managing broadcast chats and log chat through Feishu conversations.

## New Features

### BroadcastChatService
- MD file format for broadcast chat configuration
- Dynamic add/remove operations
- Cached loading for performance (5-second TTL)
- Auto-creates workspace directory if needed

### LogChatService
- JSON file format for log chat configuration
- Methods to get/set/clear log chat ID
- Optional auto-creation via ChatOps

### Control Commands
| Command | Description |
|---------|-------------|
| `/add-broadcast <chatId> <name> [description]` | Add broadcast chat |
| `/remove-broadcast <chatId>` | Remove broadcast chat |
| `/list-broadcast` | List all broadcast chats |
| `/set-log-chat <chatId> [topic]` | Set log chat |
| `/clear-log-chat` | Clear log chat |

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/broadcast-chat-service.ts` | New service for managing broadcast chats |
| `src/platforms/feishu/log-chat-service.ts` | New service for managing log chat |
| `src/platforms/feishu/broadcast-chat-service.test.ts` | 13 unit tests |
| `src/platforms/feishu/log-chat-service.test.ts` | 11 unit tests |
| `src/channels/types.ts` | Add new control command types |
| `src/channels/feishu-channel.ts` | Add commands to CONTROL_COMMANDS, update help |
| `src/nodes/communication-node.ts` | Add command handlers |
| `src/platforms/feishu/index.ts` | Export new services |

## Test Results

| Metric | Value |
|--------|-------|
| Total tests | 1253 passed, 8 skipped |
| Type Check | ✅ Pass |
| Lint | ✅ 0 errors (62 warnings) |

## Design Principles

1. **MD file storage**: Broadcast chats stored in `workspace/broadcast-chats.md`
2. **JSON file storage**: Log chat stored in `workspace/log-chat.json`
3. **Dynamic management**: Add/remove via commands, no restart needed
4. **Consistent with Skills architecture**: Similar file format pattern

## Usage Example

```
User: /add-broadcast oc_debug_chat 调试日志群 接收所有调试消息
Bot: ✅ **广播群已添加**
     
     - **Chat ID**: `oc_debug_chat`
     - **名称**: 调试日志群
     - **描述**: 接收所有调试消息

User: /list-broadcast
Bot: 📋 **广播群列表**
     
     - **调试日志群**: `oc_debug_chat` - 接收所有调试消息

User: /set-log-chat oc_log_chat
Bot: ✅ **日志群已设置**
     
     - **Chat ID**: `oc_log_chat`
```

## Related

- Issue #460: 群管理控制指令
- Issue #453: 广播群配置 (design reference)
- Issue #347: 动态管理员设置与日志群 (design reference)

## Test plan

- [x] BroadcastChatService stores chats in MD file
- [x] LogChatService stores config in JSON file
- [x] All control commands work correctly
- [x] Help text includes new commands
- [x] All existing tests pass
- [x] Type check passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)