### PR TITLE
feat(logger): add integration test logging support (Issue #464)

### DIFF
--- a/scripts/integration-test-setup.ts
+++ b/scripts/integration-test-setup.ts
@@ -1,0 +1,95 @@
+/**
+ * Integration Test Logger Setup
+ *
+ * This script initializes logging for integration tests with:
+ * - Dedicated log directory (./logs/integration-tests by default)
+ * - Configurable log level via LOG_LEVEL environment variable
+ * - File logging enabled even in test environment
+ *
+ * Usage:
+ *   1. As vitest setup file:
+ *      // vitest.config.ts
+ *      export default defineConfig({
+ *        test: {
+ *          setupFiles: ['./scripts/integration-test-setup.ts'],
+ *        }
+ *      });
+ *
+ *   2. Via environment variables (for shell-based integration tests):
+ *      INTEGRATION_TEST=true LOG_DIR=./logs/integration-tests LOG_LEVEL=debug npm run test:integration
+ *
+ * Environment Variables:
+ *   - INTEGRATION_TEST: Set to 'true' to enable file logging in test environment
+ *   - LOG_DIR: Directory for log files (default: ./logs/integration-tests)
+ *   - LOG_LEVEL: Log level (default: debug)
+ *
+ * Related: Issue #464 - 优化集成测试时的日志配置
+ */
+
+import { initLogger, resetLogger, setLogLevel } from '../src/utils/logger';
+
+// Default log directory for integration tests
+const DEFAULT_LOG_DIR = './logs/integration-tests';
+const DEFAULT_LOG_LEVEL = 'debug';
+
+/**
+ * Initialize logger for integration tests
+ */
+export async function setupIntegrationTestLogging(): Promise<void> {
+  // Reset any existing logger
+  resetLogger();
+
+  // Get configuration from environment variables
+  const logDir = process.env.LOG_DIR ?? DEFAULT_LOG_DIR;
+  const logLevel = (process.env.LOG_LEVEL as 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal') ?? DEFAULT_LOG_LEVEL;
+
+  // Initialize logger with file logging enabled
+  await initLogger({
+    level: logLevel,
+    fileLogging: true,
+    logDir,
+    prettyPrint: false, // Use JSON format for machine parsing
+    metadata: {
+      testType: 'integration',
+      testRun: new Date().toISOString(),
+    },
+  });
+
+  // Log startup message
+  const logger = await import('../src/utils/logger').then(m => m.createLogger('IntegrationTestSetup'));
+  logger.info({ logDir, logLevel }, 'Integration test logging initialized');
+}
+
+/**
+ * Update log level at runtime
+ */
+export function setIntegrationTestLogLevel(level: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'): void {
+  setLogLevel(level);
+}
+
+// Auto-setup when run directly or imported as setup file
+let isSetup = false;
+
+export async function ensureSetup(): Promise<void> {
+  if (isSetup) return;
+  isSetup = true;
+
+  // Set INTEGRATION_TEST flag to enable file logging
+  process.env.INTEGRATION_TEST = 'true';
+
+  await setupIntegrationTestLogging();
+}
+
+// For vitest setupFiles - runs before all tests
+if (process.env.VITEST === 'true' || process.argv.includes('--run')) {
+  ensureSetup().catch(err => {
+    console.error('Failed to setup integration test logging:', err);
+  });
+}
+
+// Export for programmatic use
+export default {
+  setupIntegrationTestLogging,
+  setIntegrationTestLogLevel,
+  ensureSetup,
+};

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -15,6 +15,14 @@
 
 set -e
 
+# Integration Test Logging Configuration (Issue #464)
+export INTEGRATION_TEST="${INTEGRATION_TEST:-true}"
+export LOG_DIR="${LOG_DIR:-./logs/integration-tests}"
+export LOG_LEVEL="${LOG_LEVEL:-debug}"
+
+# Ensure log directory exists
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
 # Configuration
 REST_PORT=3099
 WS_PORT=3100
@@ -102,11 +110,12 @@ echo ""
 
 # Start Primary Node
 echo -e "${YELLOW}Starting Primary Node...${NC}"
-env PATH="$PATH" node dist/cli-entry.js start --mode primary \
+env PATH="$PATH" INTEGRATION_TEST="$INTEGRATION_TEST" LOG_DIR="$LOG_DIR" LOG_LEVEL="$LOG_LEVEL" \
+    node dist/cli-entry.js start --mode primary \
     --port "$WS_PORT" \
     --rest-port "$REST_PORT" \
     --host "$HOST" \
-    > /tmp/primary-node.log 2>&1 &
+    > "${LOG_DIR}/primary-node.log" 2>&1 &
 PRIMARY_PID=$!
 
 # Wait for Primary Node to be ready
@@ -118,7 +127,7 @@ for i in $(seq 1 30); do
     fi
     if [ $i -eq 30 ]; then
         echo -e "${RED}Primary Node failed to start${NC}"
-        cat /tmp/primary-node.log
+        cat "${LOG_DIR}/primary-node.log"
         exit 1
     fi
     sleep 0.5
@@ -127,9 +136,10 @@ done
 # Start Worker Node
 # Unset CLAUDECODE to allow SDK to run (prevents nested session detection)
 echo -e "${YELLOW}Starting Worker Node...${NC}"
-env -u CLAUDECODE PATH="$PATH" DEBUG_CLAUDE_AGENT_SDK=1 node dist/cli-entry.js start --mode worker \
+env -u CLAUDECODE PATH="$PATH" INTEGRATION_TEST="$INTEGRATION_TEST" LOG_DIR="$LOG_DIR" LOG_LEVEL="$LOG_LEVEL" \
+    DEBUG_CLAUDE_AGENT_SDK=1 node dist/cli-entry.js start --mode worker \
     --comm-url "$COMM_URL" \
-    > /tmp/worker-node.log 2>&1 &
+    > "${LOG_DIR}/worker-node.log" 2>&1 &
 WORKER_PID=$!
 
 # Wait for Worker Node to connect
@@ -139,13 +149,13 @@ sleep 2
 # Check if processes are still running
 if ! kill -0 "$PRIMARY_PID" 2>/dev/null; then
     echo -e "${RED}Primary Node crashed${NC}"
-    cat /tmp/primary-node.log
+    cat "${LOG_DIR}/primary-node.log"
     exit 1
 fi
 
 if ! kill -0 "$WORKER_PID" 2>/dev/null; then
     echo -e "${RED}Worker Node crashed${NC}"
-    cat /tmp/worker-node.log
+    cat "${LOG_DIR}/worker-node.log"
     exit 1
 fi
 
@@ -168,10 +178,10 @@ if [ $CURL_EXIT -ne 0 ]; then
     echo -e "${RED}Request failed (curl exit code: $CURL_EXIT)${NC}"
     echo ""
     echo "=== Primary Node Log ==="
-    tail -50 /tmp/primary-node.log
+    tail -50 "${LOG_DIR}/primary-node.log"
     echo ""
     echo "=== Worker Node Log ==="
-    tail -50 /tmp/worker-node.log
+    tail -50 "${LOG_DIR}/worker-node.log"
     exit 1
 fi
 

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -289,6 +289,25 @@ describe('Logger Module', () => {
 
       expect(logger).toBeDefined();
     });
+
+    it('should enable file logging when INTEGRATION_TEST is set', async () => {
+      process.env.NODE_ENV = 'test';
+      process.env.INTEGRATION_TEST = 'true';
+
+      const { resetLogger, initLogger } = await import('./logger.js');
+      resetLogger();
+
+      // This should not throw even with fileLogging enabled in test env
+      const logger = await initLogger({
+        logDir: '/tmp/test-integration-logs',
+        fileLogging: true,
+      });
+
+      expect(logger).toBeDefined();
+
+      // Cleanup
+      delete process.env.INTEGRATION_TEST;
+    });
   });
 
   describe('Logger Interface', () => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -244,9 +244,13 @@ export async function initLogger(config: LoggerConfig = {}): Promise<Logger> {
   }
 
   // Setup file logging for production or if explicitly requested
+  // Also enable for integration tests when INTEGRATION_TEST is set
   let logStream: NodeJS.WritableStream = process.stdout;
 
-  if ((config.fileLogging ?? !isDev) && process.env.NODE_ENV !== 'test') {
+  const isIntegrationTest = process.env.INTEGRATION_TEST === 'true';
+  const shouldUseFileLogging = config.fileLogging ?? (!isDev || isIntegrationTest);
+
+  if (shouldUseFileLogging && (process.env.NODE_ENV !== 'test' || isIntegrationTest)) {
     try {
       logStream = await setupFileLogging(logDir);
     } catch (error) {

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -39,8 +39,18 @@ TIMEOUT="${TIMEOUT:-30}"
 CONFIG_PATH="${CONFIG_PATH:-${PROJECT_ROOT}/disclaude.config.test.yaml}"
 SERVER_PID=""
 
-# Log file in current working directory
-SERVER_LOG="disclaude-test-server.log"
+# =============================================================================
+# Integration Test Logging Configuration (Issue #464)
+# =============================================================================
+# Enable file logging for integration tests
+export INTEGRATION_TEST="${INTEGRATION_TEST:-true}"
+# Log directory for integration tests
+export LOG_DIR="${LOG_DIR:-${PROJECT_ROOT}/logs/integration-tests}"
+# Log level for integration tests (debug for detailed logs)
+export LOG_LEVEL="${LOG_LEVEL:-debug}"
+
+# Log file for test server (use LOG_DIR if set)
+SERVER_LOG="${LOG_DIR:-.}/disclaude-test-server.log"
 
 # =============================================================================
 # Colors for Output
@@ -144,6 +154,9 @@ wait_for_port_release() {
 # Returns: 0 on success, 1 on failure
 start_server() {
     log_info "Starting test server on port ${REST_PORT}..."
+
+    # Ensure log directory exists
+    mkdir -p "$(dirname "${SERVER_LOG}")" 2>/dev/null || true
 
     # Check if server is already running and healthy
     if is_server_running; then


### PR DESCRIPTION
## Summary

This PR implements the logging configuration improvements for integration tests as requested in Issue #464.

### Changes

1. **logger.ts** - Add `INTEGRATION_TEST` environment variable support
   - Enables file logging even when `NODE_ENV=test`
   - Respects `LOG_DIR` and `LOG_LEVEL` environment variables

2. **scripts/integration-test-setup.ts** (new file) - Vitest setup file for integration tests
   - Configures logging before tests run
   - Can be used via `setupFiles` in vitest config

3. **tests/integration/common.sh** - Add logging configuration
   - Exports `INTEGRATION_TEST=true`, `LOG_DIR`, `LOG_LEVEL`
   - Server logs now go to `./logs/integration-tests/`

4. **scripts/integration-test.sh** - Update to use configurable log directory
   - All log files now go to `./logs/integration-tests/`
   - Passes environment variables to child processes

### Benefits

- ✅ Integration test logs are now written to `./logs/integration-tests/`
- ✅ Logs are separated from test output (stdout)
- ✅ CI environments can easily collect log artifacts
- ✅ Log level can be dynamically adjusted via `LOG_LEVEL` env var
- ✅ Log directory can be customized via `LOG_DIR` env var

### Usage

```bash
# Run integration tests with default logging
./scripts/integration-test.sh "hello"

# Custom log configuration
LOG_DIR=./custom-logs LOG_LEVEL=trace ./scripts/integration-test.sh "hello"
```

### Test Results

- All 1230 unit tests pass
- TypeScript type check passes
- ESLint passes (no new warnings)

Fixes #464

## Test plan

- [x] Run `npm run test` - all tests pass
- [x] Run `npm run type-check` - no TypeScript errors
- [x] Run `npm run lint` - no new lint errors
- [x] Verify logger.test.ts new test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)