### PR TITLE
fix(mcp): add CDP endpoint health check for Playwright MCP (Issue #499)

### DIFF
--- a/src/agents/site-miner.ts
+++ b/src/agents/site-miner.ts
@@ -18,6 +18,7 @@ import { getProvider, type AgentQueryOptions } from '../sdk/index.js';
 import { Config } from '../config/index.js';
 import { createLogger } from '../utils/logger.js';
 import { buildSdkEnv } from '../utils/sdk.js';
+import { checkCdpEndpointHealth, parseCdpEndpoint } from '../utils/cdp-health-check.js';
 import { BaseAgent, type BaseAgentConfig } from './base-agent.js';
 import type { Subagent, UserInput, SubagentConfig } from './types.js';
 import type { InlineToolDefinition, McpServerConfig } from '../sdk/types.js';
@@ -67,6 +68,59 @@ export interface SiteMinerOptions {
 export function isPlaywrightAvailable(): boolean {
   const mcpServers = Config.getMcpServersConfig();
   return !!(mcpServers?.playwright);
+}
+
+/**
+ * Check if Playwright MCP is fully available (configured + CDP endpoint healthy).
+ *
+ * This performs a health check on the CDP endpoint to ensure Chrome remote
+ * debugging is running before attempting to use Playwright.
+ *
+ * @returns Health check result with detailed error information
+ */
+export async function checkPlaywrightHealth(): Promise<{
+  available: boolean;
+  error?: string;
+  suggestion?: string;
+}> {
+  const mcpServers = Config.getMcpServersConfig();
+
+  // Check if Playwright MCP is configured
+  if (!mcpServers?.playwright) {
+    return {
+      available: false,
+      error: 'Playwright MCP not configured',
+      suggestion: `Add playwright MCP server to disclaude.config.yaml:
+
+  tools:
+    mcpServers:
+      playwright:
+        command: npx
+        args: [@playwright/mcp@latest, --cdp-endpoint=http://localhost:9222]`,
+    };
+  }
+
+  // Parse CDP endpoint from args
+  const cdpEndpoint = parseCdpEndpoint(mcpServers.playwright.args);
+
+  if (!cdpEndpoint) {
+    // No CDP endpoint configured - might use browser mode
+    logger.debug('No CDP endpoint configured, assuming browser mode');
+    return { available: true };
+  }
+
+  // Check CDP endpoint health
+  const healthResult = await checkCdpEndpointHealth(cdpEndpoint);
+
+  if (!healthResult.healthy) {
+    return {
+      available: false,
+      error: healthResult.error,
+      suggestion: healthResult.suggestion,
+    };
+  }
+
+  return { available: true };
 }
 
 /**
@@ -137,17 +191,18 @@ export class SiteMiner extends BaseAgent implements Subagent {
 
     this.logger.info({ options }, 'Starting site mining operation');
 
-    // Check if Playwright is available
-    if (!isPlaywrightAvailable()) {
-      this.logger.warn('Playwright MCP not configured');
+    // Check if Playwright is fully available (config + CDP endpoint)
+    const healthCheck = await checkPlaywrightHealth();
+    if (!healthCheck.available) {
+      this.logger.warn({ error: healthCheck.error }, 'Playwright MCP not available');
       yield {
         content: JSON.stringify({
           success: false,
           target_url: options.url,
           information_found: {},
-          summary: 'Playwright MCP not configured',
+          summary: healthCheck.error || 'Playwright MCP not available',
           confidence: 0,
-          notes: 'Add playwright MCP server to disclaude.config.yaml under tools.mcpServers',
+          notes: healthCheck.suggestion,
         }),
         role: 'assistant',
         messageType: 'result',
@@ -299,16 +354,17 @@ The tool returns structured results with extracted information and confidence sc
 
     logger.info({ url, task, timeout }, 'Running site mining operation');
 
-    // Check if Playwright is available
-    if (!isPlaywrightAvailable()) {
-      logger.warn('Playwright MCP not configured');
+    // Check if Playwright is fully available (config + CDP endpoint)
+    const healthCheck = await checkPlaywrightHealth();
+    if (!healthCheck.available) {
+      logger.warn({ error: healthCheck.error }, 'Playwright MCP not available');
       return {
         success: false,
         target_url: url,
         information_found: {},
-        summary: 'Playwright MCP not configured',
+        summary: healthCheck.error || 'Playwright MCP not available',
         confidence: 0,
-        notes: 'Add playwright MCP server to disclaude.config.yaml under tools.mcpServers',
+        notes: healthCheck.suggestion,
       };
     }
 

--- a/src/utils/cdp-health-check.test.ts
+++ b/src/utils/cdp-health-check.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for CDP (Chrome DevTools Protocol) endpoint health check utility.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseCdpEndpoint, checkCdpEndpointHealth, formatCdpHealthError } from './cdp-health-check.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('CDP Health Check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('parseCdpEndpoint', () => {
+    it('should parse --cdp-endpoint=<url> format', () => {
+      const args = ['--cdp-endpoint=http://localhost:9222'];
+      expect(parseCdpEndpoint(args)).toBe('http://localhost:9222');
+    });
+
+    it('should parse --cdp-endpoint <url> format', () => {
+      const args = ['--cdp-endpoint', 'http://localhost:9222'];
+      expect(parseCdpEndpoint(args)).toBe('http://localhost:9222');
+    });
+
+    it('should return undefined if no CDP endpoint found', () => {
+      const args = ['--other-arg', 'value'];
+      expect(parseCdpEndpoint(args)).toBeUndefined();
+    });
+
+    it('should return undefined for empty args', () => {
+      expect(parseCdpEndpoint([])).toBeUndefined();
+      expect(parseCdpEndpoint(undefined as unknown as string[])).toBeUndefined();
+    });
+
+    it('should handle various endpoint formats', () => {
+      expect(parseCdpEndpoint(['--cdp-endpoint=http://192.168.1.1:9222'])).toBe('http://192.168.1.1:9222');
+      expect(parseCdpEndpoint(['--cdp-endpoint', 'http://127.0.0.1:9223'])).toBe('http://127.0.0.1:9223');
+    });
+  });
+
+  describe('checkCdpEndpointHealth', () => {
+    it('should return healthy when endpoint responds with OK', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ Browser: 'Chrome/120.0.0' }),
+      });
+
+      const result = await checkCdpEndpointHealth('http://localhost:9222');
+
+      expect(result.healthy).toBe(true);
+      expect(result.endpoint).toBe('http://localhost:9222');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9222/json/version',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('should return unhealthy when endpoint returns non-OK status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await checkCdpEndpointHealth('http://localhost:9222');
+
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('404');
+      expect(result.suggestion).toBeDefined();
+    });
+
+    it('should return unhealthy with suggestion on connection refused', async () => {
+      const error = new Error('ECONNREFUSED');
+      error.name = 'Error';
+      mockFetch.mockRejectedValueOnce(error);
+
+      const result = await checkCdpEndpointHealth('http://localhost:9222');
+
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('Connection refused');
+      expect(result.suggestion).toContain('remote-debugging-port');
+    });
+
+    it('should return unhealthy on timeout', async () => {
+      mockFetch.mockImplementationOnce(() => {
+        return new Promise((_, reject) => {
+          const error = new Error('Aborted');
+          error.name = 'AbortError';
+          setTimeout(() => reject(error), 100);
+        });
+      });
+
+      const resultPromise = checkCdpEndpointHealth('http://localhost:9222');
+
+      // Advance timers to trigger timeout
+      await vi.advanceTimersByTimeAsync(5000);
+
+      const result = await resultPromise;
+
+      expect(result.healthy).toBe(false);
+      expect(result.error).toContain('timeout');
+    });
+
+    it('should handle endpoints with trailing slash', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ Browser: 'Chrome/120.0.0' }),
+      });
+
+      const result = await checkCdpEndpointHealth('http://localhost:9222/');
+
+      expect(result.healthy).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:9222/json/version',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+  });
+
+  describe('formatCdpHealthError', () => {
+    it('should format error with all fields', () => {
+      const result = {
+        healthy: false,
+        error: 'Connection refused',
+        suggestion: 'Start Chrome with --remote-debugging-port=9222',
+        endpoint: 'http://localhost:9222',
+      };
+
+      const formatted = formatCdpHealthError(result);
+
+      expect(formatted).toContain('Playwright MCP: CDP Endpoint Unavailable');
+      expect(formatted).toContain('Connection refused');
+      expect(formatted).toContain('http://localhost:9222');
+      expect(formatted).toContain('Start Chrome');
+    });
+
+    it('should handle missing suggestion', () => {
+      const result = {
+        healthy: false,
+        error: 'Unknown error',
+        endpoint: 'http://localhost:9222',
+      };
+
+      const formatted = formatCdpHealthError(result);
+
+      expect(formatted).toContain('Unknown error');
+      expect(formatted).toContain('http://localhost:9222');
+    });
+  });
+});

--- a/src/utils/cdp-health-check.ts
+++ b/src/utils/cdp-health-check.ts
@@ -1,0 +1,157 @@
+/**
+ * CDP (Chrome DevTools Protocol) endpoint health check utility.
+ *
+ * Used to verify that Chrome remote debugging is available before
+ * starting Playwright MCP server.
+ *
+ * @module utils/cdp-health-check
+ */
+
+import { createLogger } from './logger.js';
+
+const logger = createLogger('CdpHealthCheck');
+
+/**
+ * CDP endpoint health check result.
+ */
+export interface CdpHealthCheckResult {
+  /** Whether the endpoint is healthy */
+  healthy: boolean;
+  /** Error message if unhealthy */
+  error?: string;
+  /** Suggested fix for the error */
+  suggestion?: string;
+  /** Endpoint URL that was checked */
+  endpoint?: string;
+}
+
+/**
+ * Parse CDP endpoint URL from Playwright MCP args.
+ *
+ * @param args - Playwright MCP command line arguments
+ * @returns CDP endpoint URL or undefined if not found
+ */
+export function parseCdpEndpoint(args: string[] = []): string | undefined {
+  // Look for --cdp-endpoint=<url> or --cdp-endpoint <url>
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--cdp-endpoint=')) {
+      return arg.split('=')[1];
+    }
+    if (arg === '--cdp-endpoint' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Check if a CDP endpoint is healthy.
+ *
+ * This function attempts to connect to the Chrome DevTools Protocol
+ * endpoint to verify that Chrome remote debugging is running.
+ *
+ * @param endpoint - CDP endpoint URL (e.g., http://localhost:9222)
+ * @returns Health check result
+ */
+export async function checkCdpEndpointHealth(endpoint: string): Promise<CdpHealthCheckResult> {
+  logger.debug({ endpoint }, 'Checking CDP endpoint health');
+
+  try {
+    // Try to fetch the JSON version info from Chrome
+    const versionUrl = `${endpoint.replace(/\/$/, '')}/json/version`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(versionUrl, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      return {
+        healthy: false,
+        error: `CDP endpoint returned status ${response.status}`,
+        suggestion: 'Ensure Chrome is running with remote debugging enabled',
+        endpoint,
+      };
+    }
+
+    const data = await response.json() as { Browser?: string };
+
+    logger.debug({ endpoint, browser: data.Browser }, 'CDP endpoint is healthy');
+
+    return {
+      healthy: true,
+      endpoint,
+    };
+  } catch (error) {
+    const err = error as Error;
+
+    // Provide specific error messages and suggestions
+    if (err.name === 'AbortError') {
+      return {
+        healthy: false,
+        error: 'Connection timeout (5s)',
+        suggestion: 'Chrome may be slow to respond. Check if Chrome is running properly.',
+        endpoint,
+      };
+    }
+
+    if (err.message.includes('ECONNREFUSED') || err.message.includes('connection refused')) {
+      return {
+        healthy: false,
+        error: 'Connection refused - Chrome is not running or remote debugging is not enabled',
+        suggestion: `Start Chrome with remote debugging:
+  macOS: /Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222
+  Linux: google-chrome --remote-debugging-port=9222
+  Windows: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe" --remote-debugging-port=9222`,
+        endpoint,
+      };
+    }
+
+    if (err.message.includes('ENOTFOUND') || err.message.includes('dns')) {
+      return {
+        healthy: false,
+        error: 'DNS resolution failed - invalid hostname',
+        suggestion: 'Check the CDP endpoint URL in your configuration',
+        endpoint,
+      };
+    }
+
+    // Generic error
+    return {
+      healthy: false,
+      error: err.message,
+      suggestion: 'Ensure Chrome is running with remote debugging enabled on the specified port',
+      endpoint,
+    };
+  }
+}
+
+/**
+ * Format a CDP health check error for display.
+ *
+ * @param result - Unhealthy health check result
+ * @returns Formatted error message
+ */
+export function formatCdpHealthError(result: CdpHealthCheckResult): string {
+  const lines = [
+    '❌ **Playwright MCP: CDP Endpoint Unavailable**',
+    '',
+    `**Error**: ${result.error}`,
+    `**Endpoint**: ${result.endpoint || 'unknown'}`,
+    '',
+    '**How to fix**:',
+  ];
+
+  if (result.suggestion) {
+    // Add each line of suggestion with proper indentation
+    lines.push(...result.suggestion.split('\n').map(line => `  ${line}`));
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Implements #499 - Adds CDP endpoint health check to provide better error messages when Playwright MCP fails to start.

## Problem

Playwright MCP server fails to start with only `status: failed` message when Chrome remote debugging is not running, providing no helpful guidance to users.

## Solution

Add CDP (Chrome DevTools Protocol) endpoint health check before starting Playwright MCP operations:

### New `cdp-health-check.ts` utility
- `parseCdpEndpoint()`: Extract CDP endpoint URL from Playwright MCP args
- `checkCdpEndpointHealth()`: Verify endpoint is accessible via `/json/version`
- `formatCdpHealthError()`: Format user-friendly error messages

### Updated SiteMiner
- New `checkPlaywrightHealth()` function for comprehensive health check
- Report detailed errors when CDP endpoint is unavailable
- Include instructions for starting Chrome with remote debugging

## Changes

| File | Description |
|------|-------------|
| `src/utils/cdp-health-check.ts` | New CDP health check utility |
| `src/utils/cdp-health-check.test.ts` | 12 tests for health check |
| `src/agents/site-miner.ts` | Use health check before operations |

## Error Messages

| Error | Suggestion |
|-------|------------|
| Connection refused | Shows how to start Chrome with `--remote-debugging-port` |
| Timeout | Suggests checking if Chrome is running properly |
| DNS errors | Suggests checking the endpoint URL |

## Example Output

```
❌ **Playwright MCP: CDP Endpoint Unavailable**

**Error**: Connection refused - Chrome is not running or remote debugging is not enabled
**Endpoint**: http://localhost:9222

**How to fix**:
  Start Chrome with remote debugging:
  macOS: /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
  Linux: google-chrome --remote-debugging-port=9222
  Windows: "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
```

## Test Results

| Metric | Value |
|--------|-------|
| New tests | 12 passed |
| SiteMiner tests | 24 passed |
| TypeScript | ✅ Pass |

## Test plan

- [x] Unit tests for CDP health check utility
- [x] SiteMiner tests pass
- [x] TypeScript compilation passes
- [ ] Manual test: Verify error message when Chrome is not running
- [ ] Manual test: Verify successful operation when Chrome is running

Fixes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)