### PR TITLE
feat(mcp): add create_discussion_chat tool and update PR Scanner (Issue #393)

### DIFF
--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -6,15 +6,16 @@ blocking: true
 chatId: "oc_REPLACE_WITH_YOUR_CHAT_ID"
 ---
 
-# PR Scanner - Phase 1
+# PR Scanner - Phase 2 (with Group Chat Creation)
 
-定期扫描仓库的 open PR，发现新 PR 时发送通知到指定群聊。
+定期扫描仓库的 open PR，发现新 PR 时创建专属群聊并发送通知。
 
 ## 配置
 
 - **仓库**: hs3180/disclaude
 - **扫描间隔**: 每 30 分钟
-- **通知目标**: 配置的 chatId
+- **通知目标**: 配置的 chatId（用于错误通知和 fallback）
+- **群聊创建**: 为每个新 PR 创建专属讨论群
 
 ## 执行步骤
 
@@ -47,53 +48,105 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
 
 1. 获取详细信息：
    ```bash
-   gh pr view {number} --repo hs3180/disclaude
+   gh pr view {number} --repo hs3180/disclaude --json number,title,author,state,body,mergeable,statusCheckRollup,url
    ```
 
-2. 使用 `send_user_feedback` 发送通知：
-   - PR 标题和编号
-   - 作者
-   - 状态（可合并/有冲突）
-   - CI 检查状态
-   - 链接
+2. **创建专属群聊**（使用 `create_discussion_chat` 工具）：
+   - 群聊名称: `PR #{number}: {title}` (标题过长时截断)
+   - 成员列表: 暂时为空（用户可手动加入）
 
-3. 更新历史记录
+3. **存储群聊映射**：
+   将 `{prNumber: chatId}` 添加到 `prChats` 字段
+
+4. **发送 PR 信息到新群聊**（使用 `send_user_feedback`）：
+   ```markdown
+   ## PR #{number}: {title}
+
+   **作者**: {author}
+   **状态**: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
+   **CI 检查**: {statusCheckRollup}
+
+   ### 描述
+   {body}
+
+   ### 快捷操作
+   - 🔗 [查看 PR]({url})
+
+   ---
+   💡 这是一个自动化创建的 PR 讨论群。您可以在这里讨论 PR 的内容。
+   ```
+
+5. 更新历史记录
 
 ### 5. 更新历史文件
 
-将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳。
+将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳，更新 `prChats` 映射。
+
+## 历史文件结构
+
+```json
+{
+  "lastScan": "2026-03-02T10:00:00Z",
+  "processedPRs": [439, 437, 436],
+  "prChats": {
+    "439": "oc_xxxx",
+    "437": "oc_yyyy"
+  }
+}
+```
 
 ## 通知消息模板
 
+### PR 讨论群消息
+
 ```
-🔔 新 PR 检测到
+## PR #{number}: {title}
 
-PR #{number}: {title}
+**作者**: {author}
+**状态**: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
+**CI 检查**: {statusCheckRollup}
 
-👤 作者: {author}
-📊 状态: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
-🔍 检查: {ciStatus}
+### 描述
+{body}
 
-📋 描述:
-{description}
+---
 
-🔗 链接: https://github.com/hs3180/disclaude/pull/{number}
+🔗 [查看 PR](https://github.com/hs3180/disclaude/pull/{number})
+
+💡 这是一个自动化创建的 PR 讨论群。
+```
+
+### Admin 通知（错误或 fallback）
+
+```
+⚠️ PR Scanner 通知
+
+{消息内容}
 ```
 
 ## 错误处理
 
-- 如果 `gh` 命令失败，记录错误并发送错误通知
+- 如果 `gh` 命令失败，记录错误并发送错误通知到 admin chat
+- 如果群聊创建失败，回退到发送通知到 admin chat
 - 如果历史文件损坏，重置并重新开始
 - 如果发送通知失败，记录错误但继续处理其他 PR
 
 ## 使用说明
 
 1. 复制此文件到 `workspace/schedules/pr-scanner.md`
-2. 替换 `chatId` 为实际的飞书群聊 ID
+2. 替换 `chatId` 为实际的飞书群聊 ID（用于 admin 通知）
 3. 设置 `enabled: true`
 4. 调度器将自动加载并执行
 
-## 未来扩展 (Phase 2 & 3)
+## 未来扩展 (Phase 3)
 
-- **Phase 2**: 为每个 PR 创建独立群聊（需要 PR #423 ChatOps）
-- **Phase 3**: 支持交互式操作按钮（需要 PR #412 FeedbackController）
+- **交互式操作**: 支持通过按钮执行 PR 操作（合并、关闭等）
+- **自动邀请**: 根据 PR 作者和 reviewer 自动邀请成员
+- **状态更新**: PR 状态变化时更新群聊消息
+
+## 依赖
+
+- ✅ Scheduler 基础设施
+- ✅ `send_user_feedback` 工具
+- ✅ `create_discussion_chat` 工具 (Phase 2)
+- ⏳ `wait_for_interaction` 工具 (Phase 3)

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { Config } from '../config/index.js';
+import { createDiscussionChat } from '../platforms/feishu/chat-ops.js';
 
 const logger = createLogger('FeishuContextMCP');
 
@@ -795,6 +796,86 @@ export async function wait_for_interaction(params: {
   }
 }
 
+// ============================================================================
+// Chat Operations Tools (Issue #393 Phase 2)
+// ============================================================================
+
+/**
+ * Tool: Create a discussion group chat.
+ *
+ * Creates a new Feishu group chat with the specified topic and members.
+ * Returns the chat ID of the newly created chat.
+ *
+ * @param params - Tool parameters
+ * @returns Result object with chat ID
+ */
+export async function create_discussion_chat(params: {
+  topic: string;
+  members?: string[];
+}): Promise<{
+  success: boolean;
+  message: string;
+  chatId?: string;
+  error?: string;
+}> {
+  const { topic, members = [] } = params;
+
+  logger.info({
+    topic,
+    memberCount: members.length,
+  }, 'create_discussion_chat called');
+
+  try {
+    if (!topic) {
+      throw new Error('topic is required');
+    }
+
+    // Read credentials from Config
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET must be configured in Config');
+    }
+
+    // Create Lark client
+    const client = new lark.Client({
+      appId,
+      appSecret,
+      domain: lark.Domain.Feishu,
+    });
+
+    // Create the discussion chat
+    const chatId = await createDiscussionChat(client, {
+      topic,
+      members,
+    });
+
+    logger.info({ chatId, topic, memberCount: members.length }, 'Discussion chat created');
+
+    return {
+      success: true,
+      message: `✅ Discussion chat created: ${topic}`,
+      chatId,
+    };
+
+  } catch (error) {
+    logger.error({
+      err: error,
+      topic,
+      members,
+    }, 'create_discussion_chat failed');
+
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ Failed to create discussion chat: ${errorMessage}`,
+    };
+  }
+}
+
 /**
  * Tool definitions for Agent SDK integration.
  *
@@ -895,6 +976,25 @@ export const feishuContextTools = {
       required: ['messageId', 'chatId'],
     },
     handler: wait_for_interaction,
+  },
+  create_discussion_chat: {
+    description: 'Create a new Feishu group chat for discussions. Use this to create dedicated chat groups for specific topics (e.g., PR discussions, issue tracking). Returns the chat ID of the newly created group.',
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: {
+          type: 'string',
+          description: 'The name/topic for the new group chat',
+        },
+        members: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional list of member open_ids to add to the chat',
+        },
+      },
+      required: ['topic'],
+    },
+    handler: create_discussion_chat,
   },
 };
 
@@ -1009,6 +1109,26 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
         }
       } catch (error) {
         return toolSuccess(`⚠️ Wait failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'create_discussion_chat',
+    description: 'Create a new Feishu group chat for discussions.\n\n**Use Cases:**\n- Create dedicated chat groups for PR discussions\n- Set up discussion channels for specific issues\n- Create temporary chats for collaborative work\n\n**Returns:**\n- chatId: The ID of the newly created chat\n\n**Note:** The bot will be the owner of the created chat.',
+    parameters: z.object({
+      topic: z.string().describe('The name/topic for the new group chat'),
+      members: z.array(z.string()).optional().describe('Optional list of member open_ids to add to the chat'),
+    }),
+    handler: async ({ topic, members }) => {
+      try {
+        const result = await create_discussion_chat({ topic, members });
+        if (result.success) {
+          return toolSuccess(`${result.message}\nChat ID: ${result.chatId}`);
+        } else {
+          return toolSuccess(`⚠️ ${result.message}`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Chat creation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -21,7 +21,7 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction } from './feishu-context-mcp.js';
+import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction, create_discussion_chat } from './feishu-context-mcp.js';
 
 const logger = createLogger('FeishuMCPServer');
 
@@ -130,6 +130,25 @@ async function handleMessage(message: unknown) {
                   required: ['messageId', 'chatId'],
                 },
               },
+              {
+                name: 'create_discussion_chat',
+                description: 'Create a new Feishu group chat for discussions. Returns the chat ID of the newly created group.',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    topic: {
+                      type: 'string',
+                      description: 'The name/topic for the new group chat',
+                    },
+                    members: {
+                      type: 'array',
+                      items: { type: 'string' },
+                      description: 'Optional list of member open_ids to add to the chat',
+                    },
+                  },
+                  required: ['topic'],
+                },
+              },
             ],
           },
         };
