### PR TITLE
feat(group): add passive mode control command for group chats (Issue #511)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -460,4 +460,120 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       expect(senderInstance?.addReaction).toHaveBeenCalledWith('test-msg-id', 'Typing');
     });
   });
+
+  /**
+   * Issue #511: Passive mode control for group chats
+   */
+  describe('Passive mode control (Issue #511)', () => {
+    it('should process group chat message when passive mode is disabled', async () => {
+      // Disable passive mode for this chat
+      channel.setPassiveModeDisabled('oc_test_group', true);
+
+      await simulateMessageReceive({
+        text: 'Hello everyone!',
+        chatId: 'oc_test_group',
+        mentions: undefined, // No mentions
+      });
+
+      // Message SHOULD be passed to agent (passive mode disabled)
+      expect(messageHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Hello everyone!',
+        })
+      );
+    });
+
+    it('should skip group chat message when passive mode is re-enabled', async () => {
+      // First disable, then re-enable passive mode
+      channel.setPassiveModeDisabled('oc_test_group', true);
+      channel.setPassiveModeDisabled('oc_test_group', false);
+
+      await simulateMessageReceive({
+        text: 'Hello everyone!',
+        chatId: 'oc_test_group',
+        mentions: undefined,
+      });
+
+      // Message should NOT be passed to agent (passive mode re-enabled)
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should track passive mode state per chat', async () => {
+      // Disable passive mode for one chat
+      channel.setPassiveModeDisabled('oc_group_1', true);
+
+      // Simulate message in group 1 (passive mode disabled)
+      await simulateMessageReceive({
+        text: 'Hello group 1',
+        chatId: 'oc_group_1',
+        mentions: undefined,
+      });
+
+      // Should be processed
+      expect(messageHandler).toHaveBeenCalledTimes(1);
+
+      // Simulate message in group 2 (passive mode enabled by default)
+      await simulateMessageReceive({
+        text: 'Hello group 2',
+        chatId: 'oc_group_2',
+        mentions: undefined,
+      });
+
+      // Should NOT be processed (passive mode still enabled for group 2)
+      expect(messageHandler).toHaveBeenCalledTimes(1); // Still 1, not incremented
+    });
+
+    it('should correctly report passive mode status', async () => {
+      // Initially passive mode is enabled (not disabled)
+      expect(channel.isPassiveModeDisabled('oc_test_group')).toBe(false);
+
+      // After disabling
+      channel.setPassiveModeDisabled('oc_test_group', true);
+      expect(channel.isPassiveModeDisabled('oc_test_group')).toBe(true);
+
+      // After re-enabling
+      channel.setPassiveModeDisabled('oc_test_group', false);
+      expect(channel.isPassiveModeDisabled('oc_test_group')).toBe(false);
+    });
+
+    it('should return list of chats with passive mode disabled', () => {
+      // Initially empty
+      expect(channel.getPassiveModeDisabledChats()).toEqual([]);
+
+      // Add some chats
+      channel.setPassiveModeDisabled('oc_group_1', true);
+      channel.setPassiveModeDisabled('oc_group_2', true);
+
+      expect(channel.getPassiveModeDisabledChats()).toContain('oc_group_1');
+      expect(channel.getPassiveModeDisabledChats()).toContain('oc_group_2');
+
+      // Remove one
+      channel.setPassiveModeDisabled('oc_group_1', false);
+      expect(channel.getPassiveModeDisabledChats()).not.toContain('oc_group_1');
+      expect(channel.getPassiveModeDisabledChats()).toContain('oc_group_2');
+    });
+
+    it('should still process @mentioned messages when passive mode is disabled', async () => {
+      channel.setPassiveModeDisabled('oc_test_group', true);
+
+      await simulateMessageReceive({
+        text: '@bot Hello!',
+        chatId: 'oc_test_group',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'bot-open-id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Message SHOULD be passed to agent
+      expect(messageHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '@bot Hello!',
+        })
+      );
+    });
+  });
 });

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -71,6 +71,13 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
   private readonly MAX_MESSAGE_AGE = DEDUPLICATION.MAX_MESSAGE_AGE;
 
