### PR TITLE
fix(build): add axios CJS dependencies to external for ESM build

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,13 @@ const EXTERNAL_DEPS = [
   'pino-roll',
   'sonic-boom',
   'pino-file',
+  // CJS modules that use dynamic require - must be external for ESM build
+  // These are dependencies of @larksuiteoapi/node-sdk -> axios
+  'axios',
+  'form-data',
+  'follow-redirects',
+  'combined-stream',
+  'proxy-from-env',
 ];
 
 export default defineConfig([


### PR DESCRIPTION
## Summary

Fixes #530 - ESM build was failing with "Dynamic require is not supported" error when loading `form-data` and its dependencies.

## Root Cause

tsup bundled CJS modules (`form-data`, `follow-redirects`, `combined-stream`, `proxy-from-env`) that use dynamic `require()`, which is not supported in ESM runtime.

The error occurred because:
1. `@larksuiteoapi/node-sdk` depends on `axios`
2. `axios` depends on `form-data` and `follow-redirects`
3. These CJS modules use `require('util')`, `require('url')` etc.
4. ESM loader doesn't support dynamic require

## Solution

Add the entire axios dependency chain to `EXTERNAL_DEPS` in `tsup.config.ts`:
- `axios` (HTTP client used by @larksuiteoapi/node-sdk)
- `form-data` (multipart form handling)
- `follow-redirects` (HTTP redirect handling)
- `combined-stream` (stream utilities)
- `proxy-from-env` (proxy configuration)

## Test Results

| Metric | Value |
|--------|-------|
| Build | ✅ Success |
| CLI Start | ✅ No dynamic require errors |
| Unit Tests | 1283 passed, 5 pre-existing failures |

Pre-existing failures are in `task-file-watcher.test.ts` (unrelated to this fix).

## Test Plan

- [x] `npm run build` succeeds
- [x] `node dist/cli-entry.js --help` shows help without errors
- [x] `npm test` passes (1283/1288 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)