### PR TITLE
fix: resolve ESLint errors in create-feishu-client.ts and merge conflict in constants.ts

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -64,7 +64,6 @@ export const FEISHU_API = {
 } as const;
 
 /**
-<<<<<<< feat/issue-517-passive-mode-chat-history
  * Chat history configuration for passive mode (Issue #517)
  */
 export const CHAT_HISTORY = {
@@ -74,8 +73,9 @@ export const CHAT_HISTORY = {
   /** Maximum number of messages to include in context */
   MAX_MESSAGES: 50,
 } as const;
-=======
- * Error codes that should trigger a retry
+
+/**
+ * Error codes that should trigger a retry (Issue #507)
  */
 export const RETRYABLE_ERROR_CODES = [
   'ETIMEDOUT',
@@ -87,4 +87,3 @@ export const RETRYABLE_ERROR_CODES = [
   'ENETUNREACH',
   'EPROTO',
 ] as const;
->>>>>>> main

--- a/src/platforms/feishu/create-feishu-client.ts
+++ b/src/platforms/feishu/create-feishu-client.ts
@@ -34,7 +34,7 @@ function isRetryableError(error: unknown): boolean {
 
   // Server errors (5xx) are potentially retryable
   if (axiosError.response?.status) {
-    const status = axiosError.response.status;
+    const { status } = axiosError.response;
     // 429 Too Many Requests, 500+ server errors
     return status === 429 || (status >= 500 && status < 600);
   }
@@ -124,7 +124,7 @@ async function requestWithRetry<T>(
 function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstance {
   return {
     request: async (opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.request({
           url: opts.url,
           method: opts.method,
@@ -138,7 +138,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     get: async (url, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.get(url, {
           params: opts?.params,
           headers: opts?.headers,
@@ -149,7 +149,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     delete: async (url, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.delete(url, {
           params: opts?.params,
           headers: opts?.headers,
@@ -160,7 +160,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     head: async (url, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.head(url, {
           params: opts?.params,
           headers: opts?.headers,
@@ -171,7 +171,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     options: async (url, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.options(url, {
           params: opts?.params,
           headers: opts?.headers,
@@ -182,7 +182,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     post: async (url, data, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.post(url, data, {
           params: opts?.params,
           headers: opts?.headers,
@@ -193,7 +193,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     put: async (url, data, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.put(url, data, {
           params: opts?.params,
           headers: opts?.headers,
@@ -204,7 +204,7 @@ function wrapAxiosAsHttpInstance(axiosInstance: AxiosInstance): lark.HttpInstanc
       );
     },
     patch: async (url, data, opts) => {
-      return requestWithRetry(
+      return await requestWithRetry(
         () => axiosInstance.patch(url, data, {
           params: opts?.params,
           headers: opts?.headers,


### PR DESCRIPTION
## Summary

Fixes #552

解决 `create-feishu-client.ts` 中的 9 个 ESLint 错误，并修复 `constants.ts` 中的 merge conflict。

## Changes

### create-feishu-client.ts
- **prefer-destructuring**: 使用对象解构替代属性访问
  ```typescript
  // Before
  const status = axiosError.response.status;
  // After
  const { status } = axiosError.response;
  ```
- **require-await**: 在 async 方法中添加 `await` 关键字
  ```typescript
  // Before
  return requestWithRetry(...)
  // After
  return await requestWithRetry(...)
  ```

### constants.ts
- 解决 `feat/issue-517-passive-mode-chat-history` 和 `main` 分支之间的 merge conflict
- 保留两边的代码：`CHAT_HISTORY` 和 `RETRYABLE_ERROR_CODES`

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| ESLint (modified files) | ✅ No errors |
| Test Files | 73 passed, 2 pre-existing failures |
| Tests | 1359 passed, 5 pre-existing failures |

## Test Plan

- [x] ESLint 检查通过（修改的文件无错误）
- [x] TypeScript 类型检查通过
- [x] 单元测试通过（无新增失败）

🤖 Generated with [Claude Code](https://claude.com/claude-code)