### PR TITLE
feat(messaging): add ChannelMessageService for multi-channel MCP support (Issue #445)

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -154,7 +154,7 @@ describe('Feishu Context MCP Tools', () => {
         });
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('CLI mode');
+        expect(result.message).toContain('CLI');
       });
 
       it('should display content in CLI mode', async () => {

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -2,16 +2,21 @@
  * Feishu Context MCP Tools - In-process tool implementation.
  *
  * This module provides tool definitions that allow agents to send feedback
- * and files to Feishu chats directly using Feishu API.
+ * and files to chats through a unified message service.
  *
  * Tools provided:
- * - send_user_feedback: Send a message to a Feishu chat (text or card format, REQUIRED)
+ * - send_user_feedback: Send a message to a chat (text or card format, REQUIRED)
  * - send_file_to_feishu: Send a file to a Feishu chat
+ *
+ * **Channel Support**: Messages are automatically routed to the correct channel
+ * based on chatId format (Feishu, REST, CLI). See ChannelMessageService for details.
  *
  * **Note**: task_done is now an inline tool provided by the Evaluator agent,
  * not part of the Feishu MCP server.
  *
  * **No global state**: Credentials are read from Config, chatId is passed as parameter.
+ *
+ * @see Issue #445 - Multi-channel MCP support
  */
 
 import * as fs from 'fs/promises';
@@ -19,6 +24,10 @@ import * as path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { Config } from '../config/index.js';
+import {
+  getChannelMessageService,
+  detectChannelType,
+} from '../messaging/channel-message-service.js';
 
 const logger = createLogger('FeishuContextMCP');
 
@@ -42,57 +51,6 @@ let messageSentCallback: MessageSentCallback | null = null;
  */
 export function setMessageSentCallback(callback: MessageSentCallback | null): void {
   messageSentCallback = callback;
-}
-
-/**
- * Internal helper: Send a message to Feishu chat.
- *
- * Handles the common logic for sending messages to Feishu API.
- * Supports thread replies via parent_id parameter.
- *
- * @param client - Lark client instance
- * @param chatId - Feishu chat ID
- * @param msgType - Message type ('text' or 'interactive')
- * @param content - Message content (JSON stringified)
- * @param parentId - Optional parent message ID for thread replies
- * @throws Error if sending fails
- */
-async function sendMessageToFeishu(
-  client: lark.Client,
-  chatId: string,
-  msgType: 'text' | 'interactive',
-  content: string,
-  parentId?: string
-): Promise<void> {
-  const messageData: {
-    receive_id_type?: string;
-    msg_type: string;
-    content: string;
-  } = {
-    msg_type: msgType,
-    content,
-  };
-
-  // When replying to a message, use reply method to properly quote the user's message
-  if (parentId) {
-    await client.im.message.reply({
-      path: {
-        message_id: parentId,
-      },
-      data: messageData,
-    });
-  } else {
-    // New message: use create method with receive_id
-    await client.im.message.create({
-      params: {
-        receive_id_type: 'chat_id',
-      },
-      data: {
-        receive_id: chatId,
-        ...messageData,
-      },
-    });
-  }
 }
 
 /**
@@ -164,15 +122,21 @@ function getCardValidationError(content: unknown): string {
 /**
  * Tool: Send user feedback (text or card message)
  *
- * This tool allows agents to send messages directly to Feishu chats.
+ * This tool allows agents to send messages to any chat through the unified
+ * ChannelMessageService, which automatically routes to the correct channel
+ * based on chatId format.
+ *
+ * Channel Detection:
+ * - `cli-*`: CLI channel (logs to console)
+ * - UUID format: REST channel
+ * - `oc_*` / `ou_*`: Feishu channel
+ * - Other: Feishu channel (backward compatibility)
+ *
  * Requires explicit format specification: 'text' or 'card'.
  * Credentials are read from Config, chatId is required parameter.
  *
  * Thread Support: When parentMessageId is provided, the message is sent
- * as a reply to that message, creating a thread in Feishu.
- *
- * CLI Mode: When chatId starts with "cli-", the message is logged
- * instead of being sent to Feishu API.
+ * as a reply to that message, creating a thread (for Feishu).
  *
  * @param params - Tool parameters
  * @returns Result object with success status
@@ -189,10 +153,14 @@ export async function send_user_feedback(params: {
 }> {
   const { content, format, chatId, parentMessageId } = params;
 
+  // Detect channel type for routing
+  const channelType = detectChannelType(chatId);
+
   // DIAGNOSTIC: Log all send_user_feedback calls
   logger.info({
     chatId,
     format,
+    channelType,
     contentType: typeof content,
     contentPreview: typeof content === 'string' ? content.substring(0, 100) : JSON.stringify(content).substring(0, 100),
   }, 'send_user_feedback called');
@@ -208,73 +176,41 @@ export async function send_user_feedback(params: {
       throw new Error('chatId is required');
     }
 
-    // CLI mode: Log the message instead of sending to Feishu
-    if (chatId.startsWith('cli-')) {
-      const displayContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
-      logger.info({ chatId, format, contentPreview: displayContent.substring(0, 100) }, 'CLI mode: User feedback');
-      // Use console.log for direct visibility in CLI mode
-      console.log(`\n${displayContent}\n`);
-
-      // Notify callback that a message was sent (for dialogue bridge tracking)
-      if (messageSentCallback) {
-        try {
-          messageSentCallback(chatId);
-        } catch (error) {
-          logger.error({ err: error }, 'Failed to invoke message sent callback');
-        }
-      }
-
-      return {
-        success: true,
-        message: `✅ Feedback displayed (CLI mode, format: ${format})`,
-      };
-    }
-
-    // Read credentials from Config
-    const appId = Config.FEISHU_APP_ID;
-    const appSecret = Config.FEISHU_APP_SECRET;
-
-    if (!appId || !appSecret) {
-      throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET must be configured in Config');
-    }
-
-    // Create Lark client and send message
-    const client = new lark.Client({
-      appId,
-      appSecret,
-      domain: lark.Domain.Feishu,
-    });
+    // Get the unified message service
+    const messageService = getChannelMessageService();
 
     if (format === 'text') {
-      // Send as text message
+      // Send as text message through unified service
       const textContent = typeof content === 'string' ? content : JSON.stringify(content);
-      await sendMessageToFeishu(client, chatId, 'text', JSON.stringify({ text: textContent }), parentMessageId);
+      await messageService.sendText(chatId, textContent, parentMessageId);
 
       logger.debug({
         chatId,
+        channelType,
         messageLength: textContent.length,
-        message: textContent,
         parentMessageId,
       }, 'User feedback sent (text)');
     } else {
-      // Card format: strict validation, no fallback
+      // Card format: validate for Feishu, send through unified service
+      let cardContent: Record<string, unknown>;
+
       if (typeof content === 'object' && isValidFeishuCard(content)) {
         // Valid card object - send as-is
-        await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(content), parentMessageId);
-        logger.debug({ chatId, hasValidStructure: true, parentMessageId }, 'User card sent (interactive)');
+        cardContent = content;
+        logger.debug({ chatId, channelType, hasValidStructure: true, parentMessageId }, 'User card validated');
       } else if (typeof content === 'string') {
         // String content - must be valid JSON card
         try {
           const parsed = JSON.parse(content);
           if (isValidFeishuCard(parsed)) {
-            // Valid JSON card string - send directly
-            await sendMessageToFeishu(client, chatId, 'interactive', content, parentMessageId);
-            logger.debug({ chatId, wasJsonString: true, parentMessageId }, 'User card sent (from JSON string)');
+            cardContent = parsed;
+            logger.debug({ chatId, channelType, wasJsonString: true, parentMessageId }, 'User card validated (from JSON string)');
           } else {
             // Valid JSON but not a valid card - return error for LLM to fix
             const validationError = getCardValidationError(parsed);
             logger.error({
               chatId,
+              channelType,
               contentType: 'string',
               parsedType: Array.isArray(parsed) ? 'array' : typeof parsed,
               parsedKeys: typeof parsed === 'object' && parsed !== null ? Object.keys(parsed) : [],
@@ -292,6 +228,7 @@ export async function send_user_feedback(params: {
           // Invalid JSON - return error for LLM to fix
           logger.error({
             chatId,
+            channelType,
             contentType: 'string',
             parseError: parseError instanceof Error ? parseError.message : String(parseError),
             contentPreview: content.substring(0, 500),
@@ -308,6 +245,7 @@ export async function send_user_feedback(params: {
         const actualType = content === null ? 'null' : typeof content;
         logger.error({
           chatId,
+          channelType,
           contentType: actualType,
           contentPreview: JSON.stringify(content).substring(0, 500),
         }, 'Card validation failed: invalid content type');
@@ -318,6 +256,10 @@ export async function send_user_feedback(params: {
           message: '❌ Invalid content type. Expected Feishu card object or JSON string.',
         };
       }
+
+      // Send card through unified service
+      await messageService.sendCard(chatId, cardContent, undefined, parentMessageId);
+      logger.debug({ chatId, channelType, parentMessageId }, 'User card sent');
     }
 
     // Notify callback that a message was sent (for dialogue bridge tracking)
@@ -329,9 +271,14 @@ export async function send_user_feedback(params: {
       }
     }
 
+    // Build success message based on channel type
+    const channelName = channelType === 'cli' ? 'CLI' :
+                       channelType === 'rest' ? 'REST' :
+                       channelType === 'feishu' ? 'Feishu' : 'Feishu';
+
     return {
       success: true,
-      message: `✅ Feedback sent (format: ${format})`,
+      message: `✅ Feedback sent to ${channelName} (format: ${format})`,
     };
 
   } catch (error) {
@@ -339,6 +286,7 @@ export async function send_user_feedback(params: {
     logger.error({
       err: error,
       chatId,
+      channelType,
       errorMessage: error instanceof Error ? error.message : String(error),
       errorStack: error instanceof Error ? error.stack : undefined,
     }, 'send_user_feedback FAILED');

--- a/src/messaging/channel-message-service.test.ts
+++ b/src/messaging/channel-message-service.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for ChannelMessageService.
+ *
+ * @see Issue #445 - Multi-channel MCP support
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  ChannelMessageService,
+  getChannelMessageService,
+  setChannelMessageService,
+  resetChannelMessageService,
+  detectChannelType,
+} from './channel-message-service.js';
+import type { IChannel } from '../channels/types.js';
+
+// Mock logger
+vi.mock('../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Mock Config
+vi.mock('../config/index.js', () => ({
+  Config: {
+    FEISHU_APP_ID: 'test_app_id',
+    FEISHU_APP_SECRET: 'test_app_secret',
+  },
+}));
+
+// Mock lark SDK
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    im: {
+      message: {
+        create: vi.fn().mockResolvedValue({}),
+        reply: vi.fn().mockResolvedValue({}),
+      },
+    },
+  })),
+  Domain: {
+    Feishu: 'feishu',
+  },
+}));
+
+describe('detectChannelType', () => {
+  it('should detect CLI channel', () => {
+    expect(detectChannelType('cli-abc123')).toBe('cli');
+    expect(detectChannelType('cli-test-123')).toBe('cli');
+    expect(detectChannelType('cli-')).toBe('cli');
+  });
+
+  it('should detect REST channel (UUID format)', () => {
+    expect(detectChannelType('550e8400-e29b-41d4-a716-446655440000')).toBe('rest');
+    expect(detectChannelType('6ba7b810-9dad-11d1-80b4-00c04fd430c8')).toBe('rest');
+    // Mixed case should also work
+    expect(detectChannelType('550E8400-E29B-41D4-A716-446655440000')).toBe('rest');
+  });
+
+  it('should detect Feishu channel', () => {
+    expect(detectChannelType('oc_abc123')).toBe('feishu');
+    expect(detectChannelType('ou_xyz789')).toBe('feishu');
+    expect(detectChannelType('oc_chat_id_here')).toBe('feishu');
+  });
+
+  it('should return unknown for unrecognized formats', () => {
+    expect(detectChannelType('some-random-id')).toBe('unknown');
+    expect(detectChannelType('12345')).toBe('unknown');
+    expect(detectChannelType('')).toBe('unknown');
+  });
+});
+
+describe('ChannelMessageService', () => {
+  let service: ChannelMessageService;
+  let mockChannel: IChannel;
+
+  beforeEach(() => {
+    service = new ChannelMessageService();
+
+    // Create a mock channel
+    mockChannel = {
+      id: 'test-channel',
+      name: 'Test Channel',
+      status: 'running',
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      isHealthy: vi.fn().mockReturnValue(true),
+      onMessage: vi.fn(),
+      onControl: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    resetChannelMessageService();
+  });
+
+  describe('registerChannel', () => {
+    it('should register a channel', () => {
+      service.registerChannel(mockChannel);
+      expect(service.getChannel('test-channel')).toBe(mockChannel);
+    });
+
+    it('should replace existing channel with same ID', () => {
+      service.registerChannel(mockChannel);
+      const newChannel = { ...mockChannel, name: 'New Channel' };
+      service.registerChannel(newChannel);
+      expect(service.getChannel('test-channel')).toBe(newChannel);
+    });
+  });
+
+  describe('unregisterChannel', () => {
+    it('should unregister a channel', () => {
+      service.registerChannel(mockChannel);
+      service.unregisterChannel('test-channel');
+      expect(service.getChannel('test-channel')).toBeUndefined();
+    });
+  });
+
+  describe('getChannels', () => {
+    it('should return all registered channels', () => {
+      const mockChannel2 = { ...mockChannel, id: 'test-channel-2' };
+      service.registerChannel(mockChannel);
+      service.registerChannel(mockChannel2);
+      expect(service.getChannels()).toHaveLength(2);
+    });
+  });
+
+  describe('sendText', () => {
+    it('should handle CLI chatId', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await service.sendText('cli-test', 'Hello CLI');
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Hello CLI'));
+      consoleSpy.mockRestore();
+    });
+
+    it('should route to REST channel for UUID chatId', async () => {
+      const restChannel = {
+        ...mockChannel,
+        id: 'rest',
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      service.registerChannel(restChannel);
+
+      await service.sendText('550e8400-e29b-41d4-a716-446655440000', 'Hello REST');
+
+      expect(restChannel.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: '550e8400-e29b-41d4-a716-446655440000',
+          type: 'text',
+          text: 'Hello REST',
+        })
+      );
+    });
+
+    it('should call onMessageSent callback', async () => {
+      const callback = vi.fn();
+      const serviceWithCallback = new ChannelMessageService({
+        onMessageSent: callback,
+      });
+
+      await serviceWithCallback.sendText('cli-test', 'Hello');
+
+      expect(callback).toHaveBeenCalledWith('cli-test');
+    });
+  });
+
+  describe('sendCard', () => {
+    it('should handle CLI chatId with card description', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const card = { config: {}, header: { title: 'Test' }, elements: [] };
+      await service.sendCard('cli-test', card, 'Card Description');
+
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Card Description'));
+      consoleSpy.mockRestore();
+    });
+
+    it('should route to REST channel for UUID chatId', async () => {
+      const restChannel = {
+        ...mockChannel,
+        id: 'rest',
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      service.registerChannel(restChannel);
+
+      const card = { config: {}, header: { title: 'Test' }, elements: [] };
+      await service.sendCard('550e8400-e29b-41d4-a716-446655440000', card, 'Test Card');
+
+      expect(restChannel.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: '550e8400-e29b-41d4-a716-446655440000',
+          type: 'card',
+          card,
+          description: 'Test Card',
+        })
+      );
+    });
+  });
+});
+
+describe('Global instance management', () => {
+  afterEach(() => {
+    resetChannelMessageService();
+  });
+
+  it('should create global instance on first call', () => {
+    const instance = getChannelMessageService();
+    expect(instance).toBeInstanceOf(ChannelMessageService);
+  });
+
+  it('should return same instance on subsequent calls', () => {
+    const instance1 = getChannelMessageService();
+    const instance2 = getChannelMessageService();
+    expect(instance1).toBe(instance2);
+  });
+
+  it('should allow setting custom instance', () => {
+    const customInstance = new ChannelMessageService();
+    setChannelMessageService(customInstance);
+
+    expect(getChannelMessageService()).toBe(customInstance);
+  });
+
+  it('should reset global instance', () => {
+    getChannelMessageService();
+    resetChannelMessageService();
+
+    // After reset, should create new instance
+    const instance = getChannelMessageService();
+    expect(instance).toBeInstanceOf(ChannelMessageService);
+  });
+});

--- a/src/messaging/channel-message-service.ts
+++ b/src/messaging/channel-message-service.ts
@@ -1,0 +1,422 @@
+/**
+ * Channel Message Service - Unified message sending abstraction.
+ *
+ * This service provides a unified interface for sending messages across
+ * different channels (Feishu, REST, CLI, etc.). It handles channel detection
+ * and routing based on chatId format, so MCP tools don't need to know about
+ * specific channels.
+ *
+ * Architecture:
+ * ```
+ * MCP Tools (send_user_feedback, etc.)
+ *     │
+ *     ▼
+ * ChannelMessageService (unified interface)
+ *     │
+ *     ├── CLI Adapter (cli-* chatIds)
+ *     ├── REST Adapter (UUID chatIds)
+ *     └── Feishu Adapter (oc_*, ou_* chatIds)
+ * ```
+ *
+ * @see Issue #445
+ */
+
+import { createLogger } from '../utils/logger.js';
+import type { IChannel, OutgoingMessage } from '../channels/types.js';
+import type { IMessageSender } from '../channels/adapters/types.js';
+import { Config } from '../config/index.js';
+import * as lark from '@larksuiteoapi/node-sdk';
+
+const logger = createLogger('ChannelMessageService');
+
+/**
+ * ChatId format patterns for channel detection.
+ */
+const CHAT_ID_PATTERNS = {
+  /** CLI channel: starts with "cli-" */
+  CLI: /^cli-/,
+  /** REST channel: UUID format */
+  REST: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+  /** Feishu channel: starts with "oc_" (group) or "ou_" (user) */
+  FEISHU: /^(oc_|ou_)/,
+} as const;
+
+/**
+ * Detected channel type based on chatId format.
+ */
+export type DetectedChannelType = 'cli' | 'rest' | 'feishu' | 'unknown';
+
+/**
+ * Detect channel type from chatId format.
+ *
+ * @param chatId - Chat ID to detect
+ * @returns Detected channel type
+ */
+export function detectChannelType(chatId: string): DetectedChannelType {
+  if (CHAT_ID_PATTERNS.CLI.test(chatId)) {
+    return 'cli';
+  }
+  if (CHAT_ID_PATTERNS.REST.test(chatId)) {
+    return 'rest';
+  }
+  if (CHAT_ID_PATTERNS.FEISHU.test(chatId)) {
+    return 'feishu';
+  }
+  // Default to feishu for backward compatibility
+  return 'unknown';
+}
+
+/**
+ * Message sent callback type.
+ * Called when a message is successfully sent to track user communication.
+ */
+export type MessageSentCallback = (chatId: string) => void;
+
+/**
+ * ChannelMessageService options.
+ */
+export interface ChannelMessageServiceOptions {
+  /** Callback when message is sent successfully */
+  onMessageSent?: MessageSentCallback;
+  /** Feishu credentials (optional, uses Config if not provided) */
+  feishuCredentials?: {
+    appId: string;
+    appSecret: string;
+  };
+}
+
+/**
+ * Channel Message Service - Unified message sending abstraction.
+ *
+ * This service provides a unified interface for sending messages across
+ * different channels. It automatically detects the channel type based on
+ * chatId format and routes messages accordingly.
+ *
+ * Usage:
+ * ```typescript
+ * const service = new ChannelMessageService();
+ *
+ * // Send to Feishu chat
+ * await service.sendText('oc_xxx', 'Hello!');
+ *
+ * // Send to CLI (logs to console)
+ * await service.sendText('cli-xxx', 'Hello!');
+ * ```
+ */
+export class ChannelMessageService implements IMessageSender {
+  private readonly options: ChannelMessageServiceOptions;
+  private readonly channels = new Map<string, IChannel>();
+  private feishuClient?: lark.Client;
+
+  constructor(options: ChannelMessageServiceOptions = {}) {
+    this.options = options;
+    logger.info('ChannelMessageService created');
+  }
+
+  /**
+   * Register a channel for message routing.
+   *
+   * @param channel - Channel to register
+   */
+  registerChannel(channel: IChannel): void {
+    this.channels.set(channel.id, channel);
+    logger.info({ channelId: channel.id, channelName: channel.name }, 'Channel registered');
+  }
+
+  /**
+   * Unregister a channel.
+   *
+   * @param channelId - Channel ID to unregister
+   */
+  unregisterChannel(channelId: string): void {
+    this.channels.delete(channelId);
+    logger.info({ channelId }, 'Channel unregistered');
+  }
+
+  /**
+   * Get a registered channel by ID.
+   *
+   * @param channelId - Channel ID
+   * @returns Channel if found, undefined otherwise
+   */
+  getChannel(channelId: string): IChannel | undefined {
+    return this.channels.get(channelId);
+  }
+
+  /**
+   * Get all registered channels.
+   *
+   * @returns Array of registered channels
+   */
+  getChannels(): IChannel[] {
+    return Array.from(this.channels.values());
+  }
+
+  /**
+   * Send a text message.
+   *
+   * @param chatId - Target chat ID
+   * @param text - Message text content
+   * @param threadId - Optional thread ID for threaded replies
+   */
+  async sendText(chatId: string, text: string, threadId?: string): Promise<void> {
+    const channelType = detectChannelType(chatId);
+    logger.debug({ chatId, channelType, textLength: text.length }, 'sendText called');
+
+    switch (channelType) {
+      case 'cli':
+        await this.sendToCli(text);
+        break;
+
+      case 'rest':
+        await this.sendToChannel('rest', {
+          chatId,
+          type: 'text',
+          text,
+          threadId,
+        });
+        break;
+
+      case 'feishu':
+      case 'unknown':
+      default:
+        await this.sendToFeishu(chatId, 'text', JSON.stringify({ text }), threadId);
+        break;
+    }
+
+    this.notifyMessageSent(chatId);
+  }
+
+  /**
+   * Send an interactive card message.
+   *
+   * @param chatId - Target chat ID
+   * @param card - Platform-specific card structure
+   * @param description - Optional description for logging
+   * @param threadId - Optional thread ID for threaded replies
+   */
+  async sendCard(
+    chatId: string,
+    card: Record<string, unknown>,
+    description?: string,
+    threadId?: string
+  ): Promise<void> {
+    const channelType = detectChannelType(chatId);
+    logger.debug(
+      { chatId, channelType, hasCard: !!card, description },
+      'sendCard called'
+    );
+
+    switch (channelType) {
+      case 'cli':
+        await this.sendToCli(description || JSON.stringify(card, null, 2));
+        break;
+
+      case 'rest':
+        await this.sendToChannel('rest', {
+          chatId,
+          type: 'card',
+          card,
+          description,
+          threadId,
+        });
+        break;
+
+      case 'feishu':
+      case 'unknown':
+      default:
+        await this.sendToFeishu(chatId, 'interactive', JSON.stringify(card), threadId);
+        break;
+    }
+
+    this.notifyMessageSent(chatId);
+  }
+
+  /**
+   * Send a file attachment.
+   *
+   * @param chatId - Target chat ID
+   * @param filePath - Local file path to send
+   * @param threadId - Optional thread ID for threaded replies
+   */
+  async sendFile(chatId: string, filePath: string, threadId?: string): Promise<void> {
+    const channelType = detectChannelType(chatId);
+    logger.debug({ chatId, channelType, filePath }, 'sendFile called');
+
+    switch (channelType) {
+      case 'cli':
+        await this.sendToCli(`[File: ${filePath}]`);
+        break;
+
+      case 'rest':
+        await this.sendToChannel('rest', {
+          chatId,
+          type: 'file',
+          filePath,
+          threadId,
+        });
+        break;
+
+      case 'feishu':
+      case 'unknown':
+      default:
+        // For Feishu, we need to use the file upload API
+        // This is handled separately in send_file_to_feishu
+        throw new Error('File sending to Feishu requires send_file_to_feishu tool');
+    }
+
+    this.notifyMessageSent(chatId);
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  /**
+   * Send message to CLI (log to console).
+   */
+  private async sendToCli(content: string): Promise<void> {
+    logger.info({ contentPreview: content.substring(0, 100) }, 'CLI mode: User feedback');
+    console.log(`\n${content}\n`);
+  }
+
+  /**
+   * Send message through a registered channel.
+   */
+  private async sendToChannel(channelId: string, message: OutgoingMessage): Promise<void> {
+    const channel = this.channels.get(channelId);
+    if (!channel) {
+      logger.warn({ channelId }, 'Channel not found, falling back to Feishu');
+      // Fallback to Feishu if channel not found
+      await this.sendToFeishu(
+        message.chatId,
+        message.type === 'card' ? 'interactive' : 'text',
+        message.type === 'text'
+          ? JSON.stringify({ text: message.text })
+          : JSON.stringify(message.card),
+        message.threadId
+      );
+      return;
+    }
+
+    await channel.sendMessage(message);
+  }
+
+  /**
+   * Send message to Feishu.
+   */
+  private async sendToFeishu(
+    chatId: string,
+    msgType: 'text' | 'interactive',
+    content: string,
+    parentId?: string
+  ): Promise<void> {
+    const client = await this.getFeishuClient();
+
+    const messageData: {
+      receive_id_type?: string;
+      msg_type: string;
+      content: string;
+    } = {
+      msg_type: msgType,
+      content,
+    };
+
+    if (parentId) {
+      await client.im.message.reply({
+        path: {
+          message_id: parentId,
+        },
+        data: messageData,
+      });
+    } else {
+      await client.im.message.create({
+        params: {
+          receive_id_type: 'chat_id',
+        },
+        data: {
+          receive_id: chatId,
+          ...messageData,
+        },
+      });
+    }
+
+    logger.debug({ chatId, msgType, parentId }, 'Message sent to Feishu');
+  }
+
+  /**
+   * Get or create Feishu client.
+   */
+  private async getFeishuClient(): Promise<lark.Client> {
+    if (!this.feishuClient) {
+      const appId =
+        this.options.feishuCredentials?.appId || Config.FEISHU_APP_ID;
+      const appSecret =
+        this.options.feishuCredentials?.appSecret || Config.FEISHU_APP_SECRET;
+
+      if (!appId || !appSecret) {
+        throw new Error(
+          'Feishu credentials not configured. Set FEISHU_APP_ID and FEISHU_APP_SECRET.'
+        );
+      }
+
+      this.feishuClient = new lark.Client({
+        appId,
+        appSecret,
+        domain: lark.Domain.Feishu,
+      });
+    }
+
+    return this.feishuClient;
+  }
+
+  /**
+   * Notify callback that a message was sent.
+   */
+  private notifyMessageSent(chatId: string): void {
+    if (this.options.onMessageSent) {
+      try {
+        this.options.onMessageSent(chatId);
+      } catch (error) {
+        logger.error({ err: error, chatId }, 'Failed to invoke message sent callback');
+      }
+    }
+  }
+}
+
+// ============================================================================
+// Singleton Instance for MCP Tools
+// ============================================================================
+
+let globalInstance: ChannelMessageService | null = null;
+
+/**
+ * Get the global ChannelMessageService instance.
+ * Creates one if it doesn't exist.
+ *
+ * @returns Global ChannelMessageService instance
+ */
+export function getChannelMessageService(): ChannelMessageService {
+  if (!globalInstance) {
+    globalInstance = new ChannelMessageService();
+  }
+  return globalInstance;
+}
+
+/**
+ * Set the global ChannelMessageService instance.
+ * Used for testing or when custom configuration is needed.
+ *
+ * @param service - Service instance to set
+ */
+export function setChannelMessageService(service: ChannelMessageService | null): void {
+  globalInstance = service;
+}
+
+/**
+ * Reset the global instance.
+ * Useful for testing.
+ */
+export function resetChannelMessageService(): void {
+  globalInstance = null;
+}

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -63,3 +63,15 @@ export {
   SimpleUserOutputAdapter,
   type RoutedOutputAdapterOptions,
 } from './routed-output-adapter.js';
+
+// Channel Message Service (Issue #445)
+export {
+  ChannelMessageService,
+  getChannelMessageService,
+  setChannelMessageService,
+  resetChannelMessageService,
+  detectChannelType,
+  type DetectedChannelType,
+  type MessageSentCallback,
+  type ChannelMessageServiceOptions,
+} from './channel-message-service.js';


### PR DESCRIPTION
## Summary

Implements #445 - Refactors the MCP message sending to support multi-channel routing with automatic channel detection.

## Problem

When using MCP tools to send messages to a chat, if the chat is not from the Feishu channel (e.g., from CLI, REST API, or other channels), the current implementation would fail or behave unexpectedly.

Previous PR #447 was closed because the architecture was wrong - it did channel detection in the MCP layer. The correct approach is to provide a unified abstraction layer that handles channel routing transparently.

## Solution

### ChannelMessageService

Created a new `ChannelMessageService` that provides a unified interface for sending messages across different channels:

| chatId Format | Channel | Behavior |
|---------------|---------|----------|
| `cli-*` | CLI | Logs to console |
| UUID format | REST | Routes through registered channels |
| `oc_*`, `ou_*` | Feishu | Sends via Feishu API |
| Unknown | Feishu | Falls back to Feishu (backward compatibility) |

### Architecture

```
MCP Tools (send_user_feedback)
    │
    ▼
ChannelMessageService (unified interface)
    │
    ├── CLI Adapter (cli-* chatIds)
    ├── REST Adapter (UUID chatIds)
    └── Feishu Adapter (oc_*, ou_* chatIds)
```

### Key Design Principles

1. **No channel detection in MCP layer**: MCP tools call the unified service
2. **Automatic routing**: Service detects channel type from chatId format
3. **Backward compatible**: Unknown formats default to Feishu
4. **Extensible**: Easy to add new channel types

## Changes

| File | Description |
|------|-------------|
| `src/messaging/channel-message-service.ts` | New unified message service |
| `src/messaging/channel-message-service.test.ts` | 17 unit tests |
| `src/messaging/index.ts` | Export new service |
| `src/mcp/feishu-context-mcp.ts` | Use ChannelMessageService |
| `src/mcp/feishu-context-mcp.test.ts` | Update test expectations |

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 17 |
| Total tests | 1245 passed, 8 skipped |
| Type Check | ✅ Pass |
| Pre-existing failures | 1 (Config.LOG_LEVEL, unrelated) |

## Related

- Issue #445: Feishu MCP 兼容性：非 Feishu Channel 的 Chat 应转义为兼容方式
- Closed PR #447: Previous attempt (closed for architecture design issues)

## Test plan

- [x] ChannelMessageService unit tests (17 tests)
- [x] All existing tests pass (except pre-existing failure)
- [x] Type check passes
- [ ] Manual test: send_user_feedback to CLI chatId
- [ ] Manual test: send_user_feedback to REST chatId
- [ ] Manual test: send_user_feedback to Feishu chatId

🤖 Generated with [Claude Code](https://claude.com/claude-code)