### PR TITLE
fix(feishu): add request timeout configuration for Feishu API calls (Issue #498)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -24,6 +24,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
     register: vi.fn().mockReturnThis(),
   })),
   LoggerLevel: { info: 'info' },
+  Domain: { Feishu: 'https://open.feishu.cn' },
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -46,6 +47,7 @@ vi.mock('../config/index.js', () => ({
 vi.mock('../config/constants.js', () => ({
   DEDUPLICATION: { MAX_MESSAGE_AGE: 300000 },
   REACTIONS: { TYPING: 'Typing' },
+  FEISHU_API: { REQUEST_TIMEOUT_MS: 30000 },
 }));
 
 vi.mock('../feishu/message-logger.js', () => ({

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -14,6 +14,7 @@ import { messageLogger } from '../feishu/message-logger.js';
 import { FeishuFileHandler } from '../platforms/feishu/feishu-file-handler.js';
 import { FeishuMessageSender } from '../platforms/feishu/feishu-message-sender.js';
 import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
+import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
 import { resolvePendingInteraction } from '../mcp/feishu-context-mcp.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
@@ -222,14 +223,11 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
-   * Get or create Lark HTTP client.
+   * Get or create Lark HTTP client with timeout configuration.
    */
   private getClient(): lark.Client {
     if (!this.client) {
-      this.client = new lark.Client({
-        appId: this.appId,
-        appSecret: this.appSecret,
-      });
+      this.client = createFeishuClient(this.appId, this.appSecret);
       this.messageSender = new FeishuMessageSender({
         client: this.client,
         logger,

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -42,3 +42,11 @@ export const REACTIONS = {
   /** Emoji to indicate the bot is typing/processing (👀 = 正在查看/处理中) */
   TYPING: 'Typing',
 } as const;
+
+/**
+ * Feishu API configuration constants (Issue #498, #507)
+ */
+export const FEISHU_API = {
+  /** Request timeout in milliseconds (30 seconds) */
+  REQUEST_TIMEOUT_MS: 30 * 1000,
+} as const;

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -19,6 +19,7 @@ import * as path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { Config } from '../config/index.js';
+import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
 
 const logger = createLogger('FeishuContextMCP');
 
@@ -239,9 +240,7 @@ export async function send_user_feedback(params: {
     }
 
     // Create Lark client and send message
-    const client = new lark.Client({
-      appId,
-      appSecret,
+    const client = createFeishuClient(appId, appSecret, {
       domain: lark.Domain.Feishu,
     });
 
@@ -410,9 +409,7 @@ export async function send_file_to_feishu(params: {
     const { uploadAndSendFile } = await import('../file-transfer/outbound/feishu-uploader.js');
 
     // Create client with credentials from Config
-    const client = new lark.Client({
-      appId,
-      appSecret,
+    const client = createFeishuClient(appId, appSecret, {
       domain: lark.Domain.Feishu,
     });
 
@@ -633,9 +630,7 @@ export async function update_card(params: {
     }
 
     // Create Lark client
-    const client = new lark.Client({
-      appId,
-      appSecret,
+    const client = createFeishuClient(appId, appSecret, {
       domain: lark.Domain.Feishu,
     });
 

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -57,6 +57,7 @@ import {
   getMembers,
 } from '../platforms/feishu/chat-ops.js';
 import { GroupService, getGroupService } from '../platforms/feishu/group-service.js';
+import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
 // Debug group (Issue #487)
 import { getDebugGroupService } from './debug-group-service.js';
 
@@ -207,17 +208,14 @@ export class PrimaryNode extends EventEmitter {
   }
 
   /**
-   * Get or create Feishu client for group management.
+   * Get or create Feishu client for group management with timeout configuration.
    */
   private getFeishuClient(): lark.Client {
     if (!this.feishuClient) {
       if (!this.feishuAppId || !this.feishuAppSecret) {
         throw new Error('Feishu credentials not configured');
       }
-      this.feishuClient = new lark.Client({
-        appId: this.feishuAppId,
-        appSecret: this.feishuAppSecret,
-      });
+      this.feishuClient = createFeishuClient(this.feishuAppId, this.feishuAppSecret);
     }
     return this.feishuClient;
   }

--- a/src/platforms/feishu/create-feishu-client.ts
+++ b/src/platforms/feishu/create-feishu-client.ts
@@ -1,0 +1,138 @@
+/**
+ * Factory function to create Lark Client with timeout configuration.
+ *
+ * The @larksuiteoapi/node-sdk doesn't support requestTimeout directly,
+ * so we create a custom axios instance with timeout and wrap it as HttpInstance.
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import axios, { AxiosInstance } from 'axios';
+import { FEISHU_API } from '../../config/constants.js';
+
+/**
+ * Wrap an axios instance to match lark SDK's HttpInstance interface.
+ */
+function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstance {
+  return {
+    request: async (opts) => {
+      const response = await axiosInstance.request({
+        url: opts.url,
+        method: opts.method,
+        headers: opts.headers,
+        params: opts.params,
+        data: opts.data,
+        responseType: opts.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        timeout: opts.timeout,
+      });
+      return response.data;
+    },
+    get: async (url, opts) => {
+      const response = await axiosInstance.get(url, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    delete: async (url, opts) => {
+      const response = await axiosInstance.delete(url, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    head: async (url, opts) => {
+      const response = await axiosInstance.head(url, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    options: async (url, opts) => {
+      const response = await axiosInstance.options(url, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    post: async (url, data, opts) => {
+      const response = await axiosInstance.post(url, data, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    put: async (url, data, opts) => {
+      const response = await axiosInstance.put(url, data, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+    patch: async (url, data, opts) => {
+      const response = await axiosInstance.patch(url, data, {
+        params: opts?.params,
+        headers: opts?.headers,
+        timeout: opts?.timeout,
+        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+      });
+      return response.data;
+    },
+  };
+}
+
+/**
+ * Options for creating a Feishu client.
+ */
+export interface CreateFeishuClientOptions {
+  /** API domain (Feishu or Lark) */
+  domain?: lark.Domain | string;
+  /** Custom logger instance */
+  logger?: unknown;
+  /** Logger level */
+  loggerLevel?: lark.LoggerLevel;
+}
+
+/**
+ * Create a Lark Client with configured request timeout.
+ *
+ * @param appId - Feishu App ID
+ * @param appSecret - Feishu App Secret
+ * @param options - Optional configuration
+ * @returns Configured Lark Client instance
+ */
+export function createFeishuClient(
+  appId: string,
+  appSecret: string,
+  options?: CreateFeishuClientOptions
+): lark.Client {
+  // Create axios instance with default timeout
+  const axiosInstance = axios.create({
+    timeout: FEISHU_API.REQUEST_TIMEOUT_MS,
+  });
+
+  // Wrap axios as lark HttpInstance
+  const httpInstance = wrapAxiosAsHttpInstance(axiosInstance);
+
+  // Create and return lark Client with custom httpInstance
+  return new lark.Client({
+    appId,
+    appSecret,
+    domain: options?.domain ?? lark.Domain.Feishu,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    logger: options?.logger as any,
+    loggerLevel: options?.loggerLevel,
+    httpInstance,
+  });
+}

--- a/src/platforms/feishu/feishu-adapter.test.ts
+++ b/src/platforms/feishu/feishu-adapter.test.ts
@@ -48,6 +48,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
       },
     },
   })),
+  Domain: { Feishu: 'https://open.feishu.cn' },
 }));
 
 describe('FeishuPlatformAdapter', () => {

--- a/src/platforms/feishu/feishu-adapter.ts
+++ b/src/platforms/feishu/feishu-adapter.ts
@@ -10,6 +10,7 @@ import type { Logger } from 'pino';
 import type { IPlatformAdapter } from '../../channels/adapters/types.js';
 import { FeishuMessageSender, type FeishuMessageSenderConfig } from './feishu-message-sender.js';
 import { FeishuFileHandler, type FeishuFileHandlerConfig } from './feishu-file-handler.js';
+import { createFeishuClient } from './create-feishu-client.js';
 
 /**
  * Feishu Platform Adapter Configuration.
@@ -85,14 +86,9 @@ export class FeishuPlatformAdapter implements IPlatformAdapter {
   }
 
   /**
-   * Create a new Lark client.
+   * Create a new Lark client with timeout configuration.
    */
   private createClient(appId: string, appSecret: string): lark.Client {
-    // Dynamic import to avoid circular dependencies
-    const larkModule = require('@larksuiteoapi/node-sdk');
-    return new larkModule.Client({
-      appId,
-      appSecret,
-    });
+    return createFeishuClient(appId, appSecret);
   }
 }


### PR DESCRIPTION
## Summary

- Add request timeout configuration for all Feishu API calls
- Create `createFeishuClient()` factory function with custom axios httpInstance
- Configure 30-second timeout to prevent long waits on network failures

## Problem

Feishu API calls had no request timeout configuration, causing:
- `ETIMEDOUT` errors when network is unstable
- Users waiting 80+ seconds for TCP timeout before knowing failure
- Poor user experience during network issues

Issues reported: #498, #507

## Solution

Since `@larksuiteoapi/node-sdk` doesn't support `requestTimeout` directly:

1. Add `FEISHU_API.REQUEST_TIMEOUT_MS` constant (30 seconds)
2. Create `createFeishuClient()` factory that:
   - Creates axios instance with default timeout
   - Wraps it as lark SDK's `HttpInstance` interface
   - Passes to `lark.Client` constructor
3. Update all 6 places that create `lark.Client` to use the factory

## Changes

| File | Description |
|------|-------------|
| `src/config/constants.ts` | Add `FEISHU_API.REQUEST_TIMEOUT_MS` (30s) |
| `src/platforms/feishu/create-feishu-client.ts` | New factory function |
| `src/platforms/feishu/feishu-adapter.ts` | Use `createFeishuClient()` |
| `src/channels/feishu-channel.ts` | Use `createFeishuClient()` |
| `src/mcp/feishu-context-mcp.ts` | Use `createFeishuClient()` (3 places) |
| `src/nodes/primary-node.ts` | Use `createFeishuClient()` |

## Technical Details

The `@larksuiteoapi/node-sdk` doesn't support `requestTimeout` parameter in `IClientParams`. 

Workaround:
```typescript
// Create axios instance with timeout
const axiosInstance = axios.create({
  timeout: FEISHU_API.REQUEST_TIMEOUT_MS, // 30 seconds
});

// Wrap as lark HttpInstance interface
const httpInstance = wrapAxiosAsHttpInstance(axiosInstance);

// Create client with custom httpInstance
return new lark.Client({
  appId,
  appSecret,
  httpInstance,
});
```

## Test Results

| Test | Result |
|------|--------|
| TypeScript type check | ✅ Pass |
| feishu-message-sender.test.ts | ✅ 14 tests passed |
| feishu-adapter.test.ts | ✅ 7 tests passed |

## Related

- Fixes #498
- Related #507

## Test plan

- [x] TypeScript compilation successful
- [x] Unit tests for Feishu components pass
- [x] All lark.Client creation points updated
- [ ] Manual test: Verify timeout works when network is slow

🤖 Generated with [Claude Code](https://claude.com/claude-code)