### PR TITLE
feat(feishu): add debug chat configuration commands (Issue #487)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -449,6 +449,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       'reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
       // Group management commands (Issue #486)
       'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group',
+      // Debug chat commands (Issue #487)
+      'set-debug', 'show-debug', 'clear-debug',
     ];
 
     if (trimmedText.startsWith('/')) {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -121,7 +121,11 @@ export type ControlCommandType =
   | 'remove-member'
   | 'list-member'
   | 'list-group'
-  | 'dissolve-group';
+  | 'dissolve-group'
+  // Debug chat commands (Issue #487)
+  | 'set-debug'
+  | 'show-debug'
+  | 'clear-debug';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -57,6 +57,8 @@ import {
   getMembers,
 } from '../platforms/feishu/chat-ops.js';
 import { GroupService, getGroupService } from '../platforms/feishu/group-service.js';
+// Debug chat (Issue #487)
+import { DebugChatService, getDebugChatService } from '../platforms/feishu/debug-chat-service.js';
 
 const logger = createLogger('PrimaryNode');
 
@@ -110,6 +112,9 @@ export class PrimaryNode extends EventEmitter {
   private feishuAppId?: string;
   private feishuAppSecret?: string;
 
+  // Debug chat (Issue #487)
+  private debugChatService: DebugChatService;
+
   constructor(config: PrimaryNodeConfig) {
     super();
     this.port = config.port || 3001;
@@ -120,6 +125,9 @@ export class PrimaryNode extends EventEmitter {
 
     // Initialize GroupService
     this.groupService = getGroupService();
+
+    // Initialize DebugChatService
+    this.debugChatService = getDebugChatService();
 
     // Store Feishu credentials for group management
     this.feishuAppId = config.appId || Config.FEISHU_APP_ID;
@@ -706,6 +714,49 @@ export class PrimaryNode extends EventEmitter {
           logger.error({ err: error }, 'Failed to dissolve group');
           return { success: false, error: `解散群失败: ${(error as Error).message}` };
         }
+      }
+
+      // Debug chat commands (Issue #487)
+      case 'set-debug': {
+        const previousChatId = this.debugChatService.setDebugChat(command.chatId);
+        if (previousChatId) {
+          return {
+            success: true,
+            message: `✅ **调试群已转移**\n\n从 \`${previousChatId}\` 转移至此群 (\`${command.chatId}\`)`,
+          };
+        }
+        return {
+          success: true,
+          message: `✅ **调试群已设置**\n\n此群 (\`${command.chatId}\`) 已设为调试群`,
+        };
+      }
+
+      case 'show-debug': {
+        const debugChatId = this.debugChatService.getDebugChat();
+        if (debugChatId) {
+          return {
+            success: true,
+            message: `📋 **当前调试群**\n\n群 ID: \`${debugChatId}\``,
+          };
+        }
+        return {
+          success: true,
+          message: '📋 **当前调试群**\n\n尚未设置调试群',
+        };
+      }
+
+      case 'clear-debug': {
+        const previousChatId = this.debugChatService.clearDebugChat();
+        if (previousChatId) {
+          return {
+            success: true,
+            message: `✅ **调试群已清除**\n\n原调试群: \`${previousChatId}\``,
+          };
+        }
+        return {
+          success: true,
+          message: '✅ **调试群已清除**\n\n（此前未设置调试群）',
+        };
       }
 
       default:

--- a/src/platforms/feishu/debug-chat-service.test.ts
+++ b/src/platforms/feishu/debug-chat-service.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for DebugChatService.
+ *
+ * @see Issue #487 - Debug chat configuration commands
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DebugChatService } from './debug-chat-service.js';
+
+describe('DebugChatService', () => {
+  let tempDir: string;
+  let testFilePath: string;
+  let service: DebugChatService;
+
+  beforeEach(() => {
+    // Create a temp directory for each test
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'debug-chat-service-test-'));
+    testFilePath = path.join(tempDir, 'debug-chat.json');
+    service = new DebugChatService({ filePath: testFilePath });
+  });
+
+  afterEach(() => {
+    // Cleanup temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('setDebugChat', () => {
+    it('should set debug chat', () => {
+      const previousChatId = service.setDebugChat('oc_test123');
+
+      expect(previousChatId).toBeNull();
+      expect(service.getDebugChat()).toBe('oc_test123');
+    });
+
+    it('should return previous chat ID when overwriting', () => {
+      service.setDebugChat('oc_first');
+      const previousChatId = service.setDebugChat('oc_second');
+
+      expect(previousChatId).toBe('oc_first');
+      expect(service.getDebugChat()).toBe('oc_second');
+    });
+
+    it('should persist config to file', () => {
+      service.setDebugChat('oc_test123');
+
+      // Create a new service instance to verify persistence
+      const newService = new DebugChatService({ filePath: testFilePath });
+      expect(newService.getDebugChat()).toBe('oc_test123');
+    });
+  });
+
+  describe('getDebugChat', () => {
+    it('should return null when not set', () => {
+      expect(service.getDebugChat()).toBeNull();
+    });
+
+    it('should return chat ID when set', () => {
+      service.setDebugChat('oc_test123');
+      expect(service.getDebugChat()).toBe('oc_test123');
+    });
+  });
+
+  describe('clearDebugChat', () => {
+    it('should clear debug chat', () => {
+      service.setDebugChat('oc_test123');
+      const previousChatId = service.clearDebugChat();
+
+      expect(previousChatId).toBe('oc_test123');
+      expect(service.getDebugChat()).toBeNull();
+    });
+
+    it('should return null when clearing non-existent config', () => {
+      const previousChatId = service.clearDebugChat();
+      expect(previousChatId).toBeNull();
+    });
+
+    it('should remove file when clearing', () => {
+      service.setDebugChat('oc_test123');
+      expect(fs.existsSync(testFilePath)).toBe(true);
+
+      service.clearDebugChat();
+      expect(fs.existsSync(testFilePath)).toBe(false);
+    });
+  });
+
+  describe('isDebugChat', () => {
+    it('should return true for debug chat', () => {
+      service.setDebugChat('oc_test123');
+      expect(service.isDebugChat('oc_test123')).toBe(true);
+    });
+
+    it('should return false for non-debug chat', () => {
+      service.setDebugChat('oc_test123');
+      expect(service.isDebugChat('oc_other')).toBe(false);
+    });
+
+    it('should return false when not set', () => {
+      expect(service.isDebugChat('oc_test123')).toBe(false);
+    });
+  });
+
+  describe('persistence', () => {
+    it('should handle corrupted file gracefully', () => {
+      // Write invalid JSON
+      fs.writeFileSync(testFilePath, 'not valid json');
+
+      // Should not throw and start with null config
+      const newService = new DebugChatService({ filePath: testFilePath });
+      expect(newService.getDebugChat()).toBeNull();
+    });
+
+    it('should handle missing file gracefully', () => {
+      const missingPath = path.join(tempDir, 'nonexistent', 'debug-chat.json');
+      const newService = new DebugChatService({ filePath: missingPath });
+
+      // Should start with null config
+      expect(newService.getDebugChat()).toBeNull();
+    });
+
+    it('should create directory if not exists', () => {
+      const nestedPath = path.join(tempDir, 'nested', 'dir', 'debug-chat.json');
+      const newService = new DebugChatService({ filePath: nestedPath });
+
+      newService.setDebugChat('oc_test');
+
+      expect(fs.existsSync(nestedPath)).toBe(true);
+    });
+
+    it('should handle file with empty chatId', () => {
+      // Write config with empty chatId
+      fs.writeFileSync(testFilePath, JSON.stringify({ chatId: '' }));
+
+      const newService = new DebugChatService({ filePath: testFilePath });
+      expect(newService.getDebugChat()).toBeNull();
+    });
+  });
+
+  describe('getFilePath', () => {
+    it('should return the configured file path', () => {
+      expect(service.getFilePath()).toBe(testFilePath);
+    });
+  });
+});

