### PR TITLE
feat(schedule): add schedule control commands (Issue #469)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -449,6 +449,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       'reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
       // Group management commands (Issue #486)
       'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group',
+      // Schedule control commands (Issue #469)
+      'schedule',
     ];
 
     if (trimmedText.startsWith('/')) {

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -125,7 +125,9 @@ export type ControlCommandType =
   // Debug group commands (Issue #487)
   | 'set-debug'
   | 'show-debug'
-  | 'clear-debug';
+  | 'clear-debug'
+  // Schedule control commands (Issue #469)
+  | 'schedule';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -763,6 +763,133 @@ export class PrimaryNode extends EventEmitter {
         };
       }
 
+      // Schedule control commands (Issue #469)
+      case 'schedule': {
+        if (!this.schedulerService) {
+          return { success: false, error: '调度器服务未初始化' };
+        }
+
+        const args = command.data?.args as string[] | undefined;
+        const subCommand = args?.[0]?.toLowerCase();
+
+        if (!subCommand) {
+          return {
+            success: false,
+            error: '用法: `/schedule <list|enable|disable|run|status> [taskId]`\n\n示例:\n- `/schedule list` - 列出所有定时任务\n- `/schedule enable schedule-daily` - 启用任务\n- `/schedule disable schedule-daily` - 禁用任务\n- `/schedule run schedule-daily` - 手动触发任务\n- `/schedule status schedule-daily` - 查看任务状态',
+          };
+        }
+
+        switch (subCommand) {
+          case 'list': {
+            const tasks = await this.schedulerService.listSchedules();
+            if (tasks.length === 0) {
+              return { success: true, message: '📋 **定时任务列表**\n\n暂无定时任务' };
+            }
+
+            const enabledCount = tasks.filter(t => t.enabled).length;
+            const disabledCount = tasks.length - enabledCount;
+            const scheduler = this.schedulerService.getScheduler();
+
+            const taskList = tasks.map(t => {
+              const status = t.enabled ? '✅' : '⏸️';
+              const running = scheduler?.isTaskRunning(t.id) ? ' 🔄' : '';
+              return `- ${status} \`${t.id}\` - ${t.name} (\`${t.cron}\`)${running}`;
+            }).join('\n');
+
+            return {
+              success: true,
+              message: `📋 **定时任务列表**\n\n任务数: ${tasks.length} (启用: ${enabledCount}, 禁用: ${disabledCount})\n\n${taskList}`,
+            };
+          }
+
+          case 'enable': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule enable <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.enableSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            return { success: true, message: `✅ **定时任务已启用**\n\n任务: ${task.name}\nID: \`${taskId}\`` };
+          }
+
+          case 'disable': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule disable <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.disableSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            return { success: true, message: `⏸️ **定时任务已禁用**\n\n任务: ${task.name}\nID: \`${taskId}\`` };
+          }
+
+          case 'run': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule run <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.getSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            // Run the task asynchronously
+            this.schedulerService.runSchedule(taskId, command.chatId).then(success => {
+              if (success) {
+                logger.info({ taskId }, 'Manual schedule run completed');
+              }
+            }).catch(error => {
+              logger.error({ err: error, taskId }, 'Manual schedule run failed');
+            });
+
+            return { success: true, message: `🔄 **定时任务已触发**\n\n任务: ${task.name}\nID: \`${taskId}\`\n\n执行结果将发送到此会话` };
+          }
+
+          case 'status': {
+            const taskId = args?.[1];
+
+            if (taskId) {
+              const status = await this.schedulerService.getScheduleStatus(taskId);
+              if (!status.task) {
+                return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+              }
+
+              const task = status.task;
+              const enabledStatus = task.enabled ? '✅ 已启用' : '⏸️ 已禁用';
+              const runningStatus = status.isCurrentlyRunning ? '\n执行中: 🔄 是' : '';
+              const blockingStatus = task.blocking ? '是' : '否';
+              const createdAt = new Date(task.createdAt).toLocaleString('zh-CN');
+
+              return {
+                success: true,
+                message: `📋 **定时任务状态**\n\n**名称**: ${task.name}\n**ID**: \`${task.id}\`\n**状态**: ${enabledStatus}${runningStatus}\n**Cron**: \`${task.cron}\`\n**阻塞模式**: ${blockingStatus}\n**创建时间**: ${createdAt}`,
+              };
+            }
+
+            // Show scheduler status
+            const status = await this.schedulerService.getScheduleStatus();
+            return {
+              success: true,
+              message: `📋 **调度器状态**\n\n运行中: ${status.running ? '✅' : '❌'}\n活跃任务: ${status.activeJobsCount ?? 0}`,
+            };
+          }
+
+          default:
+            return {
+              success: false,
+              error: `未知的 schedule 子命令: \`${subCommand}\`\n\n可用子命令: list, enable, disable, run, status`,
+            };
+        }
+      }
+
       default:
         return { success: false, error: `Unknown command: ${command.type}` };
     }

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -5,6 +5,7 @@
  * - Scheduler initialization and lifecycle
  * - Schedule file watching for hot reload
  * - Callbacks for schedule execution
