### PR TITLE
fix(lint): 修复命令系统代码的 39 个 ESLint 错误

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -634,7 +634,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    const event = data.event;
+    const { event } = data;
     if (!event?.user?.open_id) {
       logger.debug('P2P chat entered event missing user info');
       return;
@@ -656,7 +656,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    const event = data.event;
+    const { event } = data;
     if (!event?.chat_id || !event?.members || event.members.length === 0) {
       logger.debug('Chat member added event missing required fields');
       return;

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -16,7 +16,7 @@ export class ResetCommand implements Command {
   readonly category = 'session' as const;
   readonly description = '重置对话';
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     // Actual reset is handled by PrimaryNode
     return {
       success: true,
@@ -33,7 +33,7 @@ export class StatusCommand implements Command {
   readonly category = 'session' as const;
   readonly description = '查看状态';
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     // Actual status is handled by PrimaryNode
     return {
       success: true,
@@ -56,7 +56,7 @@ export class HelpCommand implements Command {
     this.generateHelpText = generateHelpText;
   }
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     return {
       success: true,
       message: this.generateHelpText(),
@@ -72,7 +72,7 @@ export class ListNodesCommand implements Command {
   readonly category = 'node' as const;
   readonly description = '列出执行节点';
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     // Actual implementation is handled by PrimaryNode
     return {
       success: true,
@@ -90,7 +90,7 @@ export class SwitchNodeCommand implements Command {
   readonly description = '切换执行节点';
   readonly usage = 'switch-node <nodeId>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length === 0) {
       return {
         success: false,
@@ -113,7 +113,7 @@ export class RestartCommand implements Command {
   readonly category = 'node' as const;
   readonly description = '重启服务';
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     // Actual implementation is handled by PrimaryNode
     return {
       success: true,
@@ -131,7 +131,7 @@ export class CreateGroupCommand implements Command {
   readonly description = '创建群';
   readonly usage = 'create-group <name> <members>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length < 2) {
       return {
         success: false,
@@ -155,7 +155,7 @@ export class AddMemberCommand implements Command {
   readonly description = '添加成员';
   readonly usage = 'add-member <groupId> <member>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length < 2) {
       return {
         success: false,
@@ -179,7 +179,7 @@ export class RemoveMemberCommand implements Command {
   readonly description = '移除成员';
   readonly usage = 'remove-member <groupId> <member>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length < 2) {
       return {
         success: false,
@@ -203,7 +203,7 @@ export class ListMemberCommand implements Command {
   readonly description = '列出成员';
   readonly usage = 'list-member <groupId>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length < 1) {
       return {
         success: false,
@@ -226,7 +226,7 @@ export class ListGroupCommand implements Command {
   readonly category = 'group' as const;
   readonly description = '列出群';
 
-  async execute(_context: CommandContext): Promise<CommandResult> {
+  execute(_context: CommandContext): CommandResult {
     // Actual implementation is handled by PrimaryNode
     return {
       success: true,
@@ -244,7 +244,7 @@ export class DissolveGroupCommand implements Command {
   readonly description = '解散群';
   readonly usage = 'dissolve-group <groupId>';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     if (context.args.length < 1) {
       return {
         success: false,

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -27,7 +27,7 @@ describe('CommandRegistry', () => {
         name: 'test',
         description: 'Test command',
         category: 'session',
-        execute: async () => ({ success: true, message: 'Test' }),
+        execute: () => ({ success: true, message: 'Test' }),
       };
 
       registry.register(cmd);
@@ -42,13 +42,13 @@ describe('CommandRegistry', () => {
         name: 'test',
         description: 'First',
         category: 'session',
-        execute: async () => ({ success: true }),
+        execute: () => ({ success: true }),
       };
       const cmd2: Command = {
         name: 'test',
         description: 'Second',
         category: 'session',
-        execute: async () => ({ success: true }),
+        execute: () => ({ success: true }),
       };
 
       registry.register(cmd1);
@@ -61,8 +61,8 @@ describe('CommandRegistry', () => {
   describe('registerAll', () => {
     it('should register multiple commands', () => {
       const commands: Command[] = [
-        { name: 'cmd1', description: 'Command 1', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'cmd2', description: 'Command 2', category: 'group', execute: async () => ({ success: true }) },
+        { name: 'cmd1', description: 'Command 1', category: 'session', execute: () => ({ success: true }) },
+        { name: 'cmd2', description: 'Command 2', category: 'group', execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -75,8 +75,8 @@ describe('CommandRegistry', () => {
   describe('getAll', () => {
     it('should return all enabled commands', () => {
       const commands: Command[] = [
-        { name: 'enabled', description: 'Enabled', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: async () => ({ success: true }) },
+        { name: 'enabled', description: 'Enabled', category: 'session', execute: () => ({ success: true }) },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -90,8 +90,8 @@ describe('CommandRegistry', () => {
   describe('getByCategory', () => {
     it('should filter commands by category', () => {
       const commands: Command[] = [
-        { name: 'session-cmd', description: 'Session', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'group-cmd', description: 'Group', category: 'group', execute: async () => ({ success: true }) },
+        { name: 'session-cmd', description: 'Session', category: 'session', execute: () => ({ success: true }) },
+        { name: 'group-cmd', description: 'Group', category: 'group', execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -105,9 +105,9 @@ describe('CommandRegistry', () => {
   describe('getActiveCategories', () => {
     it('should return categories in correct order', () => {
       const commands: Command[] = [
-        { name: 'schedule-cmd', description: 'Schedule', category: 'schedule', execute: async () => ({ success: true }) },
-        { name: 'session-cmd', description: 'Session', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'group-cmd', description: 'Group', category: 'group', execute: async () => ({ success: true }) },
+        { name: 'schedule-cmd', description: 'Schedule', category: 'schedule', execute: () => ({ success: true }) },
+        { name: 'session-cmd', description: 'Session', category: 'session', execute: () => ({ success: true }) },
+        { name: 'group-cmd', description: 'Group', category: 'group', execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -120,9 +120,9 @@ describe('CommandRegistry', () => {
   describe('generateHelpText', () => {
     it('should generate formatted help text', () => {
       const commands: Command[] = [
-        { name: 'reset', description: '重置对话', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'status', description: '查看状态', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'create-group', description: '创建群', usage: 'create-group <name> <members>', category: 'group', execute: async () => ({ success: true }) },
+        { name: 'reset', description: '重置对话', category: 'session', execute: () => ({ success: true }) },
+        { name: 'status', description: '查看状态', category: 'session', execute: () => ({ success: true }) },
+        { name: 'create-group', description: '创建群', usage: 'create-group <name> <members>', category: 'group', execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -138,8 +138,8 @@ describe('CommandRegistry', () => {
 
     it('should not include disabled commands', () => {
       const commands: Command[] = [
-        { name: 'enabled', description: 'Enabled', category: 'session', execute: async () => ({ success: true }) },
-        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: async () => ({ success: true }) },
+        { name: 'enabled', description: 'Enabled', category: 'session', execute: () => ({ success: true }) },
+        { name: 'disabled', description: 'Disabled', category: 'session', enabled: false, execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -153,7 +153,7 @@ describe('CommandRegistry', () => {
   describe('generateWelcomeMessage', () => {
     it('should generate welcome message with help', () => {
       const commands: Command[] = [
-        { name: 'reset', description: '重置对话', category: 'session', execute: async () => ({ success: true }) },
+        { name: 'reset', description: '重置对话', category: 'session', execute: () => ({ success: true }) },
       ];
 
       registry.registerAll(commands);
@@ -171,7 +171,7 @@ describe('CommandRegistry', () => {
         name: 'test',
         description: 'Test',
         category: 'session',
-        execute: async (ctx: CommandContext) => ({
+        execute: (ctx: CommandContext) => ({
           success: true,
           message: `Executed with args: ${ctx.args.join(', ')}`,
         }),
@@ -206,7 +206,7 @@ describe('CommandRegistry', () => {
         description: 'Disabled',
         category: 'session',
         enabled: false,
-        execute: async () => ({ success: true }),
+        execute: () => ({ success: true }),
       };
 
       registry.register(cmd);
@@ -225,7 +225,7 @@ describe('CommandRegistry', () => {
         name: 'error-cmd',
         description: 'Error',
         category: 'session',
-        execute: async () => {
+        execute: () => {
           throw new Error('Test error');
         },
       };

--- a/src/nodes/commands/command-registry.ts
+++ b/src/nodes/commands/command-registry.ts
@@ -9,8 +9,7 @@
  * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
  */
 
-import type { Command, CommandCategory, CommandContext, CommandResult } from './types.js';
-import { CATEGORY_CONFIG } from './types.js';
+import { CATEGORY_CONFIG, type Command, type CommandCategory, type CommandContext, type CommandResult } from './types.js';
 
 /**
  * Command Registry - Manages control command instances.
@@ -122,10 +121,14 @@ export class CommandRegistry {
 
     for (const category of categories) {
       const info = CATEGORY_CONFIG[category];
-      if (!info) continue;
+      if (!info) {
+        continue;
+      }
 
       const commands = this.getByCategory(category);
-      if (commands.length === 0) continue;
+      if (commands.length === 0) {
+        continue;
+      }
 
       lines.push(`${info.emoji} ${info.label}：`);
 

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -71,9 +71,9 @@ export interface Command {
    * Execute the command.
    *
    * @param context - Command execution context
-   * @returns Command execution result
+   * @returns Command execution result (can be sync or async)
    */
-  execute(context: CommandContext): Promise<CommandResult>;
+  execute(context: CommandContext): CommandResult | Promise<CommandResult>;
 }
 
 /**

--- a/src/platforms/feishu/welcome-service.ts
+++ b/src/platforms/feishu/welcome-service.ts
@@ -110,7 +110,7 @@ export class WelcomeService {
    * Handle P2P chat entered event.
    * This is called when a user starts a private chat with the bot.
    */
-  async handleP2PChatEntered(chatId: string): Promise<boolean> {
+  handleP2PChatEntered(chatId: string): Promise<boolean> {
     return this.handleFirstPrivateChat(chatId);
   }
 


### PR DESCRIPTION
## Summary
- 修复 35 个 require-await ESLint 错误：移除不必要的 async 关键字
- 修复 1 个 no-duplicate-imports 错误：合并重复导入
- 修复 2 个 curly 错误：为 if 语句添加花括号
- 修复 2 个 prefer-destructuring 错误：使用对象解构

## Changes
1. types.ts: 修改 Command.execute 返回类型支持同步和异步实现
2. builtin-commands.ts: 移除所有命令类中不必要的 async 关键字
3. command-registry.ts: 合并重复导入，修复 curly 错误
4. command-registry.test.ts: 移除测试中 mock 函数不必要的 async 关键字
5. feishu-channel.ts: 使用对象解构替代属性访问
6. welcome-service.ts: 移除不必要的 async 关键字

## Test Results
- Lint: 0 errors (修复前: 39 errors)
- TypeScript 类型检查: 通过
- 命令系统测试: 17/17 通过

Fixes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)