### PR TITLE
feat(feishu): add debug group control commands (Issue #487)

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -121,7 +121,11 @@ export type ControlCommandType =
   | 'remove-member'
   | 'list-member'
   | 'list-group'
-  | 'dissolve-group';
+  | 'dissolve-group'
+  // Debug group commands (Issue #487)
+  | 'set-debug'
+  | 'show-debug'
+  | 'clear-debug';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/debug-group-service.test.ts
+++ b/src/nodes/debug-group-service.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for DebugGroupService.
+ *
+ * @see Issue #487
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DebugGroupService, getDebugGroupService } from './debug-group-service.js';
+
+describe('DebugGroupService', () => {
+  let service: DebugGroupService;
+
+  beforeEach(() => {
+    // Create a fresh instance for each test
+    service = new DebugGroupService();
+  });
+
+  describe('setDebugGroup', () => {
+    it('should set the debug group', () => {
+      const previous = service.setDebugGroup('oc_test123', 'Test Group');
+
+      expect(previous).toBeNull();
+
+      const current = service.getDebugGroup();
+      expect(current).not.toBeNull();
+      expect(current?.chatId).toBe('oc_test123');
+      expect(current?.name).toBe('Test Group');
+      expect(current?.setAt).toBeGreaterThan(0);
+    });
+
+    it('should return previous group when overwriting', () => {
+      service.setDebugGroup('oc_first', 'First Group');
+      const previous = service.setDebugGroup('oc_second', 'Second Group');
+
+      expect(previous).not.toBeNull();
+      expect(previous?.chatId).toBe('oc_first');
+      expect(previous?.name).toBe('First Group');
+
+      const current = service.getDebugGroup();
+      expect(current?.chatId).toBe('oc_second');
+    });
+
+    it('should work without a name', () => {
+      const previous = service.setDebugGroup('oc_noname');
+
+      expect(previous).toBeNull();
+
+      const current = service.getDebugGroup();
+      expect(current?.chatId).toBe('oc_noname');
+      expect(current?.name).toBeUndefined();
+    });
+  });
+
+  describe('getDebugGroup', () => {
+    it('should return null when no group is set', () => {
+      expect(service.getDebugGroup()).toBeNull();
+    });
+
+    it('should return the current debug group', () => {
+      service.setDebugGroup('oc_current', 'Current Group');
+
+      const current = service.getDebugGroup();
+      expect(current?.chatId).toBe('oc_current');
+      expect(current?.name).toBe('Current Group');
+    });
+  });
+
+  describe('clearDebugGroup', () => {
+    it('should return null when no group is set', () => {
+      const previous = service.clearDebugGroup();
+      expect(previous).toBeNull();
+    });
+
+    it('should clear the debug group and return previous', () => {
+      service.setDebugGroup('oc_to_clear', 'To Clear');
+
+      const previous = service.clearDebugGroup();
+      expect(previous?.chatId).toBe('oc_to_clear');
+      expect(service.getDebugGroup()).toBeNull();
+    });
+  });
+
+  describe('isDebugGroup', () => {
+    it('should return false when no group is set', () => {
+      expect(service.isDebugGroup('oc_any')).toBe(false);
+    });
+
+    it('should return true for the debug group chat ID', () => {
+      service.setDebugGroup('oc_debug');
+
+      expect(service.isDebugGroup('oc_debug')).toBe(true);
+      expect(service.isDebugGroup('oc_other')).toBe(false);
+    });
+  });
+});
+
+describe('getDebugGroupService', () => {
+  it('should return a singleton instance', () => {
+    const instance1 = getDebugGroupService();
+    const instance2 = getDebugGroupService();
+
+    expect(instance1).toBe(instance2);
+  });
+});

--- a/src/nodes/debug-group-service.ts
+++ b/src/nodes/debug-group-service.ts
@@ -1,0 +1,101 @@
+/**
+ * Debug Group Service - Manages the debug group setting.
+ *
+ * This service provides a simple in-memory storage for the debug group chat ID.
+ * The debug group is where debug-level messages are sent.
+ *
+ * Features:
+ * - Single instance pattern - only one debug group per bot instance
+ * - Memory-only storage - resets on restart
+ * - Automatic transfer - setting a new group overwrites the previous one
+ *
+ * @see Issue #487
+ */
+
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('DebugGroupService');
+
+/**
+ * Debug group configuration.
+ */
+export interface DebugGroupInfo {
+  /** The chat ID of the debug group */
+  chatId: string;
+
+  /** The name of the debug group (if available) */
+  name?: string;
+
+  /** When the debug group was set */
+  setAt: number;
+}
+
+/**
+ * Debug Group Service - manages the debug group setting.
+ */
+export class DebugGroupService {
+  private debugGroup: DebugGroupInfo | null = null;
+
+  /**
+   * Set the debug group.
+   * @param chatId - The chat ID of the debug group
+   * @param name - Optional name of the group
+   * @returns The previous debug group info if there was one, null otherwise
+   */
+  setDebugGroup(chatId: string, name?: string): DebugGroupInfo | null {
+    const previous = this.debugGroup;
+
+    this.debugGroup = {
+      chatId,
+      name,
+      setAt: Date.now(),
+    };
+
+    logger.info({ chatId, name, previousChatId: previous?.chatId }, 'Debug group set');
+
+    return previous;
+  }
+
+  /**
+   * Get the current debug group info.
+   * @returns The current debug group info, or null if not set
+   */
+  getDebugGroup(): DebugGroupInfo | null {
+    return this.debugGroup;
+  }
+
+  /**
+   * Clear the debug group setting.
+   * @returns The previous debug group info if there was one, null otherwise
+   */
+  clearDebugGroup(): DebugGroupInfo | null {
+    const previous = this.debugGroup;
+    this.debugGroup = null;
+
+    logger.info({ previousChatId: previous?.chatId }, 'Debug group cleared');
+
+    return previous;
+  }
+
+  /**
+   * Check if a chat ID is the debug group.
+   * @param chatId - The chat ID to check
+   * @returns True if the chat ID is the debug group
+   */
+  isDebugGroup(chatId: string): boolean {
+    return this.debugGroup?.chatId === chatId;
+  }
+}
+
+// Singleton instance
+let debugGroupService: DebugGroupService | null = null;
+
+/**
+ * Get the singleton DebugGroupService instance.
+ */
+export function getDebugGroupService(): DebugGroupService {
+  if (!debugGroupService) {
+    debugGroupService = new DebugGroupService();
+  }
+  return debugGroupService;
+}

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -57,6 +57,8 @@ import {
   getMembers,
 } from '../platforms/feishu/chat-ops.js';
 import { GroupService, getGroupService } from '../platforms/feishu/group-service.js';