+  /**
+   * Passive mode state storage.
+   * Key: chatId, Value: true if passive mode is disabled (bot responds to all messages)
+   * Issue #511: Group chat passive mode control
+   */
+  private passiveModeDisabled: Map<string, boolean> = new Map();
+
   constructor(config: FeishuChannelConfig = {}) {
     super(config, 'feishu', 'Feishu');
     this.appId = config.appId || Config.FEISHU_APP_ID;
@@ -317,6 +324,48 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
+   * Check if passive mode is disabled for a specific chat.
+   * When passive mode is disabled, the bot responds to all messages in group chats.
+   *
+   * Issue #511: Group chat passive mode control
+   *
+   * @param chatId - Chat ID to check
+   * @returns true if passive mode is disabled (bot responds to all messages)
+   */
+  isPassiveModeDisabled(chatId: string): boolean {
+    return this.passiveModeDisabled.get(chatId) === true;
+  }
+
+  /**
+   * Set passive mode state for a specific chat.
+   *
+   * Issue #511: Group chat passive mode control
+   *
+   * @param chatId - Chat ID to configure
+   * @param disabled - true to disable passive mode (respond to all messages)
+   */
+  setPassiveModeDisabled(chatId: string, disabled: boolean): void {
+    if (disabled) {
+      this.passiveModeDisabled.set(chatId, true);
+      logger.info({ chatId }, 'Passive mode disabled for chat');
+    } else {
+      this.passiveModeDisabled.delete(chatId);
+      logger.info({ chatId }, 'Passive mode enabled for chat');
+    }
+  }
+
+  /**
+   * Get all chats with passive mode disabled.
+   *
+   * Issue #511: Group chat passive mode control
+   *
+   * @returns Array of chat IDs with passive mode disabled
+   */
+  getPassiveModeDisabledChats(): string[] {
+    return Array.from(this.passiveModeDisabled.keys());
+  }
+
+  /**
    * Handle incoming message event from WebSocket.
    */
   private async handleMessageReceive(data: FeishuEventData): Promise<void> {
@@ -519,10 +568,12 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
     }
 
-    // Issue #460: Group chat passive mode
+    // Issue #460 & #511: Group chat passive mode
     // In group chats, only respond when bot is mentioned (@bot)
     // This allows scheduled tasks to broadcast without triggering unwanted responses
-    if (this.isGroupChat(chat_type) && !botMentioned) {
+    // Issue #511: Passive mode can be disabled per chat via /passive command
+    const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
+    if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled) {
       logger.debug(
         { messageId: message_id, chatId: chat_id, chat_type },
         'Skipped group chat message without @mention (passive mode)'

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -126,7 +126,9 @@ export type ControlCommandType =
   // Debug group commands (Issue #487)
   | 'set-debug'
   | 'show-debug'
-  | 'clear-debug';
+  | 'clear-debug'
+  // Passive mode control (Issue #511)
+  | 'passive';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -260,6 +260,36 @@ export class DissolveGroupCommand implements Command {
 }
 
 /**
+ * Passive Command - Control passive mode for group chats.
+ * Issue #511: Group chat passive mode control
+ */
+export class PassiveCommand implements Command {
+  readonly name = 'passive';
+  readonly category = 'group' as const;
+  readonly description = '群聊被动模式开关';
+  readonly usage = 'passive [on|off|status]';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    // Default to status if no args
+    const subCommand = context.args[0]?.toLowerCase() || 'status';
+
+    // Validate subcommand
+    if (!['on', 'off', 'status'].includes(subCommand)) {
+      return {
+        success: false,
+        error: '用法: `/passive [on|off|status]`\n\n- `on` - 开启被动模式（仅响应 @提及）\n- `off` - 关闭被动模式（响应所有消息）\n- `status` - 查看当前状态',
+      };
+    }
+
+    // Actual implementation is handled by PrimaryNode/CommunicationNode
+    return {
+      success: true,
+      message: `🔄 **被动模式设置中...**`,
+    };
+  }
+}
+
+/**
  * Register default commands to a registry.
  */
 export function registerDefaultCommands(
@@ -278,4 +308,5 @@ export function registerDefaultCommands(
   registry.register(new ListMemberCommand());
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());
+  registry.register(new PassiveCommand());
 }

--- a/src/nodes/communication-node.ts
+++ b/src/nodes/communication-node.ts
@@ -400,6 +400,51 @@ export class CommunicationNode extends EventEmitter {
         }
       }
 
+      // Issue #511: Passive mode control for group chats
+      case 'passive': {
+        const feishuChannel = this.channelManager.get('feishu') as FeishuChannel | undefined;
+        if (!feishuChannel) {
+          return { success: false, error: 'Feishu 通道不可用' };
+        }
+
+        const args = command.data?.args as string[] | undefined;
+        const subCommand = (args?.[0] as string)?.toLowerCase() || 'status';
+
+        switch (subCommand) {
+          case 'off': {
+            // Disable passive mode - respond to all messages
+            feishuChannel.setPassiveModeDisabled(command.chatId, true);
+            return {
+              success: true,
+              message: '✅ **被动模式已关闭**\n\nBot 将响应此群聊的所有消息，无需 @提及。',
+            };
+          }
+          case 'on': {
+            // Enable passive mode - only respond when mentioned
+            feishuChannel.setPassiveModeDisabled(command.chatId, false);
+            return {
+              success: true,
+              message: '✅ **被动模式已开启**\n\nBot 将仅在此群聊被 @提及时响应。',
+            };
+          }
+          case 'status': {
+            const isDisabled = feishuChannel.isPassiveModeDisabled(command.chatId);
+            const statusText = isDisabled
+              ? '关闭（Bot 响应所有消息）'
+              : '开启（Bot 仅响应 @提及）';
+            return {
+              success: true,
+              message: `📊 **被动模式状态**\n\n当前状态: ${statusText}\n\n用法:\n- \`/passive off\` - 关闭被动模式\n- \`/passive on\` - 开启被动模式`,
+            };
+          }
+          default:
+            return {
+              success: false,
+              error: '用法: `/passive [on|off|status]`\n\n- `on` - 开启被动模式（仅响应 @提及）\n- `off` - 关闭被动模式（响应所有消息）\n- `status` - 查看当前状态',
+            };
+        }
+      }
+
       default:
         return { success: false, error: `Unknown command: ${command.type}` };
     }


