### PR TITLE
feat(feishu): add dynamic /help command with CommandRegistry (Issue #463)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -501,15 +501,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           });
           return;
         }
-
-        if (cmd === 'help') {
-          await this.sendMessage({
-            chatId: chat_id,
-            type: 'text',
-            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
-          });
-          return;
-        }
       }
     }
 

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -113,6 +113,7 @@ export type ControlCommandType =
   | 'reset'
   | 'restart'
   | 'status'
+  | 'help'
   | 'list-nodes'
   | 'switch-node'
   // Group management commands (Issue #486)

--- a/src/nodes/command-registry.test.ts
+++ b/src/nodes/command-registry.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for CommandRegistry.
+ *
+ * Issue #463: /help 指令 - 动态展示可用指令列表
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  CommandRegistry,
+  createDefaultCommandRegistry,
+  getCommandRegistry,
+  resetCommandRegistry,
+} from './command-registry.js';
+
+describe('CommandRegistry', () => {
+  let registry: CommandRegistry;
+
+  beforeEach(() => {
+    registry = new CommandRegistry();
+    resetCommandRegistry();
+  });
+
+  afterEach(() => {
+    resetCommandRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a command', () => {
+      registry.register({
+        name: 'test',
+        description: 'Test command',
+        category: 'session',
+      });
+
+      const cmd = registry.get('test');
+      expect(cmd).toBeDefined();
+      expect(cmd?.name).toBe('test');
+      expect(cmd?.description).toBe('Test command');
+      expect(cmd?.enabled).toBe(true);
+    });
+
+    it('should respect enabled flag', () => {
+      registry.register({
+        name: 'disabled',
+        description: 'Disabled command',
+        category: 'session',
+        enabled: false,
+      });
+
+      const cmd = registry.get('disabled');
+      expect(cmd?.enabled).toBe(false);
+    });
+  });
+
+  describe('registerAll', () => {
+    it('should register multiple commands', () => {
+      registry.registerAll([
+        { name: 'cmd1', description: 'Command 1', category: 'session' },
+        { name: 'cmd2', description: 'Command 2', category: 'group' },
+      ]);
+
+      expect(registry.get('cmd1')).toBeDefined();
+      expect(registry.get('cmd2')).toBeDefined();
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all enabled commands', () => {
+      registry.registerAll([
+        { name: 'enabled', description: 'Enabled', category: 'session' },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false },
+      ]);
+
+      const commands = registry.getAll();
+      expect(commands).toHaveLength(1);
+      expect(commands[0].name).toBe('enabled');
+    });
+  });
+
+  describe('getByCategory', () => {
+    it('should filter commands by category', () => {
+      registry.registerAll([
+        { name: 'session-cmd', description: 'Session', category: 'session' },
+        { name: 'group-cmd', description: 'Group', category: 'group' },
+        { name: 'debug-cmd', description: 'Debug', category: 'debug' },
+      ]);
+
+      const sessionCommands = registry.getByCategory('session');
+      expect(sessionCommands).toHaveLength(1);
+      expect(sessionCommands[0].name).toBe('session-cmd');
+    });
+  });
+
+  describe('getActiveCategories', () => {
+    it('should return categories in correct order', () => {
+      registry.registerAll([
+        { name: 'schedule-cmd', description: 'Schedule', category: 'schedule' },
+        { name: 'session-cmd', description: 'Session', category: 'session' },
+        { name: 'group-cmd', description: 'Group', category: 'group' },
+      ]);
+
+      const categories = registry.getActiveCategories();
+      expect(categories).toEqual(['session', 'group', 'schedule']);
+    });
+  });
+
+  describe('generateHelpText', () => {
+    it('should generate formatted help text', () => {
+      registry.registerAll([
+        { name: 'reset', description: '重置对话', category: 'session' },
+        { name: 'status', description: '查看状态', category: 'session' },
+        { name: 'create-group', description: '创建群', usage: 'create-group <name> <members>', category: 'group' },
+      ]);
+
+      const helpText = registry.generateHelpText();
+
+      expect(helpText).toContain('📋 **可用指令**');
+      expect(helpText).toContain('💬 对话：');
+      expect(helpText).toContain('- /reset - 重置对话');
+      expect(helpText).toContain('- /status - 查看状态');
+      expect(helpText).toContain('👥 群管理：');
+      expect(helpText).toContain('- /create-group <name> <members> - 创建群');
+    });
+
+    it('should not include disabled commands', () => {
+      registry.registerAll([
+        { name: 'enabled', description: 'Enabled', category: 'session' },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false },
+      ]);
+
+      const helpText = registry.generateHelpText();
+      expect(helpText).toContain('enabled');
+      expect(helpText).not.toContain('disabled');
+    });
+  });
+});
+
+describe('createDefaultCommandRegistry', () => {
+  it('should create registry with default commands', () => {
+    const registry = createDefaultCommandRegistry();
+
+    // Session commands
+    expect(registry.get('reset')).toBeDefined();
+    expect(registry.get('status')).toBeDefined();
+
+    // Node commands
+    expect(registry.get('list-nodes')).toBeDefined();
+    expect(registry.get('switch-node')).toBeDefined();
+    expect(registry.get('restart')).toBeDefined();
+
+    // Group commands
+    expect(registry.get('create-group')).toBeDefined();
+    expect(registry.get('add-member')).toBeDefined();
+    expect(registry.get('remove-member')).toBeDefined();
+    expect(registry.get('list-member')).toBeDefined();
+    expect(registry.get('list-group')).toBeDefined();
+    expect(registry.get('dissolve-group')).toBeDefined();
+  });
+
+  it('should generate help text with all categories', () => {
+    const registry = createDefaultCommandRegistry();
+    const helpText = registry.generateHelpText();
+
+    expect(helpText).toContain('💬 对话：');
+    expect(helpText).toContain('👥 群管理：');
+    expect(helpText).toContain('🖥️ 节点：');
+  });
+});
+
+describe('global registry', () => {
+  beforeEach(() => {
+    resetCommandRegistry();
+  });
+
+  afterEach(() => {
+    resetCommandRegistry();
+  });
+
+  it('should return a singleton registry', () => {
+    const registry1 = getCommandRegistry();
+    const registry2 = getCommandRegistry();
+    expect(registry1).toBe(registry2);
+  });
+
+  it('should reset to new registry', () => {
+    const registry1 = getCommandRegistry();
+    resetCommandRegistry();
+    const registry2 = getCommandRegistry();
+    expect(registry1).not.toBe(registry2);
+  });
+});

