### PR TITLE
feat(messaging): add Universal Message Format + Channel Adapters (Issue #515)

### DIFF
--- a/src/messaging/adapters/cli-adapter.ts
+++ b/src/messaging/adapters/cli-adapter.ts
@@ -1,0 +1,108 @@
+/**
+ * CLI Channel Adapter - Converts UMF to console output.
+ *
+ * This adapter handles message conversion and output for CLI mode.
+ * It converts Universal Message Format to human-readable text for console.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { createLogger } from '../../utils/logger.js';
+import type { IChannelAdapter, ChannelCapabilities } from '../channel-adapter.js';
+import type { UniversalMessage, SendResult, MessageContent } from '../universal-message.js';
+import { cardToText } from '../channel-adapter.js';
+
+const logger = createLogger('CliAdapter');
+
+/**
+ * CLI Adapter - Converts UMF to text and outputs to console.
+ */
+export class CliAdapter implements IChannelAdapter {
+  readonly name = 'cli';
+  readonly capabilities: ChannelCapabilities = {
+    supportsCard: false,
+    supportsThread: false,
+    supportsFile: false,
+    supportsMarkdown: true,
+    maxMessageLength: Infinity,
+    supportedContentTypes: ['text', 'markdown', 'done'],
+    supportsUpdate: false,
+    supportsDelete: false,
+    supportsMention: false,
+    supportsReactions: false,
+  };
+
+  /**
+   * Check if this adapter can handle the given chatId.
+   * CLI chat IDs start with "cli-".
+   */
+  canHandle(chatId: string): boolean {
+    return chatId.startsWith('cli-');
+  }
+
+  /**
+   * Convert Universal Message to CLI text format.
+   */
+  convert(message: UniversalMessage): string {
+    const { content } = message;
+    const prefix = `[${message.chatId}]`;
+
+    switch (content.type) {
+      case 'text':
+        return `${prefix} ${content.text}`;
+
+      case 'markdown':
+        return `${prefix}\n${content.text}`;
+
+      case 'card':
+        // Convert card to text representation
+        const cardText = cardToText(content);
+        return `${prefix}\n${cardText}`;
+
+      case 'file':
+        return `${prefix} 📎 File: ${content.name || content.path}`;
+
+      case 'done':
+        const status = content.success ? '✅' : '❌';
+        const msg = content.success ? content.message : content.error;
+        return `${prefix} ${status} ${msg || 'Task completed'}`;
+
+      default:
+        return `${prefix} Unknown message type: ${(content as MessageContent).type}`;
+    }
+  }
+
+  /**
+   * Send a message to the console.
+   */
+  async send(message: UniversalMessage): Promise<SendResult> {
+    try {
+      const text = this.convert(message);
+
+      // Output to console
+      console.log(`\n${text}\n`);
+
+      logger.debug({ chatId: message.chatId }, 'CLI message displayed');
+
+      return {
+        success: true,
+        // CLI doesn't have real message IDs, generate a pseudo one
+        messageId: `cli-${Date.now()}`,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, chatId: message.chatId }, 'Failed to display CLI message');
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+}
+
+/**
+ * Create a new CLI adapter instance.
+ */
+export function createCliAdapter(): CliAdapter {
+  return new CliAdapter();
+}

--- a/src/messaging/adapters/feishu-adapter.ts
+++ b/src/messaging/adapters/feishu-adapter.ts
@@ -1,0 +1,414 @@
+/**
+ * Feishu Channel Adapter - Converts UMF to Feishu Card format.
+ *
+ * This adapter handles message conversion and sending for Feishu platform.
+ * It converts Universal Message Format to Feishu's interactive card format.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import type {
+  IChannelAdapter,
+  ChannelCapabilities,
+} from '../channel-adapter.js';
+import type {
+  UniversalMessage,
+  SendResult,
+  MessageContent,
+  CardContent,
+  CardSection,
+  CardAction,
+} from '../universal-message.js';
+
+const logger = createLogger('FeishuAdapter');
+
+/**
+ * Feishu card theme colors mapping.
+ */
+const THEME_MAP: Record<string, string> = {
+  blue: 'blue',
+  wathet: 'wathet',
+  turquoise: 'turquoise',
+  green: 'green',
+  yellow: 'yellow',
+  orange: 'orange',
+  red: 'red',
+  carmine: 'carmine',
+  violet: 'violet',
+  purple: 'purple',
+  indigo: 'indigo',
+  grey: 'grey',
+};
+
+/**
+ * Feishu Adapter - Converts UMF to Feishu format and sends via API.
+ */
+export class FeishuAdapter implements IChannelAdapter {
+  readonly name = 'feishu';
+  readonly capabilities: ChannelCapabilities = {
+    supportsCard: true,
+    supportsThread: true,
+    supportsFile: true,
+    supportsMarkdown: true,
+    maxMessageLength: 30000,
+    supportedContentTypes: ['text', 'markdown', 'card', 'file'],
+    supportsUpdate: true,
+    supportsDelete: true,
+    supportsMention: true,
+    supportsReactions: true,
+  };
+
+  private client: lark.Client | null = null;
+
+  /**
+   * Get or create the Lark client.
+   */
+  private getClient(): lark.Client {
+    if (!this.client) {
+      const appId = Config.FEISHU_APP_ID;
+      const appSecret = Config.FEISHU_APP_SECRET;
+      if (!appId || !appSecret) {
+        throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET must be configured');
+      }
+      this.client = createFeishuClient(appId, appSecret, {
+        domain: lark.Domain.Feishu,
+      });
+    }
+    return this.client;
+  }
+
+  /**
+   * Check if this adapter can handle the given chatId.
+   * Feishu chat IDs start with: oc_ (group), ou_ (user), on_ (bot)
+   */
+  canHandle(chatId: string): boolean {
+    return /^(oc_|ou_|on_)/.test(chatId);
+  }
+
+  /**
+   * Convert Universal Message to Feishu format.
+   */
+  convert(message: UniversalMessage): unknown {
+    const { content } = message;
+
+    switch (content.type) {
+      case 'text':
+        return {
+          msg_type: 'text',
+          content: JSON.stringify({ text: content.text }),
+        };
+
+      case 'markdown':
+        return {
+          msg_type: 'interactive',
+          content: JSON.stringify(this.markdownToCard(content.text)),
+        };
+
+      case 'card':
+        return {
+          msg_type: 'interactive',
+          content: JSON.stringify(this.convertCard(content)),
+        };
+
+      case 'file':
+        return {
+          msg_type: 'file',
+          content: JSON.stringify({ file_path: content.path }),
+        };
+
+      case 'done':
+        return {
+          msg_type: 'text',
+          content: JSON.stringify({
+            text: content.success
+              ? `✅ ${content.message || 'Task completed'}`
+              : `❌ ${content.error || 'Task failed'}`,
+          }),
+        };
+
+      default:
+        throw new Error(`Unsupported content type: ${(content as MessageContent).type}`);
+    }
+  }
+
+  /**
+   * Convert UMF Card to Feishu Card format.
+   */
+  private convertCard(card: CardContent): Record<string, unknown> {
+    const elements: Record<string, unknown>[] = [];
+
+    // Convert sections to Feishu elements
+    for (const section of card.sections) {
+      const element = this.convertSection(section);
+      if (element) {
+        elements.push(element);
+      }
+    }
+
+    // Convert actions to Feishu actions
+    let actions: Record<string, unknown>[] | undefined;
+    if (card.actions && card.actions.length > 0) {
+      actions = card.actions.map((action) => this.convertAction(action));
+    }
+
+    return {
+      config: {
+        wide_screen_mode: true,
+      },
+      header: {
+        title: {
+          tag: 'plain_text',
+          content: card.title,
+        },
+        template: THEME_MAP[card.theme || 'blue'] || 'blue',
+        ...(card.subtitle && {
+          subtitle: {
+            tag: 'plain_text',
+            content: card.subtitle,
+          },
+        }),
+      },
+      elements,
+      ...(actions && actions.length > 0 && { card_link: actions[0] }),
+    };
+  }
+
+  /**
+   * Convert UMF section to Feishu element.
+   */
+  private convertSection(section: CardSection): Record<string, unknown> | null {
+    switch (section.type) {
+      case 'text':
+        return {
+          tag: 'div',
+          text: {
+            tag: 'plain_text',
+            content: section.content || '',
+          },
+        };
+
+      case 'markdown':
+        return {
+          tag: 'markdown',
+          content: section.content || '',
+        };
+
+      case 'divider':
+        return { tag: 'hr' };
+
+      case 'fields':
+        if (!section.fields || section.fields.length === 0) {
+          return null;
+        }
+        return {
+          tag: 'div',
+          fields: section.fields.map((field) => ({
+            is_short: true,
+            text: {
+              tag: 'lark_md',
+              content: `**${field.label}**\n${field.value}`,
+            },
+          })),
+        };
+
+      case 'image':
+        return {
+          tag: 'img',
+          img_key: section.imageUrl || '',
+          alt: {
+            tag: 'plain_text',
+            content: 'Image',
+          },
+        };
+
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Convert UMF action to Feishu action.
+   */
+  private convertAction(action: CardAction): Record<string, unknown> {
+    switch (action.type) {
+      case 'button':
+        return {
+          tag: 'button',
+          text: {
+            tag: 'plain_text',
+            content: action.label,
+          },
+          value: { action: action.value },
+          type: {
+            primary: 'primary',
+            secondary: 'default',
+            danger: 'danger',
+          }[action.style || 'primary'] || 'primary',
+        };
+
+      case 'select':
+        return {
+          tag: 'select_static',
+          placeholder: {
+            tag: 'plain_text',
+            content: action.label,
+          },
+          options: action.options?.map((opt) => ({
+            text: {
+              tag: 'plain_text',
+              content: opt.label,
+            },
+            value: opt.value,
+          })) || [],
+        };
+
+      case 'link':
+        return {
+          tag: 'action',
+          actions: [
+            {
+              tag: 'button',
+              text: {
+                tag: 'plain_text',
+                content: action.label,
+              },
+              url: action.url || '',
+              type: 'primary',
+            },
+          ],
+        };
+
+      default:
+        return {
+          tag: 'button',
+          text: {
+            tag: 'plain_text',
+            content: action.label,
+          },
+          value: { action: action.value },
+        };
+    }
+  }
+
+  /**
+   * Convert markdown to a simple Feishu card.
+   */
+  private markdownToCard(text: string): Record<string, unknown> {
+    return {
+      config: {
+        wide_screen_mode: true,
+      },
+      elements: [
+        {
+          tag: 'markdown',
+          content: text,
+        },
+      ],
+    };
+  }
+
+  /**
+   * Send a message through Feishu API.
+   */
+  async send(message: UniversalMessage): Promise<SendResult> {
+    try {
+      const client = this.getClient();
+      const feishuMessage = this.convert(message) as {
+        msg_type: string;
+        content: string;
+      };
+
+      // Use thread reply if threadId is provided
+      if (message.threadId) {
+        await client.im.message.reply({
+          path: {
+            message_id: message.threadId,
+          },
+          data: {
+            msg_type: feishuMessage.msg_type,
+            content: feishuMessage.content,
+          },
+        });
+      } else {
+        const response = await client.im.message.create({
+          params: {
+            receive_id_type: 'chat_id',
+          },
+          data: {
+            receive_id: message.chatId,
+            msg_type: feishuMessage.msg_type,
+            content: feishuMessage.content,
+          },
+        });
+
+        const messageId = response.data?.message_id;
+        logger.debug({ chatId: message.chatId, messageId }, 'Message sent to Feishu');
+
+        return {
+          success: true,
+          messageId,
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, chatId: message.chatId }, 'Failed to send message to Feishu');
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Update an existing message.
+   */
+  async update(messageId: string, message: UniversalMessage): Promise<SendResult> {
+    try {
+      const client = this.getClient();
+      const feishuMessage = this.convert(message) as {
+        msg_type: string;
+        content: string;
+      };
+
+      // Only cards can be updated
+      if (message.content.type !== 'card') {
+        return {
+          success: false,
+          error: 'Only card messages can be updated',
+        };
+      }
+
+      await client.im.message.patch({
+        path: {
+          message_id: messageId,
+        },
+        data: {
+          content: feishuMessage.content,
+        },
+      });
+
+      logger.debug({ messageId }, 'Message updated in Feishu');
+      return { success: true, messageId };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, messageId }, 'Failed to update message in Feishu');
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+}
+
+/**
+ * Create a new Feishu adapter instance.
+ */
+export function createFeishuAdapter(): FeishuAdapter {
+  return new FeishuAdapter();
+}

--- a/src/messaging/adapters/index.test.ts
+++ b/src/messaging/adapters/index.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for Channel Adapters.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CliAdapter, createCliAdapter } from './cli-adapter.js';
+import { RestAdapter, createRestAdapter, resetRestAdapter, getRestAdapter } from './rest-adapter.js';
+import { isTextContent } from '../universal-message.js';
+import type { UniversalMessage } from '../universal-message.js';
+
+// Mock Config for Feishu adapter tests
+vi.mock('../../config/index.js', () => ({
+  Config: {
+    FEISHU_APP_ID: 'test_app_id',
+    FEISHU_APP_SECRET: 'test_app_secret',
+  },
+}));
+
+describe('Channel Adapters', () => {
+  describe('CliAdapter', () => {
+    let adapter: CliAdapter;
+
+    beforeEach(() => {
+      adapter = createCliAdapter();
+    });
+
+    describe('canHandle', () => {
+      it('should handle CLI chat IDs', () => {
+        expect(adapter.canHandle('cli-123')).toBe(true);
+        expect(adapter.canHandle('cli-test-abc')).toBe(true);
+      });
+
+      it('should not handle non-CLI chat IDs', () => {
+        expect(adapter.canHandle('oc_123')).toBe(false);
+        expect(adapter.canHandle('ou_456')).toBe(false);
+        expect(adapter.canHandle('uuid-1234')).toBe(false);
+      });
+    });
+
+    describe('capabilities', () => {
+      it('should have correct capabilities', () => {
+        expect(adapter.name).toBe('cli');
+        expect(adapter.capabilities.supportsCard).toBe(false);
+        expect(adapter.capabilities.supportsMarkdown).toBe(true);
+        expect(adapter.capabilities.maxMessageLength).toBe(Infinity);
+      });
+    });
+
+    describe('convert', () => {
+      it('should convert text message', () => {
+        const msg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'text', text: 'Hello' },
+        };
+        const result = adapter.convert(msg);
+        expect(result).toContain('[cli-test]');
+        expect(result).toContain('Hello');
+      });
+
+      it('should convert markdown message', () => {
+        const msg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'markdown', text: '**Bold**' },
+        };
+        const result = adapter.convert(msg);
+        expect(result).toContain('**Bold**');
+      });
+
+      it('should convert card to text', () => {
+        const msg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: {
+            type: 'card',
+            title: 'Card Title',
+            sections: [{ type: 'text', content: 'Card Content' }],
+          },
+        };
+        const result = adapter.convert(msg);
+        expect(result).toContain('**Card Title**');
+        expect(result).toContain('Card Content');
+      });
+
+      it('should convert done message', () => {
+        const successMsg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'done', success: true, message: 'Completed' },
+        };
+        expect(adapter.convert(successMsg)).toContain('✅');
+        expect(adapter.convert(successMsg)).toContain('Completed');
+
+        const failMsg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'done', success: false, error: 'Failed' },
+        };
+        expect(adapter.convert(failMsg)).toContain('❌');
+        expect(adapter.convert(failMsg)).toContain('Failed');
+      });
+
+      it('should convert file message', () => {
+        const msg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'file', path: '/path/to/file.txt', name: 'file.txt' },
+        };
+        const result = adapter.convert(msg);
+        expect(result).toContain('📎');
+        expect(result).toContain('file.txt');
+      });
+    });
+
+    describe('send', () => {
+      it('should send message successfully', async () => {
+        const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        const msg: UniversalMessage = {
+          chatId: 'cli-test',
+          content: { type: 'text', text: 'Hello' },
+        };
+        const result = await adapter.send(msg);
+        expect(result.success).toBe(true);
+        expect(result.messageId).toBeDefined();
+        expect(consoleSpy).toHaveBeenCalled();
+        consoleSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('RestAdapter', () => {
+    let adapter: RestAdapter;
+
+    beforeEach(() => {
+      resetRestAdapter();
+      adapter = createRestAdapter();
+    });
+
+    describe('canHandle', () => {
+      it('should handle UUID format chat IDs', () => {
+        expect(adapter.canHandle('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+        expect(adapter.canHandle('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')).toBe(true);
+      });
+
+      it('should not handle non-UUID chat IDs', () => {
+        expect(adapter.canHandle('oc_123')).toBe(false);
+        expect(adapter.canHandle('cli-test')).toBe(false);
+        expect(adapter.canHandle('not-a-uuid')).toBe(false);
+      });
+    });
+
+    describe('capabilities', () => {
+      it('should have correct capabilities', () => {
+        expect(adapter.name).toBe('rest');
+        expect(adapter.capabilities.supportsCard).toBe(true);
+        expect(adapter.capabilities.supportedContentTypes).toContain('done');
+      });
+    });
+
+    describe('convert', () => {
+      it('should convert message to REST format', () => {
+        const msg: UniversalMessage = {
+          chatId: '123e4567-e89b-12d3-a456-426614174000',
+          content: { type: 'text', text: 'Hello' },
+        };
+        const result = adapter.convert(msg);
+        expect(result.id).toBeDefined();
+        expect(result.chatId).toBe(msg.chatId);
+        expect(result.content).toEqual(msg.content);
+        expect(result.timestamp).toBeDefined();
+      });
+
+      it('should preserve threadId', () => {
+        const msg: UniversalMessage = {
+          chatId: '123e4567-e89b-12d3-a456-426614174000',
+          threadId: 'thread-123',
+          content: { type: 'text', text: 'Hello' },
+        };
+        const result = adapter.convert(msg);
+        expect(result.threadId).toBe('thread-123');
+      });
+    });
+
+    describe('send', () => {
+      it('should store message successfully', async () => {
+        const msg: UniversalMessage = {
+          chatId: '123e4567-e89b-12d3-a456-426614174000',
+          content: { type: 'text', text: 'Hello' },
+        };
+        const result = await adapter.send(msg);
+        expect(result.success).toBe(true);
+        expect(result.messageId).toBeDefined();
+        expect(result.platformData).toBeDefined();
+      });
+
+      it('should allow message retrieval', async () => {
+        const chatId = '123e4567-e89b-12d3-a456-426614174000';
+        const msg: UniversalMessage = {
+          chatId,
+          content: { type: 'text', text: 'Test message' },
+        };
+        await adapter.send(msg);
+
+        const messages = adapter.getMessages(chatId);
+        expect(messages).toHaveLength(1);
+        const content = messages[0].content;
+        expect(isTextContent(content) && content.text).toBe('Test message');
+      });
+
+      it('should support getMessagesSince', async () => {
+        const chatId = '123e4567-e89b-12d3-a456-426614174000';
+
+        await adapter.send({
+          chatId,
+          content: { type: 'text', text: 'Message 1' },
+        });
+        const result2 = await adapter.send({
+          chatId,
+          content: { type: 'text', text: 'Message 2' },
+        });
+        await adapter.send({
+          chatId,
+          content: { type: 'text', text: 'Message 3' },
+        });
+
+        const newMessages = adapter.getMessagesSince(chatId, result2.messageId!);
+        expect(newMessages).toHaveLength(1);
+        const content = newMessages[0].content;
+        expect(isTextContent(content) && content.text).toBe('Message 3');
+      });
+
+      it('should support clearMessages', async () => {
+        const chatId = '123e4567-e89b-12d3-a456-426614174000';
+        await adapter.send({
+          chatId,
+          content: { type: 'text', text: 'Test' },
+        });
+
+        adapter.clearMessages(chatId);
+        expect(adapter.getMessages(chatId)).toHaveLength(0);
+      });
+    });
+
+    describe('getRestAdapter singleton', () => {
+      it('should return the same instance', () => {
+        const instance1 = getRestAdapter();
+        const instance2 = getRestAdapter();
+        expect(instance1).toBe(instance2);
+      });
+    });
+  });
+});

--- a/src/messaging/adapters/rest-adapter.ts
+++ b/src/messaging/adapters/rest-adapter.ts
@@ -1,0 +1,183 @@
+/**
+ * REST Channel Adapter - Converts UMF to JSON for REST API responses.
+ *
+ * This adapter handles message conversion for REST API channel.
+ * It keeps messages in JSON format for programmatic access.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { createLogger } from '../../utils/logger.js';
+import type { IChannelAdapter, ChannelCapabilities } from '../channel-adapter.js';
+import type { UniversalMessage, SendResult } from '../universal-message.js';
+
+const logger = createLogger('RestAdapter');
+
+/**
+ * REST message format - The JSON structure returned to REST clients.
+ */
+export interface RestMessage {
+  /** Message ID */
+  id: string;
+  /** Chat ID */
+  chatId: string;
+  /** Thread ID if part of a thread */
+  threadId?: string;
+  /** Message content (UMF format) */
+  content: UniversalMessage['content'];
+  /** Timestamp */
+  timestamp: number;
+  /** Metadata */
+  metadata?: UniversalMessage['metadata'];
+}
+
+/**
+ * REST Adapter - Keeps messages in JSON format for REST clients.
+ *
+ * Note: This adapter doesn't actually "send" messages anywhere.
+ * Instead, it converts messages to a format that can be polled or
+ * streamed by REST clients. The actual delivery mechanism is handled
+ * by the REST channel implementation.
+ */
+export class RestAdapter implements IChannelAdapter {
+  readonly name = 'rest';
+  readonly capabilities: ChannelCapabilities = {
+    supportsCard: true,
+    supportsThread: false,
+    supportsFile: false,
+    supportsMarkdown: true,
+    maxMessageLength: Infinity,
+    supportedContentTypes: ['text', 'markdown', 'card', 'file', 'done'],
+    supportsUpdate: false,
+    supportsDelete: false,
+    supportsMention: false,
+    supportsReactions: false,
+  };
+
+  // Message store for REST polling (in-memory, for demo purposes)
+  // In production, this would be replaced with a proper message queue
+  private messageStore: Map<string, RestMessage[]> = new Map();
+
+  /**
+   * Check if this adapter can handle the given chatId.
+   * REST chat IDs are UUID format.
+   */
+  canHandle(chatId: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(chatId);
+  }
+
+  /**
+   * Convert Universal Message to REST JSON format.
+   */
+  convert(message: UniversalMessage): RestMessage {
+    return {
+      id: this.generateMessageId(),
+      chatId: message.chatId,
+      threadId: message.threadId,
+      content: message.content,
+      timestamp: Date.now(),
+      metadata: message.metadata,
+    };
+  }
+
+  /**
+   * Generate a unique message ID.
+   */
+  private generateMessageId(): string {
+    return `msg_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  /**
+   * Store a message for REST polling.
+   *
+   * Note: In a real implementation, this would push to a message queue
+   * or notify connected WebSocket clients.
+   */
+  async send(message: UniversalMessage): Promise<SendResult> {
+    try {
+      const restMessage = this.convert(message);
+
+      // Store the message for this chat
+      const chatMessages = this.messageStore.get(message.chatId) || [];
+      chatMessages.push(restMessage);
+      this.messageStore.set(message.chatId, chatMessages);
+
+      logger.debug(
+        {
+          chatId: message.chatId,
+          messageId: restMessage.id,
+          contentType: message.content.type,
+        },
+        'REST message stored'
+      );
+
+      return {
+        success: true,
+        messageId: restMessage.id,
+        platformData: restMessage as unknown as Record<string, unknown>,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, chatId: message.chatId }, 'Failed to store REST message');
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Get all messages for a chat (for polling).
+   */
+  getMessages(chatId: string): RestMessage[] {
+    return this.messageStore.get(chatId) || [];
+  }
+
+  /**
+   * Get messages since a specific message ID.
+   */
+  getMessagesSince(chatId: string, sinceId: string): RestMessage[] {
+    const messages = this.messageStore.get(chatId) || [];
+    const index = messages.findIndex((m) => m.id === sinceId);
+    if (index === -1) {
+      return messages;
+    }
+    return messages.slice(index + 1);
+  }
+
+  /**
+   * Clear messages for a chat.
+   */
+  clearMessages(chatId: string): void {
+    this.messageStore.delete(chatId);
+  }
+}
+
+/**
+ * Global REST adapter instance for message polling.
+ */
+let globalRestAdapter: RestAdapter | null = null;
+
+/**
+ * Get the global REST adapter instance.
+ */
+export function getRestAdapter(): RestAdapter {
+  if (!globalRestAdapter) {
+    globalRestAdapter = new RestAdapter();
+  }
+  return globalRestAdapter;
+}
+
+/**
+ * Reset the global REST adapter (for testing).
+ */
+export function resetRestAdapter(): void {
+  globalRestAdapter = null;
+}
+
+/**
+ * Create a new REST adapter instance.
+ */
+export function createRestAdapter(): RestAdapter {
+  return new RestAdapter();
+}

--- a/src/messaging/channel-adapter.test.ts
+++ b/src/messaging/channel-adapter.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for Channel Adapter interface and utilities.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_CAPABILITIES,
+  FEISHU_CAPABILITIES,
+  CLI_CAPABILITIES,
+  REST_CAPABILITIES,
+  cardToText,
+  truncateText,
+  isContentTypeSupported,
+  getFallbackContentType,
+  negotiateContentType,
+} from './channel-adapter.js';
+import type { CardContent } from './universal-message.js';
+
+describe('Channel Adapter', () => {
+  describe('Capabilities', () => {
+    it('should have correct default capabilities', () => {
+      expect(DEFAULT_CAPABILITIES.supportsCard).toBe(false);
+      expect(DEFAULT_CAPABILITIES.supportsThread).toBe(false);
+      expect(DEFAULT_CAPABILITIES.supportsMarkdown).toBe(false);
+      expect(DEFAULT_CAPABILITIES.maxMessageLength).toBe(4096);
+    });
+
+    it('should have correct Feishu capabilities', () => {
+      expect(FEISHU_CAPABILITIES.supportsCard).toBe(true);
+      expect(FEISHU_CAPABILITIES.supportsThread).toBe(true);
+      expect(FEISHU_CAPABILITIES.supportsMarkdown).toBe(true);
+      expect(FEISHU_CAPABILITIES.supportedContentTypes).toContain('card');
+    });
+
+    it('should have correct CLI capabilities', () => {
+      expect(CLI_CAPABILITIES.supportsCard).toBe(false);
+      expect(CLI_CAPABILITIES.supportsMarkdown).toBe(true);
+      expect(CLI_CAPABILITIES.maxMessageLength).toBe(Infinity);
+    });
+
+    it('should have correct REST capabilities', () => {
+      expect(REST_CAPABILITIES.supportsCard).toBe(true);
+      expect(REST_CAPABILITIES.supportedContentTypes).toContain('done');
+    });
+  });
+
+  describe('cardToText', () => {
+    it('should convert a simple card to text', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Task Complete',
+        sections: [{ type: 'text', content: 'All done!' }],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('**Task Complete**');
+      expect(text).toContain('All done!');
+    });
+
+    it('should include subtitle in text', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Title',
+        subtitle: 'Subtitle',
+        sections: [],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('Subtitle');
+    });
+
+    it('should convert divider sections', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Title',
+        sections: [
+          { type: 'text', content: 'Before' },
+          { type: 'divider' },
+          { type: 'text', content: 'After' },
+        ],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('---');
+    });
+
+    it('should convert field sections', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Title',
+        sections: [
+          {
+            type: 'fields',
+            fields: [
+              { label: 'Name', value: 'John' },
+              { label: 'Age', value: '30' },
+            ],
+          },
+        ],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('**Name**: John');
+      expect(text).toContain('**Age**: 30');
+    });
+
+    it('should convert actions', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Title',
+        sections: [],
+        actions: [
+          { type: 'button', label: 'OK', value: 'ok' },
+          { type: 'button', label: 'Cancel', value: 'cancel' },
+        ],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('[OK]');
+      expect(text).toContain('[Cancel]');
+    });
+
+    it('should handle image sections', () => {
+      const card: CardContent = {
+        type: 'card',
+        title: 'Title',
+        sections: [{ type: 'image', imageUrl: 'https://example.com/image.png' }],
+      };
+      const text = cardToText(card);
+      expect(text).toContain('[Image: https://example.com/image.png]');
+    });
+  });
+
+  describe('truncateText', () => {
+    it('should not truncate short text', () => {
+      const text = 'Hello World';
+      expect(truncateText(text, 100)).toBe(text);
+    });
+
+    it('should truncate long text with default suffix', () => {
+      const text = 'This is a very long text that needs to be truncated';
+      expect(truncateText(text, 20)).toBe('This is a very lo...');
+    });
+
+    it('should truncate with custom suffix', () => {
+      const text = 'This is a very long text';
+      expect(truncateText(text, 15, '…')).toBe('This is a very…');
+    });
+  });
+
+  describe('isContentTypeSupported', () => {
+    it('should return true for supported types', () => {
+      expect(isContentTypeSupported(FEISHU_CAPABILITIES, 'card')).toBe(true);
+      expect(isContentTypeSupported(CLI_CAPABILITIES, 'text')).toBe(true);
+    });
+
+    it('should return false for unsupported types', () => {
+      expect(isContentTypeSupported(CLI_CAPABILITIES, 'card')).toBe(false);
+      expect(isContentTypeSupported(DEFAULT_CAPABILITIES, 'markdown')).toBe(false);
+    });
+  });
+
+  describe('getFallbackContentType', () => {
+    it('should return same type if supported', () => {
+      expect(getFallbackContentType(FEISHU_CAPABILITIES, 'card')).toBe('card');
+    });
+
+    it('should fallback card to markdown then text', () => {
+      expect(getFallbackContentType(CLI_CAPABILITIES, 'card')).toBe('markdown');
+    });
+
+    it('should fallback markdown to text', () => {
+      const caps = { ...DEFAULT_CAPABILITIES, supportedContentTypes: ['text'] };
+      expect(getFallbackContentType(caps, 'markdown')).toBe('text');
+    });
+
+    it('should return null if no fallback available', () => {
+      const caps = { ...DEFAULT_CAPABILITIES, supportedContentTypes: [] };
+      expect(getFallbackContentType(caps, 'card')).toBeNull();
+    });
+  });
+
+  describe('negotiateContentType', () => {
+    it('should return first supported type', () => {
+      const result = negotiateContentType(FEISHU_CAPABILITIES, ['card', 'text']);
+      expect(result).toBe('card');
+    });
+
+    it('should skip unsupported types', () => {
+      const result = negotiateContentType(CLI_CAPABILITIES, ['card', 'markdown', 'text']);
+      expect(result).toBe('markdown');
+    });
+
+    it('should return null if no type is supported', () => {
+      const caps = { ...DEFAULT_CAPABILITIES, supportedContentTypes: [] };
+      const result = negotiateContentType(caps, ['card', 'markdown']);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/messaging/channel-adapter.ts
+++ b/src/messaging/channel-adapter.ts
@@ -1,0 +1,334 @@
+/**
+ * Channel Adapter Interface - Platform-specific message conversion.
+ *
+ * This module defines the interface that all channel adapters must implement
+ * to convert Universal Message Format (UMF) to platform-specific formats.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ *
+ * @example
+ * ```typescript
+ * class FeishuAdapter implements IChannelAdapter {
+ *   readonly name = 'feishu';
+ *   readonly capabilities = {
+ *     supportsCard: true,
+ *     supportsThread: true,
+ *     supportsFile: true,
+ *     supportsMarkdown: true,
+ *     maxMessageLength: 30000,
+ *   };
+ *
+ *   canHandle(chatId: string): boolean {
+ *     return chatId.startsWith('oc_') || chatId.startsWith('ou_');
+ *   }
+ *
+ *   convert(message: UniversalMessage): FeishuCard {
+ *     // Convert UMF to Feishu format
+ *   }
+ *
+ *   async send(message: UniversalMessage): Promise<SendResult> {
+ *     // Send via Feishu API
+ *   }
+ * }
+ * ```
+ */
+
+import type { UniversalMessage, SendResult, CardContent } from './universal-message.js';
+
+// ============================================================================
+// Channel Capabilities
+// ============================================================================
+
+/**
+ * Channel capabilities - Describes what a channel supports.
+ *
+ * Used for capability negotiation between the agent and the channel.
+ * The agent can adjust its output based on channel capabilities.
+ */
+export interface ChannelCapabilities {
+  /** Whether the channel supports interactive cards */
+  supportsCard: boolean;
+  /** Whether the channel supports threaded replies */
+  supportsThread: boolean;
+  /** Whether the channel supports file attachments */
+  supportsFile: boolean;
+  /** Whether the channel supports markdown formatting */
+  supportsMarkdown: boolean;
+  /** Maximum message length in characters */
+  maxMessageLength: number;
+  /** Supported content types */
+  supportedContentTypes: string[];
+  /** Whether the channel supports message updates */
+  supportsUpdate: boolean;
+  /** Whether the channel supports message deletion */
+  supportsDelete: boolean;
+  /** Whether the channel supports @mentions */
+  supportsMention: boolean;
+  /** Whether the channel supports reactions/emoji */
+  supportsReactions: boolean;
+}
+
+/**
+ * Default capabilities for a basic channel.
+ */
+export const DEFAULT_CAPABILITIES: ChannelCapabilities = {
+  supportsCard: false,
+  supportsThread: false,
+  supportsFile: false,
+  supportsMarkdown: false,
+  maxMessageLength: 4096,
+  supportedContentTypes: ['text'],
+  supportsUpdate: false,
+  supportsDelete: false,
+  supportsMention: false,
+  supportsReactions: false,
+};
+
+/**
+ * Feishu channel capabilities.
+ */
+export const FEISHU_CAPABILITIES: ChannelCapabilities = {
+  supportsCard: true,
+  supportsThread: true,
+  supportsFile: true,
+  supportsMarkdown: true,
+  maxMessageLength: 30000,
+  supportedContentTypes: ['text', 'markdown', 'card', 'file'],
+  supportsUpdate: true,
+  supportsDelete: true,
+  supportsMention: true,
+  supportsReactions: true,
+};
+
+/**
+ * CLI channel capabilities.
+ */
+export const CLI_CAPABILITIES: ChannelCapabilities = {
+  supportsCard: false,
+  supportsThread: false,
+  supportsFile: false,
+  supportsMarkdown: true,
+  maxMessageLength: Infinity,
+  supportedContentTypes: ['text', 'markdown'],
+  supportsUpdate: false,
+  supportsDelete: false,
+  supportsMention: false,
+  supportsReactions: false,
+};
+
+/**
+ * REST channel capabilities.
+ */
+export const REST_CAPABILITIES: ChannelCapabilities = {
+  supportsCard: true,
+  supportsThread: false,
+  supportsFile: false,
+  supportsMarkdown: true,
+  maxMessageLength: Infinity,
+  supportedContentTypes: ['text', 'markdown', 'card', 'file', 'done'],
+  supportsUpdate: false,
+  supportsDelete: false,
+  supportsMention: false,
+  supportsReactions: false,
+};
+
+// ============================================================================
+// Channel Adapter Interface
+// ============================================================================
+
+/**
+ * Channel Adapter interface.
+ *
+ * All channel adapters must implement this interface to:
+ * 1. Detect if they can handle a chatId
+ * 2. Convert UMF to platform format
+ * 3. Send messages via platform API
+ */
+export interface IChannelAdapter {
+  /** Adapter name (e.g., 'feishu', 'cli', 'rest') */
+  readonly name: string;
+
+  /** Channel capabilities */
+  readonly capabilities: ChannelCapabilities;
+
+  /**
+   * Check if this adapter can handle the given chatId.
+   * @param chatId - Chat ID to check
+   * @returns true if this adapter can handle the chatId
+   */
+  canHandle(chatId: string): boolean;
+
+  /**
+   * Convert Universal Message to platform-specific format.
+   * @param message - Universal message to convert
+   * @returns Platform-specific message format
+   */
+  convert(message: UniversalMessage): unknown;
+
+  /**
+   * Send a message through this channel.
+   * @param message - Universal message to send
+   * @returns Send result with success status and message ID
+   */
+  send(message: UniversalMessage): Promise<SendResult>;
+
+  /**
+   * Update an existing message (optional).
+   * @param messageId - Message ID to update
+   * @param message - New message content
+   * @returns Send result
+   */
+  update?(messageId: string, message: UniversalMessage): Promise<SendResult>;
+
+  /**
+   * Delete a message (optional).
+   * @param messageId - Message ID to delete
+   * @returns Whether deletion was successful
+   */
+  delete?(messageId: string): Promise<boolean>;
+}
+
+// ============================================================================
+// Format Conversion Utilities
+// ============================================================================
+
+/**
+ * Convert UMF Card to a simple text representation.
+ * Used for fallback when a channel doesn't support cards.
+ *
+ * @param card - UMF Card content
+ * @returns Plain text representation
+ */
+export function cardToText(card: CardContent): string {
+  const parts: string[] = [];
+
+  // Title
+  parts.push(`**${card.title}**`);
+  if (card.subtitle) {
+    parts.push(card.subtitle);
+  }
+  parts.push('');
+
+  // Sections
+  for (const section of card.sections) {
+    switch (section.type) {
+      case 'text':
+      case 'markdown':
+        if (section.content) {
+          parts.push(section.content);
+        }
+        break;
+      case 'divider':
+        parts.push('---');
+        break;
+      case 'fields':
+        if (section.fields) {
+          for (const field of section.fields) {
+            parts.push(`**${field.label}**: ${field.value}`);
+          }
+        }
+        break;
+      case 'image':
+        if (section.imageUrl) {
+          parts.push(`[Image: ${section.imageUrl}]`);
+        }
+        break;
+    }
+    parts.push('');
+  }
+
+  // Actions
+  if (card.actions && card.actions.length > 0) {
+    parts.push('**Actions:**');
+    for (const action of card.actions) {
+      parts.push(`[${action.label}]`);
+    }
+  }
+
+  return parts.join('\n').trim();
+}
+
+/**
+ * Truncate text to fit within max length.
+ *
+ * @param text - Text to truncate
+ * @param maxLength - Maximum length
+ * @param suffix - Suffix to add when truncated (default: '...')
+ * @returns Truncated text
+ */
+export function truncateText(text: string, maxLength: number, suffix = '...'): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.substring(0, maxLength - suffix.length) + suffix;
+}
+
+// ============================================================================
+// Capability Negotiation
+// ============================================================================
+
+/**
+ * Check if a content type is supported by a channel.
+ *
+ * @param capabilities - Channel capabilities
+ * @param contentType - Content type to check
+ * @returns true if supported
+ */
+export function isContentTypeSupported(
+  capabilities: ChannelCapabilities,
+  contentType: string
+): boolean {
+  return capabilities.supportedContentTypes.includes(contentType);
+}
+
+/**
+ * Get fallback content type for unsupported types.
+ *
+ * @param capabilities - Channel capabilities
+ * @param contentType - Original content type
+ * @returns Fallback content type or null if no fallback
+ */
+export function getFallbackContentType(
+  capabilities: ChannelCapabilities,
+  contentType: string
+): string | null {
+  if (isContentTypeSupported(capabilities, contentType)) {
+    return contentType;
+  }
+
+  // Fallback chain
+  const fallbacks: Record<string, string[]> = {
+    card: ['markdown', 'text'],
+    markdown: ['text'],
+    file: ['text'],
+    done: ['text'],
+  };
+
+  const fallbackChain = fallbacks[contentType] || ['text'];
+  for (const fallback of fallbackChain) {
+    if (isContentTypeSupported(capabilities, fallback)) {
+      return fallback;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Negotiate the best content type for a channel.
+ *
+ * @param capabilities - Channel capabilities
+ * @param preferredTypes - Preferred content types in order
+ * @returns Best supported content type
+ */
+export function negotiateContentType(
+  capabilities: ChannelCapabilities,
+  preferredTypes: string[]
+): string | null {
+  for (const type of preferredTypes) {
+    if (isContentTypeSupported(capabilities, type)) {
+      return type;
+    }
+  }
+  return getFallbackContentType(capabilities, preferredTypes[0] || 'text');
+}

--- a/src/messaging/index.ts
+++ b/src/messaging/index.ts
@@ -4,6 +4,7 @@
  * This module implements:
  * - Issue #266: Message Level Routing System
  * - Issue #513: Multi-channel Message Routing Layer (Phase 1)
+ * - Issue #515: Universal Message Format + Channel Adapters (Phase 2)
  *
  * Features:
  * - Routes execution progress to admin chats
@@ -12,6 +13,8 @@
  * - Throttling for progress messages
  * - Channel-type detection (Feishu, CLI, REST)
  * - Multi-channel message routing
+ * - Universal Message Format (UMF) for platform-agnostic messages
+ * - Channel Adapters for format conversion
  *
  * @example
  * ```typescript
@@ -21,6 +24,11 @@
  *   RoutedOutputAdapter,
  *   MessageLevel,
  *   createDefaultRouteConfig,
+ *   // UMF and Adapters (Phase 2)
+ *   MessageService,
+ *   UniversalMessage,
+ *   createTextMessage,
+ *   createCardMessage,
  * } from './messaging/index.js';
  *
  * // Create level-based router
@@ -42,10 +50,24 @@
  *
  * // Route message
  * await channelRouter.route('oc_abc123', { type: 'text', text: 'Hello' });
+ *
+ * // Using UMF and MessageService (Phase 2)
+ * const messageService = new MessageService({
+ *   adapters: [new FeishuAdapter(), new CliAdapter(), new RestAdapter()],
+ * });
+ *
+ * // Send platform-agnostic message
+ * await messageService.send(createTextMessage('oc_xxx', 'Hello!'));
+ *
+ * // Send card message (auto-converts for each platform)
+ * await messageService.send(createCardMessage('oc_xxx', 'Task Complete', [
+ *   { type: 'text', content: 'All done!' }
+ * ]));
  * ```
  *
  * @see Issue #266
  * @see Issue #513
+ * @see Issue #515
  */
 
 // Types
@@ -85,3 +107,70 @@ export {
   type ChannelMessageRouterOptions,
   type RoutingResult,
 } from './channel-message-router.js';
+
+// Universal Message Format (Issue #515 Phase 2)
+export {
+  // Types
+  type TextContent,
+  type MarkdownContent,
+  type CardContent,
+  type FileContent,
+  type DoneContent,
+  type CardSection,
+  type CardAction,
+  type CardSectionType,
+  type CardActionType,
+  type MessageContent,
+  type UniversalMessage,
+  type UniversalMessageMetadata,
+  type SendResult,
+  // Type Guards
+  isTextContent,
+  isMarkdownContent,
+  isCardContent,
+  isFileContent,
+  isDoneContent,
+  // Helpers
+  createTextMessage,
+  createMarkdownMessage,
+  createCardMessage,
+  createDoneMessage,
+} from './universal-message.js';
+
+// Channel Adapters (Issue #515 Phase 2)
+export {
+  // Types
+  type ChannelCapabilities,
+  type IChannelAdapter,
+  // Capabilities
+  DEFAULT_CAPABILITIES,
+  FEISHU_CAPABILITIES,
+  CLI_CAPABILITIES,
+  REST_CAPABILITIES,
+  // Utilities
+  cardToText,
+  truncateText,
+  isContentTypeSupported,
+  getFallbackContentType,
+  negotiateContentType,
+} from './channel-adapter.js';
+
+// Message Service (Issue #515 Phase 2)
+export {
+  MessageService,
+  initMessageService,
+  getMessageService,
+  resetMessageService,
+  type MessageServiceOptions,
+} from './message-service.js';
+
+// Adapters
+export { FeishuAdapter, createFeishuAdapter } from './adapters/feishu-adapter.js';
+export { CliAdapter, createCliAdapter } from './adapters/cli-adapter.js';
+export {
+  RestAdapter,
+  createRestAdapter,
+  getRestAdapter,
+  resetRestAdapter,
+  type RestMessage,
+} from './adapters/rest-adapter.js';

--- a/src/messaging/message-service.test.ts
+++ b/src/messaging/message-service.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for Message Service.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageService, resetMessageService } from './message-service.js';
+import { CliAdapter } from './adapters/cli-adapter.js';
+import { RestAdapter } from './adapters/rest-adapter.js';
+import type { IChannelAdapter, ChannelCapabilities } from './channel-adapter.js';
+import type { UniversalMessage, SendResult } from './universal-message.js';
+
+// Mock adapter for testing
+class MockAdapter implements IChannelAdapter {
+  name: string;
+  capabilities: ChannelCapabilities;
+  canHandleFn: (chatId: string) => boolean;
+  sendFn: (message: UniversalMessage) => Promise<SendResult>;
+
+  constructor(
+    name: string,
+    canHandle: (chatId: string) => boolean,
+    send: (message: UniversalMessage) => Promise<SendResult>,
+    capabilities?: Partial<ChannelCapabilities>
+  ) {
+    this.name = name;
+    this.canHandleFn = canHandle;
+    this.sendFn = send;
+    this.capabilities = {
+      supportsCard: false,
+      supportsThread: false,
+      supportsFile: false,
+      supportsMarkdown: true,
+      maxMessageLength: 4096,
+      supportedContentTypes: ['text', 'markdown'],
+      supportsUpdate: false,
+      supportsDelete: false,
+      supportsMention: false,
+      supportsReactions: false,
+      ...capabilities,
+    };
+  }
+
+  canHandle(chatId: string): boolean {
+    return this.canHandleFn(chatId);
+  }
+
+  convert(message: UniversalMessage): unknown {
+    return message;
+  }
+
+  async send(message: UniversalMessage): Promise<SendResult> {
+    return this.sendFn(message);
+  }
+}
+
+describe('MessageService', () => {
+  let service: MessageService;
+
+  beforeEach(() => {
+    resetMessageService();
+  });
+
+  describe('constructor', () => {
+    it('should register adapters', () => {
+      const adapter = new MockAdapter(
+        'mock',
+        () => true,
+        async () => ({ success: true })
+      );
+      service = new MessageService({ adapters: [adapter] });
+      expect(service.getAdapterNames()).toContain('mock');
+    });
+
+    it('should register multiple adapters', () => {
+      const adapter1 = new MockAdapter('mock1', () => false, async () => ({ success: true }));
+      const adapter2 = new MockAdapter('mock2', () => true, async () => ({ success: true }));
+      service = new MessageService({ adapters: [adapter1, adapter2] });
+      expect(service.getAdapterNames()).toHaveLength(2);
+    });
+  });
+
+  describe('registerAdapter', () => {
+    it('should add new adapter', () => {
+      service = new MessageService({ adapters: [] });
+      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      service.registerAdapter(adapter);
+      expect(service.getAdapterNames()).toContain('mock');
+    });
+  });
+
+  describe('getAdapter', () => {
+    it('should return adapter that can handle chatId', () => {
+      const adapter = new MockAdapter(
+        'mock',
+        (chatId) => chatId.startsWith('test_'),
+        async () => ({ success: true })
+      );
+      service = new MessageService({ adapters: [adapter] });
+
+      expect(service.getAdapter('test_123')).toBe(adapter);
+      expect(service.getAdapter('other_123')).toBeUndefined();
+    });
+  });
+
+  describe('getCapabilities', () => {
+    it('should return adapter capabilities', () => {
+      const adapter = new MockAdapter(
+        'mock',
+        () => true,
+        async () => ({ success: true }),
+        { supportsCard: true, maxMessageLength: 10000 }
+      );
+      service = new MessageService({ adapters: [adapter] });
+
+      const caps = service.getCapabilities('any_id');
+      expect(caps.supportsCard).toBe(true);
+      expect(caps.maxMessageLength).toBe(10000);
+    });
+
+    it('should return default capabilities for unknown chatId', () => {
+      service = new MessageService({ adapters: [] });
+      const caps = service.getCapabilities('unknown');
+      expect(caps.supportsCard).toBe(false);
+      expect(caps.maxMessageLength).toBe(4096);
+    });
+  });
+
+  describe('send', () => {
+    it('should send message via correct adapter', async () => {
+      const sendMock = vi.fn().mockResolvedValue({ success: true, messageId: 'msg_123' });
+      const adapter = new MockAdapter('mock', () => true, sendMock);
+      service = new MessageService({ adapters: [adapter] });
+
+      const msg: UniversalMessage = {
+        chatId: 'test_chat',
+        content: { type: 'text', text: 'Hello' },
+      };
+
+      const result = await service.send(msg);
+      expect(result.success).toBe(true);
+      expect(sendMock).toHaveBeenCalledWith(msg);
+    });
+
+    it('should return error for unknown chatId', async () => {
+      const adapter = new MockAdapter('mock', () => false, async () => ({ success: true }));
+      service = new MessageService({ adapters: [adapter] });
+
+      const msg: UniversalMessage = {
+        chatId: 'unknown_chat',
+        content: { type: 'text', text: 'Hello' },
+      };
+
+      const result = await service.send(msg);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No adapter');
+    });
+
+    it('should fallback card to text when not supported', async () => {
+      const sendMock = vi.fn().mockResolvedValue({ success: true });
+      const adapter = new MockAdapter(
+        'mock',
+        () => true,
+        sendMock,
+        { supportedContentTypes: ['text'] }
+      );
+      service = new MessageService({ adapters: [adapter], autoFallback: true });
+
+      const msg: UniversalMessage = {
+        chatId: 'test_chat',
+        content: {
+          type: 'card',
+          title: 'Title',
+          sections: [{ type: 'text', content: 'Content' }],
+        },
+      };
+
+      await service.send(msg);
+      expect(sendMock).toHaveBeenCalled();
+      const sentMsg = sendMock.mock.calls[0][0] as UniversalMessage;
+      expect(sentMsg.content.type).toBe('text');
+    });
+
+    it('should not fallback when autoFallback is false', async () => {
+      const sendMock = vi.fn().mockResolvedValue({ success: true });
+      const adapter = new MockAdapter(
+        'mock',
+        () => true,
+        sendMock,
+        { supportedContentTypes: ['text'] }
+      );
+      service = new MessageService({ adapters: [adapter], autoFallback: false });
+
+      const msg: UniversalMessage = {
+        chatId: 'test_chat',
+        content: {
+          type: 'card',
+          title: 'Title',
+          sections: [],
+        },
+      };
+
+      const result = await service.send(msg);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('not supported');
+    });
+  });
+
+  describe('update', () => {
+    it('should update message if adapter supports it', async () => {
+      const updateMock = vi.fn().mockResolvedValue({ success: true });
+      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      (adapter as any).update = updateMock;
+      service = new MessageService({ adapters: [adapter] });
+
+      const msg: UniversalMessage = {
+        chatId: 'test_chat',
+        content: { type: 'text', text: 'Updated' },
+      };
+
+      await service.update('msg_123', msg);
+      expect(updateMock).toHaveBeenCalledWith('msg_123', msg);
+    });
+
+    it('should return error if adapter does not support update', async () => {
+      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      service = new MessageService({ adapters: [adapter] });
+
+      const msg: UniversalMessage = {
+        chatId: 'test_chat',
+        content: { type: 'text', text: 'Updated' },
+      };
+
+      const result = await service.update('msg_123', msg);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('does not support');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete message if adapter supports it', async () => {
+      const deleteMock = vi.fn().mockResolvedValue(true);
+      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      (adapter as any).delete = deleteMock;
+      service = new MessageService({ adapters: [adapter] });
+
+      const result = await service.delete('test_chat', 'msg_123');
+      expect(result).toBe(true);
+    });
+
+    it('should return false if adapter does not support delete', async () => {
+      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      service = new MessageService({ adapters: [adapter] });
+
+      const result = await service.delete('test_chat', 'msg_123');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('broadcast', () => {
+    it('should send message to all adapters', async () => {
+      const sendMock1 = vi.fn().mockResolvedValue({ success: true });
+      const sendMock2 = vi.fn().mockResolvedValue({ success: true });
+      const adapter1 = new MockAdapter('mock1', () => true, sendMock1);
+      const adapter2 = new MockAdapter('mock2', () => true, sendMock2);
+      service = new MessageService({ adapters: [adapter1, adapter2] });
+
+      const msg: UniversalMessage = {
+        chatId: 'broadcast',
+        content: { type: 'text', text: 'Broadcast' },
+      };
+
+      const results = await service.broadcast(msg);
+      expect(results.size).toBe(2);
+      expect(results.get('mock1')?.success).toBe(true);
+      expect(results.get('mock2')?.success).toBe(true);
+    });
+
+    it('should handle adapter failures', async () => {
+      const sendMock1 = vi.fn().mockResolvedValue({ success: true });
+      const sendMock2 = vi.fn().mockRejectedValue(new Error('Failed'));
+      const adapter1 = new MockAdapter('mock1', () => true, sendMock1);
+      const adapter2 = new MockAdapter('mock2', () => true, sendMock2);
+      service = new MessageService({ adapters: [adapter1, adapter2] });
+
+      const msg: UniversalMessage = {
+        chatId: 'broadcast',
+        content: { type: 'text', text: 'Broadcast' },
+      };
+
+      const results = await service.broadcast(msg);
+      expect(results.get('mock1')?.success).toBe(true);
+      expect(results.get('mock2')?.success).toBe(false);
+    });
+  });
+
+  describe('with real adapters', () => {
+    it('should route to CLI adapter', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      service = new MessageService({ adapters: [new CliAdapter()] });
+
+      const msg: UniversalMessage = {
+        chatId: 'cli-test',
+        content: { type: 'text', text: 'CLI message' },
+      };
+
+      const result = await service.send(msg);
+      expect(result.success).toBe(true);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should route to REST adapter', async () => {
+      service = new MessageService({ adapters: [new RestAdapter()] });
+
+      const msg: UniversalMessage = {
+        chatId: '123e4567-e89b-12d3-a456-426614174000',
+        content: { type: 'text', text: 'REST message' },
+      };
+
+      const result = await service.send(msg);
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/messaging/message-service.ts
+++ b/src/messaging/message-service.ts
@@ -1,0 +1,298 @@
+/**
+ * Message Service - Unified message routing and format conversion.
+ *
+ * This service integrates channel adapters and provides a unified interface
+ * for sending messages to any channel type.
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ *
+ * @example
+ * ```typescript
+ * const messageService = new MessageService({
+ *   adapters: [new FeishuAdapter(), new CliAdapter(), new RestAdapter()],
+ * });
+ *
+ * // Send a message - automatically routed to the correct adapter
+ * await messageService.send({
+ *   chatId: 'oc_xxx',
+ *   content: { type: 'text', text: 'Hello!' }
+ * });
+ *
+ * // Query capabilities
+ * const caps = messageService.getCapabilities('oc_xxx');
+ * console.log(caps.supportsCard); // true for Feishu
+ * ```
+ */
+
+import { createLogger } from '../utils/logger.js';
+import type { IChannelAdapter, ChannelCapabilities } from './channel-adapter.js';
+import type { UniversalMessage, SendResult, CardContent } from './universal-message.js';
+import { cardToText, getFallbackContentType } from './channel-adapter.js';
+
+const logger = createLogger('MessageService');
+
+/**
+ * Message Service options.
+ */
+export interface MessageServiceOptions {
+  /** Channel adapters to register */
+  adapters: IChannelAdapter[];
+  /** Whether to auto-fallback to text for unsupported content types */
+  autoFallback?: boolean;
+}
+
+/**
+ * Message Service - Routes messages to appropriate channel adapters.
+ *
+ * Features:
+ * - Automatic channel detection and routing
+ * - Capability negotiation
+ * - Format fallback for unsupported content types
+ * - Unified send interface
+ */
+export class MessageService {
+  private adapters: Map<string, IChannelAdapter> = new Map();
+  private autoFallback: boolean;
+
+  constructor(options: MessageServiceOptions) {
+    this.autoFallback = options.autoFallback ?? true;
+
+    // Register adapters
+    for (const adapter of options.adapters) {
+      this.registerAdapter(adapter);
+    }
+
+    logger.info({ adapterCount: this.adapters.size }, 'MessageService initialized');
+  }
+
+  /**
+   * Register a channel adapter.
+   */
+  registerAdapter(adapter: IChannelAdapter): void {
+    this.adapters.set(adapter.name, adapter);
+    logger.debug({ adapterName: adapter.name }, 'Adapter registered');
+  }
+
+  /**
+   * Get the adapter for a chatId.
+   * @returns The adapter or undefined if no adapter can handle it
+   */
+  getAdapter(chatId: string): IChannelAdapter | undefined {
+    for (const adapter of this.adapters.values()) {
+      if (adapter.canHandle(chatId)) {
+        return adapter;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get capabilities for a chatId.
+   */
+  getCapabilities(chatId: string): ChannelCapabilities {
+    const adapter = this.getAdapter(chatId);
+    return adapter?.capabilities ?? {
+      supportsCard: false,
+      supportsThread: false,
+      supportsFile: false,
+      supportsMarkdown: false,
+      maxMessageLength: 4096,
+      supportedContentTypes: ['text'],
+      supportsUpdate: false,
+      supportsDelete: false,
+      supportsMention: false,
+      supportsReactions: false,
+    };
+  }
+
+  /**
+   * Check if a content type is supported for a chatId.
+   */
+  isContentTypeSupported(chatId: string, contentType: string): boolean {
+    const capabilities = this.getCapabilities(chatId);
+    return capabilities.supportedContentTypes.includes(contentType);
+  }
+
+  /**
+   * Send a message to the appropriate channel.
+   *
+   * Automatically:
+   * 1. Detects the channel from chatId
+   * 2. Checks if content type is supported
+   * 3. Falls back to text if needed
+   * 4. Sends via the appropriate adapter
+   */
+  async send(message: UniversalMessage): Promise<SendResult> {
+    const adapter = this.getAdapter(message.chatId);
+
+    if (!adapter) {
+      logger.warn({ chatId: message.chatId }, 'No adapter found for chatId');
+      return {
+        success: false,
+        error: `No adapter can handle chatId: ${message.chatId}`,
+      };
+    }
+
+    // Check content type support
+    const contentType = message.content.type;
+    const isSupported = this.isContentTypeSupported(message.chatId, contentType);
+
+    let messageToSend = message;
+
+    // If content type is not supported
+    if (!isSupported) {
+      if (!this.autoFallback) {
+        // Auto fallback disabled - return error
+        return {
+          success: false,
+          error: `Content type '${contentType}' not supported by adapter '${adapter.name}'`,
+        };
+      }
+
+      // Try to fallback to a supported format
+      const fallbackType = getFallbackContentType(adapter.capabilities, contentType);
+
+      if (fallbackType === 'text' && contentType === 'card') {
+        // Convert card to text
+        logger.debug({ chatId: message.chatId }, 'Falling back card to text');
+        messageToSend = {
+          ...message,
+          content: {
+            type: 'text',
+            text: cardToText(message.content as CardContent),
+          },
+        };
+      } else if (fallbackType === 'text' && contentType === 'markdown') {
+        // Markdown can be sent as text (with formatting lost)
+        logger.debug({ chatId: message.chatId }, 'Falling back markdown to text');
+        messageToSend = {
+          ...message,
+          content: {
+            type: 'text',
+            text: message.content.text,
+          },
+        };
+      } else if (!fallbackType) {
+        return {
+          success: false,
+          error: `Content type '${contentType}' not supported and no fallback available`,
+        };
+      }
+    }
+
+    logger.debug(
+      {
+        chatId: message.chatId,
+        adapterName: adapter.name,
+        contentType: messageToSend.content.type,
+      },
+      'Sending message'
+    );
+
+    return adapter.send(messageToSend);
+  }
+
+  /**
+   * Update an existing message.
+   */
+  async update(messageId: string, message: UniversalMessage): Promise<SendResult> {
+    const adapter = this.getAdapter(message.chatId);
+
+    if (!adapter) {
+      return {
+        success: false,
+        error: `No adapter can handle chatId: ${message.chatId}`,
+      };
+    }
+
+    if (!adapter.update) {
+      return {
+        success: false,
+        error: `Adapter '${adapter.name}' does not support message updates`,
+      };
+    }
+
+    return adapter.update(messageId, message);
+  }
+
+  /**
+   * Delete a message.
+   */
+  async delete(chatId: string, messageId: string): Promise<boolean> {
+    const adapter = this.getAdapter(chatId);
+
+    if (!adapter) {
+      logger.warn({ chatId }, 'No adapter found for chatId');
+      return false;
+    }
+
+    if (!adapter.delete) {
+      logger.warn({ adapterName: adapter.name }, 'Adapter does not support message deletion');
+      return false;
+    }
+
+    return adapter.delete(messageId);
+  }
+
+  /**
+   * Broadcast a message to all registered adapters.
+   */
+  async broadcast(message: UniversalMessage): Promise<Map<string, SendResult>> {
+    const results = new Map<string, SendResult>();
+
+    for (const [name, adapter] of this.adapters) {
+      try {
+        const result = await adapter.send(message);
+        results.set(name, result);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        results.set(name, {
+          success: false,
+          error: errorMessage,
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all registered adapter names.
+   */
+  getAdapterNames(): string[] {
+    return Array.from(this.adapters.keys());
+  }
+}
+
+// ============================================================================
+// Global Instance Management
+// ============================================================================
+
+let globalMessageService: MessageService | null = null;
+
+/**
+ * Initialize the global message service.
+ */
+export function initMessageService(options: MessageServiceOptions): MessageService {
+  globalMessageService = new MessageService(options);
+  logger.info('Global MessageService initialized');
+  return globalMessageService;
+}
+
+/**
+ * Get the global message service.
+ * @throws Error if not initialized
+ */
+export function getMessageService(): MessageService {
+  if (!globalMessageService) {
+    throw new Error('MessageService not initialized. Call initMessageService first.');
+  }
+  return globalMessageService;
+}
+
+/**
+ * Reset the global message service (for testing).
+ */
+export function resetMessageService(): void {
+  globalMessageService = null;
+}

--- a/src/messaging/universal-message.test.ts
+++ b/src/messaging/universal-message.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for Universal Message Format (UMF).
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isTextContent,
+  isMarkdownContent,
+  isCardContent,
+  isFileContent,
+  isDoneContent,
+  createTextMessage,
+  createMarkdownMessage,
+  createCardMessage,
+  createDoneMessage,
+  type TextContent,
+  type MarkdownContent,
+  type CardContent,
+  type FileContent,
+  type DoneContent,
+} from './universal-message.js';
+
+describe('Universal Message Format', () => {
+  describe('Type Guards', () => {
+    it('should identify TextContent', () => {
+      const content: TextContent = { type: 'text', text: 'Hello' };
+      expect(isTextContent(content)).toBe(true);
+      expect(isMarkdownContent(content)).toBe(false);
+      expect(isCardContent(content)).toBe(false);
+    });
+
+    it('should identify MarkdownContent', () => {
+      const content: MarkdownContent = { type: 'markdown', text: '**Bold**' };
+      expect(isMarkdownContent(content)).toBe(true);
+      expect(isTextContent(content)).toBe(false);
+    });
+
+    it('should identify CardContent', () => {
+      const content: CardContent = {
+        type: 'card',
+        title: 'Title',
+        sections: [{ type: 'text', content: 'Content' }],
+      };
+      expect(isCardContent(content)).toBe(true);
+      expect(isTextContent(content)).toBe(false);
+    });
+
+    it('should identify FileContent', () => {
+      const content: FileContent = { type: 'file', path: '/path/to/file' };
+      expect(isFileContent(content)).toBe(true);
+    });
+
+    it('should identify DoneContent', () => {
+      const content: DoneContent = { type: 'done', success: true };
+      expect(isDoneContent(content)).toBe(true);
+    });
+  });
+
+  describe('Helper Functions', () => {
+    describe('createTextMessage', () => {
+      it('should create a text message', () => {
+        const msg = createTextMessage('oc_xxx', 'Hello');
+        expect(msg.chatId).toBe('oc_xxx');
+        expect(msg.content.type).toBe('text');
+        expect(isTextContent(msg.content) && msg.content.text).toBe('Hello');
+        expect(msg.threadId).toBeUndefined();
+      });
+
+      it('should create a text message with threadId', () => {
+        const msg = createTextMessage('oc_xxx', 'Hello', 'thread_123');
+        expect(msg.threadId).toBe('thread_123');
+      });
+    });
+
+    describe('createMarkdownMessage', () => {
+      it('should create a markdown message', () => {
+        const msg = createMarkdownMessage('oc_xxx', '**Bold**');
+        expect(msg.chatId).toBe('oc_xxx');
+        expect(msg.content.type).toBe('markdown');
+        expect(isMarkdownContent(msg.content) && msg.content.text).toBe('**Bold**');
+      });
+    });
+
+    describe('createCardMessage', () => {
+      it('should create a card message with minimal options', () => {
+        const msg = createCardMessage('oc_xxx', 'Title', [
+          { type: 'text', content: 'Content' },
+        ]);
+        expect(msg.chatId).toBe('oc_xxx');
+        expect(msg.content.type).toBe('card');
+        if (isCardContent(msg.content)) {
+          expect(msg.content.title).toBe('Title');
+          expect(msg.content.sections).toHaveLength(1);
+          expect(msg.content.subtitle).toBeUndefined();
+          expect(msg.content.actions).toBeUndefined();
+        }
+      });
+
+      it('should create a card message with all options', () => {
+        const msg = createCardMessage('oc_xxx', 'Title', [
+          { type: 'text', content: 'Content' },
+        ], {
+          subtitle: 'Subtitle',
+          actions: [{ type: 'button', label: 'Click', value: 'click' }],
+          theme: 'green',
+          threadId: 'thread_123',
+        });
+        if (isCardContent(msg.content)) {
+          expect(msg.content.subtitle).toBe('Subtitle');
+          expect(msg.content.actions).toHaveLength(1);
+          expect(msg.content.theme).toBe('green');
+        }
+        expect(msg.threadId).toBe('thread_123');
+      });
+    });
+
+    describe('createDoneMessage', () => {
+      it('should create a success done message', () => {
+        const msg = createDoneMessage('oc_xxx', true, 'Task completed');
+        expect(msg.chatId).toBe('oc_xxx');
+        expect(msg.content.type).toBe('done');
+        if (isDoneContent(msg.content)) {
+          expect(msg.content.success).toBe(true);
+          expect(msg.content.message).toBe('Task completed');
+          expect(msg.content.error).toBeUndefined();
+        }
+      });
+
+      it('should create a failure done message', () => {
+        const msg = createDoneMessage('oc_xxx', false, undefined, 'Error occurred');
+        if (isDoneContent(msg.content)) {
+          expect(msg.content.success).toBe(false);
+          expect(msg.content.message).toBeUndefined();
+          expect(msg.content.error).toBe('Error occurred');
+        }
+      });
+    });
+  });
+});

--- a/src/messaging/universal-message.ts
+++ b/src/messaging/universal-message.ts
@@ -1,0 +1,317 @@
+/**
+ * Universal Message Format (UMF) - Platform-agnostic message types.
+ *
+ * This module defines a platform-independent message format that can be
+ * converted to platform-specific formats (Feishu Card, CLI Text, REST JSON).
+ *
+ * Issue #515: Universal Message Format + Channel Adapters (Phase 2)
+ *
+ * @example
+ * ```typescript
+ * // Text message
+ * const textMsg: UniversalMessage = {
+ *   chatId: 'oc_xxx',
+ *   content: { type: 'text', text: 'Hello!' }
+ * };
+ *
+ * // Card message
+ * const cardMsg: UniversalMessage = {
+ *   chatId: 'oc_xxx',
+ *   content: {
+ *     type: 'card',
+ *     title: 'Task Complete',
+ *     sections: [
+ *       { type: 'text', content: 'All files processed.' }
+ *     ],
+ *     actions: [
+ *       { type: 'button', label: 'View Results', value: 'view_results' }
+ *     ]
+ *   }
+ * };
+ * ```
+ */
+
+// ============================================================================
+// Content Types
+// ============================================================================
+
+/**
+ * Text content - Plain text message.
+ */
+export interface TextContent {
+  type: 'text';
+  /** Plain text content */
+  text: string;
+}
+
+/**
+ * Markdown content - Markdown formatted text.
+ */
+export interface MarkdownContent {
+  type: 'markdown';
+  /** Markdown formatted content */
+  text: string;
+}
+
+/**
+ * Card section types - Platform-independent section definitions.
+ */
+export type CardSectionType = 'text' | 'markdown' | 'image' | 'divider' | 'fields';
+
+/**
+ * Card section - A section within a card.
+ */
+export interface CardSection {
+  /** Section type */
+  type: CardSectionType;
+  /** Text content (for text/markdown types) */
+  content?: string;
+  /** Image URL (for image type) */
+  imageUrl?: string;
+  /** Field list (for fields type) - label/value pairs */
+  fields?: Array<{ label: string; value: string }>;
+}
+
+/**
+ * Card action types - Platform-independent action definitions.
+ */
+export type CardActionType = 'button' | 'select' | 'link';
+
+/**
+ * Card action - An interactive action within a card.
+ */
+export interface CardAction {
+  /** Action type */
+  type: CardActionType;
+  /** Button/option label */
+  label: string;
+  /** Action value (returned when clicked) */
+  value: string;
+  /** URL for link type */
+  url?: string;
+  /** Options for select type */
+  options?: Array<{ label: string; value: string }>;
+  /** Button style (primary, secondary, danger) */
+  style?: 'primary' | 'secondary' | 'danger';
+}
+
+/**
+ * Card content - Platform-independent interactive card.
+ */
+export interface CardContent {
+  type: 'card';
+  /** Card title */
+  title: string;
+  /** Optional subtitle */
+  subtitle?: string;
+  /** Card sections */
+  sections: CardSection[];
+  /** Optional interactive actions */
+  actions?: CardAction[];
+  /** Optional header color theme */
+  theme?: 'blue' | 'wathet' | 'turquoise' | 'green' | 'yellow' | 'orange' | 'red' | 'carmine' | 'violet' | 'purple' | 'indigo' | 'grey';
+}
+
+/**
+ * File content - File attachment.
+ */
+export interface FileContent {
+  type: 'file';
+  /** File path (local or URL) */
+  path: string;
+  /** File name */
+  name?: string;
+  /** MIME type */
+  mimeType?: string;
+}
+
+/**
+ * Done content - Task completion signal.
+ */
+export interface DoneContent {
+  type: 'done';
+  /** Whether task succeeded */
+  success: boolean;
+  /** Result message */
+  message?: string;
+  /** Error details if failed */
+  error?: string;
+}
+
+/**
+ * Union type for all content types.
+ */
+export type MessageContent =
+  | TextContent
+  | MarkdownContent
+  | CardContent
+  | FileContent
+  | DoneContent;
+
+// ============================================================================
+// Universal Message
+// ============================================================================
+
+/**
+ * Universal Message - Platform-agnostic message format.
+ *
+ * This is the core message type that all channels should accept.
+ * Channel Adapters convert this to platform-specific formats.
+ */
+export interface UniversalMessage {
+  /** Target chat/conversation ID */
+  chatId: string;
+  /** Thread ID for replies (optional) */
+  threadId?: string;
+  /** Message content */
+  content: MessageContent;
+  /** Optional metadata */
+  metadata?: UniversalMessageMetadata;
+}
+
+/**
+ * Metadata for universal messages.
+ */
+export interface UniversalMessageMetadata {
+  /** Message ID (for updates/references) */
+  messageId?: string;
+  /** Original message type from agent */
+  originalType?: string;
+  /** Task ID if part of a task */
+  taskId?: string;
+  /** Timestamp (ms since epoch) */
+  timestamp?: number;
+  /** Priority level */
+  priority?: 'low' | 'normal' | 'high';
+}
+
+// ============================================================================
+// Send Result
+// ============================================================================
+
+/**
+ * Result of sending a message.
+ */
+export interface SendResult {
+  /** Whether the send was successful */
+  success: boolean;
+  /** Message ID of the sent message (if available) */
+  messageId?: string;
+  /** Error message if failed */
+  error?: string;
+  /** Platform-specific data */
+  platformData?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+/**
+ * Check if content is TextContent.
+ */
+export function isTextContent(content: MessageContent): content is TextContent {
+  return content.type === 'text';
+}
+
+/**
+ * Check if content is MarkdownContent.
+ */
+export function isMarkdownContent(content: MessageContent): content is MarkdownContent {
+  return content.type === 'markdown';
+}
+
+/**
+ * Check if content is CardContent.
+ */
+export function isCardContent(content: MessageContent): content is CardContent {
+  return content.type === 'card';
+}
+
+/**
+ * Check if content is FileContent.
+ */
+export function isFileContent(content: MessageContent): content is FileContent {
+  return content.type === 'file';
+}
+
+/**
+ * Check if content is DoneContent.
+ */
+export function isDoneContent(content: MessageContent): content is DoneContent {
+  return content.type === 'done';
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create a simple text message.
+ */
+export function createTextMessage(chatId: string, text: string, threadId?: string): UniversalMessage {
+  return {
+    chatId,
+    threadId,
+    content: { type: 'text', text },
+  };
+}
+
+/**
+ * Create a simple markdown message.
+ */
+export function createMarkdownMessage(chatId: string, text: string, threadId?: string): UniversalMessage {
+  return {
+    chatId,
+    threadId,
+    content: { type: 'markdown', text },
+  };
+}
+
+/**
+ * Create a card message.
+ */
+export function createCardMessage(
+  chatId: string,
+  title: string,
+  sections: CardSection[],
+  options?: {
+    subtitle?: string;
+    actions?: CardAction[];
+    theme?: CardContent['theme'];
+    threadId?: string;
+  }
+): UniversalMessage {
+  return {
+    chatId,
+    threadId: options?.threadId,
+    content: {
+      type: 'card',
+      title,
+      subtitle: options?.subtitle,
+      sections,
+      actions: options?.actions,
+      theme: options?.theme,
+    },
+  };
+}
+
+/**
+ * Create a done signal message.
+ */
+export function createDoneMessage(
+  chatId: string,
+  success: boolean,
+  message?: string,
+  error?: string
+): UniversalMessage {
+  return {
+    chatId,
+    content: {
+      type: 'done',
+      success,
+      message,
+      error,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the messaging system with platform-agnostic Universal Message Format (UMF) and channel adapters for format conversion.

Fixes #515

## Changes

| File | Description |
|------|-------------|
| `src/messaging/universal-message.ts` | UMF type definitions and helpers |
| `src/messaging/channel-adapter.ts` | IChannelAdapter interface and capabilities |
| `src/messaging/message-service.ts` | Unified message routing service |
| `src/messaging/adapters/feishu-adapter.ts` | Feishu Card format adapter |
| `src/messaging/adapters/cli-adapter.ts` | Console text output adapter |
| `src/messaging/adapters/rest-adapter.ts` | JSON format adapter for REST |
| `src/config/constants.ts` | Fix merge conflict (CHAT_HISTORY + RETRYABLE_ERROR_CODES) |

## New Features

### Universal Message Format (UMF)

Platform-agnostic message types:
- `text` - Plain text message
- `markdown` - Markdown formatted text
- `card` - Platform-independent interactive card with sections and actions
- `file` - File attachment
- `done` - Task completion signal

```typescript
// Create a card message
const msg = createCardMessage('oc_xxx', 'Task Complete', [
  { type: 'text', content: 'All files processed.' }
], {
  actions: [{ type: 'button', label: 'View', value: 'view' }]
});
```

### Channel Adapters

| Adapter | Converts To | ChatId Pattern |
|---------|-------------|----------------|
| FeishuAdapter | Feishu interactive card | `oc_*`, `ou_*`, `on_*` |
| CliAdapter | Console text | `cli-*` |
| RestAdapter | JSON | UUID format |

### MessageService

Unified message routing:
- Automatic channel detection from chatId
- Capability negotiation
- Format fallback (e.g., card → text for CLI)
- Unified send interface

```typescript
const messageService = new MessageService({
  adapters: [new FeishuAdapter(), new CliAdapter(), new RestAdapter()],
});

// Send to any channel - automatically routed
await messageService.send({
  chatId: 'oc_xxx',
  content: { type: 'text', text: 'Hello!' }
});
```

## Test Results

| Metric | Value |
|--------|-------|
| Test Files | 6 passed |
| Tests | 142 passed |
| TypeScript | ✅ Pass |

## Test Plan

- [x] Unit tests for UniversalMessage types (13 tests)
- [x] Unit tests for ChannelAdapter utilities (22 tests)
- [x] Unit tests for CliAdapter (8 tests)
- [x] Unit tests for RestAdapter (8 tests)
- [x] Unit tests for MessageService (15 tests)
- [x] TypeScript type check passes
- [ ] Manual test: Send card to Feishu → verify format
- [ ] Manual test: Send card to CLI → verify text fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)