--- a/src/platforms/feishu/debug-chat-service.ts
+++ b/src/platforms/feishu/debug-chat-service.ts
@@ -1,0 +1,158 @@
+/**
+ * DebugChatService - Manages debug chat configuration.
+ *
+ * Provides a simple way to configure which chat receives debug-level messages.
+ * Uses singleton pattern - only one debug chat per instance.
+ * Stores configuration in workspace/debug-chat.json.
+ *
+ * @see Issue #487 - Debug chat configuration commands
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('DebugChatService');
+
+/**
+ * Debug chat configuration.
+ */
+interface DebugChatConfig {
+  /** Chat ID for debug messages */
+  chatId: string;
+}
+
+/**
+ * DebugChatService configuration.
+ */
+export interface DebugChatServiceConfig {
+  /** Storage file path (default: workspace/debug-chat.json) */
+  filePath?: string;
+}
+
+/**
+ * Service for managing debug chat configuration.
+ *
+ * Features:
+ * - Set/get/clear debug chat
+ * - Persistent storage
+ * - Singleton pattern (one debug chat per instance)
+ */
+export class DebugChatService {
+  private filePath: string;
+  private config: DebugChatConfig | null;
+
+  constructor(config: DebugChatServiceConfig = {}) {
+    this.filePath = config.filePath || path.join(process.cwd(), 'workspace', 'debug-chat.json');
+    this.config = this.load();
+  }
+
+  /**
+   * Load configuration from file.
+   */
+  private load(): DebugChatConfig | null {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const content = fs.readFileSync(this.filePath, 'utf-8');
+        const data = JSON.parse(content) as DebugChatConfig;
+        if (data.chatId) {
+          logger.info({ chatId: data.chatId }, 'Debug chat config loaded');
+          return data;
+        }
+      }
+    } catch (error) {
+      logger.warn({ err: error }, 'Failed to load debug chat config, starting fresh');
+    }
+    return null;
+  }
+
+  /**
+   * Save configuration to file.
+   */
+  private save(): void {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      if (this.config) {
+        fs.writeFileSync(this.filePath, JSON.stringify(this.config, null, 2));
+      } else {
+        // Remove file if no config
+        if (fs.existsSync(this.filePath)) {
+          fs.unlinkSync(this.filePath);
+        }
+      }
+      logger.debug({ config: this.config }, 'Debug chat config saved');
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to save debug chat config');
+    }
+  }
+
+  /**
+   * Set the debug chat.
+   * This will replace any existing debug chat.
+   *
+   * @param chatId - Chat ID to set as debug chat
+   * @returns Previous chat ID if there was one
+   */
+  setDebugChat(chatId: string): string | null {
+    const previousChatId = this.config?.chatId || null;
+    this.config = { chatId };
+    this.save();
+    logger.info({ chatId, previousChatId }, 'Debug chat set');
+    return previousChatId;
+  }
+
+  /**
+   * Get the current debug chat ID.
+   *
+   * @returns Debug chat ID or null if not set
+   */
+  getDebugChat(): string | null {
+    return this.config?.chatId || null;
+  }
+
+  /**
+   * Clear the debug chat configuration.
+   *
+   * @returns The previous chat ID if there was one
+   */
+  clearDebugChat(): string | null {
+    const previousChatId = this.config?.chatId || null;
+    this.config = null;
+    this.save();
+    logger.info({ previousChatId }, 'Debug chat cleared');
+    return previousChatId;
+  }
+
+  /**
+   * Check if a chat is the debug chat.
+   *
+   * @param chatId - Chat ID to check
+   * @returns Whether this is the debug chat
+   */
+  isDebugChat(chatId: string): boolean {
+    return this.config?.chatId === chatId;
+  }
+
+  /**
+   * Get the storage file path.
+   */
+  getFilePath(): string {
+    return this.filePath;
+  }
+}
+
+// Singleton instance for convenience
+let defaultInstance: DebugChatService | undefined;
+
+/**
+ * Get the default DebugChatService instance.
+ */
+export function getDebugChatService(): DebugChatService {
+  if (!defaultInstance) {
+    defaultInstance = new DebugChatService();
+  }
+  return defaultInstance;
+}

