### PR TITLE
feat(help): add DI-based command system with welcome messages (Issue #463)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -95,6 +95,16 @@ vi.mock('../utils/task-tracker.js', () => ({
   TaskTracker: vi.fn(),
 }));
 
+vi.mock('../nodes/commands/command-registry.js', () => ({
+  getCommandRegistry: vi.fn(() => ({
+    has: (name: string) => ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
+      'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group'].includes(name),
+    getAll: () => [],
+    register: vi.fn(),
+  })),
+  resetCommandRegistry: vi.fn(),
+}));
+
 import { FeishuChannel } from './feishu-channel.js';
 
 describe('FeishuChannel - Control Command Handling (Issue #387)', () => {

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -15,6 +15,8 @@ import { FeishuFileHandler } from '../platforms/feishu/feishu-file-handler.js';
 import { FeishuMessageSender } from '../platforms/feishu/feishu-message-sender.js';
 import { InteractionManager } from '../platforms/feishu/interaction-manager.js';
 import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
+import type { WelcomeService } from '../platforms/feishu/welcome-service.js';
+import { getCommandRegistry } from '../nodes/commands/command-registry.js';
 import { resolvePendingInteraction } from '../mcp/feishu-context-mcp.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
@@ -24,6 +26,8 @@ import type {
   FeishuMessageEvent,
   FeishuCardActionEvent,
   FeishuCardActionEventData,
+  FeishuChatMemberAddedEventData,
+  FeishuP2PChatEnteredEventData,
 } from '../types/platform.js';
 import type {
   ChannelConfig,
@@ -63,6 +67,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   private taskTracker: TaskTracker;
   private taskFlowOrchestrator?: TaskFlowOrchestrator;
   private interactionManager: InteractionManager;
+  private welcomeService?: WelcomeService;
 
   private readonly MAX_MESSAGE_AGE = DEDUPLICATION.MAX_MESSAGE_AGE;
 
@@ -117,7 +122,22 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
         }
       },
       'im.message.message_read_v1': async () => {},
-      'im.chat.access_event.bot_p2p_chat_entered_v1': async () => {},
+      // Issue #463: Handle P2P chat entered for welcome message
+      'im.chat.access_event.bot_p2p_chat_entered_v1': async (data: unknown) => {
+        try {
+          await this.handleP2PChatEntered(data as FeishuP2PChatEnteredEventData);
+        } catch (error) {
+          logger.error({ err: error }, 'Failed to handle P2P chat entered');
+        }
+      },
+      // Issue #463: Handle bot added to group for welcome message
+      'im.chat.member.added_v1': async (data: unknown) => {
+        try {
+          await this.handleChatMemberAdded(data as FeishuChatMemberAddedEventData);
+        } catch (error) {
+          logger.error({ err: error }, 'Failed to handle chat member added');
+        }
+      },
     });
 
     // Create WebSocket client
@@ -438,13 +458,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
-    // Control commands that should always be handled locally through the control channel
-    // These commands affect session/agent lifecycle and should not be passed to the agent
-    const CONTROL_COMMANDS = [
-      'reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
-      // Group management commands (Issue #486)
-      'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group',
-    ];
+    // Get control commands from CommandRegistry (Issue #463: removed hardcoded list)
+    const commandRegistry = getCommandRegistry();
 
     if (trimmedText.startsWith('/')) {
       const [command, ...args] = trimmedText.slice(1).split(/\s+/);
@@ -453,7 +468,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       // Handle control commands through the control channel
       // Control commands are ALWAYS handled locally, regardless of @mentions
       // Non-control commands with @mention are passed to agent
-      const isControlCommand = CONTROL_COMMANDS.includes(cmd);
+      const isControlCommand = commandRegistry.has(cmd);
 
       if (isControlCommand || !botMentioned) {
         if (this.controlHandler) {
@@ -493,15 +508,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
             chatId: chat_id,
             type: 'text',
             text: `📊 **状态**\n\nChannel: ${this.name}\nStatus: ${this.status}`,
-          });
-          return;
-        }
-
-        if (cmd === 'help') {
-          await this.sendMessage({
-            chatId: chat_id,
-            type: 'text',
-            text: '📖 **帮助**\n\n可用命令:\n- /reset - 重置对话\n- /status - 查看状态\n- /help - 显示帮助',
           });
           return;
         }
@@ -619,10 +625,67 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
+   * Handle P2P chat entered event.
+   * Triggered when a user starts a private chat with the bot.
+   * Issue #463: Send welcome message on first private chat.
+   */
+  private async handleP2PChatEntered(data: FeishuP2PChatEnteredEventData): Promise<void> {
+    if (!this.isRunning || !this.welcomeService) {
+      return;
+    }
+
+    const event = data.event;
+    if (!event?.user?.open_id) {
+      logger.debug('P2P chat entered event missing user info');
+      return;
+    }
+
+    const userId = event.user.open_id;
+    logger.info({ userId }, 'P2P chat entered, sending welcome message');
+
+    await this.welcomeService.handleP2PChatEntered(userId);
+  }
+
+  /**
+   * Handle chat member added event.
+   * Triggered when members are added to a chat.
+   * Issue #463: Send welcome message when new members join a group.
+   */
+  private async handleChatMemberAdded(data: FeishuChatMemberAddedEventData): Promise<void> {
+    if (!this.isRunning || !this.welcomeService) {
+      return;
+    }
+
+    const event = data.event;
+    if (!event?.chat_id || !event?.members || event.members.length === 0) {
+      logger.debug('Chat member added event missing required fields');
+      return;
+    }
+
+    // Only send welcome to group chats
+    if (!this.isGroupChat(event.chat_id)) {
+      logger.debug({ chatId: event.chat_id }, 'Member added to non-group chat, skipping welcome');
+      return;
+    }
+
+    logger.info({ chatId: event.chat_id, memberCount: event.members.length }, 'New members joined group, sending welcome message');
+
+    await this.welcomeService.handleBotAddedToGroup(event.chat_id);
+  }
+
+  /**
    * Get the InteractionManager for this channel.
    * Used for registering custom interaction handlers.
    */
   getInteractionManager(): InteractionManager {
     return this.interactionManager;
+  }
+
+  /**
+   * Set the WelcomeService for this channel.
+   * Used for sending welcome messages on bot added to group or first private chat.
+   */
+  setWelcomeService(service: WelcomeService): void {
+    this.welcomeService = service;
   }
 }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -113,6 +113,7 @@ export type ControlCommandType =
   | 'reset'
   | 'restart'
   | 'status'
