### PR TITLE
feat(schedule): add schedule control commands (Issue #469)

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -548,6 +548,181 @@ export class NodeCommand implements Command {
 }
 
 /**
+ * Schedule Command - Unified schedule management commands.
+ * Issue #469: 定时任务控制指令
+ *
+ * Subcommands:
+ * - list: List all schedules for current chat
+ * - status <name>: View schedule details
+ * - enable <name>: Enable a schedule
+ * - disable <name>: Disable a schedule
+ * - run <name>: Manually trigger a schedule
+ */
+export class ScheduleCommand implements Command {
+  readonly name = 'schedule';
+  readonly category = 'schedule' as const;
+  readonly description = '定时任务管理';
+  readonly usage = 'schedule <list|status|enable|disable|run> [name]';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const subCommand = context.args[0]?.toLowerCase();
+
+    // If no subcommand, show help
+    if (!subCommand) {
+      return {
+        success: true,
+        message: `⏰ **定时任务管理指令**
+
+用法: \`/schedule <子命令> [参数]\`
+
+**可用子命令:**
+- \`list\` - 列出当前聊天的所有定时任务
+- \`status <任务ID>\` - 查看任务详细状态
+- \`enable <任务ID>\` - 启用定时任务
+- \`disable <任务ID>\` - 禁用定时任务
+- \`run <任务ID>\` - 手动触发定时任务
+
+示例:
+\`\`\`
+/schedule list
+/schedule status schedule-daily-report
+/schedule enable schedule-daily-report
+/schedule run schedule-daily-report
+\`\`\``,
+      };
+    }
+
+    const { services, chatId } = context;
+    const taskId = context.args[1];
+
+    switch (subCommand) {
+      case 'list':
+        return this.listSchedules(services, chatId);
+
+      case 'status':
+        if (!taskId) {
+          return { success: false, error: '请指定任务ID\n\n用法: `/schedule status <任务ID>`' };
+        }
+        return this.showScheduleStatus(services, taskId);
+
+      case 'enable':
+        if (!taskId) {
+          return { success: false, error: '请指定任务ID\n\n用法: `/schedule enable <任务ID>`' };
+        }
+        return this.toggleSchedule(services, taskId, true);
+
+      case 'disable':
+        if (!taskId) {
+          return { success: false, error: '请指定任务ID\n\n用法: `/schedule disable <任务ID>`' };
+        }
+        return this.toggleSchedule(services, taskId, false);
+
+      case 'run':
+        if (!taskId) {
+          return { success: false, error: '请指定任务ID\n\n用法: `/schedule run <任务ID>`' };
+        }
+        return this.triggerSchedule(services, taskId);
+
+      default:
+        return {
+          success: false,
+          error: `未知的子命令: \`${subCommand}\`
+
+可用子命令: \`list\`, \`status\`, \`enable\`, \`disable\`, \`run\``,
+        };
+    }
+  }
+
+  private async listSchedules(
+    services: CommandContext['services'],
+    chatId: string
+  ): Promise<CommandResult> {
+    const schedules = await services.listSchedules(chatId);
+
+    if (schedules.length === 0) {
+      return { success: true, message: '⏰ **定时任务列表**\n\n当前聊天没有定时任务' };
+    }
+
+    const scheduleList = schedules.map(s => {
+      const status = s.enabled ? '✅' : '❌';
+      const running = s.isRunning ? ' 🔄执行中' : '';
+      return `- ${status} \`${s.id}\` - ${s.name} (\`${s.cron}\`)${running}`;
+    }).join('\n');
+
+    return {
+      success: true,
+      message: `⏰ **定时任务列表**\n\n任务数: ${schedules.length}\n\n${scheduleList}`,
+    };
+  }
+
+  private async showScheduleStatus(
+    services: CommandContext['services'],
+    taskId: string
+  ): Promise<CommandResult> {
+    const schedule = await services.getSchedule(taskId);
+
+    if (!schedule) {
+      return { success: false, error: `任务 \`${taskId}\` 不存在` };
+    }
+
+    const status = schedule.enabled ? '✅ 已启用' : '❌ 已禁用';
+    const running = schedule.isRunning ? '\n\n🔄 **正在执行中**' : '';
+    const blocking = schedule.blocking ? '是' : '否';
+
+    return {
+      success: true,
+      message: `⏰ **定时任务详情**
+
+**ID:** \`${schedule.id}\`
+**名称:** ${schedule.name}
+**状态:** ${status}
+**Cron:** \`${schedule.cron}\`
+**阻塞模式:** ${blocking}
+**聊天ID:** \`${schedule.chatId}\`
+
+**任务内容:**
+\`\`\`
+${schedule.prompt.slice(0, 200)}${schedule.prompt.length > 200 ? '...' : ''}
+\`\`\`${running}`,
+    };
+  }
+
+  private async toggleSchedule(
+    services: CommandContext['services'],
+    taskId: string,
+    enabled: boolean
+  ): Promise<CommandResult> {
+    const success = await services.toggleSchedule(taskId, enabled);
+
+    if (!success) {
+      return { success: false, error: `任务 \`${taskId}\` 不存在或操作失败` };
+    }
+
+    const action = enabled ? '启用' : '禁用';
+    return {
+      success: true,
+      message: `✅ **定时任务已${action}**\n\n任务 \`${taskId}\` 已${action}`,
+    };
+  }
+
+  private async triggerSchedule(
+    services: CommandContext['services'],
+    taskId: string
+  ): Promise<CommandResult> {
+    const success = await services.triggerSchedule(taskId);
+
+    if (!success) {
+      return { success: false, error: `任务 \`${taskId}\` 不存在或触发失败` };
+    }
+
+    return {
+      success: true,
+      message: `🚀 **定时任务已触发**\n\n任务 \`${taskId}\` 已开始执行`,
+    };
+  }
+}
+
+/**
  * Register default commands to a registry.
  */
 export function registerDefaultCommands(
@@ -572,4 +747,6 @@ export function registerDefaultCommands(
   registry.register(new ClearDebugCommand());
   // Issue #541: Node management command
   registry.register(new NodeCommand());
+  // Issue #469: Schedule management command
+  registry.register(new ScheduleCommand());
 }

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for ScheduleCommand.
+ *
+ * Issue #469: 定时任务控制指令
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScheduleCommand } from './builtin-commands.js';
+import type { CommandContext, CommandServices } from './types.js';
+
+describe('ScheduleCommand', () => {
+  let command: ScheduleCommand;
+  let mockServices: CommandServices;
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    command = new ScheduleCommand();
+
+    mockServices = {
+      isRunning: vi.fn(() => true),
+      getLocalNodeId: vi.fn(() => 'test-node'),
+      getExecNodes: vi.fn(() => []),
+      getChatNodeAssignment: vi.fn(),
+      switchChatNode: vi.fn(),
+      getNode: vi.fn(),
+      sendCommand: vi.fn(),
+      getFeishuClient: vi.fn(),
+      createDiscussionChat: vi.fn(),
+      addMembers: vi.fn(),
+      removeMembers: vi.fn(),
+      getMembers: vi.fn(),
+      dissolveChat: vi.fn(),
+      registerGroup: vi.fn(),
+      unregisterGroup: vi.fn(),
+      listGroups: vi.fn(() => []),
+      setDebugGroup: vi.fn(),
+      getDebugGroup: vi.fn(),
+      clearDebugGroup: vi.fn(),
+      getChannelStatus: vi.fn(() => 'ok'),
+      // Schedule management methods
+      listSchedules: vi.fn(),
+      getSchedule: vi.fn(),
+      toggleSchedule: vi.fn(),
+      triggerSchedule: vi.fn(),
+    };
+
+    mockContext = {
+      chatId: 'oc_test_chat',
+      userId: 'ou_test_user',
+      args: [],
+      rawText: '',
+      services: mockServices,
+    };
+  });
+
+  describe('metadata', () => {
+    it('should have correct name and category', () => {
+      expect(command.name).toBe('schedule');
+      expect(command.category).toBe('schedule');
+      expect(command.description).toBe('定时任务管理');
+    });
+  });
+
+  describe('help', () => {
+    it('should show help when no subcommand', async () => {
+      const result = await command.execute({ ...mockContext, args: [] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('定时任务管理指令');
+      expect(result.message).toContain('list');
+      expect(result.message).toContain('status');
+      expect(result.message).toContain('enable');
+      expect(result.message).toContain('disable');
+      expect(result.message).toContain('run');
+    });
+  });
+
+  describe('list', () => {
+    it('should list schedules for current chat', async () => {
+      vi.mocked(mockServices.listSchedules).mockResolvedValue([
+        { id: 'schedule-task1', name: 'Task 1', cron: '0 9 * * *', enabled: true },
+        { id: 'schedule-task2', name: 'Task 2', cron: '0 18 * * *', enabled: false },
+      ]);
+
+      const result = await command.execute({ ...mockContext, args: ['list'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('定时任务列表');
+      expect(result.message).toContain('schedule-task1');
+      expect(result.message).toContain('schedule-task2');
+      expect(mockServices.listSchedules).toHaveBeenCalledWith('oc_test_chat');
+    });
+
+    it('should show empty message when no schedules', async () => {
+      vi.mocked(mockServices.listSchedules).mockResolvedValue([]);
+
+      const result = await command.execute({ ...mockContext, args: ['list'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('没有定时任务');
+    });
+  });
+
+  describe('status', () => {
+    it('should show schedule status', async () => {
+      vi.mocked(mockServices.getSchedule).mockResolvedValue({
+        id: 'schedule-task1',
+        name: 'Task 1',
+        cron: '0 9 * * *',
+        enabled: true,
+        chatId: 'oc_test_chat',
+        prompt: 'This is a test prompt',
+        blocking: true,
+        isRunning: false,
+      });
+
+      const result = await command.execute({ ...mockContext, args: ['status', 'schedule-task1'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('定时任务详情');
+      expect(result.message).toContain('schedule-task1');
+      expect(result.message).toContain('Task 1');
+      expect(result.message).toContain('已启用');
+      expect(mockServices.getSchedule).toHaveBeenCalledWith('schedule-task1');
+    });
+
+    it('should return error when task not found', async () => {
+      vi.mocked(mockServices.getSchedule).mockResolvedValue(undefined);
+
+      const result = await command.execute({ ...mockContext, args: ['status', 'schedule-notexist'] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('不存在');
+    });
+
+    it('should return error when no task id provided', async () => {
+      const result = await command.execute({ ...mockContext, args: ['status'] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('请指定任务ID');
+    });
+  });
+
+  describe('enable', () => {
+    it('should enable a schedule', async () => {
+      vi.mocked(mockServices.toggleSchedule).mockResolvedValue(true);
+
+      const result = await command.execute({ ...mockContext, args: ['enable', 'schedule-task1'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('已启用');
+      expect(mockServices.toggleSchedule).toHaveBeenCalledWith('schedule-task1', true);
+    });
+
+    it('should return error when toggle fails', async () => {
+      vi.mocked(mockServices.toggleSchedule).mockResolvedValue(false);
+
+      const result = await command.execute({ ...mockContext, args: ['enable', 'schedule-notexist'] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('不存在或操作失败');
+    });
+  });
+
+  describe('disable', () => {
+    it('should disable a schedule', async () => {
+      vi.mocked(mockServices.toggleSchedule).mockResolvedValue(true);
+
+      const result = await command.execute({ ...mockContext, args: ['disable', 'schedule-task1'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('已禁用');
+      expect(mockServices.toggleSchedule).toHaveBeenCalledWith('schedule-task1', false);
+    });
+  });
+
+  describe('run', () => {
+    it('should trigger a schedule', async () => {
+      vi.mocked(mockServices.triggerSchedule).mockResolvedValue(true);
+
+      const result = await command.execute({ ...mockContext, args: ['run', 'schedule-task1'] });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('已触发');
+      expect(mockServices.triggerSchedule).toHaveBeenCalledWith('schedule-task1');
+    });
+
+    it('should return error when trigger fails', async () => {
+      vi.mocked(mockServices.triggerSchedule).mockResolvedValue(false);
+
+      const result = await command.execute({ ...mockContext, args: ['run', 'schedule-notexist'] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('不存在或触发失败');
+    });
+  });
+
+  describe('invalid subcommand', () => {
+    it('should return error for unknown subcommand', async () => {
+      const result = await command.execute({ ...mockContext, args: ['invalid'] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('未知的子命令');
+    });
+  });
+});

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -111,6 +111,35 @@ export interface CommandServices {
 
   /** Get channel status list */
   getChannelStatus: () => string;
+
+  // Schedule management (Issue #469)
+
+  /** List all schedules for current chat */
+  listSchedules: (chatId: string) => Promise<{
+    id: string;
+    name: string;
+    cron: string;
+    enabled: boolean;
+    isRunning?: boolean;
+  }[]>;
+
+  /** Get a specific schedule by ID */
+  getSchedule: (taskId: string) => Promise<{
+    id: string;
+    name: string;
+    cron: string;
+    enabled: boolean;
+    chatId: string;
+    prompt: string;
+    blocking?: boolean;
+    isRunning?: boolean;
+  } | undefined>;
+
+  /** Toggle schedule enabled state */
+  toggleSchedule: (taskId: string, enabled: boolean) => Promise<boolean>;
+
+  /** Trigger a schedule manually */
+  triggerSchedule: (taskId: string) => Promise<boolean>;
 }
 
 /**

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -550,6 +550,23 @@ export class PrimaryNode extends EventEmitter {
         getDebugGroup: () => debugGroupService.getDebugGroup(),
         clearDebugGroup: () => debugGroupService.clearDebugGroup(),
         getChannelStatus: () => this.feedbackRouter.getChannels().map(ch => `${ch.name}: ${ch.status}`).join(', '),
+        // Schedule management (Issue #469)
+        listSchedules: async (chatId: string) => {
+          if (!this.schedulerService) return [];
+          return this.schedulerService.listSchedules(chatId);
+        },
+        getSchedule: async (taskId: string) => {
+          if (!this.schedulerService) return undefined;
+          return this.schedulerService.getSchedule(taskId);
+        },
+        toggleSchedule: async (taskId: string, enabled: boolean) => {
+          if (!this.schedulerService) return false;
+          return this.schedulerService.toggleSchedule(taskId, enabled);
+        },
+        triggerSchedule: async (taskId: string) => {
+          if (!this.schedulerService) return false;
+          return this.schedulerService.triggerSchedule(taskId);
+        },
       },
     };
 

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -21,9 +21,11 @@ import {
   ScheduleManager,
   Scheduler,
   ScheduleFileWatcher,
+  ScheduleFileScanner,
 } from '../schedule/index.js';
 import type { FeedbackMessage } from '../types/websocket-messages.js';
 import type { ChatAgent } from '../agents/types.js';
+import type { ScheduledTask } from '../schedule/schedule-manager.js';
 
 const logger = createLogger('SchedulerService');
 
@@ -64,6 +66,8 @@ export class SchedulerService {
   private readonly pilot: SchedulerServiceConfig['pilot'];
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
+  private scheduleManager?: ScheduleManager;
+  private fileScanner?: ScheduleFileScanner;
   private schedulesDir: string;
 
   constructor(config: SchedulerServiceConfig) {
@@ -78,10 +82,11 @@ export class SchedulerService {
    * Start the scheduler service.
    */
   async start(): Promise<void> {
-    const scheduleManager = new ScheduleManager({ schedulesDir: this.schedulesDir });
+    this.scheduleManager = new ScheduleManager({ schedulesDir: this.schedulesDir });
+    this.fileScanner = new ScheduleFileScanner({ schedulesDir: this.schedulesDir });
 
     this.scheduler = new Scheduler({
-      scheduleManager,
+      scheduleManager: this.scheduleManager,
       pilot: this.pilot,
       callbacks: {
         // Directly route messages through PrimaryNode's handleFeedback
@@ -143,5 +148,124 @@ export class SchedulerService {
    */
   getScheduler(): Scheduler | undefined {
     return this.scheduler;
+  }
+
+  /**
+   * Get the schedule manager instance.
+   */
+  getScheduleManager(): ScheduleManager | undefined {
+    return this.scheduleManager;
+  }
+
+  /**
+   * List all schedules for a specific chat.
+   */
+  async listSchedules(chatId: string): Promise<{
+    id: string;
+    name: string;
+    cron: string;
+    enabled: boolean;
+    isRunning?: boolean;
+  }[]> {
+    if (!this.scheduleManager || !this.scheduler) {
+      return [];
+    }
+
+    const tasks = await this.scheduleManager.listByChatId(chatId);
+    return tasks.map(task => ({
+      id: task.id,
+      name: task.name,
+      cron: task.cron,
+      enabled: task.enabled,
+      isRunning: this.scheduler!.isTaskRunning(task.id),
+    }));
+  }
+
+  /**
+   * Get a specific schedule by ID.
+   */
+  async getSchedule(taskId: string): Promise<{
+    id: string;
+    name: string;
+    cron: string;
+    enabled: boolean;
+    chatId: string;
+    prompt: string;
+    blocking?: boolean;
+    isRunning?: boolean;
+  } | undefined> {
+    if (!this.scheduleManager || !this.scheduler) {
+      return undefined;
+    }
+
+    const task = await this.scheduleManager.get(taskId);
+    if (!task) {
+      return undefined;
+    }
+
+    return {
+      id: task.id,
+      name: task.name,
+      cron: task.cron,
+      enabled: task.enabled,
+      chatId: task.chatId,
+      prompt: task.prompt,
+      blocking: task.blocking,
+      isRunning: this.scheduler.isTaskRunning(task.id),
+    };
+  }
+
+  /**
+   * Toggle schedule enabled state.
+   * Updates the schedule file and reloads the scheduler.
+   */
+  async toggleSchedule(taskId: string, enabled: boolean): Promise<boolean> {
+    if (!this.scheduleManager || !this.fileScanner || !this.scheduler) {
+      return false;
+    }
+
+    const task = await this.scheduleManager.get(taskId);
+    if (!task) {
+      return false;
+    }
+
+    // Update the task file
+    const updatedTask: ScheduledTask = {
+      ...task,
+      enabled,
+    };
+
+    await this.fileScanner.writeTask(updatedTask);
+
+    // The file watcher will pick up the change and update the scheduler
+    // But we can also update directly for immediate effect
+    this.scheduler.addTask(updatedTask);
+
+    logger.info({ taskId, enabled }, 'Schedule toggled');
+    return true;
+  }
+
+  /**
+   * Trigger a schedule manually.
+   */
+  async triggerSchedule(taskId: string): Promise<boolean> {
+    if (!this.scheduleManager || !this.scheduler) {
+      return false;
+    }
+
+    const task = await this.scheduleManager.get(taskId);
+    if (!task) {
+      return false;
+    }
+
+    // Check if task is already running
+    if (this.scheduler.isTaskRunning(taskId)) {
+      logger.warn({ taskId }, 'Task is already running, skipping trigger');
+      return false;
+    }
+
+    // Trigger the task execution directly
+    await this.scheduler.triggerTask(task);
+    return true;
   }
 }

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -292,4 +292,14 @@ ${task.prompt}`;
   getRunningTaskIds(): string[] {
     return Array.from(this.runningTasks);
   }
+
+  /**
+   * Manually trigger a task execution.
+   * Issue #469: Schedule control commands
+   *
+   * @param task - Task to execute
+   */
+  async triggerTask(task: ScheduledTask): Promise<void> {
+    await this.executeTask(task);
+  }
 }


### PR DESCRIPTION
## Summary
- Add `/schedule` command with subcommands: `list`, `status`, `enable`, `disable`, `run`
- Implement schedule management services in `CommandServices` interface
- Add `triggerTask()` method to `Scheduler` for manual execution
- Include 13 tests for `ScheduleCommand`

## Changes
1. Add `ScheduleCommand` class with subcommands:
   - `list`: List schedules for current chat
   - `status <id>`: Show schedule details
   - `enable <id>`: Enable a schedule
   - `disable <id>`: Disable a schedule
   - `run <id>`: Manually trigger a schedule

2. Add schedule services to `CommandServices` interface:
   - `listSchedules(chatId)`
   - `getSchedule(taskId)`
   - `toggleSchedule(taskId, enabled)`
   - `triggerSchedule(taskId)`

3. Update `SchedulerService`:
   - Expose `ScheduleManager` and `ScheduleFileScanner`
   - Add methods for schedule management
   - Implement schedule toggle and trigger

4. Update `Scheduler`:
   - Add `triggerTask()` method for manual execution

5. Add tests for `ScheduleCommand` (13 tests)

## Test Plan
- [x] All existing tests pass
- [x] New tests for ScheduleCommand pass (13 tests)
- [x] Build succeeds

Fixes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>