### PR TITLE
docs(pr-scanner): update to Phase 2 with ChatOps support (Issue #393)

### DIFF
--- a/docs/designs/pr-scanner-design.md
+++ b/docs/designs/pr-scanner-design.md
@@ -89,9 +89,9 @@ This document covers:
 | Dependency | Status | PR/Issue | Blocking | Notes |
 |------------|--------|----------|----------|-------|
 | Scheduler | ✅ Ready | #357 | No | Already implemented |
-| ChatOps (createDiscussionChat) | ⏳ Pending | PR #423 | **Yes** | Group chat creation |
-| FeedbackController | ⏳ Pending | PR #412 | Partial | Interactive cards |
-| PR State Storage | ❓ Needed | This doc | No | Simple JSON file |
+| ChatOps (createDiscussionChat) | ✅ Ready | PR #423 (merged) | ~~Yes~~ No | Group chat creation |
+| FeedbackController | ⏳ Optional | PR #412 | Partial | Interactive cards (Phase 3) |
+| PR State Storage | ✅ Ready | This doc | No | Simple JSON file |
 
 ### 3.2 ChatOps API (PR #423)
 
@@ -180,12 +180,12 @@ Scan for new PRs and send notifications.
 5. Update history file
 ```
 
-### Phase 2: Group Chat Creation ⏳ Blocked by PR #423
+### Phase 2: Group Chat Creation ✅ Ready (PR #423 merged)
 
 **Goal**: Create dedicated group chat for each PR
 
 **Requirements**:
-- ⏳ ChatOps `createDiscussionChat()` (PR #423)
+- ✅ ChatOps `createDiscussionChat()` (PR #423 merged)
 
 **Additional Steps**:
 1. Call `createDiscussionChat()` for new PRs
@@ -302,9 +302,10 @@ interface PRScannerHistory {
 - [ ] Create history file schema
 - [ ] Test with notification-only mode
 
-### Blocked (Phase 2)
-- [ ] Wait for PR #423 (ChatOps) to merge
-- [ ] Add group chat creation
+### Ready (Phase 2)
+- [x] PR #423 (ChatOps) merged
+- [x] createDiscussionChat() available in chat-ops.ts
+- [ ] Update schedule file to use create_discussion
 - [ ] Test group chat flow
 
 ### Blocked (Phase 3)
@@ -343,6 +344,6 @@ interface PRScannerHistory {
 
 - Issue #393: feat: 定时扫描 PR 并创建讨论群聊
 - Issue #357: 智能定时任务推荐系统
-- PR #423: feat(feishu): add ChatOps utility (pending)
-- PR #412: feat(feedback): add FeedbackController (pending)
+- PR #423: feat(feishu): add ChatOps utility (**merged** - ChatOps available)
+- PR #412: feat(feedback): add FeedbackController (pending - Phase 3)
 - PR #421: Previous attempt (closed - lacked design analysis)

--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -6,15 +6,16 @@ blocking: true
 chatId: "oc_REPLACE_WITH_YOUR_CHAT_ID"
 ---
 
-# PR Scanner - Phase 1
+# PR Scanner - 完整版 (Phase 2)
 
-定期扫描仓库的 open PR，发现新 PR 时发送通知到指定群聊。
+定期扫描仓库的 open PR，发现新 PR 时创建群聊并发送通知。
 
 ## 配置
 
 - **仓库**: hs3180/disclaude
 - **扫描间隔**: 每 30 分钟
-- **通知目标**: 配置的 chatId
+- **通知目标**: 配置的 chatId（用于错误通知）
+- **默认成员**: 新建群聊时邀请的成员列表
 
 ## 执行步骤
 
@@ -45,55 +46,91 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
 
 对于每个新 PR：
 
-1. 获取详细信息：
-   ```bash
-   gh pr view {number} --repo hs3180/disclaude
-   ```
+#### 4.1 获取详细信息
 
-2. 使用 `send_user_feedback` 发送通知：
-   - PR 标题和编号
-   - 作者
-   - 状态（可合并/有冲突）
-   - CI 检查状态
-   - 链接
+```bash
+gh pr view {number} --repo hs3180/disclaude --json title,body,author,state,mergeable,headRefName,baseRefName,commits,files
+```
 
-3. 更新历史记录
+#### 4.2 创建群聊
+
+使用 `create_discussion` 工具为该 PR 创建专属群聊：
+- 群聊名称: `PR #{number}: {title}` (如果太长则截断)
+- 初始成员: PR 作者 + 默认成员列表
+
+#### 4.3 发送 PR 信息卡片
+
+使用 `send_user_feedback` 发送包含 PR 详细信息的卡片：
+
+```
+## PR #{number}: {title}
+
+**作者**: {author}
+**分支**: {headRefName} → {baseRefName}
+**状态**: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
+**检查**: {ciStatus}
+
+### 描述
+{body}
+
+### 文件变更
+{files}
+
+### 操作建议
+- 审核代码变更
+- 检查 CI 是否通过
+- 确认是否有冲突
+- 决定是否合并
+
+🔗 [查看 PR](https://github.com/hs3180/disclaude/pull/{number})
+```
+
+#### 4.4 更新历史记录
+
+将 PR 编号和对应的 chatId 记录到历史文件中。
 
 ### 5. 更新历史文件
 
-将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳。
+将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳，保存 `prChats` 映射。
 
-## 通知消息模板
+## 历史文件结构
 
-```
-🔔 新 PR 检测到
-
-PR #{number}: {title}
-
-👤 作者: {author}
-📊 状态: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
-🔍 检查: {ciStatus}
-
-📋 描述:
-{description}
-
-🔗 链接: https://github.com/hs3180/disclaude/pull/{number}
+```json
+{
+  "lastScan": "2026-03-04T00:00:00Z",
+  "processedPRs": [100, 101, 102],
+  "prChats": {
+    "100": "oc_xxxx",
+    "101": "oc_yyyy"
+  }
+}
 ```
 
 ## 错误处理
 
-- 如果 `gh` 命令失败，记录错误并发送错误通知
-- 如果历史文件损坏，重置并重新开始
-- 如果发送通知失败，记录错误但继续处理其他 PR
+- 如果 `gh` 命令失败：记录错误，发送错误通知到配置的 chatId
+- 如果创建群聊失败：回退到只发送通知到配置的 chatId
+- 如果历史文件损坏：重置并重新开始
+- 如果发送通知失败：记录错误但继续处理其他 PR
 
 ## 使用说明
 
 1. 复制此文件到 `workspace/schedules/pr-scanner.md`
-2. 替换 `chatId` 为实际的飞书群聊 ID
+2. 替换 `chatId` 为实际的飞书群聊 ID（用于错误通知）
 3. 设置 `enabled: true`
 4. 调度器将自动加载并执行
 
-## 未来扩展 (Phase 2 & 3)
+## 依赖状态
 
-- **Phase 2**: 为每个 PR 创建独立群聊（需要 PR #423 ChatOps）
-- **Phase 3**: 支持交互式操作按钮（需要 PR #412 FeedbackController）
+| 依赖 | 状态 | 说明 |
+|------|------|------|
+| Scheduler 基础设施 | ✅ 已有 | cron 调度 |
+| ChatOps | ✅ 已有 | PR #423 已合并 |
+| send_user_feedback | ✅ 已有 | 发送卡片通知 |
+| FeedbackController | ⏳ 可选 | Phase 3 交互按钮 |
+
+## 未来扩展 (Phase 3)
+
+- 添加交互式操作按钮（合并、关闭、请求修改）
+- 支持 PR 状态变更检测（新增评论、CI 完成等）
+- 支持自动合并符合条件的 PR


### PR DESCRIPTION
## Summary

Update PR Scanner design and example to support Phase 2 (group chat creation),
now that ChatOps (PR #423) has been merged.

## Changes

| File | Description |
|------|-------------|
| `docs/designs/pr-scanner-design.md` | Mark ChatOps dependency as ready |
| `examples/schedules/pr-scanner.example.md` | Update to Phase 2 with create_discussion |

## Updates

### Design Document
- Mark ChatOps (PR #423) as merged and ready
- Update Phase 2 status from "Blocked" to "Ready"
- Update dependency matrix

### Example Schedule File
- Add Phase 2 group chat creation instructions
- Add `create_discussion` tool usage
- Update message template with more PR details
- Add dependency status table
- Add history file structure with prChats mapping

## Dependencies Status

| Dependency | Status |
|------------|--------|
| Scheduler | ✅ Ready |
| ChatOps | ✅ Ready (PR #423 merged) |
| send_user_feedback | ✅ Ready |
| FeedbackController | ⏳ Optional (Phase 3) |

## Test Plan

- [x] TypeScript type check passes
- [x] Schedule tests pass
- [ ] Manual test: Copy example to workspace/schedules/
- [ ] Manual test: Enable and verify cron scheduling

Fixes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)