### PR TITLE
feat(schedule): add schedule control commands (Issue #469)

### DIFF
--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -130,7 +130,9 @@ export type ControlCommandType =
   // Passive mode control (Issue #511)
   | 'passive'
   // Node management commands (Issue #541)
-  | 'node';
+  | 'node'
+  // Schedule control commands (Issue #469)
+  | 'schedule';
 
 /**
  * Control command from user to agent.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -64,7 +64,6 @@ export const FEISHU_API = {
 } as const;
 
 /**
-<<<<<<< feat/issue-517-passive-mode-chat-history
  * Chat history configuration for passive mode (Issue #517)
  */
 export const CHAT_HISTORY = {
@@ -74,7 +73,8 @@ export const CHAT_HISTORY = {
   /** Maximum number of messages to include in context */
   MAX_MESSAGES: 50,
 } as const;
-=======
+
+/**
  * Error codes that should trigger a retry
  */
 export const RETRYABLE_ERROR_CODES = [
@@ -87,4 +87,3 @@ export const RETRYABLE_ERROR_CODES = [
   'ENETUNREACH',
   'EPROTO',
 ] as const;
->>>>>>> main

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -359,6 +359,75 @@ export class NodeCommand implements Command {
 }
 
 /**
+ * Schedule Command - Manage scheduled tasks.
+ * Issue #469: 定时任务控制指令
+ *
+ * Subcommands:
+ * - list: List all scheduled tasks
+ * - enable <taskId>: Enable a task
+ * - disable <taskId>: Disable a task
+ * - run <taskId>: Manually trigger a task
+ * - status [taskId]: View task or scheduler status
+ */
+export class ScheduleCommand implements Command {
+  readonly name = 'schedule';
+  readonly category = 'schedule' as const;
+  readonly description = '定时任务管理';
+  readonly usage = 'schedule <list|enable|disable|run|status> [taskId]';
+
+  execute(context: CommandContext): CommandResult {
+    const subCommand = context.args[0]?.toLowerCase();
+
+    // If no subcommand, show help
+    if (!subCommand) {
+      return {
+        success: true,
+        message: `⏰ **定时任务管理指令**
+
+用法: \`/schedule <子命令> [任务ID]\`
+
+**可用子命令:**
+- \`list\` - 列出所有定时任务
+- \`enable <taskId>\` - 启用任务
+- \`disable <taskId>\` - 禁用任务
+- \`run <taskId>\` - 手动触发任务
+- \`status [taskId]\` - 查看任务或调度器状态
+
+示例:
+\`\`\`
+/schedule list
+/schedule enable schedule-daily
+/schedule run schedule-daily
+/schedule status schedule-daily
+\`\`\``,
+      };
+    }
+
+    // Validate subcommand
+    const validSubcommands = ['list', 'enable', 'disable', 'run', 'status'];
+    if (!validSubcommands.includes(subCommand)) {
+      return {
+        success: false,
+        error: `未知的子命令: \`${subCommand}\`
+
+可用子命令: ${validSubcommands.map(c => `\`${c}\``).join(', ')}`,
+      };
+    }
+
+    // Actual implementation is handled by PrimaryNode
+    return {
+      success: true,
+      message: `🔄 **定时任务命令执行中...**`,
+      // Pass through the subcommand and remaining args for PrimaryNode to handle
+      data: {
+        subcommand: subCommand,
+        scheduleArgs: context.args.slice(1),
+      },
+    };
+  }
+}
+
+/**
  * Register default commands to a registry.
  */
 export function registerDefaultCommands(
@@ -380,4 +449,6 @@ export function registerDefaultCommands(
   registry.register(new PassiveCommand());
   // Issue #541: Node management command
   registry.register(new NodeCommand());
+  // Issue #469: Schedule control command
+  registry.register(new ScheduleCommand());
 }

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -938,6 +938,133 @@ export class PrimaryNode extends EventEmitter {
         };
       }
 
+      // Schedule control commands (Issue #469)
+      case 'schedule': {
+        if (!this.schedulerService) {
+          return { success: false, error: '调度器服务未初始化' };
+        }
+
+        const args = command.data?.args as string[] | undefined;
+        const subCommand = args?.[0]?.toLowerCase();
+
+        if (!subCommand) {
+          return {
+            success: false,
+            error: '用法: `/schedule <list|enable|disable|run|status> [taskId]`\n\n示例:\n- `/schedule list` - 列出所有定时任务\n- `/schedule enable schedule-daily` - 启用任务\n- `/schedule disable schedule-daily` - 禁用任务\n- `/schedule run schedule-daily` - 手动触发任务\n- `/schedule status schedule-daily` - 查看任务状态',
+          };
+        }
+
+        switch (subCommand) {
+          case 'list': {
+            const tasks = await this.schedulerService.listSchedules();
+            if (tasks.length === 0) {
+              return { success: true, message: '📋 **定时任务列表**\n\n暂无定时任务' };
+            }
+
+            const enabledCount = tasks.filter(t => t.enabled).length;
+            const disabledCount = tasks.length - enabledCount;
+            const scheduler = this.schedulerService.getScheduler();
+
+            const taskList = tasks.map(t => {
+              const status = t.enabled ? '✅' : '⏸️';
+              const running = scheduler?.isTaskRunning(t.id) ? ' 🔄' : '';
+              return `- ${status} \`${t.id}\` - ${t.name} (\`${t.cron}\`)${running}`;
+            }).join('\n');
+
+            return {
+              success: true,
+              message: `📋 **定时任务列表**\n\n任务数: ${tasks.length} (启用: ${enabledCount}, 禁用: ${disabledCount})\n\n${taskList}`,
+            };
+          }
+
+          case 'enable': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule enable <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.enableSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            return { success: true, message: `✅ **定时任务已启用**\n\n任务: ${task.name}\nID: \`${taskId}\`` };
+          }
+
+          case 'disable': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule disable <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.disableSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            return { success: true, message: `⏸️ **定时任务已禁用**\n\n任务: ${task.name}\nID: \`${taskId}\`` };
+          }
+
+          case 'run': {
+            const taskId = args?.[1];
+            if (!taskId) {
+              return { success: false, error: '用法: `/schedule run <taskId>`\n\n使用 `/schedule list` 查看所有任务 ID' };
+            }
+
+            const task = await this.schedulerService.getSchedule(taskId);
+            if (!task) {
+              return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+            }
+
+            // Run the task asynchronously
+            this.schedulerService.runSchedule(taskId, command.chatId).then(success => {
+              if (success) {
+                logger.info({ taskId }, 'Manual schedule run completed');
+              }
+            }).catch(error => {
+              logger.error({ err: error, taskId }, 'Manual schedule run failed');
+            });
+
+            return { success: true, message: `🔄 **定时任务已触发**\n\n任务: ${task.name}\nID: \`${taskId}\`\n\n执行结果将发送到此会话` };
+          }
+
+          case 'status': {
+            const taskId = args?.[1];
+
+            if (taskId) {
+              const status = await this.schedulerService.getScheduleStatus(taskId);
+              if (!status.task) {
+                return { success: false, error: `定时任务 \`${taskId}\` 不存在` };
+              }
+
+              const task = status.task;
+              const enabledStatus = task.enabled ? '✅ 已启用' : '⏸️ 已禁用';
+              const runningStatus = status.isCurrentlyRunning ? '\n执行中: 🔄 是' : '';
+              const blockingStatus = task.blocking ? '是' : '否';
+              const createdAt = new Date(task.createdAt).toLocaleString('zh-CN');
+
+              return {
+                success: true,
+                message: `📋 **定时任务状态**\n\n**名称**: ${task.name}\n**ID**: \`${task.id}\`\n**状态**: ${enabledStatus}${runningStatus}\n**Cron**: \`${task.cron}\`\n**阻塞模式**: ${blockingStatus}\n**创建时间**: ${createdAt}`,
+              };
+            }
+
+            // Show scheduler status
+            const status = await this.schedulerService.getScheduleStatus();
+            return {
+              success: true,
+              message: `📋 **调度器状态**\n\n运行中: ${status.running ? '✅' : '❌'}\n活跃任务: ${status.activeJobsCount ?? 0}`,
+            };
+          }
+
+          default:
+            return {
+              success: false,
+              error: `未知的 schedule 子命令: \`${subCommand}\`\n\n可用子命令: list, enable, disable, run, status`,
+            };
+        }
+      }
+
       default:
         return { success: false, error: `Unknown command: ${command.type}` };
     }

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -21,9 +21,11 @@ import {
   ScheduleManager,
   Scheduler,
   ScheduleFileWatcher,
+  ScheduleFileScanner,
 } from '../schedule/index.js';
 import type { FeedbackMessage } from '../types/websocket-messages.js';
 import type { ChatAgent } from '../agents/types.js';
