### PR TITLE
feat(feishu): add retry mechanism with exponential backoff for API calls (Issue #507)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -49,4 +49,30 @@ export const REACTIONS = {
 export const FEISHU_API = {
   /** Request timeout in milliseconds (30 seconds) */
   REQUEST_TIMEOUT_MS: 30 * 1000,
+
+  /** Retry configuration for transient errors */
+  RETRY: {
+    /** Maximum number of retry attempts */
+    MAX_RETRIES: 3,
+    /** Initial delay in milliseconds before first retry */
+    INITIAL_DELAY_MS: 1000,
+    /** Maximum delay in milliseconds between retries */
+    MAX_DELAY_MS: 10000,
+    /** Multiplier for exponential backoff */
+    BACKOFF_MULTIPLIER: 2,
+  },
 } as const;
+
+/**
+ * Error codes that should trigger a retry
+ */
+export const RETRYABLE_ERROR_CODES = [
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPROTO',
+] as const;

--- a/src/platforms/feishu/create-feishu-client.test.ts
+++ b/src/platforms/feishu/create-feishu-client.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for createFeishuClient factory with retry logic (Issue #507).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import { createFeishuClient } from './create-feishu-client.js';
+import { FEISHU_API } from '../../config/constants.js';
+
+// Mock axios
+vi.mock('axios', () => {
+  const mockAxios = {
+    create: vi.fn(() => mockAxiosInstance),
+    isAxiosError: vi.fn((error) => error && error.isAxiosError === true),
+  };
+  return {
+    default: mockAxios,
+  };
+});
+
+// Mock axios instance
+const mockAxiosInstance = {
+  request: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  patch: vi.fn(),
+  delete: vi.fn(),
+  head: vi.fn(),
+  options: vi.fn(),
+};
+
+// Mock logger
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+describe('createFeishuClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: successful response
+    mockAxiosInstance.get.mockResolvedValue({ data: 'success' });
+    mockAxiosInstance.post.mockResolvedValue({ data: 'success' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create client with correct timeout configuration', () => {
+    createFeishuClient('test-app-id', 'test-app-secret');
+
+    expect(axios.create).toHaveBeenCalledWith({
+      timeout: FEISHU_API.REQUEST_TIMEOUT_MS,
+    });
+  });
+
+  describe('retry logic', () => {
+    it('should retry on ETIMEDOUT error', async () => {
+      const timeoutError = {
+        isAxiosError: true,
+        code: 'ETIMEDOUT',
+        message: 'timeout of 30000ms exceeded',
+        response: undefined,
+      };
+
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(timeoutError)
+        .mockRejectedValueOnce(timeoutError)
+        .mockResolvedValueOnce({ data: 'success after retries' });
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      // Speed up test by mocking setTimeout
+      vi.useFakeTimers();
+      const resultPromise = httpInstance.get('https://test.com');
+
+      // Fast-forward through delays
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      vi.useRealTimers();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(3);
+      expect(result).toBe('success after retries');
+    });
+
+    it('should retry on ECONNRESET error', async () => {
+      const connResetError = {
+        isAxiosError: true,
+        code: 'ECONNRESET',
+        message: 'socket hang up',
+        response: undefined,
+      };
+
+      mockAxiosInstance.post
+        .mockRejectedValueOnce(connResetError)
+        .mockResolvedValueOnce({ data: 'success' });
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        post: (url: string, data: unknown) => Promise<unknown>;
+      };
+
+      vi.useFakeTimers();
+      const resultPromise = httpInstance.post('https://test.com', { foo: 'bar' });
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+      vi.useRealTimers();
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+      expect(result).toBe('success');
+    });
+
+    it('should retry on 5xx server errors', async () => {
+      const serverError = {
+        isAxiosError: true,
+        code: 'ERR_BAD_RESPONSE',
+        message: 'Request failed with status code 500',
+        response: { status: 500, data: 'Internal Server Error' },
+      };
+
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(serverError)
+        .mockResolvedValueOnce({ data: 'success' });
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      vi.useFakeTimers();
+      const resultPromise = httpInstance.get('https://test.com');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+      vi.useRealTimers();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      expect(result).toBe('success');
+    });
+
+    it('should retry on 429 Too Many Requests', async () => {
+      const rateLimitError = {
+        isAxiosError: true,
+        code: 'ERR_BAD_RESPONSE',
+        message: 'Request failed with status code 429',
+        response: { status: 429, data: 'Rate limited' },
+      };
+
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({ data: 'success' });
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      vi.useFakeTimers();
+      const resultPromise = httpInstance.get('https://test.com');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+      vi.useRealTimers();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      expect(result).toBe('success');
+    });
+
+    it('should NOT retry on 4xx client errors (except 429)', async () => {
+      const badRequestError = {
+        isAxiosError: true,
+        code: 'ERR_BAD_REQUEST',
+        message: 'Request failed with status code 400',
+        response: { status: 400, data: 'Bad Request' },
+      };
+
+      mockAxiosInstance.get.mockRejectedValue(badRequestError);
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      await expect(httpInstance.get('https://test.com')).rejects.toBeDefined();
+
+      // Should not retry for 4xx errors
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw after max retries exhausted', async () => {
+      const timeoutError = {
+        isAxiosError: true,
+        code: 'ETIMEDOUT',
+        message: 'timeout of 30000ms exceeded',
+        response: undefined,
+      };
+
+      // All attempts fail
+      mockAxiosInstance.get.mockRejectedValue(timeoutError);
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      vi.useFakeTimers();
+
+      // Start the request and catch rejection immediately
+      const resultPromise = httpInstance.get('https://test.com').catch(e => {
+        // Catch the rejection to prevent unhandled rejection warning
+        return Promise.reject(e);
+      });
+
+      // Fast-forward through all delays
+      await vi.runAllTimersAsync();
+
+      // Now await the result
+      await expect(resultPromise).rejects.toBeDefined();
+
+      vi.useRealTimers();
+
+      // Initial attempt + MAX_RETRIES (3) = 4 total calls
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1 + FEISHU_API.RETRY.MAX_RETRIES);
+    });
+
+    it('should use exponential backoff for delays', async () => {
+      const timeoutError = {
+        isAxiosError: true,
+        code: 'ETIMEDOUT',
+        message: 'timeout',
+        response: undefined,
+      };
+
+      mockAxiosInstance.get.mockRejectedValue(timeoutError);
+
+      const client = createFeishuClient('test-app-id', 'test-app-secret');
+      const httpInstance = (client as unknown as { httpInstance: unknown }).httpInstance as {
+        get: (url: string) => Promise<unknown>;
+      };
+
+      vi.useFakeTimers();
+
+      // Start the request with catch to prevent unhandled rejection
+      const resultPromise = httpInstance.get('https://test.com').catch(e => e);
+
+      // Let it run through all retries
+      await vi.runAllTimersAsync();
+
+      // Await and verify it failed
+      const result = await resultPromise;
+      expect(result).toBeDefined();
+
+      vi.useRealTimers();
+
+      // Verify it attempted multiple times (exponential backoff would cause delays)
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1 + FEISHU_API.RETRY.MAX_RETRIES);
+    });
+  });
+});