+ * - Schedule CRUD operations (list, enable, disable, run)
  *
  * Architecture:
  * ```
@@ -21,9 +22,11 @@ import {
   ScheduleManager,
   Scheduler,
   ScheduleFileWatcher,
+  ScheduleFileScanner,
 } from '../schedule/index.js';
 import type { FeedbackMessage } from '../types/websocket-messages.js';
 import type { ChatAgent } from '../agents/types.js';
+import type { ScheduledTask } from '../schedule/schedule-manager.js';
 
 const logger = createLogger('SchedulerService');
 
@@ -66,6 +69,7 @@ interface FeedbackContext {
  * - Scheduler initialization
  * - Schedule file watching
  * - Feedback channel management
+ * - Schedule CRUD operations
  */
 export class SchedulerService {
   private readonly callbacks: SchedulerCallbacks;
@@ -73,6 +77,7 @@ export class SchedulerService {
   private readonly activeFeedbackChannels = new Map<string, FeedbackContext>();
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
+  private fileScanner: ScheduleFileScanner;
   private schedulesDir: string;
 
   constructor(config: SchedulerServiceConfig) {
@@ -81,6 +86,7 @@ export class SchedulerService {
 
     const workspaceDir = Config.getWorkspaceDir();
     this.schedulesDir = path.join(workspaceDir, 'schedules');
+    this.fileScanner = new ScheduleFileScanner({ schedulesDir: this.schedulesDir });
   }
 
   /**
@@ -189,5 +195,160 @@ export class SchedulerService {
    */
   getScheduler(): Scheduler | undefined {
     return this.scheduler;
+  }
+
+  // ============================================================================
+  // Schedule CRUD Operations (Issue #469)
+  // ============================================================================
+
+  /**
+   * List all scheduled tasks.
+   *
+   * @returns Array of all scheduled tasks
+   */
+  async listSchedules(): Promise<ScheduledTask[]> {
+    const tasks = await this.fileScanner.scanAll();
+    return tasks.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Get a schedule by ID.
+   *
+   * @param taskId - Task ID
+   * @returns The task or undefined if not found
+   */
+  async getSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const tasks = await this.fileScanner.scanAll();
+    return tasks.find(t => t.id === taskId);
+  }
+
+  /**
+   * Enable a scheduled task.
+   *
+   * @param taskId - Task ID to enable
+   * @returns The updated task or undefined if not found
+   */
+  async enableSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return undefined;
+    }
+
+    if (task.enabled) {
+      return task; // Already enabled
+    }
+
+    // Update the task file
+    const updatedTask: ScheduledTask = { ...task, enabled: true };
+    await this.fileScanner.writeTask(updatedTask);
+
+    logger.info({ taskId, name: task.name }, 'Schedule enabled');
+    return updatedTask;
+  }
+
+  /**
+   * Disable a scheduled task.
+   *
+   * @param taskId - Task ID to disable
+   * @returns The updated task or undefined if not found
+   */
+  async disableSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return undefined;
+    }
+
+    if (!task.enabled) {
+      return task; // Already disabled
+    }
+
+    // Update the task file
+    const updatedTask: ScheduledTask = { ...task, enabled: false };
+    await this.fileScanner.writeTask(updatedTask);
+
+    // Remove from scheduler immediately
+    this.scheduler?.removeTask(taskId);
+
+    logger.info({ taskId, name: task.name }, 'Schedule disabled');
+    return updatedTask;
+  }
+
+  /**
+   * Manually trigger a scheduled task.
+   *
+   * @param taskId - Task ID to run
+   * @param chatId - Chat ID to send results to (optional, defaults to task's chatId)
+   * @returns true if task was triggered, false if not found
+   */
+  async runSchedule(taskId: string, chatId?: string): Promise<boolean> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return false;
+    }
+
+    // Use provided chatId or task's chatId
+    const targetChatId = chatId || task.chatId;
+
+    // Execute the task
+    logger.info({ taskId, name: task.name, chatId: targetChatId }, 'Manually triggering schedule');
+
+    // Set up feedback channel
+    if (this.scheduler) {
+      // Send start notification
+      await this.callbacks.sendMessage(targetChatId, `🔄 手动触发定时任务「${task.name}」...`);
+
+      try {
+        // Execute task using Pilot's executeOnce method
+        await this.pilot.executeOnce(
+          targetChatId,
+          task.prompt,
+          undefined,
+          undefined
+        );
+
+        logger.info({ taskId }, 'Manually triggered schedule completed');
+        return true;
+
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.error({ err: error, taskId }, 'Manually triggered schedule failed');
+
+        // Send error notification
+        await this.callbacks.sendMessage(
+          targetChatId,
+          `❌ 定时任务「${task.name}」执行失败: ${errorMessage}`
+        );
+        return false;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get schedule status.
+   *
+   * @param taskId - Task ID (optional, if not provided returns scheduler status)
+   * @returns Schedule status info
+   */
+  async getScheduleStatus(taskId?: string): Promise<{
+    running: boolean;
+    task?: ScheduledTask;
+    isCurrentlyRunning?: boolean;
+    activeJobsCount?: number;
+  }> {
+    if (taskId) {
+      const task = await this.getSchedule(taskId);
+      return {
+        running: this.scheduler?.isRunning() ?? false,
+        task,
+        isCurrentlyRunning: this.scheduler?.isTaskRunning(taskId) ?? false,
+      };
+    }
+
+    return {
+      running: this.scheduler?.isRunning() ?? false,
+      activeJobsCount: this.scheduler?.getActiveJobs().length ?? 0,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Implements #469 - Adds schedule control commands for managing scheduled tasks through Feishu conversations.

Based on the feedback from closed PRs #473 and #494 (both closed due to merge conflicts), this implementation recreates the functionality on a fresh branch.

## New Commands

| Command | Description |
|---------|-------------|
| `/schedule list` | List all scheduled tasks |
| `/schedule enable <taskId>` | Enable a scheduled task |
| `/schedule disable <taskId>` | Disable a scheduled task |
| `/schedule run <taskId>` | Manually trigger a task |
| `/schedule status [taskId]` | View scheduler or task status |

## Usage Examples

### List all schedules
```
User: /schedule list
Bot: 📋 **定时任务列表**

     任务数: 2 (启用: 2, 禁用: 0)

     - ✅ `schedule-daily-report` - 每日报告 (`0 9 * * *`)
     - ✅ `schedule-weekly-summary` - 每周汇总 (`0 9 * * 1`)
