### PR TITLE
feat(feishu): add configurable passive mode with /passive command (Issue #511)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -62,6 +62,21 @@ feishu:
     # Default: 60000 (1 minute)
     maxAgeMs: 60000
 
+  # Group chat passive mode configuration (Issue #511)
+  # When enabled (default), bot only responds when @mentioned in group chats
+  passiveMode:
+    # Enable/disable passive mode globally
+    # Default: true
+    enabled: true
+
+    # Per-chat exceptions to override global setting
+    # Use this to disable passive mode for specific groups
+    # exceptions:
+    #   - chatId: "oc_xxx"
+    #     passiveMode: false  # This group will respond to all messages
+    #   - chatId: "oc_yyy"
+    #     passiveMode: true   # Explicitly enable for this group
+
 # -----------------------------------------------------------------------------
 # GLM (Zhipu AI) API Configuration
 # -----------------------------------------------------------------------------

--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -22,6 +22,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
     register: vi.fn().mockReturnThis(),
   })),
   LoggerLevel: { info: 'info' },
+  Domain: { Feishu: 'https://open.feishu.cn' },
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -38,12 +39,17 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getPassiveModeConfig: () => ({
+      enabled: true,
+      exceptions: [],
+    }),
   },
 }));
 
 vi.mock('../config/constants.js', () => ({
   DEDUPLICATION: { MAX_MESSAGE_AGE: 300000 },
   REACTIONS: { TYPING: 'Typing' },
+  FEISHU_API: { REQUEST_TIMEOUT_MS: 30000 },
 }));
 
 vi.mock('../feishu/message-logger.js', () => ({

--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -41,6 +41,10 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getPassiveModeConfig: () => ({
+      enabled: true,
+      exceptions: [],
+    }),
   },
 }));
 
@@ -458,6 +462,98 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
 
       // Reaction SHOULD be added for private chat messages
       expect(senderInstance?.addReaction).toHaveBeenCalledWith('test-msg-id', 'Typing');