--- a/src/platforms/feishu/create-feishu-client.ts
+++ b/src/platforms/feishu/create-feishu-client.ts
@@ -1,93 +1,218 @@
 /**
- * Factory function to create Lark Client with timeout configuration.
+ * Factory function to create Lark Client with timeout and retry configuration.
  *
  * The @larksuiteoapi/node-sdk doesn't support requestTimeout directly,
  * so we create a custom axios instance with timeout and wrap it as HttpInstance.
+ *
+ * Retry mechanism (Issue #507):
+ * - Automatically retries on transient network errors (ETIMEDOUT, ECONNRESET, etc.)
+ * - Uses exponential backoff with jitter to avoid thundering herd
+ * - Logs retry attempts for debugging
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
-import axios, { AxiosInstance } from 'axios';
-import { FEISHU_API } from '../../config/constants.js';
+import axios, { AxiosInstance, AxiosError } from 'axios';
+import { FEISHU_API, RETRYABLE_ERROR_CODES } from '../../config/constants.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('FeishuClient');
+
+/**
+ * Check if an error is retryable (transient network error).
+ */
+function isRetryableError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+
+  const axiosError = error as AxiosError;
+
+  // Network errors (no response received)
+  if (!axiosError.response && axiosError.code) {
+    return RETRYABLE_ERROR_CODES.includes(axiosError.code as typeof RETRYABLE_ERROR_CODES[number]);
+  }
+
+  // Server errors (5xx) are potentially retryable
+  if (axiosError.response?.status) {
+    const status = axiosError.response.status;
+    // 429 Too Many Requests, 500+ server errors
+    return status === 429 || (status >= 500 && status < 600);
+  }
+
+  return false;
+}
+
+/**
+ * Calculate delay with exponential backoff and jitter.
+ * This helps avoid thundering herd problem when multiple clients retry simultaneously.
+ */
+function calculateRetryDelay(attempt: number): number {
+  const { INITIAL_DELAY_MS, MAX_DELAY_MS, BACKOFF_MULTIPLIER } = FEISHU_API.RETRY;
+  const exponentialDelay = INITIAL_DELAY_MS * Math.pow(BACKOFF_MULTIPLIER, attempt);
+  const cappedDelay = Math.min(exponentialDelay, MAX_DELAY_MS);
+  // Add jitter (random 0-20% of delay) to spread out retries
+  const jitter = cappedDelay * Math.random() * 0.2;
+  return Math.floor(cappedDelay + jitter);
+}
+
+/**
+ * Sleep for specified milliseconds.
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Wrap axios request with retry logic.
+ */
+async function requestWithRetry<T>(
+  requestFn: () => Promise<T>,
+  context: string
+): Promise<T> {
+  const { MAX_RETRIES } = FEISHU_API.RETRY;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await requestFn();
+    } catch (error) {
+      lastError = error;
+
+      // Check if we should retry
+      if (!isRetryableError(error)) {
+        throw error;
+      }
+
+      // Don't sleep after the last attempt
+      if (attempt < MAX_RETRIES) {
+        const delay = calculateRetryDelay(attempt);
+        const axiosError = error as AxiosError;
+        logger.warn(
+          {
+            context,
+            attempt: attempt + 1,
+            maxRetries: MAX_RETRIES,
+            delayMs: delay,
+            errorCode: axiosError.code,
+            errorMessage: axiosError.message,
+          },
+          'Request failed, retrying...'
+        );
+        await sleep(delay);
+      }
+    }
+  }
+
+  // All retries exhausted
+  const axiosError = lastError as AxiosError;
+  logger.error(
+    {
+      context,
+      maxRetries: MAX_RETRIES,
+      errorCode: axiosError?.code,
+      errorMessage: axiosError?.message,
+    },
+    'All retry attempts exhausted'
+  );
+  throw lastError;
+}
 
 /**
  * Wrap an axios instance to match lark SDK's HttpInstance interface.
+ * Includes retry logic for transient errors.
  */
 function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstance {
   return {
     request: async (opts) => {
-      const response = await axiosInstance.request({
-        url: opts.url,
-        method: opts.method,
-        headers: opts.headers,
-        params: opts.params,
-        data: opts.data,
-        responseType: opts.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-        timeout: opts.timeout,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.request({
+          url: opts.url,
+          method: opts.method,
+          headers: opts.headers,
+          params: opts.params,
+          data: opts.data,
+          responseType: opts.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+          timeout: opts.timeout,
+        }).then(res => res.data),
+        `request ${opts.method} ${opts.url}`
+      );
     },
     get: async (url, opts) => {
-      const response = await axiosInstance.get(url, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.get(url, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `get ${url}`
+      );
     },
     delete: async (url, opts) => {
-      const response = await axiosInstance.delete(url, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.delete(url, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `delete ${url}`
+      );
     },
     head: async (url, opts) => {
-      const response = await axiosInstance.head(url, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.head(url, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `head ${url}`
+      );
     },
     options: async (url, opts) => {
-      const response = await axiosInstance.options(url, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.options(url, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `options ${url}`
+      );
     },
     post: async (url, data, opts) => {
-      const response = await axiosInstance.post(url, data, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.post(url, data, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `post ${url}`
+      );
     },
     put: async (url, data, opts) => {
-      const response = await axiosInstance.put(url, data, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.put(url, data, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `put ${url}`
+      );
     },
     patch: async (url, data, opts) => {
-      const response = await axiosInstance.patch(url, data, {
-        params: opts?.params,
-        headers: opts?.headers,
-        timeout: opts?.timeout,
-        responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
-      });
-      return response.data;
+      return requestWithRetry(
+        () => axiosInstance.patch(url, data, {
+          params: opts?.params,
+          headers: opts?.headers,
+          timeout: opts?.timeout,
+          responseType: opts?.responseType as 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata' | undefined,
+        }).then(res => res.data),
+        `patch ${url}`
+      );
     },
   };
 }
@@ -105,7 +230,7 @@ export interface CreateFeishuClientOptions {
 }
 
 /**
- * Create a Lark Client with configured request timeout.
+ * Create a Lark Client with configured request timeout and retry.
  *
  * @param appId - Feishu App ID
  * @param appSecret - Feishu App Secret
@@ -122,7 +247,7 @@ export function createFeishuClient(
     timeout: FEISHU_API.REQUEST_TIMEOUT_MS,
   });
 
-  // Wrap axios as lark HttpInstance
+  // Wrap axios as lark HttpInstance (with retry logic)
   const httpInstance = wrapAxiosAsHttpInstance(axiosInstance);
 
   // Create and return lark Client with custom httpInstance

--- a/src/platforms/feishu/feishu-adapter.test.ts
+++ b/src/platforms/feishu/feishu-adapter.test.ts
@@ -8,14 +8,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FeishuPlatformAdapter } from './feishu-adapter.js';
 import type { IAttachmentManager } from '../../channels/adapters/types.js';
 
-// Mock logger
-const mockLogger = {
+// Mock logger - use vi.hoisted to define before mock
+const mockLogger = vi.hoisted(() => ({
   debug: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
   trace: vi.fn(),
-};
+}));
 
 vi.mock('../../utils/logger.js', () => ({
   createLogger: vi.fn(() => mockLogger),


### PR DESCRIPTION
## Summary

- Add automatic retry mechanism for transient network errors (ETIMEDOUT, ECONNRESET, etc.)
- Implement exponential backoff with jitter to avoid thundering herd
- Add retry for 5xx server errors and 429 (rate limiting)
- Add comprehensive tests for retry logic
- Fix mock hoisting issue in feishu-adapter.test.ts

## Problem

Feishu API calls could fail due to temporary network issues, causing:
- Users waiting 30+ seconds for timeout
- No automatic recovery from transient errors
- Poor user experience during network instability

## Solution

### 1. Retry Configuration (`constants.ts`)
```typescript
export const FEISHU_API = {
  REQUEST_TIMEOUT_MS: 30 * 1000,
  RETRY: {
    MAX_RETRIES: 3,
    INITIAL_DELAY_MS: 1000,
    MAX_DELAY_MS: 10000,
    BACKOFF_MULTIPLIER: 2,
  },
};

export const RETRYABLE_ERROR_CODES = [
  'ETIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', ...
];
```

### 2. Retry Implementation (`create-feishu-client.ts`)
- `isRetryableError()`: Detect transient errors
- `calculateRetryDelay()`: Exponential backoff + jitter (0-20% random)
- `requestWithRetry()`: Wrap all HTTP methods with retry logic
- Structured logging for retry attempts and exhaustion

### 3. Retry Logic

| Error Type | Retry? |
|------------|--------|
| Network errors (ETIMEDOUT, ECONNRESET, etc.) | ✅ Yes |
| 5xx server errors | ✅ Yes |
| 429 Too Many Requests | ✅ Yes |
| 4xx client errors (except 429) | ❌ No |

## Test Results

- 8 new tests for retry logic ✅
- All feishu platform tests pass (127 tests) ✅
- TypeScript type check passes ✅

## Related

- Completes #507 (retry mechanism)
- PR #520 already added timeout configuration

Fixes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)