### PR TITLE
feat(messaging): add ChannelMessageRouter for multi-channel routing (Issue #513)

### DIFF
--- a/src/messaging/channel-message-router.test.ts
+++ b/src/messaging/channel-message-router.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for Channel Message Router.
+ *
+ * Issue #513: Multi-channel message routing layer (Phase 1)
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  ChannelMessageRouter,
+  ChannelType,
+  initChannelMessageRouter,
+  getChannelMessageRouter,
+  resetChannelMessageRouter,
+  type ChannelMessageRouterOptions,
+} from './channel-message-router.js';
+import type { OutgoingMessage, IChannel } from '../channels/types.js';
+
+describe('ChannelMessageRouter', () => {
+  let router: ChannelMessageRouter;
+  let mockSendToFeishu: ReturnType<typeof vi.fn>;
+  let mockSendToCli: ReturnType<typeof vi.fn>;
+  let mockSendToRest: ReturnType<typeof vi.fn>;
+
+  const createRouter = (options?: Partial<ChannelMessageRouterOptions>): ChannelMessageRouter => {
+    return new ChannelMessageRouter({
+      sendToFeishu: mockSendToFeishu,
+      sendToCli: mockSendToCli,
+      sendToRest: mockSendToRest,
+      ...options,
+    });
+  };
+
+  beforeEach(() => {
+    mockSendToFeishu = vi.fn().mockResolvedValue(undefined);
+    mockSendToCli = vi.fn().mockResolvedValue(undefined);
+    mockSendToRest = vi.fn().mockResolvedValue(undefined);
+    router = createRouter();
+    resetChannelMessageRouter();
+  });
+
+  afterEach(() => {
+    resetChannelMessageRouter();
+  });
+
+  describe('detectChannel', () => {
+    it('should detect Feishu group chat (oc_)', () => {
+      expect(router.detectChannel('oc_abc123def456')).toBe(ChannelType.FEISHU);
+    });
+
+    it('should detect Feishu user chat (ou_)', () => {
+      expect(router.detectChannel('ou_xyz789')).toBe(ChannelType.FEISHU);
+    });
+
+    it('should detect Feishu bot chat (on_)', () => {
+      expect(router.detectChannel('on_bot123')).toBe(ChannelType.FEISHU);
+    });
+
+    it('should detect CLI chat', () => {
+      expect(router.detectChannel('cli-test123')).toBe(ChannelType.CLI);
+      expect(router.detectChannel('cli-abc')).toBe(ChannelType.CLI);
+    });
+
+    it('should detect REST chat (UUID format)', () => {
+      expect(router.detectChannel('123e4567-e89b-12d3-a456-426614174000')).toBe(ChannelType.REST);
+      expect(router.detectChannel('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')).toBe(ChannelType.REST);
+    });
+
+    it('should return UNKNOWN for unrecognized formats', () => {
+      expect(router.detectChannel('random-id')).toBe(ChannelType.UNKNOWN);
+      expect(router.detectChannel('')).toBe(ChannelType.UNKNOWN);
+      expect(router.detectChannel('invalid')).toBe(ChannelType.UNKNOWN);
+    });
+
+    it('should handle null/undefined gracefully', () => {
+      expect(router.detectChannel('')).toBe(ChannelType.UNKNOWN);
+    });
+  });
+
+  describe('route', () => {
+    const textMessage: OutgoingMessage = {
+      chatId: 'oc_test',
+      type: 'text',
+      text: 'Hello World',
+    };
+
+    it('should route to Feishu for oc_ chatIds', async () => {
+      const result = await router.route('oc_test', textMessage);
+
+      expect(result.success).toBe(true);
+      expect(result.channelType).toBe(ChannelType.FEISHU);
+      expect(mockSendToFeishu).toHaveBeenCalledWith('oc_test', textMessage);
+    });
+
+    it('should route to CLI for cli- chatIds', async () => {
+      const result = await router.route('cli-test', textMessage);
+
+      expect(result.success).toBe(true);
+      expect(result.channelType).toBe(ChannelType.CLI);
+      expect(mockSendToCli).toHaveBeenCalledWith('cli-test', textMessage);
+    });
+
+    it('should route to REST for UUID chatIds', async () => {
+      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const result = await router.route(uuid, { ...textMessage, chatId: uuid });
+
+      expect(result.success).toBe(true);
+      expect(result.channelType).toBe(ChannelType.REST);
+      expect(mockSendToRest).toHaveBeenCalledWith(uuid, expect.objectContaining({ chatId: uuid }));
+    });
+
+    it('should fail for REST when no sender configured', async () => {
+      const routerNoRest = createRouter({ sendToRest: undefined });
+      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const result = await routerNoRest.route(uuid, { ...textMessage, chatId: uuid });
+
+      expect(result.success).toBe(false);
+      expect(result.channelType).toBe(ChannelType.REST);
+      expect(result.error).toBe('REST channel sender not configured');
+    });
+
+    it('should fail for unknown chatId format', async () => {
+      const result = await router.route('unknown-format', textMessage);
+
+      expect(result.success).toBe(false);
+      expect(result.channelType).toBe(ChannelType.UNKNOWN);
+      expect(result.error).toContain('Unknown chatId format');
+    });
+
+    it('should handle sender errors', async () => {
+      mockSendToFeishu.mockRejectedValueOnce(new Error('Feishu API error'));
+      const result = await router.route('oc_test', textMessage);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Feishu API error');
+    });
+
+    it('should use default CLI sender when not provided', async () => {
+      const routerNoCli = new ChannelMessageRouter({
+        sendToFeishu: mockSendToFeishu,
+      });
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      const result = await routerNoCli.route('cli-test', textMessage);
+
+      expect(result.success).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('routeText', () => {
+    it('should route text message correctly', async () => {
+      const result = await router.routeText('oc_test', 'Hello', 'thread123');
+
+      expect(result.success).toBe(true);
+      expect(mockSendToFeishu).toHaveBeenCalledWith(
+        'oc_test',
+        expect.objectContaining({
+          type: 'text',
+          text: 'Hello',
+          threadId: 'thread123',
+        })
+      );
+    });
+  });
+
+  describe('routeCard', () => {
+    it('should route card message correctly', async () => {
+      const card = { config: {}, header: {}, elements: [] };
+      const result = await router.routeCard('oc_test', card, 'thread123');
+
+      expect(result.success).toBe(true);
+      expect(mockSendToFeishu).toHaveBeenCalledWith(
+        'oc_test',
+        expect.objectContaining({
+          type: 'card',
+          card,
+          threadId: 'thread123',
+        })
+      );
+    });
+  });
+
+  describe('broadcast', () => {
+    it('should broadcast to all registered channels', async () => {
+      const mockChannel1: IChannel = {
+        id: 'channel1',
+        name: 'Test Channel 1',
+        status: 'running',
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        onMessage: vi.fn(),
+        onControl: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        isHealthy: vi.fn().mockReturnValue(true),
+      };
+
+      const mockChannel2: IChannel = {
+        id: 'channel2',
+        name: 'Test Channel 2',
+        status: 'running',
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        onMessage: vi.fn(),
+        onControl: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        isHealthy: vi.fn().mockReturnValue(true),
+      };
+
+      const channels = new Map<string, IChannel>();
+      channels.set('channel1', mockChannel1);
+      channels.set('channel2', mockChannel2);
+
+      const routerWithChannels = createRouter({ channels });
+      const message: OutgoingMessage = {
+        chatId: 'oc_test',
+        type: 'text',
+        text: 'Broadcast message',
+      };
+
+      await routerWithChannels.broadcast(message);
+
+      expect(mockChannel1.sendMessage).toHaveBeenCalledWith(message);
+      expect(mockChannel2.sendMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('should handle broadcast when no channels registered', async () => {
+      const routerNoChannels = createRouter({ channels: undefined });
+      const message: OutgoingMessage = {
+        chatId: 'oc_test',
+        type: 'text',
+        text: 'Test',
+      };
+
+      // Should not throw
+      await expect(routerNoChannels.broadcast(message)).resolves.toBeUndefined();
+    });
+
+    it('should continue broadcasting even if one channel fails', async () => {
+      const mockChannel1: IChannel = {
+        id: 'channel1',
+        name: 'Test Channel 1',
+        status: 'running',
+        sendMessage: vi.fn().mockRejectedValue(new Error('Channel error')),
+        onMessage: vi.fn(),
+        onControl: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        isHealthy: vi.fn().mockReturnValue(true),
+      };
+
+      const mockChannel2: IChannel = {
+        id: 'channel2',
+        name: 'Test Channel 2',
+        status: 'running',
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+        onMessage: vi.fn(),
+        onControl: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+        isHealthy: vi.fn().mockReturnValue(true),
+      };
+
+      const channels = new Map<string, IChannel>();
+      channels.set('channel1', mockChannel1);
+      channels.set('channel2', mockChannel2);
+
+      const routerWithChannels = createRouter({ channels });
+      const message: OutgoingMessage = {
+        chatId: 'oc_test',
+        type: 'text',
+        text: 'Broadcast message',
+      };
+
+      // Should not throw
+      await routerWithChannels.broadcast(message);
+
+      // Both channels should have been called
+      expect(mockChannel1.sendMessage).toHaveBeenCalled();
+      expect(mockChannel2.sendMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('helper methods', () => {
+    it('isFeishuChat should work correctly', () => {
+      expect(router.isFeishuChat('oc_test')).toBe(true);
+      expect(router.isFeishuChat('ou_test')).toBe(true);
+      expect(router.isFeishuChat('cli-test')).toBe(false);
+    });
+
+    it('isCliChat should work correctly', () => {
+      expect(router.isCliChat('cli-test')).toBe(true);
+      expect(router.isCliChat('oc_test')).toBe(false);
+    });
+
+    it('isRestChat should work correctly', () => {
+      expect(router.isRestChat('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+      expect(router.isRestChat('oc_test')).toBe(false);
+    });
+
+    it('getChannelTypeName should return human-readable name', () => {
+      expect(router.getChannelTypeName('oc_test')).toBe('Feishu');
+      expect(router.getChannelTypeName('cli-test')).toBe('Cli');
+      expect(router.getChannelTypeName('123e4567-e89b-12d3-a456-426614174000')).toBe('Rest');
+      expect(router.getChannelTypeName('unknown')).toBe('Unknown');
+    });
+  });
+});
+
+describe('Global router functions', () => {
+  beforeEach(() => {
+    resetChannelMessageRouter();
+  });
+
+  afterEach(() => {
+    resetChannelMessageRouter();
+  });
+
+  it('initChannelMessageRouter should create global instance', () => {
+    const mockSend = vi.fn();
+    const router = initChannelMessageRouter({ sendToFeishu: mockSend });
+
+    expect(router).toBeInstanceOf(ChannelMessageRouter);
+    expect(getChannelMessageRouter()).toBe(router);
+  });
+
+  it('getChannelMessageRouter should throw if not initialized', () => {
+    expect(() => getChannelMessageRouter()).toThrow('ChannelMessageRouter not initialized');
+  });
+
+  it('resetChannelMessageRouter should clear global instance', () => {
+    const mockSend = vi.fn();
+    initChannelMessageRouter({ sendToFeishu: mockSend });
+
+    resetChannelMessageRouter();
+
+    expect(() => getChannelMessageRouter()).toThrow('ChannelMessageRouter not initialized');
+  });
+});

--- a/src/messaging/channel-message-router.ts
+++ b/src/messaging/channel-message-router.ts
@@ -1,0 +1,310 @@
+/**
+ * Channel Message Router - Routes messages to appropriate channels based on chatId.
+ *
+ * This module provides channel-type detection and message routing for MCP tools,
+ * allowing them to work seamlessly across Feishu, CLI, and REST channels.
+ *
+ * Issue #513: Multi-channel message routing layer (Phase 1)
+ */
+
+import { createLogger } from '../utils/logger.js';
+import type { IChannel, OutgoingMessage } from '../channels/types.js';
+
+const logger = createLogger('ChannelMessageRouter');
+
+/**
+ * Channel type enumeration.
+ */
+export enum ChannelType {
+  FEISHU = 'feishu',
+  CLI = 'cli',
+  REST = 'rest',
+  UNKNOWN = 'unknown',
+}
+
+/**
+ * Channel detection patterns.
+ */
+const CHANNEL_PATTERNS = {
+  // Feishu chat IDs: oc_xxx (group), ou_xxx (user), on_xxx (bot)
+  FEISHU: /^(oc_|ou_|on_)/,
+  // CLI chat IDs: cli-xxx
+  CLI: /^cli-/,
+  // REST chat IDs: UUID format
+  REST: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+} as const;
+
+/**
+ * Channel Message Router options.
+ */
+export interface ChannelMessageRouterOptions {
+  /** Function to send message to Feishu */
+  sendToFeishu: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  /** Function to send message to CLI (optional, defaults to console.log) */
+  sendToCli?: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  /** Function to send message to REST channel (optional) */
+  sendToRest?: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  /** Registered channels for broadcasting */
+  channels?: Map<string, IChannel>;
+}
+
+/**
+ * Routing result.
+ */
+export interface RoutingResult {
+  /** Whether the routing was successful */
+  success: boolean;
+  /** Channel type that was detected */
+  channelType: ChannelType;
+  /** Error message if routing failed */
+  error?: string;
+}
+
+/**
+ * Channel Message Router - Routes messages based on chatId format.
+ *
+ * Detects the channel type from chatId format and routes messages accordingly:
+ * - `oc_*`, `ou_*`, `on_*` → Feishu
+ * - `cli-*` → CLI (console)
+ * - UUID format → REST
+ *
+ * Example usage:
+ * ```typescript
+ * const router = new ChannelMessageRouter({
+ *   sendToFeishu: async (chatId, msg) => { ... },
+ *   sendToCli: async (chatId, msg) => { ... },
+ * });
+ *
+ * // Detect channel type
+ * const type = router.detectChannel('oc_abc123'); // ChannelType.FEISHU
+ *
+ * // Route message
+ * await router.route('oc_abc123', { type: 'text', text: 'Hello' });
+ * ```
+ */
+export class ChannelMessageRouter {
+  private readonly sendToFeishu: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  private readonly sendToCli: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  private readonly sendToRest?: (chatId: string, message: OutgoingMessage) => Promise<void>;
+  private readonly channels?: Map<string, IChannel>;
+
+  constructor(options: ChannelMessageRouterOptions) {
+    this.sendToFeishu = options.sendToFeishu;
+    this.sendToCli = options.sendToCli ?? this.defaultCliSender;
+    this.sendToRest = options.sendToRest;
+    this.channels = options.channels;
+  }
+
+  /**
+   * Default CLI sender - logs to console.
+   */
+  private async defaultCliSender(chatId: string, message: OutgoingMessage): Promise<void> {
+    const content = message.text ?? JSON.stringify(message.card, null, 2);
+    logger.info({ chatId, type: message.type }, 'CLI message');
+    console.log(`\n[${chatId}] ${content}\n`);
+  }
+
+  /**
+   * Detect channel type from chatId format.
+   *
+   * @param chatId - Chat ID to detect
+   * @returns Detected channel type
+   */
+  detectChannel(chatId: string): ChannelType {
+    if (!chatId || typeof chatId !== 'string') {
+      return ChannelType.UNKNOWN;
+    }
+
+    if (CHANNEL_PATTERNS.FEISHU.test(chatId)) {
+      return ChannelType.FEISHU;
+    }
+
+    if (CHANNEL_PATTERNS.CLI.test(chatId)) {
+      return ChannelType.CLI;
+    }
+
+    if (CHANNEL_PATTERNS.REST.test(chatId)) {
+      return ChannelType.REST;
+    }
+
+    return ChannelType.UNKNOWN;
+  }
+
+  /**
+   * Route a message to the appropriate channel based on chatId.
+   *
+   * @param chatId - Target chat ID
+   * @param message - Message to send
+   * @returns Routing result
+   */
+  async route(chatId: string, message: OutgoingMessage): Promise<RoutingResult> {
+    const channelType = this.detectChannel(chatId);
+
+    logger.debug({ chatId, channelType, messageType: message.type }, 'Routing message');
+
+    try {
+      switch (channelType) {
+        case ChannelType.FEISHU:
+          await this.sendToFeishu(chatId, message);
+          return { success: true, channelType };
+
+        case ChannelType.CLI:
+          await this.sendToCli(chatId, message);
+          return { success: true, channelType };
+
+        case ChannelType.REST:
+          if (this.sendToRest) {
+            await this.sendToRest(chatId, message);
+            return { success: true, channelType };
+          }
+          return {
+            success: false,
+            channelType,
+            error: 'REST channel sender not configured',
+          };
+
+        case ChannelType.UNKNOWN:
+        default:
+          return {
+            success: false,
+            channelType,
+            error: `Unknown chatId format: ${chatId}`,
+          };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ chatId, channelType, error: errorMessage }, 'Routing failed');
+      return {
+        success: false,
+        channelType,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Route a text message.
+   *
+   * @param chatId - Target chat ID
+   * @param text - Text content
+   * @param threadId - Optional thread ID for replies
+   * @returns Routing result
+   */
+  async routeText(chatId: string, text: string, threadId?: string): Promise<RoutingResult> {
+    return this.route(chatId, { chatId, type: 'text', text, threadId });
+  }
+
+  /**
+   * Route a card message.
+   *
+   * @param chatId - Target chat ID
+   * @param card - Card content
+   * @param threadId - Optional thread ID for replies
+   * @returns Routing result
+   */
+  async routeCard(
+    chatId: string,
+    card: Record<string, unknown>,
+    threadId?: string
+  ): Promise<RoutingResult> {
+    return this.route(chatId, { chatId, type: 'card', card, threadId });
+  }
+
+  /**
+   * Broadcast a message to all registered channels.
+   *
+   * @param message - Message to broadcast
+   */
+  async broadcast(message: OutgoingMessage): Promise<void> {
+    if (!this.channels || this.channels.size === 0) {
+      logger.warn({ chatId: message.chatId }, 'No channels registered for broadcast');
+      return;
+    }
+
+    const results = await Promise.allSettled(
+      Array.from(this.channels.values()).map(async (channel) => {
+        try {
+          await channel.sendMessage(message);
+        } catch (error) {
+          logger.warn(
+            { channelId: channel.id, chatId: message.chatId, error },
+            'Channel failed to broadcast message'
+          );
+          throw error;
+        }
+      })
+    );
+
+    // Log any failures
+    const channelArray = Array.from(this.channels.values());
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logger.warn(
+          { channelId: channelArray[index].id, chatId: message.chatId },
+          'Broadcast failed for channel'
+        );
+      }
+    });
+  }
+
+  /**
+   * Check if a chatId is a valid Feishu chat.
+   */
+  isFeishuChat(chatId: string): boolean {
+    return this.detectChannel(chatId) === ChannelType.FEISHU;
+  }
+
+  /**
+   * Check if a chatId is a CLI chat.
+   */
+  isCliChat(chatId: string): boolean {
+    return this.detectChannel(chatId) === ChannelType.CLI;
+  }
+
+  /**
+   * Check if a chatId is a REST chat.
+   */
+  isRestChat(chatId: string): boolean {
+    return this.detectChannel(chatId) === ChannelType.REST;
+  }
+
+  /**
+   * Get human-readable channel type name.
+   */
+  getChannelTypeName(chatId: string): string {
+    const type = this.detectChannel(chatId);
+    return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+}
+
+// Global singleton instance
+let globalRouter: ChannelMessageRouter | undefined;
+
+/**
+ * Initialize the global channel message router.
+ */
+export function initChannelMessageRouter(
+  options: ChannelMessageRouterOptions
+): ChannelMessageRouter {
+  globalRouter = new ChannelMessageRouter(options);
+  logger.info('Global channel message router initialized');
+  return globalRouter;
+}
+
+/**
+ * Get the global channel message router.
+ * Throws if not initialized.
+ */
+export function getChannelMessageRouter(): ChannelMessageRouter {
+  if (!globalRouter) {
+    throw new Error('ChannelMessageRouter not initialized. Call initChannelMessageRouter first.');
+  }
+  return globalRouter;
+}
+
+/**
+ * Reset the global router (for testing).
+ */
+export function resetChannelMessageRouter(): void {
+  globalRouter = undefined;
+}

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -1,24 +1,29 @@
 /**
- * Message routing module for level-based message routing.
+ * Message routing module for level-based and channel-based message routing.
  *
- * This module implements Issue #266: Message Level Routing System
+ * This module implements:
+ * - Issue #266: Message Level Routing System
+ * - Issue #513: Multi-channel Message Routing Layer (Phase 1)
  *
  * Features:
  * - Routes execution progress to admin chats
  * - Routes only key interactions to user chats
  * - Configurable message levels
  * - Throttling for progress messages
+ * - Channel-type detection (Feishu, CLI, REST)
+ * - Multi-channel message routing
  *
  * @example
  * ```typescript
  * import {
  *   MessageRouter,
+ *   ChannelMessageRouter,
  *   RoutedOutputAdapter,
  *   MessageLevel,
  *   createDefaultRouteConfig,
  * } from './messaging/index.js';
  *
- * // Create router
+ * // Create level-based router
  * const config = createDefaultRouteConfig('user_chat_id');
  * config.adminChatId = 'admin_chat_id';
  *
@@ -27,14 +32,20 @@
  *   sender: feishuMessageSender,
  * });
  *
- * // Create output adapter
- * const adapter = new RoutedOutputAdapter({ router });
+ * // Create channel router for MCP tools
+ * const channelRouter = new ChannelMessageRouter({
+ *   sendToFeishu: async (chatId, msg) => { ... },
+ * });
  *
- * // Use adapter
- * await adapter.write('Task completed', 'result');
+ * // Detect channel type
+ * const type = channelRouter.detectChannel('oc_abc123'); // 'feishu'
+ *
+ * // Route message
+ * await channelRouter.route('oc_abc123', { type: 'text', text: 'Hello' });
  * ```
  *
  * @see Issue #266
+ * @see Issue #513
  */
 
 // Types
@@ -63,3 +74,14 @@ export {
   SimpleUserOutputAdapter,
   type RoutedOutputAdapterOptions,
 } from './routed-output-adapter.js';
+
+// Channel Message Router (Issue #513)
+export {
+  ChannelMessageRouter,
+  ChannelType,
+  initChannelMessageRouter,
+  getChannelMessageRouter,
+  resetChannelMessageRouter,
+  type ChannelMessageRouterOptions,
+  type RoutingResult,
+} from './channel-message-router.js';


### PR DESCRIPTION
## Summary

Implements Phase 1 of the multi-channel message routing layer, providing channel-type detection and message routing for MCP tools to work seamlessly across Feishu, CLI, and REST channels.

## Problem

Currently, MCP tools like `send_user_feedback` have hardcoded channel detection:
- Directly calls Feishu API
- CLI mode is hardcoded as `if (chatId.startsWith('cli-'))`
- Does not support REST Channel

## Solution

### ChannelMessageRouter Service

```typescript
interface IChannelMessageRouter {
  // Detect Channel type from chatId format
  detectChannel(chatId: string): ChannelType;
  
  // Route message to correct channel
  route(chatId: string, message: OutgoingMessage): Promise<RoutingResult>;
  
  // Broadcast to all channels
  broadcast(message: OutgoingMessage): Promise<void>;
}

enum ChannelType {
  FEISHU = 'feishu',   // oc_*, ou_*, on_*
  CLI = 'cli',         // cli-*
  REST = 'rest',       // UUID format
  UNKNOWN = 'unknown',
}
```

### Channel Detection

| chatId Format | Channel Type |
|---------------|--------------|
| `oc_*`, `ou_*`, `on_*` | Feishu |
| `cli-*` | CLI |
| UUID (e.g., `123e4567-...`) | REST |
| Other | Unknown |

## Changes

| File | Description |
|------|-------------|
| `src/messaging/channel-message-router.ts` | New ChannelMessageRouter service |
| `src/messaging/channel-message-router.test.ts` | Unit tests (26 tests) |
| `src/messaging/index.ts` | Export new module |

## Features

- **Channel Detection**: Detects channel type from chatId format
- **Message Routing**: Routes messages to appropriate channel
- **Broadcast**: Broadcasts messages to all registered channels
- **Helper Methods**: `isFeishuChat()`, `isCliChat()`, `isRestChat()`, `getChannelTypeName()`

## Test Results

| Test Suite | Result |
|------------|--------|
| ChannelMessageRouter tests | ✅ 26 passed |
| All messaging tests | ✅ 71 passed |
| TypeScript check | ✅ Pass |

## Usage Example

```typescript
import { ChannelMessageRouter, ChannelType } from './messaging/index.js';

const router = new ChannelMessageRouter({
  sendToFeishu: async (chatId, msg) => { /* ... */ },
  sendToCli: async (chatId, msg) => { /* ... */ },
  sendToRest: async (chatId, msg) => { /* ... */ },
});

// Detect channel type
router.detectChannel('oc_abc123');  // ChannelType.FEISHU
router.detectChannel('cli-test');   // ChannelType.CLI

// Route message
await router.route('oc_abc123', { type: 'text', text: 'Hello' });
```

## Next Steps

Phase 2 will integrate this router into MCP tools (`send_user_feedback`, etc.) to replace hardcoded channel detection.

## Test Plan

- [x] Unit tests for channel detection
- [x] Unit tests for message routing
- [x] Unit tests for broadcast
- [x] Unit tests for helper methods
- [x] TypeScript type check passes

Fixes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)