### PR TITLE
fix: resolve ESLint errors in passive mode code (Issue #544)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -523,7 +523,7 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       expect(messageHandler).toHaveBeenCalledTimes(1); // Still 1, not incremented
     });
 
-    it('should correctly report passive mode status', async () => {
+    it('should correctly report passive mode status', () => {
       // Initially passive mode is enabled (not disabled)
       expect(channel.isPassiveModeDisabled('oc_test_group')).toBe(false);
 

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -269,7 +269,7 @@ export class PassiveCommand implements Command {
   readonly description = '群聊被动模式开关';
   readonly usage = 'passive [on|off|status]';
 
-  async execute(context: CommandContext): Promise<CommandResult> {
+  execute(context: CommandContext): CommandResult {
     // Default to status if no args
     const subCommand = context.args[0]?.toLowerCase() || 'status';
 
@@ -284,7 +284,7 @@ export class PassiveCommand implements Command {
     // Actual implementation is handled by PrimaryNode/CommunicationNode
     return {
       success: true,
-      message: `🔄 **被动模式设置中...**`,
+      message: '🔄 **被动模式设置中...**',
     };
   }
 }


### PR DESCRIPTION
## Summary

- Fix 3 ESLint errors introduced in PR #543 (feat/issue-511-passive-mode-control)
- Remove unnecessary `async` keywords from synchronous functions
- Change template literal to single quote string per ESLint rules

## Changes

### 1. `src/channels/feishu-channel-passive-mode.test.ts:526`
- Remove `async` keyword from test function
- The test only contains synchronous `expect` statements, no `await` needed

### 2. `src/nodes/commands/builtin-commands.ts:272`
- Remove `async` keyword from `PassiveCommand.execute()` method
- Method only performs synchronous operations
- Interface allows both `CommandResult | Promise<CommandResult>` return types

### 3. `src/nodes/commands/builtin-commands.ts:287`
- Change template literal (backticks) to single quote string
- No interpolation in the string, ESLint `quotes` rule requires single quotes

## Test Results

```
✓ src/channels/feishu-channel-passive-mode.test.ts (22 tests) 14ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

## ESLint Results

- **Before**: 3 errors, 65 warnings
- **After**: 0 errors, 65 warnings

Fixes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)