### PR DESCRIPTION
## Summary
- Add `/passive` command to control passive mode per group chat
- Allow disabling passive mode so bot responds to all messages in specific groups
- Add `setPassiveModeDisabled`, `isPassiveModeDisabled`, `getPassiveModeDisabledChats` methods to FeishuChannel

## Changes
1. **FeishuChannel**: Add passive mode state management
   - New `passiveModeDisabled` Map to track per-chat passive mode state
   - Methods to set/get passive mode status
   - Updated passive mode check to consider disabled state

2. **PassiveCommand**: New command for controlling passive mode
   - `/passive on` - Enable passive mode (only respond when @mentioned)
   - `/passive off` - Disable passive mode (respond to all messages)
   - `/passive status` - Show current passive mode status

3. **CommunicationNode**: Handle `passive` control command
   - Get FeishuChannel and call appropriate methods

4. **Types**: Add `passive` to ControlCommandType

5. **Tests**: Add comprehensive tests for passive mode control

## Usage
```
/passive off    # Bot responds to all messages in this group
/passive on     # Bot only responds when @mentioned
/passive status # Show current status
```

## Test Results
- TypeScript: ✅ Pass
- Command Registry Tests: ✅ 17/17 Pass
- Channels Tests: ✅ 84/84 Pass (including 22 passive mode tests)
- Communication Node Tests: ✅ 16/16 Pass

Fixes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)