--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -24,3 +24,9 @@ export {
   type CreateDiscussionOptions,
   type ChatOpsConfig,
 } from './chat-ops.js';
+
+// Group Service (Issue #486)
+export { GroupService, getGroupService, type GroupInfo, type GroupServiceConfig } from './group-service.js';
+
+// Debug Chat Service (Issue #487)
+export { DebugChatService, getDebugChatService, type DebugChatServiceConfig } from './debug-chat-service.js';


### PR DESCRIPTION
## Summary

Implements #487 - Adds debug chat configuration commands for managing which chat receives debug-level messages.

## Commands

| Command | Description |
|---------|-------------|
| `/set-debug` | Set current chat as debug chat (auto-transfer from previous) |
| `/show-debug` | Display current debug chat |
| `/clear-debug` | Clear debug chat configuration |

## Usage Examples

### Set debug chat
```
User: /set-debug
Bot: ✅ 调试群已设置
     此群 (`oc_xxx`) 已设为调试群
```

### Transfer debug chat
```
User: /set-debug
Bot: ✅ 调试群已转移
     从 `oc_old` 转移至此群 (`oc_new`)
```

### Show debug chat
```
User: /show-debug
Bot: 📋 当前调试群
     群 ID: `oc_xxx`
```

### Clear debug chat
```
User: /clear-debug
Bot: ✅ 调试群已清除
     原调试群: `oc_xxx`
```

## Implementation

| File | Description |
|------|-------------|
| `src/platforms/feishu/debug-chat-service.ts` | DebugChatService for managing config |
| `src/platforms/feishu/debug-chat-service.test.ts` | 16 unit tests |
| `src/channels/types.ts` | Add command types |
| `src/channels/feishu-channel.ts` | Add commands to CONTROL_COMMANDS |
| `src/nodes/primary-node.ts` | Add command handlers |

## Design

- **Singleton pattern**: One debug chat per instance
- **Auto-transfer**: Multiple `/set-debug` calls automatically transfer
- **Persistent storage**: Config saved to `workspace/debug-chat.json`
- **Simple data**: Only stores `{ "chatId": "oc_xxx" }`

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 16 passed |
| Total tests | 1278 passed |
| Pre-existing failures | 1 (LOG_LEVEL test, unrelated) |
| Type Check | ✅ Pass |

Fixes #487

## Test plan

- [x] DebugChatService unit tests (16 tests)
- [x] All existing tests pass (except pre-existing failure)
- [x] Type check passes
- [ ] Manual test: `/set-debug` sets debug chat
- [ ] Manual test: `/show-debug` displays current debug chat
- [ ] Manual test: `/clear-debug` clears configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)