### PR TITLE
feat(node): add unified node management commands (Issue #541)

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -128,7 +128,9 @@ export type ControlCommandType =
   | 'show-debug'
   | 'clear-debug'
   // Passive mode control (Issue #511)
-  | 'passive';
+  | 'passive'
+  // Node management commands (Issue #541)
+  | 'node';
 
 /**
  * Control command from user to agent.

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -290,6 +290,75 @@ export class PassiveCommand implements Command {
 }
 
 /**
+ * Node Command - Unified node management commands.
+ * Issue #541: 节点管理指令
+ *
+ * Subcommands:
+ * - list: List all nodes and their status
+ * - status [node-id]: View node detailed status
+ * - info: View current node info
+ * - switch <node-id>: Switch to specified node
+ * - auto: Switch to auto-selection mode
+ */
+export class NodeCommand implements Command {
+  readonly name = 'node';
+  readonly category = 'node' as const;
+  readonly description = '节点管理指令';
+  readonly usage = 'node <list|status|info|switch|auto>';
+
+  execute(context: CommandContext): CommandResult {
+    const subCommand = context.args[0]?.toLowerCase();
+
+    // If no subcommand, show help
+    if (!subCommand) {
+      return {
+        success: true,
+        message: `🖥️ **节点管理指令**
+
+用法: \`/node <子命令>\`
+
+**可用子命令:**
+- \`list\` - 列出所有节点及其状态
+- \`status [node-id]\` - 查看节点详细状态（不指定则查看当前）
+- \`info\` - 查看当前节点信息
+- \`switch <node-id>\` - 切换到指定节点
+- \`auto\` - 切换到自动选择模式
+
+示例:
+\`\`\`
+/node list
+/node status
+/node switch worker-abc123
+/node auto
+\`\`\``,
+      };
+    }
+
+    // Validate subcommand
+    const validSubcommands = ['list', 'status', 'info', 'switch', 'auto'];
+    if (!validSubcommands.includes(subCommand)) {
+      return {
+        success: false,
+        error: `未知的子命令: \`${subCommand}\`
+
+可用子命令: ${validSubcommands.map(c => `\`${c}\``).join(', ')}`,
+      };
+    }
+
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: `🔄 **节点命令执行中...**`,
+      // Pass through the subcommand and remaining args for PrimaryNode to handle
+      data: {
+        subcommand: subCommand,
+        nodeArgs: context.args.slice(1),
+      },
+    };
+  }
+}
+
+/**
  * Register default commands to a registry.
  */
 export function registerDefaultCommands(
@@ -309,4 +378,6 @@ export function registerDefaultCommands(
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());
   registry.register(new PassiveCommand());
+  // Issue #541: Node management command
+  registry.register(new NodeCommand());
 }

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -280,6 +280,8 @@ describe('registerDefaultCommands', () => {
     expect(registry.get('list-nodes')).toBeDefined();
     expect(registry.get('switch-node')).toBeDefined();
     expect(registry.get('restart')).toBeDefined();
+    // Issue #541: Node management command
+    expect(registry.get('node')).toBeDefined();
 
     // Group commands
     expect(registry.get('create-group')).toBeDefined();
@@ -288,6 +290,7 @@ describe('registerDefaultCommands', () => {
     expect(registry.get('list-member')).toBeDefined();
     expect(registry.get('list-group')).toBeDefined();
     expect(registry.get('dissolve-group')).toBeDefined();
+    expect(registry.get('passive')).toBeDefined();
   });
 
   it('should generate help text with all categories', () => {

--- a/src/nodes/commands/node-command.test.ts
+++ b/src/nodes/commands/node-command.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for NodeCommand.
+ *
+ * Issue #541: 节点管理指令 - 便捷的节点操作命令
+ */
+
+import { describe, it, expect } from 'vitest';
+import { NodeCommand } from './builtin-commands.js';
+import type { CommandContext } from './types.js';
+
+describe('NodeCommand', () => {
+  const command = new NodeCommand();
+
+  describe('metadata', () => {
+    it('should have correct name', () => {
+      expect(command.name).toBe('node');
+    });
+
+    it('should have node category', () => {
+      expect(command.category).toBe('node');
+    });
+
+    it('should have description', () => {
+      expect(command.description).toBe('节点管理指令');
+    });
+
+    it('should have usage', () => {
+      expect(command.usage).toBe('node <list|status|info|switch|auto>');
+    });
+  });
+
+  describe('execute', () => {
+    const createTestContext = (args: string[]): CommandContext => ({
+      chatId: 'test-chat-id',
+      args,
+      rawText: `/node ${args.join(' ')}`,
+    });
+
+    describe('no args - help', () => {
+      it('should show help when no args provided', () => {
+        const result = command.execute(createTestContext([]));
+
+        expect(result.success).toBe(true);
+        expect(result.message).toContain('节点管理指令');
+        expect(result.message).toContain('list');
+        expect(result.message).toContain('status');
+        expect(result.message).toContain('info');
+        expect(result.message).toContain('switch');
+        expect(result.message).toContain('auto');
+      });
+    });
+
+    describe('invalid subcommand', () => {
+      it('should return error for unknown subcommand', () => {
+        const result = command.execute(createTestContext(['unknown']));
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('未知的子命令');
+        expect(result.error).toContain('unknown');
+      });
+    });
+
+    describe('list subcommand', () => {
+      it('should return success for list subcommand', () => {
+        const result = command.execute(createTestContext(['list']));
+
+        expect(result.success).toBe(true);
+        expect(result.message).toBe('🔄 **节点命令执行中...**');
+        expect(result.data).toEqual({
+          subcommand: 'list',
+          nodeArgs: [],
+        });
+      });
+    });
+
+    describe('status subcommand', () => {
+      it('should return success for status subcommand', () => {
+        const result = command.execute(createTestContext(['status']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'status',
+          nodeArgs: [],
+        });
+      });
+
+      it('should pass node-id to status subcommand', () => {
+        const result = command.execute(createTestContext(['status', 'node-123']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'status',
+          nodeArgs: ['node-123'],
+        });
+      });
+    });
+
+    describe('info subcommand', () => {
+      it('should return success for info subcommand', () => {
+        const result = command.execute(createTestContext(['info']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'info',
+          nodeArgs: [],
+        });
+      });
+    });
+
+    describe('switch subcommand', () => {
+      it('should return success for switch subcommand', () => {
+        const result = command.execute(createTestContext(['switch', 'node-456']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'switch',
+          nodeArgs: ['node-456'],
+        });
+      });
+
+      it('should return success for switch without node-id', () => {
+        const result = command.execute(createTestContext(['switch']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'switch',
+          nodeArgs: [],
+        });
+      });
+    });
+
+    describe('auto subcommand', () => {
+      it('should return success for auto subcommand', () => {
+        const result = command.execute(createTestContext(['auto']));
+
+        expect(result.success).toBe(true);
+        expect(result.data).toEqual({
+          subcommand: 'auto',
+          nodeArgs: [],
+        });
+      });
+    });
+
+    describe('case insensitivity', () => {
+      it('should handle uppercase subcommands', () => {
+        const result = command.execute(createTestContext(['LIST']));
+
+        expect(result.success).toBe(true);
+        expect(result.data?.subcommand).toBe('list');
+      });
+
+      it('should handle mixed case subcommands', () => {
+        const result = command.execute(createTestContext(['StAtUs']));
+
+        expect(result.success).toBe(true);
+        expect(result.data?.subcommand).toBe('status');
+      });
+    });
+  });
+});

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -43,6 +43,9 @@ export interface CommandResult {
 
   /** Error message if failed */
   error?: string;
+
+  /** Additional data for command handler (Issue #541) */
+  data?: Record<string, unknown>;
 }
 
 /**

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -583,6 +583,149 @@ export class PrimaryNode extends EventEmitter {
         }
       }
 
+      // Issue #541: Node management command
+      case 'node': {
+        const args = command.data?.args as string[] | undefined;
+        const subCommand = args?.[0]?.toLowerCase();
+
+        if (!subCommand) {
+          // Show help
+          return {
+            success: true,
+            message: `🖥️ **节点管理指令**
+
+用法: \`/node <子命令>\`
+
+**可用子命令:**
+- \`list\` - 列出所有节点及其状态
+- \`status [node-id]\` - 查看节点详细状态（不指定则查看当前）
+- \`info\` - 查看当前节点信息
+- \`switch <node-id>\` - 切换到指定节点
+- \`auto\` - 切换到自动选择模式
+
+示例:
+\`\`\`
+/node list
+/node status
+/node switch worker-abc123
+/node auto
+\`\`\``,
+          };
+        }
+
+        switch (subCommand) {
+          case 'list': {
+            const nodes = this.execNodeRegistry.getNodes();
+            if (nodes.length === 0) {
+              return { success: true, message: '📋 **节点列表**\n\n暂无执行节点' };
+            }
+            const currentNodeId = this.execNodeRegistry.getChatNodeAssignment(command.chatId);
+            const nodesList = nodes.map(n => {
+              const isCurrent = n.nodeId === currentNodeId ? ' ✓ (当前)' : '';
+              const localTag = n.isLocal ? ' [本地]' : '';
+              const statusIcon = n.status === 'connected' ? '🟢' : '🔴';
+              return `${statusIcon} **${n.name}**${localTag}${isCurrent}\n   ID: \`${n.nodeId}\`\n   活跃会话: ${n.activeChats}`;
+            }).join('\n\n');
+            return { success: true, message: `🖥️ **节点列表**\n\n共 ${nodes.length} 个节点\n\n${nodesList}` };
+          }
+
+          case 'status': {
+            const targetNodeId = args?.[1];
+            const nodeId = targetNodeId || this.execNodeRegistry.getChatNodeAssignment(command.chatId);
+
+            if (!nodeId) {
+              return {
+                success: true,
+                message: '📊 **节点状态**\n\n当前会话未分配节点\n\n使用 `/node auto` 自动分配',
+              };
+            }
+
+            const node = this.execNodeRegistry.getNode(nodeId);
+            if (!node) {
+              return { success: false, error: `节点 \`${nodeId}\` 不存在` };
+            }
+
+            const nodes = this.execNodeRegistry.getNodes();
+            const nodeInfo = nodes.find(n => n.nodeId === nodeId);
+            const connectedAt = node.connectedAt ? new Date(node.connectedAt).toLocaleString('zh-CN') : 'N/A';
+            const statusIcon = nodeInfo?.status === 'connected' ? '🟢' : '🔴';
+            const localTag = node.isLocal ? '\n类型: 本地执行' : '\n类型: 远程节点';
+
+            return {
+              success: true,
+              message: `📊 **节点状态**\n\n名称: **${node.name}**\nID: \`${node.nodeId}\`\n状态: ${statusIcon} ${nodeInfo?.status || 'unknown'}${localTag}\n活跃会话: ${nodeInfo?.activeChats || 0}\n连接时间: ${connectedAt}`,
+            };
+          }
+
+          case 'info': {
+            const currentNodeId = this.execNodeRegistry.getChatNodeAssignment(command.chatId);
+            if (!currentNodeId) {
+              return {
+                success: true,
+                message: `📊 **当前节点信息**\n\n节点ID: ${this.localNodeId}\n会话分配: 未分配\n\n当前会话未分配执行节点，将使用自动选择模式。`,
+              };
+            }
+
+            const node = this.execNodeRegistry.getNode(currentNodeId);
+            const nodes = this.execNodeRegistry.getNodes();
+            const nodeInfo = nodes.find(n => n.nodeId === currentNodeId);
+            const connectedAt = node?.connectedAt ? new Date(node.connectedAt).toLocaleString('zh-CN') : 'N/A';
+            const statusIcon = nodeInfo?.status === 'connected' ? '🟢' : '🔴';
+
+            return {
+              success: true,
+              message: `📊 **当前节点信息**\n\n节点ID: ${this.localNodeId}\n执行节点: **${node?.name || currentNodeId}**\n执行节点ID: \`${currentNodeId}\`\n状态: ${statusIcon} ${nodeInfo?.status || 'unknown'}\n活跃会话: ${nodeInfo?.activeChats || 0}\n连接时间: ${connectedAt}`,
+            };
+          }
+
+          case 'switch': {
+            const targetNodeId = args?.[1];
+            if (!targetNodeId) {
+              const nodes = this.execNodeRegistry.getNodes();
+              const nodesList = nodes.map(n => `- \`${n.nodeId}\` (${n.name}${n.isLocal ? ', local' : ''})`).join('\n');
+              return {
+                success: false,
+                error: `请指定目标节点ID。\n\n用法: \`/node switch <node-id>\`\n\n可用节点:\n${nodesList}`,
+              };
+            }
+
+            const success = this.execNodeRegistry.switchChatNode(command.chatId, targetNodeId);
+            if (success) {
+              const node = this.execNodeRegistry.getNode(targetNodeId);
+              return { success: true, message: `✅ **已切换执行节点**\n\n当前节点: ${node?.name || targetNodeId}` };
+            } else {
+              return { success: false, error: `切换失败，节点 \`${targetNodeId}\` 不存在或不可用` };
+            }
+          }
+
+          case 'auto': {
+            // Get current assignment and switch to auto-selection
+            const availableNode = this.execNodeRegistry.getFirstAvailableNode();
+
+            if (availableNode) {
+              // Assign to first available node (auto mode)
+              this.execNodeRegistry.switchChatNode(command.chatId, availableNode.nodeId);
+              const localTag = availableNode.isLocal ? ' (本地)' : '';
+              return {
+                success: true,
+                message: `✅ **已切换到自动选择模式**\n\n自动分配到: **${availableNode.name}**${localTag}\n节点ID: \`${availableNode.nodeId}\``,
+              };
+            } else {
+              return {
+                success: false,
+                error: '没有可用的执行节点',
+              };
+            }
+          }
+
+          default:
+            return {
+              success: false,
+              error: `未知的子命令: \`${subCommand}\`\n\n可用子命令: list, status, info, switch, auto`,
+            };
+        }
+      }
+
       // Group management commands (Issue #486)
       case 'create-group': {
         const args = command.data?.args as string[] | undefined;


### PR DESCRIPTION
## Summary

Add a new `/node` command that provides unified interface for node management operations.

### New Commands

| Command | Description |
|---------|-------------|
| `/node list` | List all nodes with status, active chats count |
| `/node status [node-id]` | View detailed node status (current if no ID) |
| `/node info` | View current node info for this chat |
| `/node switch <node-id>` | Switch to specified node |
| `/node auto` | Switch to auto-selection mode |

### Changes

| File | Description |
|------|-------------|
| `src/nodes/commands/builtin-commands.ts` | Add `NodeCommand` class |
| `src/nodes/commands/types.ts` | Add `data` field to `CommandResult` |
| `src/nodes/primary-node.ts` | Add `node` case in `handleControlCommand` |
| `src/channels/types.ts` | Add `node` to `ControlCommandType` |
| `src/nodes/commands/command-registry.test.ts` | Add test for `node` command registration |
| `src/nodes/commands/node-command.test.ts` | Add comprehensive tests for `NodeCommand` |

### Benefits

- Unified command interface for node management
- Consistent command style with subcommands
- Better UX with detailed status information
- Backward compatible: `/list-nodes` and `/switch-node` still work

## Test Plan

- [x] TypeScript type check passes
- [x] Unit tests for NodeCommand class
- [x] Command registration test updated

Fixes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)