### PR TITLE
fix(test): use object destructuring for chatType in test helper

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -139,7 +139,7 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
     mentions?: Array<{ key: string; id: { open_id: string }; name: string }>;
   }): Promise<void> {
     // Determine chat_type based on chatId prefix if not explicitly provided
-    let chatType = options.chatType;
+    let { chatType } = options;
     if (!chatType) {
       const chatId = options.chatId || 'oc_test_group';
       if (chatId.startsWith('oc_')) {


### PR DESCRIPTION
## Summary

Fix ESLint `prefer-destructuring` error in `feishu-channel-passive-mode.test.ts` by using object destructuring instead of property assignment.

## Changes

- `let chatType = options.chatType;` → `let { chatType } = options;`

## Test Results

- ✅ Lint check passed (0 errors)
- ✅ All 16 tests in `feishu-channel-passive-mode.test.ts` passed

Fixes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)