+    });
+  });
+
+  describe('Passive mode control (Issue #511)', () => {
+    it('should handle /passive status command', async () => {
+      await simulateMessageReceive({
+        text: '/passive status',
+        chatId: 'oc_test_group',
+        mentions: undefined,
+      });
+
+      // Control handler should be called
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+          chatId: 'oc_test_group',
+        })
+      );
+    });
+
+    it('should handle /passive off command to disable passive mode', async () => {
+      await simulateMessageReceive({
+        text: '/passive off',
+        chatId: 'oc_test_group',
+        mentions: undefined,
+      });
+
+      // Control handler should be called
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+          chatId: 'oc_test_group',
+        })
+      );
+    });
+
+    it('should handle /passive on command to enable passive mode', async () => {
+      await simulateMessageReceive({
+        text: '/passive on',
+        chatId: 'oc_test_group',
+        mentions: undefined,
+      });
+
+      // Control handler should be called
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+          chatId: 'oc_test_group',
+        })
+      );
+    });
+
+    it('should allow messages after passive mode is disabled via setPassiveMode', async () => {
+      // Disable passive mode for this chat
+      channel.setPassiveMode('oc_test_group', false);
+
+      await simulateMessageReceive({
+        text: 'Hello everyone!',
+        chatId: 'oc_test_group',
+        mentions: undefined, // No mentions
+      });
+
+      // Message SHOULD be passed to agent because passive mode is disabled
+      expect(messageHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Hello everyone!',
+        })
+      );
+    });
+
+    it('should skip messages after passive mode is enabled via setPassiveMode', async () => {
+      // First disable, then enable
+      channel.setPassiveMode('oc_test_group', false);
+      channel.setPassiveMode('oc_test_group', true);
+
+      await simulateMessageReceive({
+        text: 'Hello everyone!',
+        chatId: 'oc_test_group',
+        mentions: undefined, // No mentions
+      });
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should return passive mode status via getPassiveModeStatus', () => {
+      const status = channel.getPassiveModeStatus();
+
+      expect(status).toHaveProperty('globalEnabled');
+      expect(status).toHaveProperty('overridesCount');
+      expect(typeof status.globalEnabled).toBe('boolean');
+      expect(typeof status.overridesCount).toBe('number');
     });
   });
 });

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -33,6 +33,17 @@ import type {
 const logger = createLogger('FeishuChannel');
 
 /**
+ * Runtime passive mode state for each chat.
+ * Stores per-chat passive mode overrides set via /passive command.
+ */
+interface PassiveModeState {
+  /** Global passive mode enabled (from config or runtime override) */
+  globalEnabled: boolean;
+  /** Per-chat passive mode overrides (chatId -> enabled) */
+  chatOverrides: Map<string, boolean>;
+}
+
+/**
  * Feishu channel configuration.
  */
 export interface FeishuChannelConfig extends ChannelConfig {
@@ -63,6 +74,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   private taskTracker: TaskTracker;
   private taskFlowOrchestrator?: TaskFlowOrchestrator;
   private interactionManager: InteractionManager;
+  /** Passive mode state (config + runtime overrides) */
+  private passiveModeState: PassiveModeState;
 
   private readonly MAX_MESSAGE_AGE = DEDUPLICATION.MAX_MESSAGE_AGE;
 
@@ -71,6 +84,17 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     this.appId = config.appId || Config.FEISHU_APP_ID;
     this.appSecret = config.appSecret || Config.FEISHU_APP_SECRET;
     this.taskTracker = new TaskTracker();
+
+    // Initialize passive mode state from config
+    const passiveConfig = Config.getPassiveModeConfig();
+    this.passiveModeState = {
+      globalEnabled: passiveConfig.enabled,
+      chatOverrides: new Map(),
+    };
+    // Load exceptions from config
+    for (const exception of passiveConfig.exceptions) {
+      this.passiveModeState.chatOverrides.set(exception.chatId, exception.passiveMode ?? true);
+    }
 
     // Initialize FileHandler
     this.fileHandler = new FeishuFileHandler({
@@ -297,6 +321,45 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
+   * Check if passive mode is enabled for a specific chat.
+   * Priority: runtime override > config exception > global default
+   *
+   * @param chatId - Chat ID to check
+   * @returns true if passive mode is enabled for this chat
+   */
+  private isPassiveModeEnabled(chatId: string): boolean {
+    // Check runtime override first
+    if (this.passiveModeState.chatOverrides.has(chatId)) {
+      return this.passiveModeState.chatOverrides.get(chatId)!;
+    }
+    // Fall back to global setting
+    return this.passiveModeState.globalEnabled;
+  }
+
+  /**
+   * Set passive mode for a specific chat (runtime override).
+   *
+   * @param chatId - Chat ID to set
+   * @param enabled - Whether passive mode should be enabled
+   */
+  setPassiveMode(chatId: string, enabled: boolean): void {
+    this.passiveModeState.chatOverrides.set(chatId, enabled);
+    logger.info({ chatId, passiveMode: enabled }, 'Passive mode updated');
+  }
+
+  /**
+   * Get current passive mode status.
+   *
+   * @returns Passive mode state info
+   */
+  getPassiveModeStatus(): { globalEnabled: boolean; overridesCount: number } {
+    return {
+      globalEnabled: this.passiveModeState.globalEnabled,
+      overridesCount: this.passiveModeState.chatOverrides.size,
+    };
+  }
+
+  /**
    * Handle incoming message event from WebSocket.
    */
   private async handleMessageReceive(data: FeishuEventData): Promise<void> {
@@ -444,6 +507,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       'reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
       // Group management commands (Issue #486)
       'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group',
+      // Passive mode commands (Issue #511)
+      'passive',
     ];
 
     if (trimmedText.startsWith('/')) {
@@ -501,9 +566,53 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           await this.sendMessage({
             chatId: chat_id,
             type: 'text',
-            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
+            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助\n- /passive [on|off|status] - 控制被动模式',
           });
           return;
+        }
+
+        // Handle /passive command (Issue #511)
+        if (cmd === 'passive') {
+          const subCommand = args[0]?.toLowerCase();
+          const currentEnabled = this.isPassiveModeEnabled(chat_id);
+
+          if (subCommand === 'on') {
+            this.setPassiveMode(chat_id, true);
+            await this.sendMessage({
+              chatId: chat_id,
+              type: 'text',
+              text: '✅ **被动模式已开启**\n\nBot 将只在被 @ 时响应群聊消息。',
+            });
+            return;
+          }
+
+          if (subCommand === 'off') {
+            this.setPassiveMode(chat_id, false);
+            await this.sendMessage({
+              chatId: chat_id,
+              type: 'text',
+              text: '✅ **被动模式已关闭**\n\nBot 将响应所有群聊消息。',
+            });
+            return;
+          }
+
+          if (subCommand === 'status' || !subCommand) {
+            const status = this.getPassiveModeStatus();
+            const chatStatus = this.isPassiveModeEnabled(chat_id);
+            await this.sendMessage({
+              chatId: chat_id,
+              type: 'text',
+              text: `📊 **被动模式状态**\n\n` +
+                `当前群聊: ${chatStatus ? '✅ 开启' : '❌ 关闭'}\n` +
+                `全局默认: ${status.globalEnabled ? '✅ 开启' : '❌ 关闭'}\n` +
+                `自定义群聊数: ${status.overridesCount}\n\n` +
+                `用法:\n` +
+                `- /passive on - 开启被动模式\n` +
+                `- /passive off - 关闭被动模式\n` +
+                `- /passive status - 查看状态`,
+            });
+            return;
+          }
         }
       }
     }
@@ -513,13 +622,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
     }
 
-    // Issue #460: Group chat passive mode
-    // In group chats, only respond when bot is mentioned (@bot)
+    // Issue #460, #511: Group chat passive mode
+    // In group chats, only respond when bot is mentioned (@bot) if passive mode is enabled
     // This allows scheduled tasks to broadcast without triggering unwanted responses
-    if (this.isGroupChat(chat_type) && !botMentioned) {
+    // Passive mode can be configured per-chat via config file or /passive command
+    if (this.isGroupChat(chat_type) && !botMentioned && this.isPassiveModeEnabled(chat_id)) {
       logger.debug(
-        { messageId: message_id, chatId: chat_id, chat_type },
-        'Skipped group chat message without @mention (passive mode)'
+        { messageId: message_id, chatId: chat_id, chat_type, passiveMode: true },
+        'Skipped group chat message without @mention (passive mode enabled)'
       );
       return;
     }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -125,7 +125,9 @@ export type ControlCommandType =
   // Debug group commands (Issue #487)
   | 'set-debug'
   | 'show-debug'
-  | 'clear-debug';
+  | 'clear-debug'
+  // Passive mode commands (Issue #511)
+  | 'passive';
 
 /**
  * Control command from user to agent.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -336,4 +336,20 @@ export class Config {
   static getGlobalEnv(): Record<string, string> {
     return fileConfigOnly.env || {};
   }
+
+  /**
+   * Get Feishu passive mode configuration.
+   *
+   * @returns Passive mode configuration or default
+   */
+  static getPassiveModeConfig(): {
+    enabled: boolean;
+    exceptions: Array<{ chatId: string; passiveMode?: boolean }>;
+  } {
+    const passiveMode = fileConfigOnly.feishu?.passiveMode;
+    return {
+      enabled: passiveMode?.enabled ?? true, // Default to true
+      exceptions: passiveMode?.exceptions || [],
+    };
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,16 @@ export interface AgentConfig {
 }
 
 /**
+ * Passive mode exception configuration for specific chats.
+ */
+export interface PassiveModeException {
+  /** Chat ID to apply exception to */
+  chatId: string;
+  /** Override passive mode for this chat (false = disabled passive mode) */
+  passiveMode?: boolean;
+}
+
+/**
  * Feishu/Lark platform configuration section.
  */
 export interface FeishuConfig {
@@ -62,6 +72,17 @@ export interface FeishuConfig {
     maxIds?: number;
     /** Maximum message age in milliseconds */
     maxAgeMs?: number;
+  };
+  /**
+   * Group chat passive mode configuration.
+   * When enabled (default), bot only responds when @mentioned in group chats.
+   * @see Issue #511
+   */
+  passiveMode?: {
+    /** Enable/disable passive mode globally (default: true) */
+    enabled?: boolean;
+    /** Per-chat exceptions to override global setting */
+    exceptions?: PassiveModeException[];
   };
 }
 


### PR DESCRIPTION
## Summary

Implements #511 - Adds configuration and runtime control for group chat passive mode.

## Problem

Group chat passive mode was hardcoded - bot only responded when @mentioned in group chats. Users had no way to:
- Disable passive mode for specific groups
- Configure passive mode via config file
- Toggle passive mode at runtime

## Solution

### Configuration File Support

Added `passiveMode` to `feishu` config section in `disclaude.config.yaml`:

```yaml
feishu:
  passiveMode:
    enabled: true  # Global default (default: true)
    exceptions:
      - chatId: "oc_xxx"
        passiveMode: false  # This group responds to all messages
      - chatId: "oc_yyy"
        passiveMode: true   # Explicitly enable for this group
```

### Runtime Command

Added `/passive` command for dynamic control:

| Command | Description |
|---------|-------------|
| `/passive on` | Enable passive mode for current chat |
| `/passive off` | Disable passive mode for current chat |
| `/passive status` | Show current passive mode status |

## Changes

| File | Description |
|------|-------------|
| `src/config/types.ts` | Add `PassiveModeException` and `passiveMode` config types |
| `src/config/index.ts` | Add `Config.getPassiveModeConfig()` method |
| `src/channels/types.ts` | Add `passive` to `ControlCommandType` |
| `src/channels/feishu-channel.ts` | Implement passive mode config and `/passive` command |
| `disclaude.config.example.yaml` | Add passive mode config example |
| `src/channels/feishu-channel-passive-mode.test.ts` | Add 6 new tests for passive mode control |
| `src/channels/feishu-channel-mention.test.ts` | Update mock for new config |

## Test Results

| Test File | Tests |
|-----------|-------|
| feishu-channel-passive-mode.test.ts | 22 passed (6 new) |
| feishu-channel-mention.test.ts | 8 passed |

## Usage Examples

### Using Config File

```yaml
feishu:
  passiveMode:
    enabled: true
    exceptions:
      # Disable passive mode for testing group
      - chatId: "oc_testing_group"
        passiveMode: false
```

### Using /passive Command

```
User: /passive status
Bot: 📊 **被动模式状态**
     当前群聊: ✅ 开启
     全局默认: ✅ 开启
     自定义群聊数: 0

User: /passive off
Bot: ✅ **被动模式已关闭**
     Bot 将响应所有群聊消息。

User: /passive on
Bot: ✅ **被动模式已开启**
     Bot 将只在被 @ 时响应群聊消息。
```

## Test plan

- [x] Configuration file parsing works correctly
- [x] `/passive on` enables passive mode
- [x] `/passive off` disables passive mode
- [x] `/passive status` shows current status
- [x] Config exceptions override global setting
- [x] Runtime overrides work via `setPassiveMode()`
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)