+  | 'help'
   | 'list-nodes'
   | 'switch-node'
   // Group management commands (Issue #486)

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -1,0 +1,281 @@
+/**
+ * Built-in Commands - Default command implementations.
+ *
+ * These commands are registered by default and provide core functionality.
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+import type { Command, CommandContext, CommandResult } from './types.js';
+
+/**
+ * Reset Command - Reset the conversation session.
+ */
+export class ResetCommand implements Command {
+  readonly name = 'reset';
+  readonly category = 'session' as const;
+  readonly description = '重置对话';
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    // Actual reset is handled by PrimaryNode
+    return {
+      success: true,
+      message: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
+    };
+  }
+}
+
+/**
+ * Status Command - Show current status.
+ */
+export class StatusCommand implements Command {
+  readonly name = 'status';
+  readonly category = 'session' as const;
+  readonly description = '查看状态';
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    // Actual status is handled by PrimaryNode
+    return {
+      success: true,
+      message: '📊 **状态**\n\n请稍后...',
+    };
+  }
+}
+
+/**
+ * Help Command - Show available commands.
+ */
+export class HelpCommand implements Command {
+  readonly name = 'help';
+  readonly category = 'session' as const;
+  readonly description = '显示帮助';
+
+  private generateHelpText: () => string;
+
+  constructor(generateHelpText: () => string) {
+    this.generateHelpText = generateHelpText;
+  }
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    return {
+      success: true,
+      message: this.generateHelpText(),
+    };
+  }
+}
+
+/**
+ * List Nodes Command - List all execution nodes.
+ */
+export class ListNodesCommand implements Command {
+  readonly name = 'list-nodes';
+  readonly category = 'node' as const;
+  readonly description = '列出执行节点';
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '📋 **执行节点列表**\n\n请稍后...',
+    };
+  }
+}
+
+/**
+ * Switch Node Command - Switch to a specific execution node.
+ */
+export class SwitchNodeCommand implements Command {
+  readonly name = 'switch-node';
+  readonly category = 'node' as const;
+  readonly description = '切换执行节点';
+  readonly usage = 'switch-node <nodeId>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length === 0) {
+      return {
+        success: false,
+        error: '请指定目标节点 ID。\n\n用法: `/switch-node <nodeId>`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **切换节点中...**',
+    };
+  }
+}
+
+/**
+ * Restart Command - Restart the service.
+ */
+export class RestartCommand implements Command {
+  readonly name = 'restart';
+  readonly category = 'node' as const;
+  readonly description = '重启服务';
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **正在重启服务...**',
+    };
+  }
+}
+
+/**
+ * Create Group Command - Create a new group chat.
+ */
+export class CreateGroupCommand implements Command {
+  readonly name = 'create-group';
+  readonly category = 'group' as const;
+  readonly description = '创建群';
+  readonly usage = 'create-group <name> <members>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length < 2) {
+      return {
+        success: false,
+        error: '用法: `/create-group <群名称> <成员1,成员2,...>`\n\n示例: `/create-group 讨论组 ou_xxx,ou_yyy`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **创建群中...**',
+    };
+  }
+}
+
+/**
+ * Add Member Command - Add a member to a group.
+ */
+export class AddMemberCommand implements Command {
+  readonly name = 'add-member';
+  readonly category = 'group' as const;
+  readonly description = '添加成员';
+  readonly usage = 'add-member <groupId> <member>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length < 2) {
+      return {
+        success: false,
+        error: '用法: `/add-member <群ID> <成员ID>`\n\n示例: `/add-member oc_xxx ou_yyy`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **添加成员中...**',
+    };
+  }
+}
+
+/**
+ * Remove Member Command - Remove a member from a group.
+ */
+export class RemoveMemberCommand implements Command {
+  readonly name = 'remove-member';
+  readonly category = 'group' as const;
+  readonly description = '移除成员';
+  readonly usage = 'remove-member <groupId> <member>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length < 2) {
+      return {
+        success: false,
+        error: '用法: `/remove-member <群ID> <成员ID>`\n\n示例: `/remove-member oc_xxx ou_yyy`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **移除成员中...**',
+    };
+  }
+}
+
+/**
+ * List Member Command - List members of a group.
+ */
+export class ListMemberCommand implements Command {
+  readonly name = 'list-member';
+  readonly category = 'group' as const;
+  readonly description = '列出成员';
+  readonly usage = 'list-member <groupId>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length < 1) {
+      return {
+        success: false,
+        error: '用法: `/list-member <群ID>`\n\n示例: `/list-member oc_xxx`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **获取成员列表中...**',
+    };
+  }
+}
+
+/**
+ * List Group Command - List all managed groups.
+ */
+export class ListGroupCommand implements Command {
+  readonly name = 'list-group';
+  readonly category = 'group' as const;
+  readonly description = '列出群';
+
+  async execute(_context: CommandContext): Promise<CommandResult> {
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **获取群列表中...**',
+    };
+  }
+}
+
+/**
+ * Dissolve Group Command - Dissolve a group.
+ */
+export class DissolveGroupCommand implements Command {
+  readonly name = 'dissolve-group';
+  readonly category = 'group' as const;
+  readonly description = '解散群';
+  readonly usage = 'dissolve-group <groupId>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    if (context.args.length < 1) {
+      return {
+        success: false,
+        error: '用法: `/dissolve-group <群ID>`\n\n示例: `/dissolve-group oc_xxx`',
+      };
+    }
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: '🔄 **解散群中...**',
+    };
+  }
+}
+
+/**
+ * Register default commands to a registry.
+ */
+export function registerDefaultCommands(
+  registry: { register: (cmd: Command) => void },
+  generateHelpText: () => string
+): void {
+  registry.register(new ResetCommand());
+  registry.register(new StatusCommand());
+  registry.register(new HelpCommand(generateHelpText));
+  registry.register(new ListNodesCommand());
+  registry.register(new SwitchNodeCommand());
+  registry.register(new RestartCommand());
+  registry.register(new CreateGroupCommand());
+  registry.register(new AddMemberCommand());
+  registry.register(new RemoveMemberCommand());
+  registry.register(new ListMemberCommand());
+  registry.register(new ListGroupCommand());
+  registry.register(new DissolveGroupCommand());
+}

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for CommandRegistry.
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { CommandRegistry, getCommandRegistry, resetCommandRegistry } from './command-registry.js';
+import { registerDefaultCommands } from './builtin-commands.js';
+import type { Command, CommandContext } from './types.js';
+
+describe('CommandRegistry', () => {
+  let registry: CommandRegistry;
+
+  beforeEach(() => {
+    registry = new CommandRegistry();
+    resetCommandRegistry();
+  });
+
+  afterEach(() => {
+    resetCommandRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a command', () => {
+      const cmd: Command = {
+        name: 'test',
+        description: 'Test command',
+        category: 'session',
+        execute: async () => ({ success: true, message: 'Test' }),
+      };
+
+      registry.register(cmd);
+
+      expect(registry.get('test')).toBeDefined();
+      expect(registry.get('test')?.name).toBe('test');
+      expect(registry.get('test')?.description).toBe('Test command');
+    });
+
+    it('should replace existing command', () => {
+      const cmd1: Command = {
+        name: 'test',
+        description: 'First',
+        category: 'session',
+        execute: async () => ({ success: true }),
+      };
+      const cmd2: Command = {
+        name: 'test',
+        description: 'Second',
+        category: 'session',
+        execute: async () => ({ success: true }),
+      };
+
+      registry.register(cmd1);
+      registry.register(cmd2);
+
+      expect(registry.get('test')?.description).toBe('Second');
+    });
+  });
+
+  describe('registerAll', () => {
+    it('should register multiple commands', () => {
+      const commands: Command[] = [
+        { name: 'cmd1', description: 'Command 1', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'cmd2', description: 'Command 2', category: 'group', execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+
+      expect(registry.get('cmd1')).toBeDefined();
+      expect(registry.get('cmd2')).toBeDefined();
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all enabled commands', () => {
+      const commands: Command[] = [
+        { name: 'enabled', description: 'Enabled', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+
+      const all = registry.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0].name).toBe('enabled');
+    });
+  });
+
+  describe('getByCategory', () => {
+    it('should filter commands by category', () => {
+      const commands: Command[] = [
+        { name: 'session-cmd', description: 'Session', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'group-cmd', description: 'Group', category: 'group', execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+
+      const sessionCommands = registry.getByCategory('session');
+      expect(sessionCommands).toHaveLength(1);
+      expect(sessionCommands[0].name).toBe('session-cmd');
+    });
+  });
+
+  describe('getActiveCategories', () => {
+    it('should return categories in correct order', () => {
+      const commands: Command[] = [
+        { name: 'schedule-cmd', description: 'Schedule', category: 'schedule', execute: async () => ({ success: true }) },
+        { name: 'session-cmd', description: 'Session', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'group-cmd', description: 'Group', category: 'group', execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+
+      const categories = registry.getActiveCategories();
+      expect(categories).toEqual(['session', 'group', 'schedule']);
+    });
+  });
+
+  describe('generateHelpText', () => {
+    it('should generate formatted help text', () => {
+      const commands: Command[] = [
+        { name: 'reset', description: '重置对话', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'status', description: '查看状态', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'create-group', description: '创建群', usage: 'create-group <name> <members>', category: 'group', execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+      const helpText = registry.generateHelpText();
+
+      expect(helpText).toContain('📋 **可用指令**');
+      expect(helpText).toContain('💬 对话：');
+      expect(helpText).toContain('- /reset - 重置对话');
+      expect(helpText).toContain('- /status - 查看状态');
+      expect(helpText).toContain('👥 群管理：');
+      expect(helpText).toContain('- /create-group <name> <members> - 创建群');
+    });
+
+    it('should not include disabled commands', () => {
+      const commands: Command[] = [
+        { name: 'enabled', description: 'Enabled', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+      const helpText = registry.generateHelpText();
+
+      expect(helpText).toContain('enabled');
+      expect(helpText).not.toContain('disabled');
+    });
+  });
+
+  describe('generateWelcomeMessage', () => {
+    it('should generate welcome message with help', () => {
+      const commands: Command[] = [
+        { name: 'reset', description: '重置对话', category: 'session', execute: async () => ({ success: true }) },
+      ];
+
+      registry.registerAll(commands);
+      const welcome = registry.generateWelcomeMessage();
+
+      expect(welcome).toContain('👋 你好！我是 Agent 助手');
+      expect(welcome).toContain('📋 **可用指令**');
+      expect(welcome).toContain('- /reset - 重置对话');
+    });
+  });
+
+  describe('execute', () => {
+    it('should execute command and return result', async () => {
+      const cmd: Command = {
+        name: 'test',
+        description: 'Test',
+        category: 'session',
+        execute: async (ctx: CommandContext) => ({
+          success: true,
+          message: `Executed with args: ${ctx.args.join(', ')}`,
+        }),
+      };
+
+      registry.register(cmd);
+      const result = await registry.execute('test', {
+        chatId: 'test-chat',
+        args: ['arg1', 'arg2'],
+        rawText: '/test arg1 arg2',
+      });
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Executed with args: arg1, arg2',
+      });
+    });
+
+    it('should return null for unknown command', async () => {
+      const result = await registry.execute('unknown', {
+        chatId: 'test-chat',
+        args: [],
+        rawText: '/unknown',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('should return error for disabled command', async () => {
+      const cmd: Command = {
+        name: 'disabled',
+        description: 'Disabled',
+        category: 'session',
+        enabled: false,
+        execute: async () => ({ success: true }),
+      };
+
+      registry.register(cmd);
+      const result = await registry.execute('disabled', {
+        chatId: 'test-chat',
+        args: [],
+        rawText: '/disabled',
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error).toContain('已禁用');
+    });
+
+    it('should handle execution errors', async () => {
+      const cmd: Command = {
+        name: 'error-cmd',
+        description: 'Error',
+        category: 'session',
+        execute: async () => {
+          throw new Error('Test error');
+        },
+      };
+
+      registry.register(cmd);
+      const result = await registry.execute('error-cmd', {
+        chatId: 'test-chat',
+        args: [],
+        rawText: '/error-cmd',
+      });
+
+      expect(result?.success).toBe(false);
+      expect(result?.error).toContain('Test error');
+    });
+  });
+});
+
+describe('getCommandRegistry', () => {
+  beforeEach(() => {
+    resetCommandRegistry();
+  });
+
+  afterEach(() => {
+    resetCommandRegistry();
+  });
+
+  it('should return a singleton registry', () => {
+    const registry1 = getCommandRegistry();
+    const registry2 = getCommandRegistry();
+    expect(registry1).toBe(registry2);
+  });
+
+  it('should reset to new registry', () => {
+    const registry1 = getCommandRegistry();
+    resetCommandRegistry();
+    const registry2 = getCommandRegistry();
+    expect(registry1).not.toBe(registry2);
+  });
+});
+
+describe('registerDefaultCommands', () => {
+  it('should register all default commands', () => {
+    const registry = new CommandRegistry();
+    registerDefaultCommands(registry, () => 'Help text');
+
+    // Session commands
+    expect(registry.get('reset')).toBeDefined();
+    expect(registry.get('status')).toBeDefined();
+    expect(registry.get('help')).toBeDefined();
+
+    // Node commands
+    expect(registry.get('list-nodes')).toBeDefined();
+    expect(registry.get('switch-node')).toBeDefined();
+    expect(registry.get('restart')).toBeDefined();
+
+    // Group commands
+    expect(registry.get('create-group')).toBeDefined();
+    expect(registry.get('add-member')).toBeDefined();
+    expect(registry.get('remove-member')).toBeDefined();
+    expect(registry.get('list-member')).toBeDefined();
+    expect(registry.get('list-group')).toBeDefined();
+    expect(registry.get('dissolve-group')).toBeDefined();
+  });
+
+  it('should generate help text with all categories', () => {
+    const registry = new CommandRegistry();
+    registerDefaultCommands(registry, () => registry.generateHelpText());
+
+    const helpText = registry.generateHelpText();
+
+    expect(helpText).toContain('💬 对话：');
+    expect(helpText).toContain('👥 群管理：');
+    expect(helpText).toContain('🖥️ 节点：');
+  });
+});

--- a/src/nodes/commands/command-registry.ts
+++ b/src/nodes/commands/command-registry.ts
@@ -1,0 +1,187 @@
+/**
+ * Command Registry - DI-based command registration and discovery.
+ *
+ * Manages control commands with:
+ * - Category-based organization
+ * - Dynamic command discovery
+ * - Help text generation
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+import type { Command, CommandCategory, CommandContext, CommandResult } from './types.js';
+import { CATEGORY_CONFIG } from './types.js';
+
+/**
+ * Command Registry - Manages control command instances.
+ *
+ * Commands are registered as instances implementing the Command interface.
+ * The registry provides dynamic discovery and help text generation.
+ */
+export class CommandRegistry {
+  private commands: Map<string, Command> = new Map();
+
+  /**
+   * Register a command instance.
+   */
+  register(command: Command): void {
+    if (this.commands.has(command.name)) {
+      console.warn(`Command "${command.name}" is already registered, replacing`);
+    }
+    this.commands.set(command.name, command);
+  }
+
+  /**
+   * Register multiple command instances.
+   */
+  registerAll(commands: Command[]): void {
+    for (const cmd of commands) {
+      this.register(cmd);
+    }
+  }
+
+  /**
+   * Get a command by name.
+   */
+  get(name: string): Command | undefined {
+    return this.commands.get(name);
+  }
+
+  /**
+   * Check if a command exists.
+   */
+  has(name: string): boolean {
+    return this.commands.has(name);
+  }
+
+  /**
+   * Get all registered commands (enabled only).
+   */
+  getAll(): Command[] {
+    return Array.from(this.commands.values()).filter(
+      cmd => cmd.enabled !== false
+    );
+  }
+
+  /**
+   * Get commands by category.
+   */
+  getByCategory(category: CommandCategory): Command[] {
+    return this.getAll().filter(cmd => cmd.category === category);
+  }
+
+  /**
+   * Get all categories that have commands.
+   */
+  getActiveCategories(): CommandCategory[] {
+    const categories = new Set<CommandCategory>();
+    for (const cmd of this.getAll()) {
+      categories.add(cmd.category);
+    }
+    return Array.from(categories).sort((a, b) => {
+      const orderA = CATEGORY_CONFIG[a]?.order || 99;
+      const orderB = CATEGORY_CONFIG[b]?.order || 99;
+      return orderA - orderB;
+    });
+  }
+
+  /**
+   * Execute a command by name.
+   *
+   * @param name - Command name
+   * @param context - Execution context
+   * @returns Command result or null if command not found
+   */
+  async execute(name: string, context: CommandContext): Promise<CommandResult | null> {
+    const command = this.commands.get(name);
+    if (!command) {
+      return null;
+    }
+
+    if (command.enabled === false) {
+      return { success: false, error: `命令 /${name} 已禁用` };
+    }
+
+    try {
+      return await command.execute(context);
+    } catch (error) {
+      return {
+        success: false,
+        error: `执行命令 /${name} 失败: ${error instanceof Error ? error.message : '未知错误'}`,
+      };
+    }
+  }
+
+  /**
+   * Generate help text with all commands grouped by category.
+   */
+  generateHelpText(): string {
+    const lines: string[] = ['📋 **可用指令**', ''];
+
+    const categories = this.getActiveCategories();
+
+    for (const category of categories) {
+      const info = CATEGORY_CONFIG[category];
+      if (!info) continue;
+
+      const commands = this.getByCategory(category);
+      if (commands.length === 0) continue;
+
+      lines.push(`${info.emoji} ${info.label}：`);
+
+      for (const cmd of commands) {
+        if (cmd.usage) {
+          lines.push(`- /${cmd.usage} - ${cmd.description}`);
+        } else {
+          lines.push(`- /${cmd.name} - ${cmd.description}`);
+        }
+      }
+
+      lines.push('');
+    }
+
+    // Remove trailing empty line
+    if (lines[lines.length - 1] === '') {
+      lines.pop();
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Generate welcome message with brief help.
+   */
+  generateWelcomeMessage(): string {
+    return `👋 你好！我是 Agent 助手
+
+我可以帮你：
+- 🔍 搜索和读取文件
+- 💻 执行代码和命令
+- 📝 创建和编辑文件
+- 🌐 搜索网络获取信息
+
+直接告诉我你想做什么即可！
+
+${this.generateHelpText()}`;
+  }
+}
+
+// Global singleton instance
+let globalRegistry: CommandRegistry | undefined;
+
+/**
+ * Get the global command registry.
+ */
+export function getCommandRegistry(): CommandRegistry {
+  if (!globalRegistry) {
+    globalRegistry = new CommandRegistry();
+  }
+  return globalRegistry;
+}
+
+/**
+ * Reset the global registry (for testing).
+ */
+export function resetCommandRegistry(): void {
+  globalRegistry = undefined;
+}

--- a/src/nodes/commands/index.ts
+++ b/src/nodes/commands/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Command System - DI-based command registration and discovery.
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+export * from './types.js';
+export * from './command-registry.js';
+export * from './builtin-commands.js';

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Command System Types.
+ *
+ * Defines the Command interface and related types for the DI-based command system.
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+/**
+ * Command category for grouping related commands.
+ */
+export type CommandCategory = 'session' | 'group' | 'debug' | 'node' | 'task' | 'schedule' | 'skill';
+
+/**
+ * Command execution context.
+ */
+export interface CommandContext {
+  /** Target chat ID */
+  chatId: string;
+
+  /** User ID who invoked the command */
+  userId?: string;
+
+  /** Command arguments */
+  args: string[];
+
+  /** Raw command text */
+  rawText: string;
+
+  /** Additional data from the channel */
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Command execution result.
+ */
+export interface CommandResult {
+  /** Whether the command was executed successfully */
+  success: boolean;
+
+  /** Response message */
+  message?: string;
+
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Command interface.
+ *
+ * All control commands must implement this interface.
+ * Commands are registered via DI and discovered dynamically.
+ */
+export interface Command {
+  /** Command name (without /) */
+  readonly name: string;
+
+  /** Command category for grouping */
+  readonly category: CommandCategory;
+
+  /** Brief description for help text */
+  readonly description: string;
+
+  /** Usage example (optional) */
+  readonly usage?: string;
+
+  /** Whether command is enabled (default: true) */
+  readonly enabled?: boolean;
+
+  /**
+   * Execute the command.
+   *
+   * @param context - Command execution context
+   * @returns Command execution result
+   */
+  execute(context: CommandContext): Promise<CommandResult>;
+}
+
+/**
+ * Category display configuration.
+ */
+export interface CategoryInfo {
+  /** Display label in Chinese */
+  label: string;
+
+  /** Emoji icon */
+  emoji: string;
+
+  /** Sort order (lower = earlier) */
+  order: number;
+}
+
+/**
+ * Category display names and order.
+ */
+export const CATEGORY_CONFIG: Record<CommandCategory, CategoryInfo> = {
+  session: { label: '对话', emoji: '💬', order: 1 },
+  debug: { label: '调试', emoji: '🔧', order: 2 },
+  group: { label: '群管理', emoji: '👥', order: 3 },
+  node: { label: '节点', emoji: '🖥️', order: 4 },
+  task: { label: '任务', emoji: '📋', order: 5 },
+  schedule: { label: '定时', emoji: '⏰', order: 6 },
+  skill: { label: '技能', emoji: '🎯', order: 7 },
+};

--- a/src/nodes/primary-node.test.ts
+++ b/src/nodes/primary-node.test.ts
@@ -64,6 +64,7 @@ vi.mock('../channels/feishu-channel.js', () => ({
     onMessage: vi.fn(),
     onControl: vi.fn(),
     initTaskFlowOrchestrator: vi.fn(),
+    setWelcomeService: vi.fn(),
   })),
 }));
 

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -60,6 +60,15 @@ import { GroupService, getGroupService } from '../platforms/feishu/group-service
 import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
 // Debug group (Issue #487)
 import { getDebugGroupService } from './debug-group-service.js';
+// Command system (Issue #463)
+import {
+  getCommandRegistry,
+  registerDefaultCommands,
+} from './commands/index.js';
+// Welcome service (Issue #463)
+import {
+  initWelcomeService,
+} from '../platforms/feishu/welcome-service.js';
 
 const logger = createLogger('PrimaryNode');
 
@@ -143,6 +152,10 @@ export class PrimaryNode extends EventEmitter {
       sendFileToUser: this.sendFileToUser.bind(this),
     });
 
+    // Issue #463: Initialize CommandRegistry with default commands
+    const commandRegistry = getCommandRegistry();
+    registerDefaultCommands(commandRegistry, () => commandRegistry.generateHelpText());
+
     // Register custom channels if provided
     if (config.channels) {
       for (const channel of config.channels) {
@@ -166,6 +179,13 @@ export class PrimaryNode extends EventEmitter {
         sendCard: this.sendCard.bind(this),
         sendFile: this.sendFileToUser.bind(this),
       });
+
+      // Issue #463: Initialize WelcomeService and set to FeishuChannel
+      const welcomeService = initWelcomeService({
+        generateWelcomeMessage: () => commandRegistry.generateWelcomeMessage(),
+        sendMessage: this.sendMessage.bind(this),
+      });
+      feishuChannel.setWelcomeService(welcomeService);
 
       this.registerChannel(feishuChannel);
       logger.info('Feishu channel registered');
@@ -521,6 +541,12 @@ export class PrimaryNode extends EventEmitter {
           success: true,
           message: `📊 **状态**\n\n状态: ${status}\n节点ID: ${this.localNodeId}\n执行节点: ${execStatus}\n当前节点: ${currentNode?.name || '未分配'}\n通道: ${channelStatus}`,
         };
+      }
+
+      // Issue #463: Help command using CommandRegistry
+      case 'help': {
+        const registry = getCommandRegistry();
+        return { success: true, message: registry.generateHelpText() };
       }
 
       case 'list-nodes': {

--- a/src/platforms/feishu/index.ts
+++ b/src/platforms/feishu/index.ts
@@ -24,3 +24,12 @@ export {
   type CreateDiscussionOptions,
   type ChatOpsConfig,
 } from './chat-ops.js';
+
+// Welcome Service (Issue #463)
+export {
+  WelcomeService,
+  initWelcomeService,
+  getWelcomeService,
+  resetWelcomeService,
+  type WelcomeServiceConfig,
+} from './welcome-service.js';

--- a/src/platforms/feishu/welcome-service.test.ts
+++ b/src/platforms/feishu/welcome-service.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for WelcomeService.
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  WelcomeService,
+  initWelcomeService,
+  getWelcomeService,
+  resetWelcomeService,
+} from './welcome-service.js';
+
+describe('WelcomeService', () => {
+  let service: WelcomeService;
+  let sendMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sendMessageMock = vi.fn().mockResolvedValue(undefined);
+    service = new WelcomeService({
+      generateWelcomeMessage: () => '👋 Welcome!',
+      sendMessage: sendMessageMock,
+    });
+    resetWelcomeService();
+  });
+
+  afterEach(() => {
+    resetWelcomeService();
+  });
+
+  describe('isPrivateChat', () => {
+    it('should return true for private chat IDs (ou_)', () => {
+      expect(service.isPrivateChat('ou_abc123')).toBe(true);
+      expect(service.isPrivateChat('ou_xyz789')).toBe(true);
+    });
+
+    it('should return false for group chat IDs (oc_)', () => {
+      expect(service.isPrivateChat('oc_abc123')).toBe(false);
+    });
+
+    it('should return false for other IDs', () => {
+      expect(service.isPrivateChat('some-random-id')).toBe(false);
+    });
+  });
+
+  describe('isGroupChat', () => {
+    it('should return true for group chat IDs (oc_)', () => {
+      expect(service.isGroupChat('oc_abc123')).toBe(true);
+      expect(service.isGroupChat('oc_xyz789')).toBe(true);
+    });
+
+    it('should return false for private chat IDs (ou_)', () => {
+      expect(service.isGroupChat('ou_abc123')).toBe(false);
+    });
+  });
+
+  describe('handleBotAddedToGroup', () => {
+    it('should send welcome message to group', async () => {
+      await service.handleBotAddedToGroup('oc_test123');
+
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageMock).toHaveBeenCalledWith('oc_test123', '👋 Welcome!');
+    });
+
+    it('should not send message to non-group chat', async () => {
+      await service.handleBotAddedToGroup('ou_test123');
+
+      expect(sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle send message error', async () => {
+      sendMessageMock.mockRejectedValueOnce(new Error('Send failed'));
+
+      // Should not throw
+      await service.handleBotAddedToGroup('oc_test123');
+
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleFirstPrivateChat', () => {
+    it('should send welcome message on first private chat', async () => {
+      const result = await service.handleFirstPrivateChat('ou_user123');
+
+      expect(result).toBe(true);
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageMock).toHaveBeenCalledWith('ou_user123', '👋 Welcome!');
+    });
+
+    it('should not send message on subsequent private chats', async () => {
+      const result1 = await service.handleFirstPrivateChat('ou_user123');
+      const result2 = await service.handleFirstPrivateChat('ou_user123');
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(false);
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not send message to non-private chat', async () => {
+      const result = await service.handleFirstPrivateChat('oc_group123');
+
+      expect(result).toBe(false);
+      expect(sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should track different users separately', async () => {
+      const result1 = await service.handleFirstPrivateChat('ou_user1');
+      const result2 = await service.handleFirstPrivateChat('ou_user2');
+
+      expect(result1).toBe(true);
+      expect(result2).toBe(true);
+      expect(sendMessageMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle send message error', async () => {
+      sendMessageMock.mockRejectedValueOnce(new Error('Send failed'));
+
+      const result = await service.handleFirstPrivateChat('ou_user123');
+
+      expect(result).toBe(false);
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleP2PChatEntered', () => {
+    it('should delegate to handleFirstPrivateChat', async () => {
+      const result = await service.handleP2PChatEntered('ou_user123');
+
+      expect(result).toBe(true);
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getFirstTimeChatCount', () => {
+    it('should return count of tracked first-time chats', async () => {
+      expect(service.getFirstTimeChatCount()).toBe(0);
+
+      await service.handleFirstPrivateChat('ou_user1');
+      expect(service.getFirstTimeChatCount()).toBe(1);
+
+      await service.handleFirstPrivateChat('ou_user2');
+      expect(service.getFirstTimeChatCount()).toBe(2);
+
+      // Same user again should not increase count
+      await service.handleFirstPrivateChat('ou_user1');
+      expect(service.getFirstTimeChatCount()).toBe(2);
+    });
+  });
+
+  describe('clearFirstTimeChats', () => {
+    it('should clear all tracked chats', async () => {
+      await service.handleFirstPrivateChat('ou_user1');
+      await service.handleFirstPrivateChat('ou_user2');
+
+      expect(service.getFirstTimeChatCount()).toBe(2);
+
+      service.clearFirstTimeChats();
+
+      expect(service.getFirstTimeChatCount()).toBe(0);
+    });
+  });
+});
+
+describe('Global WelcomeService', () => {
+  beforeEach(() => {
+    resetWelcomeService();
+  });
+
+  afterEach(() => {
+    resetWelcomeService();
+  });
+
+  describe('initWelcomeService', () => {
+    it('should initialize and return global service', () => {
+      const service = initWelcomeService({
+        generateWelcomeMessage: () => 'Welcome',
+        sendMessage: vi.fn(),
+      });
+
+      expect(service).toBeInstanceOf(WelcomeService);
+      expect(getWelcomeService()).toBe(service);
+    });
+  });
+
+  describe('getWelcomeService', () => {
+    it('should return undefined before initialization', () => {
+      expect(getWelcomeService()).toBeUndefined();
+    });
+
+    it('should return the initialized service', () => {
+      const service = initWelcomeService({
+        generateWelcomeMessage: () => 'Welcome',
+        sendMessage: vi.fn(),
+      });
+
+      expect(getWelcomeService()).toBe(service);
+    });
+  });
+
+  describe('resetWelcomeService', () => {
+    it('should clear the global service', () => {
+      initWelcomeService({
+        generateWelcomeMessage: () => 'Welcome',
+        sendMessage: vi.fn(),
+      });
+
+      expect(getWelcomeService()).toBeDefined();
+
+      resetWelcomeService();
+
+      expect(getWelcomeService()).toBeUndefined();
+    });
+  });
+});

--- a/src/platforms/feishu/welcome-service.ts
+++ b/src/platforms/feishu/welcome-service.ts
@@ -1,0 +1,155 @@
+/**
+ * Welcome Service - Handles welcome messages for new chats.
+ *
+ * Provides:
+ * - Welcome message when bot enters a new P2P chat
+ * - Welcome message when bot is added to a group
+ * - Tracks first-time private chats in memory
+ *
+ * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ */
+
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('WelcomeService');
+
+/**
+ * Welcome service configuration.
+ */
+export interface WelcomeServiceConfig {
+  /** Function to generate welcome message */
+  generateWelcomeMessage: () => string;
+
+  /** Function to send a message */
+  sendMessage: (chatId: string, text: string) => Promise<void>;
+}
+
+/**
+ * Welcome Service - Manages welcome messages for new chats.
+ */
+export class WelcomeService {
+  private generateWelcomeMessage: () => string;
+  private sendMessage: (chatId: string, text: string) => Promise<void>;
+
+  /** Track first-time private chats (memory-only, resets on restart) */
+  private firstTimePrivateChats = new Set<string>();
+
+  constructor(config: WelcomeServiceConfig) {
+    this.generateWelcomeMessage = config.generateWelcomeMessage;
+    this.sendMessage = config.sendMessage;
+  }
+
+  /**
+   * Check if a chat ID is a private chat.
+   * In Feishu, private chat IDs start with 'ou_' (user open_id).
+   */
+  isPrivateChat(chatId: string): boolean {
+    return chatId.startsWith('ou_');
+  }
+
+  /**
+   * Check if a chat ID is a group chat.
+   * In Feishu, group chat IDs start with 'oc_'.
+   */
+  isGroupChat(chatId: string): boolean {
+    return chatId.startsWith('oc_');
+  }
+
+  /**
+   * Handle bot being added to a group chat.
+   * Sends welcome message with help.
+   */
+  async handleBotAddedToGroup(chatId: string): Promise<void> {
+    if (!this.isGroupChat(chatId)) {
+      logger.warn({ chatId }, 'handleBotAddedToGroup called with non-group chat ID');
+      return;
+    }
+
+    logger.info({ chatId }, 'Bot added to group, sending welcome message');
+
+    try {
+      await this.sendMessage(chatId, this.generateWelcomeMessage());
+      logger.info({ chatId }, 'Welcome message sent to group');
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to send welcome message to group');
+    }
+  }
+
+  /**
+   * Handle first private chat with a user.
+   * Sends welcome message with help if this is the first time.
+   */
+  async handleFirstPrivateChat(chatId: string): Promise<boolean> {
+    if (!this.isPrivateChat(chatId)) {
+      logger.debug({ chatId }, 'handleFirstPrivateChat called with non-private chat ID');
+      return false;
+    }
+
+    // Check if this is the first time
+    if (this.firstTimePrivateChats.has(chatId)) {
+      logger.debug({ chatId }, 'Already sent welcome to this private chat');
+      return false;
+    }
+
+    // Mark as sent
+    this.firstTimePrivateChats.add(chatId);
+
+    logger.info({ chatId }, 'First private chat, sending welcome message');
+
+    try {
+      await this.sendMessage(chatId, this.generateWelcomeMessage());
+      logger.info({ chatId }, 'Welcome message sent to private chat');
+      return true;
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to send welcome message to private chat');
+      return false;
+    }
+  }
+
+  /**
+   * Handle P2P chat entered event.
+   * This is called when a user starts a private chat with the bot.
+   */
+  async handleP2PChatEntered(chatId: string): Promise<boolean> {
+    return this.handleFirstPrivateChat(chatId);
+  }
+
+  /**
+   * Get the count of first-time private chats tracked.
+   */
+  getFirstTimeChatCount(): number {
+    return this.firstTimePrivateChats.size;
+  }
+
+  /**
+   * Clear all tracked first-time chats (for testing).
+   */
+  clearFirstTimeChats(): void {
+    this.firstTimePrivateChats.clear();
+  }
+}
+
+// Singleton instance
+let globalWelcomeService: WelcomeService | undefined;
+
+/**
+ * Initialize the global welcome service.
+ */
+export function initWelcomeService(config: WelcomeServiceConfig): WelcomeService {
+  globalWelcomeService = new WelcomeService(config);
+  return globalWelcomeService;
+}
+
+/**
+ * Get the global welcome service.
+ */
+export function getWelcomeService(): WelcomeService | undefined {
+  return globalWelcomeService;
+}
+
+/**
+ * Reset the global welcome service (for testing).
+ */
+export function resetWelcomeService(): void {
+  globalWelcomeService = undefined;
+}

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -113,3 +113,61 @@ export interface InteractionContext {
  * Interaction handler function type.
  */
 export type InteractionHandler = (action: FeishuCardActionEvent) => Promise<void>;
+
+/**
+ * Feishu chat member added event.
+ * Triggered when members (including bot) are added to a chat.
+ * @see https://open.feishu.cn/document/client-docs/bot-v3/events/chat-member-added
+ */
+export interface FeishuChatMemberAddedEvent {
+  /** Chat ID */
+  chat_id: string;
+  /** Timestamp */
+  timestamp: string;
+  /** Members added to the chat */
+  members: Array<{
+    member_id_type: string;
+    member_id: string;
+    name?: string;
+    tenant_key?: string;
+  }>;
+  /** Operator who added the members */
+  operator: {
+    operator_id_type: string;
+    operator_id: string;
+    tenant_key?: string;
+  };
+}
+
+/**
+ * Feishu chat member added event data wrapper.
+ */
+export interface FeishuChatMemberAddedEventData {
+  event?: FeishuChatMemberAddedEvent;
+  [key: string]: unknown;
+}
+
+/**
+ * Feishu P2P chat entered event.
+ * Triggered when a user starts a private chat with the bot.
+ * @see https://open.feishu.cn/document/client-docs/bot-v3/events/bot-p2p-chat-entered
+ */
+export interface FeishuP2PChatEnteredEvent {
+  /** User who entered the chat */
+  user: {
+    open_id: string;
+    union_id?: string;
+    user_id?: string;
+    tenant_key?: string;
+  };
+  /** Timestamp */
+  timestamp: string;
+}
+
+/**
+ * Feishu P2P chat entered event data wrapper.
+ */
+export interface FeishuP2PChatEnteredEventData {
+  event?: FeishuP2PChatEnteredEvent;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary

Implements #463 - A complete help message system with DI-based command registration and welcome messages.

Based on PR #495 with user feedback incorporated:
- ✅ Remove bot self-detection in `handleChatMemberAdded` - just check for new members
- ✅ Remove unused `generateHelpText` parameter from `WelcomeServiceConfig`
- ✅ Replace hardcoded `CONTROL_COMMANDS` with dynamic lookup from `CommandRegistry`

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | Use `getCommandRegistry().has()` instead of hardcoded array; Simplify `handleChatMemberAdded` |
| `src/platforms/feishu/welcome-service.ts` | Remove unused `generateHelpText` config parameter |
| `src/nodes/commands/*` | DI-based command registration system |
| `src/platforms/feishu/welcome-service.ts` | Welcome message service |

## Key Fixes (from PR #495 feedback)

### 1. Remove bot self-detection
Before:
```typescript
const botAdded = event.members.some(
  member => member.member_id_type === 'app_id' || member.member_id_type === 'open_id'
);
if (!botAdded) { return; }
```

After:
```typescript
// Just check if there are new members - no need to detect if it's the bot itself
if (!event?.members || event.members.length === 0) { return; }
```

### 2. Remove unused parameter
Before:
```typescript
interface WelcomeServiceConfig {
  generateHelpText: () => string;  // UNUSED
  generateWelcomeMessage: () => string;
  sendMessage: (chatId: string, text: string) => Promise<void>;
}
```

After:
```typescript
interface WelcomeServiceConfig {
  generateWelcomeMessage: () => string;
  sendMessage: (chatId: string, text: string) => Promise<void>;
}
```

### 3. Remove hardcoded commands
Before:
```typescript
const CONTROL_COMMANDS = [
  'reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
  'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group',
];
const isControlCommand = CONTROL_COMMANDS.includes(cmd);
```

After:
```typescript
const commandRegistry = getCommandRegistry();
const isControlCommand = commandRegistry.has(cmd);
```

## Test Results

| Metric | Value |
|--------|-------|
| Test Files | 71 passed, 2 pre-existing failures |
| Tests | 1320 passed, 5 pre-existing failures |
| Pre-existing failures | task-file-watcher.test.ts (unrelated) |

## Related

- Issue #463: feat: 帮助消息系统 - 入群/私聊引导 + 指令注册
- Supersedes: PR #495 (closed - needed modifications per user feedback)

## Test plan

- [x] CommandRegistry unit tests pass
- [x] WelcomeService unit tests pass
- [x] FeishuChannel tests pass
- [x] TypeScript type check passes
- [ ] Manual test: Bot added to group sends welcome
- [ ] Manual test: First private chat sends welcome
- [ ] Manual test: /help shows all available commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)