--- a/src/nodes/command-registry.ts
+++ b/src/nodes/command-registry.ts
@@ -1,0 +1,248 @@
+/**
+ * Command Registry - Dynamic command registration and discovery.
+ *
+ * Provides a centralized registry for control commands with:
+ * - Category-based organization
+ * - Dynamic command discovery
+ * - Help text generation
+ *
+ * Issue #463: /help 指令 - 动态展示可用指令列表
+ */
+
+import type { ControlCommandType } from '../channels/types.js';
+
+/**
+ * Command category for grouping related commands.
+ */
+export type CommandCategory = 'session' | 'group' | 'debug' | 'node' | 'task' | 'schedule' | 'skill';
+
+/**
+ * Command definition with metadata.
+ */
+export interface CommandDefinition {
+  /** Command name (without /) */
+  name: ControlCommandType | string;
+
+  /** Brief description for help text */
+  description: string;
+
+  /** Usage example */
+  usage?: string;
+
+  /** Category for grouping */
+  category: CommandCategory;
+
+  /** Whether command is enabled */
+  enabled?: boolean;
+}
+
+/**
+ * Category display names and order.
+ */
+const CATEGORY_INFO: Record<CommandCategory, { label: string; emoji: string; order: number }> = {
+  session: { label: '对话', emoji: '💬', order: 1 },
+  debug: { label: '调试', emoji: '🔧', order: 2 },
+  group: { label: '群管理', emoji: '👥', order: 3 },
+  node: { label: '节点', emoji: '🖥️', order: 4 },
+  task: { label: '任务', emoji: '📋', order: 5 },
+  schedule: { label: '定时', emoji: '⏰', order: 6 },
+  skill: { label: '技能', emoji: '🎯', order: 7 },
+};
+
+/**
+ * Command Registry - Manages control command definitions.
+ */
+export class CommandRegistry {
+  private commands: Map<string, CommandDefinition> = new Map();
+
+  /**
+   * Register a command definition.
+   */
+  register(command: CommandDefinition): void {
+    this.commands.set(command.name, {
+      ...command,
+      enabled: command.enabled !== false,
+    });
+  }
+
+  /**
+   * Register multiple commands at once.
+   */
+  registerAll(commands: CommandDefinition[]): void {
+    for (const cmd of commands) {
+      this.register(cmd);
+    }
+  }
+
+  /**
+   * Get a command definition by name.
+   */
+  get(name: string): CommandDefinition | undefined {
+    return this.commands.get(name);
+  }
+
+  /**
+   * Get all registered commands.
+   */
+  getAll(): CommandDefinition[] {
+    return Array.from(this.commands.values()).filter(cmd => cmd.enabled !== false);
+  }
+
+  /**
+   * Get commands by category.
+   */
+  getByCategory(category: CommandCategory): CommandDefinition[] {
+    return this.getAll().filter(cmd => cmd.category === category);
+  }
+
+  /**
+   * Get all categories that have commands.
+   */
+  getActiveCategories(): CommandCategory[] {
+    const categories = new Set<CommandCategory>();
+    for (const cmd of this.getAll()) {
+      categories.add(cmd.category);
+    }
+    return Array.from(categories).sort((a, b) => {
+      const orderA = CATEGORY_INFO[a]?.order || 99;
+      const orderB = CATEGORY_INFO[b]?.order || 99;
+      return orderA - orderB;
+    });
+  }
+
+  /**
+   * Generate help text with all commands grouped by category.
+   */
+  generateHelpText(): string {
+    const lines: string[] = ['📋 **可用指令**', ''];
+
+    const categories = this.getActiveCategories();
+
+    for (const category of categories) {
+      const info = CATEGORY_INFO[category];
+      if (!info) continue;
+
+      const commands = this.getByCategory(category);
+      if (commands.length === 0) continue;
+
+      lines.push(`${info.emoji} ${info.label}：`);
+
+      for (const cmd of commands) {
+        if (cmd.usage) {
+          lines.push(`- /${cmd.usage} - ${cmd.description}`);
+        } else {
+          lines.push(`- /${cmd.name} - ${cmd.description}`);
+        }
+      }
+
+      lines.push('');
+    }
+
+    // Remove trailing empty line
+    if (lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+
+    return lines.join('\n');
+  }
+}
+
+/**
+ * Default command registry with built-in commands.
+ */
+export function createDefaultCommandRegistry(): CommandRegistry {
+  const registry = new CommandRegistry();
+
+  registry.registerAll([
+    // Session commands
+    {
+      name: 'reset',
+      description: '重置对话',
+      category: 'session',
+    },
+    {
+      name: 'status',
+      description: '查看状态',
+      category: 'session',
+    },
+
+    // Node commands
+    {
+      name: 'list-nodes',
+      description: '列出执行节点',
+      category: 'node',
+    },
+    {
+      name: 'switch-node',
+      usage: 'switch-node <nodeId>',
+      description: '切换执行节点',
+      category: 'node',
+    },
+    {
+      name: 'restart',
+      description: '重启服务',
+      category: 'node',
+    },
+
+    // Group management commands (Issue #486)
+    {
+      name: 'create-group',
+      usage: 'create-group <name> <members>',
+      description: '创建群',
+      category: 'group',
+    },
+    {
+      name: 'add-member',
+      usage: 'add-member <groupId> <member>',
+      description: '添加成员',
+      category: 'group',
+    },
+    {
+      name: 'remove-member',
+      usage: 'remove-member <groupId> <member>',
+      description: '移除成员',
+      category: 'group',
+    },
+    {
+      name: 'list-member',
+      usage: 'list-member <groupId>',
+      description: '列出成员',
+      category: 'group',
+    },
+    {
+      name: 'list-group',
+      description: '列出群',
+      category: 'group',
+    },
+    {
+      name: 'dissolve-group',
+      usage: 'dissolve-group <groupId>',
+      description: '解散群',
+      category: 'group',
+    },
+  ]);
+
+  return registry;
+}
+
+/**
+ * Global command registry instance.
+ */
+let globalRegistry: CommandRegistry | undefined;
+
+/**
+ * Get the global command registry.
+ */
+export function getCommandRegistry(): CommandRegistry {
+  if (!globalRegistry) {
+    globalRegistry = createDefaultCommandRegistry();
+  }
+  return globalRegistry;
+}
+
+/**
+ * Reset the global registry (for testing).
+ */
+export function resetCommandRegistry(): void {
+  globalRegistry = undefined;
+}

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -57,6 +57,8 @@ import {
   getMembers,
 } from '../platforms/feishu/chat-ops.js';
 import { GroupService, getGroupService } from '../platforms/feishu/group-service.js';
+// Command registry (Issue #463)
+import { getCommandRegistry } from './command-registry.js';
 
 const logger = createLogger('PrimaryNode');
 
@@ -513,6 +515,11 @@ export class PrimaryNode extends EventEmitter {
           success: true,
           message: `📊 **状态**\n\n状态: ${status}\n节点ID: ${this.localNodeId}\n执行节点: ${execStatus}\n当前节点: ${currentNode?.name || '未分配'}\n通道: ${channelStatus}`,
         };
+      }
+
+      case 'help': {
+        const registry = getCommandRegistry();
+        return { success: true, message: registry.generateHelpText() };
       }
 
       case 'list-nodes': {


### PR DESCRIPTION
## Summary

Implements #463 - Adds a dynamic /help command that displays all available control commands grouped by category.

## Changes

| File | Description |
|------|-------------|
| `src/nodes/command-registry.ts` | CommandRegistry service for dynamic command discovery |
| `src/nodes/command-registry.test.ts` | 12 unit tests for CommandRegistry |
| `src/channels/types.ts` | Add 'help' to ControlCommandType |
| `src/channels/feishu-channel.ts` | Remove hardcoded help handler |
| `src/nodes/primary-node.ts` | Add help command handler using CommandRegistry |

## Features

### CommandRegistry
- Dynamic command registration with metadata
- Category-based organization (session, group, debug, node, etc.)
- Help text generation with emoji and grouping

### /help Command Output
```
📋 **可用指令**

💬 对话：
- /reset - 重置对话
- /status - 查看状态

👥 群管理：
- /create-group <name> <members> - 创建群
- /add-member <groupId> <member> - 添加成员
- /remove-member <groupId> <member> - 移除成员
- /list-member <groupId> - 列出成员
- /list-group - 列出群
- /dissolve-group <groupId> - 解散群

🖥️ 节点：
- /list-nodes - 列出执行节点
- /switch-node <nodeId> - 切换执行节点
- /restart - 重启服务
```

## Design Principles (per Issue #463)
- **Dynamic discovery** - Commands are fetched from registry, not hardcoded
- **/help trigger** - User-initiated, no auto-send
- **No greeting detection** - Removed "你好"/"hi" trigger logic

## Related

- Issue #463: feat: /help 指令 - 动态展示可用指令列表
- Supersedes: PR #467 (closed - implementation direction needed adjustment)

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 12 passed |
| Total tests | 1274 passed |
| Pre-existing failures | 1 (LOG_LEVEL test, unrelated) |
| Type Check | ✅ Pass |

## Test plan

- [x] CommandRegistry unit tests (12 tests)
- [x] All existing tests pass (except pre-existing failure)
- [x] Type check passes
- [ ] Manual test: `/help` shows all available commands
- [ ] Manual test: Commands are grouped by category

🤖 Generated with [Claude Code](https://claude.com/claude-code)