### PR TITLE
fix(test): update mocks for FEISHU_API and Domain exports (Issue #524)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -22,6 +22,7 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
     register: vi.fn().mockReturnThis(),
   })),
   LoggerLevel: { info: 'info' },
+  Domain: { Feishu: 'https://open.feishu.cn' },
 }));
 
 vi.mock('../utils/logger.js', () => ({
@@ -44,6 +45,7 @@ vi.mock('../config/index.js', () => ({
 vi.mock('../config/constants.js', () => ({
   DEDUPLICATION: { MAX_MESSAGE_AGE: 300000 },
   REACTIONS: { TYPING: 'Typing' },
+  FEISHU_API: { REQUEST_TIMEOUT_MS: 30000 },
 }));
 
 vi.mock('../feishu/message-logger.js', () => ({


### PR DESCRIPTION
## Summary

Fixes #524 - Updates test mocks to include new exports added by PR #520.

## Problem

PR #520 (fix/issue-498-feishu-timeout) made two changes that broke the test file `src/channels/feishu-channel-mention.test.ts`:

1. Added `FEISHU_API` export to `src/config/constants.ts`
2. Used `lark.Domain.Feishu` in `src/platforms/feishu/create-feishu-client.ts`

But the test file's mocks were not updated, causing 8 test failures:
```
Error: [vitest] No "FEISHU_API" export is defined on the "../config/constants.js" mock
Error: [vitest] No "Domain" export is defined on the "@larksuiteoapi/node-sdk" mock
```

## Solution

Updated two mocks in the test file:

| Mock | Change |
|------|--------|
| `@larksuiteoapi/node-sdk` | Added `Domain: { Feishu: 'https://open.feishu.cn' }` |
| `../config/constants.js` | Added `FEISHU_API: { REQUEST_TIMEOUT_MS: 30000 }` |

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel-mention.test.ts` | Add missing mock exports |

## Test Results

```
✓ src/channels/feishu-channel-mention.test.ts (8 tests) 7ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

## Related

- Issue #524: 单元测试失败: feishu-channel-mention.test.ts mock 缺少 FEISHU_API 导出
- PR #520: fix(feishu): add request timeout configuration for Feishu API calls

## Test plan

- [x] All 8 tests in feishu-channel-mention.test.ts now pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)