```

### Enable/Disable a schedule
```
User: /schedule enable schedule-weekly-summary
Bot: ✅ **定时任务已启用**

     任务: 每周汇总
     ID: `schedule-weekly-summary`
```

### View schedule status
```
User: /schedule status schedule-daily-report
Bot: 📋 **定时任务状态**

     **名称**: 每日报告
     **ID**: `schedule-daily-report`
     **状态**: ✅ 已启用
     **Cron**: `0 9 * * *`
     **阻塞模式**: 是
     **创建时间**: 2026/3/1 09:00:00
```

### Manually trigger a schedule
```
User: /schedule run schedule-daily-report
Bot: 🔄 **定时任务已触发**

     任务: 每日报告
     ID: `schedule-daily-report`

     执行结果将发送到此会话
```

## Changes

| File | Description |
|------|-------------|
| `src/channels/types.ts` | Add 'schedule' to ControlCommandType |
| `src/channels/feishu-channel.ts` | Add 'schedule' to CONTROL_COMMANDS array |
| `src/nodes/scheduler-service.ts` | Add schedule CRUD methods (list, enable, disable, run, status) |
| `src/nodes/primary-node.ts` | Add schedule command handler |

## Test Results

| Metric | Value |
|--------|-------|
| Total tests | 1272 passed, 1 failed (pre-existing), 8 skipped |
| Type Check | ✅ Pass |

Note: The 1 failed test (`Config > Default Values > should have default LOG_LEVEL`) is a pre-existing issue unrelated to this change.

## Related

- Issue #469: feat: 定时任务控制指令 - schedule 管理
- PR #473: (Closed) feat(schedule): add schedule control commands - closed due to merge conflicts
- PR #494: (Closed) feat(schedule): add schedule control commands - closed due to merge conflicts

Fixes #469

## Test plan

- [x] TypeScript compilation passes
- [x] All existing tests pass (except pre-existing failure)
- [ ] Manual test: `/schedule list` shows all schedules
- [ ] Manual test: `/schedule enable/disable` toggles schedule state
- [ ] Manual test: `/schedule run` triggers task execution
- [ ] Manual test: `/schedule status` shows task details

🤖 Generated with [Claude Code](https://claude.com/claude-code)