+// Debug group (Issue #487)
+import { getDebugGroupService } from './debug-group-service.js';
 
 const logger = createLogger('PrimaryNode');
 
@@ -706,6 +708,59 @@ export class PrimaryNode extends EventEmitter {
           logger.error({ err: error }, 'Failed to dissolve group');
           return { success: false, error: `解散群失败: ${(error as Error).message}` };
         }
+      }
+
+      // Debug group commands (Issue #487)
+      case 'set-debug': {
+        const debugGroupService = getDebugGroupService();
+        const previous = debugGroupService.setDebugGroup(command.chatId);
+
+        if (previous) {
+          return {
+            success: true,
+            message: `✅ **调试群已转移**\n\n从 \`${previous.chatId}\` 转移至此群 (\`${command.chatId}\`)`,
+          };
+        }
+
+        return {
+          success: true,
+          message: `✅ **调试群已设置**\n\n此群 (\`${command.chatId}\`) 已设为调试群`,
+        };
+      }
+
+      case 'show-debug': {
+        const debugGroupService = getDebugGroupService();
+        const current = debugGroupService.getDebugGroup();
+
+        if (!current) {
+          return {
+            success: true,
+            message: '📋 **调试群状态**\n\n尚未设置调试群\n\n使用 `/set-debug` 设置当前群为调试群',
+          };
+        }
+
+        const setAt = new Date(current.setAt).toLocaleString('zh-CN');
+        return {
+          success: true,
+          message: `📋 **调试群状态**\n\n群 ID: \`${current.chatId}\`\n设置时间: ${setAt}`,
+        };
+      }
+
+      case 'clear-debug': {
+        const debugGroupService = getDebugGroupService();
+        const previous = debugGroupService.clearDebugGroup();
+
+        if (!previous) {
+          return {
+            success: true,
+            message: '📋 **调试群状态**\n\n没有设置调试群，无需清除',
+          };
+        }
+
+        return {
+          success: true,
+          message: `✅ **调试群已清除**\n\n原调试群: \`${previous.chatId}\``,
+        };
       }
 
       default:


### PR DESCRIPTION
## Summary

Implements #487 - Adds debug group control commands for managing the debug group setting where debug-level messages are sent.

## New Commands

| Command | Description |
|---------|-------------|
| `/set-debug` | Set current group as debug group |
| `/show-debug` | Show current debug group status |
| `/clear-debug` | Clear debug group setting |

## Features

- **Single instance pattern** - Only one debug group per bot instance
- **Memory-only storage** - Resets on restart (as designed)
- **Automatic transfer** - Setting a new group overwrites the previous one

## Changes

| File | Description |
|------|-------------|
| `src/nodes/debug-group-service.ts` | New service for managing debug group |
| `src/nodes/debug-group-service.test.ts` | 10 unit tests for DebugGroupService |
| `src/channels/types.ts` | Add 'set-debug', 'show-debug', 'clear-debug' to ControlCommandType |
| `src/nodes/primary-node.ts` | Add command handlers for debug group commands |

## Usage Example

```
User: /set-debug
Bot: ✅ **调试群已设置**
     此群 (`oc_xxx`) 已设为调试群

User: /show-debug
Bot: 📋 **调试群状态**
     群 ID: `oc_xxx`
     设置时间: 2026/3/3 09:14:00

User: /clear-debug
Bot: ✅ **调试群已清除**
     原调试群: `oc_xxx`
```

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 10 passed |
| Total tests | 1272 passed |
| Pre-existing failures | 1 (LOG_LEVEL test, unrelated) |
| Type Check | ✅ Pass |

Fixes #487

## Test plan

- [x] DebugGroupService unit tests (10 tests)
- [x] All existing tests pass (except pre-existing failure)
- [x] Type check passes
- [ ] Manual test: `/set-debug` sets current group as debug group
- [ ] Manual test: `/show-debug` shows current debug group status
- [ ] Manual test: `/clear-debug` clears debug group setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)