### PR TITLE
fix(feishu): use chat_type for accurate group chat detection (Issue #508)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -266,13 +266,25 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
   /**
    * Check if the chat is a group chat.
-   * In Feishu, group chat IDs start with 'oc_'.
+   * Uses chat_type from Feishu message event for accurate detection.
+   * Falls back to chatId prefix check if chat_type is not available.
    *
-   * @param chatId - Chat ID to check
+   * @param chatType - Chat type from Feishu message event (p2p, group, topic)
+   * @param chatId - Chat ID to check (used as fallback)
    * @returns true if it's a group chat
    */
-  private isGroupChat(chatId: string): boolean {
-    return chatId.startsWith('oc_');
+  private isGroupChat(chatType?: string, chatId?: string): boolean {
+    // Use chat_type if available (accurate method)
+    if (chatType) {
+      return chatType === 'group' || chatType === 'topic';
+    }
+    // Fallback to chatId prefix check (less accurate, private chats can also start with 'oc_')
+    // This maintains backward compatibility for cases where chat_type is not provided
+    if (chatId) {
+      return chatId.startsWith('oc_');
+    }
+    // Default to false (treat as private chat) if no information available
+    return false;
   }
 
   /**
@@ -311,7 +323,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     if (!message) {return;}
 
-    const { message_id, chat_id, content, message_type, create_time, mentions } = message;
+    const { message_id, chat_id, content, message_type, create_time, mentions, chat_type } = message;
 
     // Bot replies to user message by setting parent_id = message_id
     // Feishu automatically handles thread affiliation
@@ -521,9 +533,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #460: Group chat passive mode
     // In group chats, only respond when bot is mentioned (@bot)
     // This allows scheduled tasks to broadcast without triggering unwanted responses
-    if (this.isGroupChat(chat_id) && !botMentioned) {
+    if (this.isGroupChat(chat_type, chat_id) && !botMentioned) {
       logger.debug(
-        { messageId: message_id, chatId: chat_id },
+        { messageId: message_id, chatId: chat_id, chatType: chat_type },
         'Skipped group chat message without @mention (passive mode)'
       );
       return;

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -9,6 +9,8 @@ export interface FeishuMessageEvent {
     content: string;
     message_type: string;
     create_time?: number;
+    /** Chat type: p2p (private), group, or topic */
+    chat_type?: 'p2p' | 'group' | 'topic';
     mentions?: Array<{
       key: string;
       id: {


### PR DESCRIPTION
## Summary

Fixes #508 - Private chats (P2P) were incorrectly detected as group chats, causing messages to be skipped in passive mode.

## Problem

The `isGroupChat()` function used `chatId.startsWith('oc_')` to detect group chats. However, Feishu P2P (private) chat IDs can also start with `oc_`, leading to false positives.

**Error Log:**
```
[FeishuChannel] Skipped group chat message without @mention (passive mode)
    messageId: "om_x100b55526bfecca4b3f8532f3b8f2ee"
    chatId: "oc_3d14c151cc209fd7ac1176a2b7ecbc30"
```

## Solution

Use the `chat_type` field from Feishu message event for accurate detection:
- `p2p` - Private chat
- `group` - Group chat  
- `topic` - Topic (treated as group chat)

Falls back to chatId prefix check for backward compatibility when `chat_type` is not available.

## Changes

| File | Description |
|------|-------------|
| `src/types/platform.ts` | Add `chat_type` field to `FeishuMessageEvent.message` |
| `src/channels/feishu-channel.ts` | Update `isGroupChat()` to use `chat_type` |

## Test Results

| Metric | Value |
|--------|-------|
| FeishuChannel tests | 21 passed |
| Type check | ✅ Pass |
| Total tests | 1268 passed (5 pre-existing failures unrelated to this change) |

## Test plan

- [x] Type check passes
- [x] FeishuChannel tests pass (21 tests)
- [x] All existing tests pass
- [ ] Manual test: Send private message to bot, verify response is received
- [ ] Manual test: Send group message without @mention, verify it's skipped
- [ ] Manual test: Send group message with @mention, verify response

🤖 Generated with [Claude Code](https://claude.com/claude-code)