@@ -205,6 +224,24 @@ async function handleMessage(message: unknown) {
                 type: 'text',
                 text: result.success
                   ? `${result.message}\nAction: ${result.actionValue}\nType: ${result.actionType}\nUser: ${result.userId}`
+                  : `⚠️ ${result.message}`,
+              }],
+            },
+          };
+        }
+
+        if (name === 'create_discussion_chat') {
+          const args = toolArgs as { topic: string; members?: string[] };
+          const result = await create_discussion_chat(args);
+
+          return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              content: [{
+                type: 'text',
+                text: result.success
+                  ? `${result.message}\nChat ID: ${result.chatId}`
                   : `⚠️ ${result.message}`,
               }],
             },


### PR DESCRIPTION
## Summary

Implements #393 Phase 2 - Adds a new MCP tool `create_discussion_chat` and updates the PR Scanner schedule to create dedicated discussion chats for new PRs.

## Problem

Issue #393 requires a scheduled task that:
- Periodically scans open PRs
- Creates group chats for new PRs (Phase 2)
- Enables interactive discussion

Phase 1 (notification only) was already designed. This PR implements Phase 2 by exposing the ChatOps `createDiscussionChat` function as an MCP tool.

## Solution

### New MCP Tool: `create_discussion_chat`

| File | Changes |
|------|---------|
| `src/mcp/feishu-context-mcp.ts` | Added `create_discussion_chat` function and tool definitions |
| `src/mcp/feishu-mcp-server.ts` | Added tool to stdio MCP server |

**Features:**
- Creates Feishu group chats with specified topic
- Optional member list (open_ids)
- Returns the chat ID for further operations

### Updated PR Scanner Example

| File | Changes |
|------|---------|
| `examples/schedules/pr-scanner.example.md` | Upgraded to Phase 2 with group chat creation |

**New Capabilities:**
- Creates dedicated discussion chat for each new PR
- Stores PR-to-chat mapping in history file
- Sends PR info to the new chat

## Test Results

```
✓ All MCP tests pass (52 tests)
✓ TypeScript compilation successful
```

## Dependencies

| Dependency | Status |
|------------|--------|
| Scheduler infrastructure | ✅ Ready |
| `send_user_feedback` tool | ✅ Ready |
| `create_discussion_chat` tool | ✅ This PR |
| `wait_for_interaction` tool | ⏳ Phase 3 |

## Checklist

- [x] Code follows project style guidelines
- [x] All tests pass
- [x] TypeScript compilation successful
- [x] Documentation updated (schedule example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)