### PR TITLE
fix(feishu-mcp): use button text for card interaction prompt (Issue #525)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -693,11 +693,15 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       // Try to handle via InteractionManager
       const handled = await this.interactionManager.handleAction(event, async (defaultEvent) => {
         // Default handler: emit as interaction message
+        // Issue #525: Use button text to generate user-friendly prompt
+        const buttonText = defaultEvent.action.text || defaultEvent.action.value;
+        const messageContent = `The user clicked '${buttonText}' button`;
+
         await this.emitMessage({
           messageId: `${defaultEvent.message_id}-${defaultEvent.action.value}`,
           chatId: defaultEvent.chat_id,
           userId: defaultEvent.user?.sender_id?.open_id,
-          content: `[card_action] ${defaultEvent.action.value}`,
+          content: messageContent,
           messageType: 'card',
           timestamp: Date.now(),
           metadata: {

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -56,6 +56,12 @@ export interface FeishuCardActionEvent {
     trigger: 'button' | 'menu' | 'date' | 'input' | 'static';
     /** For menu/dropdown: the selected option */
     option?: string;
+    /**
+     * Button or option text displayed to user.
+     * Used to generate user-friendly prompt when action is triggered.
+     * Issue #525: Simple card interaction without promptTemplate
+     */
+    text?: string;
   };
   /** The message containing the card */
   message_id: string;


### PR DESCRIPTION
## Summary

Implements a simple card interaction prompt system using button text, based on feedback from PR #545.

Fixes #525

## Changes

| File | Description |
|------|-------------|
| `src/types/platform.ts` | Add optional `text` field to action type |
| `src/channels/feishu-channel.ts` | Use button text in default handler |
| `src/config/constants.ts` | Resolve merge conflict |

## Approach

Based on feedback from PR #545, this uses a simpler approach:
- When user clicks a button, generate: `The user clicked 'button text' button`
- **No promptTemplate field needed**
- Button text comes from Feishu `action.text` or falls back to `action.value`

### Example

When user clicks a button with text "确认删除":
```
The user clicked '确认删除' button
```

This prompt is then fed to the agent as if the user typed it.

## Code Changes

```typescript
// In handleCardAction default handler:
const buttonText = defaultEvent.action.text || defaultEvent.action.value;
const messageContent = `The user clicked '${buttonText}' button`;
```

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| feishu-channel tests | 30 passed |
| interaction-manager tests | 22 passed |

## Test Plan

- [x] TypeScript type check passes
- [x] Unit tests pass
- [ ] Manual test: Click button on card → verify prompt text
- [ ] Manual test: Button without text → verify fallback to value

🤖 Generated with [Claude Code](https://claude.com/claude-code)