+import type { ScheduledTask } from '../schedule/schedule-manager.js';
 
 const logger = createLogger('SchedulerService');
 
@@ -58,12 +60,14 @@ export interface SchedulerServiceConfig {
  * - Scheduler initialization
  * - Schedule file watching
  * - Feedback routing to PrimaryNode
+ * - Schedule CRUD operations (Issue #469)
  */
 export class SchedulerService {
   private readonly callbacks: SchedulerCallbacks;
   private readonly pilot: SchedulerServiceConfig['pilot'];
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
+  private fileScanner: ScheduleFileScanner;
   private schedulesDir: string;
 
   constructor(config: SchedulerServiceConfig) {
@@ -72,6 +76,7 @@ export class SchedulerService {
 
     const workspaceDir = Config.getWorkspaceDir();
     this.schedulesDir = path.join(workspaceDir, 'schedules');
+    this.fileScanner = new ScheduleFileScanner({ schedulesDir: this.schedulesDir });
   }
 
   /**
@@ -143,5 +148,142 @@ export class SchedulerService {
    */
   getScheduler(): Scheduler | undefined {
     return this.scheduler;
+  }
+
+  // ============================================================================
+  // Schedule CRUD Operations (Issue #469)
+  // ============================================================================
+
+  /**
+   * List all scheduled tasks.
+   *
+   * @returns Array of all scheduled tasks
+   */
+  async listSchedules(): Promise<ScheduledTask[]> {
+    const tasks = await this.fileScanner.scanAll();
+    return tasks.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  /**
+   * Get a schedule by ID.
+   *
+   * @param taskId - Task ID
+   * @returns The task or undefined if not found
+   */
+  async getSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const tasks = await this.fileScanner.scanAll();
+    return tasks.find(t => t.id === taskId);
+  }
+
+  /**
+   * Enable a scheduled task.
+   *
+   * @param taskId - Task ID to enable
+   * @returns The updated task or undefined if not found
+   */
+  async enableSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return undefined;
+    }
+
+    if (task.enabled) {
+      return task; // Already enabled
+    }
+
+    // Update the task file
+    const updatedTask: ScheduledTask = { ...task, enabled: true };
+    await this.fileScanner.writeTask(updatedTask);
+
+    logger.info({ taskId, name: task.name }, 'Schedule enabled');
+    return updatedTask;
+  }
+
+  /**
+   * Disable a scheduled task.
+   *
+   * @param taskId - Task ID to disable
+   * @returns The updated task or undefined if not found
+   */
+  async disableSchedule(taskId: string): Promise<ScheduledTask | undefined> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return undefined;
+    }
+
+    if (!task.enabled) {
+      return task; // Already disabled
+    }
+
+    // Update the task file
+    const updatedTask: ScheduledTask = { ...task, enabled: false };
+    await this.fileScanner.writeTask(updatedTask);
+
+    // Remove from scheduler immediately
+    this.scheduler?.removeTask(taskId);
+
+    logger.info({ taskId, name: task.name }, 'Schedule disabled');
+    return updatedTask;
+  }
+
+  /**
+   * Manually trigger a scheduled task.
+   *
+   * @param taskId - Task ID to run
+   * @param chatId - Chat ID to send results to (optional, defaults to task's chatId)
+   * @returns true if task was triggered, false if not found
+   */
+  async runSchedule(taskId: string, chatId?: string): Promise<boolean> {
+    const task = await this.getSchedule(taskId);
+    if (!task) {
+      return false;
+    }
+
+    // Use provided chatId or task's chatId
+    const targetChatId = chatId || task.chatId;
+
+    // Execute the task
+    logger.info({ taskId, name: task.name, chatId: targetChatId }, 'Manually triggering schedule');
+
+    // Run the task asynchronously
+    this.pilot.executeOnce(
+      targetChatId,
+      task.prompt,
+      undefined,
+      undefined
+    ).then(() => {
+      logger.info({ taskId }, 'Manually triggered schedule completed');
+    }).catch(error => {
+      logger.error({ err: error, taskId }, 'Manually triggered schedule failed');
+    });
+
+    return true;
+  }
+
+  /**
+   * Get schedule status.
+   *
+   * @param taskId - Task ID (optional, if not provided returns scheduler status)
+   * @returns Schedule status info
+   */
+  async getScheduleStatus(taskId?: string): Promise<{
+    running: boolean;
+    task?: ScheduledTask;
+    isCurrentlyRunning?: boolean;
+    activeJobsCount?: number;
+  }> {
+    if (taskId) {
+      const task = await this.getSchedule(taskId);
+      return {
+        running: this.scheduler?.isRunning() ?? false,
+        task,
+        isCurrentlyRunning: this.scheduler?.isTaskRunning(taskId) ?? false,
+      };
+    }
+
+    return {
+      running: this.scheduler?.isRunning() ?? false,
+      activeJobsCount: this.scheduler?.getActiveJobs().length ?? 0,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Implements schedule management commands for controlling scheduled tasks.

Fixes #469

## Changes

| File | Description |
|------|-------------|
| `src/channels/types.ts` | Add 'schedule' to ControlCommandType |
| `src/nodes/commands/builtin-commands.ts` | Add ScheduleCommand class |
| `src/nodes/scheduler-service.ts` | Add CRUD operations (listSchedules, enableSchedule, disableSchedule, runSchedule, getScheduleStatus) |
| `src/nodes/primary-node.ts` | Add schedule command handling |
| `src/config/constants.ts` | Fix merge conflict (CHAT_HISTORY + RETRYABLE_ERROR_CODES) |

## Commands

| Command | Description |
|---------|-------------|
| `/schedule list` | List all scheduled tasks |
| `/schedule enable <taskId>` | Enable a task |
| `/schedule disable <taskId>` | Disable a task |
| `/schedule run <taskId>` | Manually trigger a task |
| `/schedule status [taskId]` | View task or scheduler status |

## Implementation Details

Based on previous PR attempts (#496, #500), this implementation:
- Uses the DI-based command system (Issue #463)
- Integrates with existing ScheduleFileScanner for file operations
- Uses Scheduler methods for runtime state checking

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Test Files | 73 passed, 2 pre-existing failures |
| Tests | 1359 passed, 5 pre-existing failures |

Pre-existing failures are in `task-file-watcher.test.ts` (unrelated to this change).

## Test Plan

- [x] TypeScript type check passes
- [x] Unit tests pass (no new failures)
- [ ] Manual test: `/schedule list` shows all tasks
- [ ] Manual test: `/schedule enable/disable` updates task files
- [ ] Manual test: `/schedule run` triggers task execution
- [ ] Manual test: `/schedule status` shows correct information

🤖 Generated with [Claude Code](https://claude.com/claude-code)