### PR TITLE
fix: resolve merge conflict in constants.ts (Issue #556)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -64,7 +64,6 @@ export const FEISHU_API = {
 } as const;
 
 /**
-<<<<<<< feat/issue-517-passive-mode-chat-history
  * Chat history configuration for passive mode (Issue #517)
  */
 export const CHAT_HISTORY = {
@@ -74,7 +73,8 @@ export const CHAT_HISTORY = {
   /** Maximum number of messages to include in context */
   MAX_MESSAGES: 50,
 } as const;
-=======
+
+/**
  * Error codes that should trigger a retry
  */
 export const RETRYABLE_ERROR_CODES = [
@@ -87,4 +87,3 @@ export const RETRYABLE_ERROR_CODES = [
   'ENETUNREACH',
   'EPROTO',
 ] as const;
->>>>>>> main


### PR DESCRIPTION
## Summary

Fixes #556

解决 `src/config/constants.ts` 中未解决的 merge conflict marker。

## Changes

移除 merge conflict markers，保留两个分支的常量定义：
- `CHAT_HISTORY`: 被动模式的聊天历史配置 (来自 feat/issue-517-passive-mode-chat-history)
- `RETRYABLE_ERROR_CODES`: 触发重试的错误码列表 (来自 main 分支)

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |

## Test Plan

- [x] TypeScript 类型检查通过
- [x] 两个常量都正确保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)