### PR TITLE
fix(lint): resolve ESLint errors in messaging module (Issue #572)

### DIFF
--- a/src/messaging/adapters/cli-adapter.ts
+++ b/src/messaging/adapters/cli-adapter.ts
@@ -8,9 +8,8 @@
  */
 
 import { createLogger } from '../../utils/logger.js';
-import type { IChannelAdapter, ChannelCapabilities } from '../channel-adapter.js';
+import { cardToText, type IChannelAdapter, type ChannelCapabilities } from '../channel-adapter.js';
 import type { UniversalMessage, SendResult, MessageContent } from '../universal-message.js';
-import { cardToText } from '../channel-adapter.js';
 
 const logger = createLogger('CliAdapter');
 
@@ -75,7 +74,7 @@ export class CliAdapter implements IChannelAdapter {
   /**
    * Send a message to the console.
    */
-  async send(message: UniversalMessage): Promise<SendResult> {
+  send(message: UniversalMessage): Promise<SendResult> {
     try {
       const text = this.convert(message);
 
@@ -84,18 +83,18 @@ export class CliAdapter implements IChannelAdapter {
 
       logger.debug({ chatId: message.chatId }, 'CLI message displayed');
 
-      return {
+      return Promise.resolve({
         success: true,
         // CLI doesn't have real message IDs, generate a pseudo one
         messageId: `cli-${Date.now()}`,
-      };
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error({ err: error, chatId: message.chatId }, 'Failed to display CLI message');
-      return {
+      return Promise.resolve({
         success: false,
         error: errorMessage,
-      };
+      });
     }
   }
 }

--- a/src/messaging/adapters/index.test.ts
+++ b/src/messaging/adapters/index.test.ts
@@ -7,8 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CliAdapter, createCliAdapter } from './cli-adapter.js';
 import { RestAdapter, createRestAdapter, resetRestAdapter, getRestAdapter } from './rest-adapter.js';
-import { isTextContent } from '../universal-message.js';
-import type { UniversalMessage } from '../universal-message.js';
+import { isTextContent, type UniversalMessage } from '../universal-message.js';
 
 // Mock Config for Feishu adapter tests
 vi.mock('../../config/index.js', () => ({
@@ -200,7 +199,7 @@ describe('Channel Adapters', () => {
 
         const messages = adapter.getMessages(chatId);
         expect(messages).toHaveLength(1);
-        const content = messages[0].content;
+        const [{ content }] = messages;
         expect(isTextContent(content) && content.text).toBe('Test message');
       });
 
@@ -222,7 +221,7 @@ describe('Channel Adapters', () => {
 
         const newMessages = adapter.getMessagesSince(chatId, result2.messageId!);
         expect(newMessages).toHaveLength(1);
-        const content = newMessages[0].content;
+        const [{ content }] = newMessages;
         expect(isTextContent(content) && content.text).toBe('Message 3');
       });
 

--- a/src/messaging/adapters/rest-adapter.ts
+++ b/src/messaging/adapters/rest-adapter.ts
@@ -93,7 +93,7 @@ export class RestAdapter implements IChannelAdapter {
    * Note: In a real implementation, this would push to a message queue
    * or notify connected WebSocket clients.
    */
-  async send(message: UniversalMessage): Promise<SendResult> {
+  send(message: UniversalMessage): Promise<SendResult> {
     try {
       const restMessage = this.convert(message);
 
@@ -111,18 +111,18 @@ export class RestAdapter implements IChannelAdapter {
         'REST message stored'
       );
 
-      return {
+      return Promise.resolve({
         success: true,
         messageId: restMessage.id,
         platformData: restMessage as unknown as Record<string, unknown>,
-      };
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.error({ err: error, chatId: message.chatId }, 'Failed to store REST message');
-      return {
+      return Promise.resolve({
         success: false,
         error: errorMessage,
-      };
+      });
     }
   }
 

--- a/src/messaging/message-service.test.ts
+++ b/src/messaging/message-service.test.ts
@@ -51,7 +51,7 @@ class MockAdapter implements IChannelAdapter {
   }
 
   async send(message: UniversalMessage): Promise<SendResult> {
-    return this.sendFn(message);
+    return await this.sendFn(message);
   }
 }
 
@@ -67,15 +67,15 @@ describe('MessageService', () => {
       const adapter = new MockAdapter(
         'mock',
         () => true,
-        async () => ({ success: true })
+        () => Promise.resolve({ success: true })
       );
       service = new MessageService({ adapters: [adapter] });
       expect(service.getAdapterNames()).toContain('mock');
     });
 
     it('should register multiple adapters', () => {
-      const adapter1 = new MockAdapter('mock1', () => false, async () => ({ success: true }));
-      const adapter2 = new MockAdapter('mock2', () => true, async () => ({ success: true }));
+      const adapter1 = new MockAdapter('mock1', () => false, () => Promise.resolve({ success: true }));
+      const adapter2 = new MockAdapter('mock2', () => true, () => Promise.resolve({ success: true }));
       service = new MessageService({ adapters: [adapter1, adapter2] });
       expect(service.getAdapterNames()).toHaveLength(2);
     });
@@ -84,7 +84,7 @@ describe('MessageService', () => {
   describe('registerAdapter', () => {
     it('should add new adapter', () => {
       service = new MessageService({ adapters: [] });
-      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => true, () => Promise.resolve({ success: true }));
       service.registerAdapter(adapter);
       expect(service.getAdapterNames()).toContain('mock');
     });
@@ -95,7 +95,7 @@ describe('MessageService', () => {
       const adapter = new MockAdapter(
         'mock',
         (chatId) => chatId.startsWith('test_'),
-        async () => ({ success: true })
+        () => Promise.resolve({ success: true })
       );
       service = new MessageService({ adapters: [adapter] });
 
@@ -109,7 +109,7 @@ describe('MessageService', () => {
       const adapter = new MockAdapter(
         'mock',
         () => true,
-        async () => ({ success: true }),
+        () => Promise.resolve({ success: true }),
         { supportsCard: true, maxMessageLength: 10000 }
       );
       service = new MessageService({ adapters: [adapter] });
@@ -144,7 +144,7 @@ describe('MessageService', () => {
     });
 
     it('should return error for unknown chatId', async () => {
-      const adapter = new MockAdapter('mock', () => false, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => false, () => Promise.resolve({ success: true }));
       service = new MessageService({ adapters: [adapter] });
 
       const msg: UniversalMessage = {
@@ -210,7 +210,7 @@ describe('MessageService', () => {
   describe('update', () => {
     it('should update message if adapter supports it', async () => {
       const updateMock = vi.fn().mockResolvedValue({ success: true });
-      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => true, () => Promise.resolve({ success: true }));
       (adapter as any).update = updateMock;
       service = new MessageService({ adapters: [adapter] });
 
@@ -224,7 +224,7 @@ describe('MessageService', () => {
     });
 
     it('should return error if adapter does not support update', async () => {
-      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => true, () => Promise.resolve({ success: true }));
       service = new MessageService({ adapters: [adapter] });
 
       const msg: UniversalMessage = {
@@ -241,7 +241,7 @@ describe('MessageService', () => {
   describe('delete', () => {
     it('should delete message if adapter supports it', async () => {
       const deleteMock = vi.fn().mockResolvedValue(true);
-      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => true, () => Promise.resolve({ success: true }));
       (adapter as any).delete = deleteMock;
       service = new MessageService({ adapters: [adapter] });
 
@@ -250,7 +250,7 @@ describe('MessageService', () => {
     });
 
     it('should return false if adapter does not support delete', async () => {
-      const adapter = new MockAdapter('mock', () => true, async () => ({ success: true }));
+      const adapter = new MockAdapter('mock', () => true, () => Promise.resolve({ success: true }));
       service = new MessageService({ adapters: [adapter] });
 
       const result = await service.delete('test_chat', 'msg_123');

--- a/src/messaging/message-service.ts
+++ b/src/messaging/message-service.ts
@@ -25,9 +25,8 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import type { IChannelAdapter, ChannelCapabilities } from './channel-adapter.js';
+import { cardToText, getFallbackContentType, type IChannelAdapter, type ChannelCapabilities } from './channel-adapter.js';
 import type { UniversalMessage, SendResult, CardContent } from './universal-message.js';
-import { cardToText, getFallbackContentType } from './channel-adapter.js';
 
 const logger = createLogger('MessageService');
 
@@ -189,7 +188,7 @@ export class MessageService {
       'Sending message'
     );
 
-    return adapter.send(messageToSend);
+    return await adapter.send(messageToSend);
   }
 
   /**
@@ -212,7 +211,7 @@ export class MessageService {
       };
     }
 
-    return adapter.update(messageId, message);
+    return await adapter.update(messageId, message);
   }
 
   /**
@@ -231,7 +230,7 @@ export class MessageService {
       return false;
     }
 
-    return adapter.delete(messageId);
+    return await adapter.delete(messageId);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixed all 22 ESLint errors reported in Issue #572
- Changes are limited to the `src/messaging/` module only
- All 142 tests in the messaging module pass

## Changes

### no-duplicate-imports
- Merged separate `import` and `import type` statements for the same module
- Used inline type imports: `import { value, type Type } from 'module'`

### require-await
- `cli-adapter.ts`: Converted `async send()` to sync method returning `Promise.resolve()`
- `rest-adapter.ts`: Converted `async send()` to sync method returning `Promise.resolve()`
- `message-service.ts`: Added `await` keywords to adapter method calls
- `message-service.test.ts`: Replaced `async () => ({ success: true })` with `() => Promise.resolve({ success: true })`

### prefer-destructuring
- `index.test.ts`: Used array destructuring `const [{ content }] = messages` instead of `const { content } = messages[0]`

## Test Results

```
 ✓ src/messaging/message-router.test.ts (45 tests)
 ✓ src/messaging/channel-message-router.test.ts (26 tests)
 ✓ src/messaging/message-service.test.ts (18 tests)
 ✓ src/messaging/adapters/index.test.ts (19 tests)
 ✓ src/messaging/channel-adapter.test.ts (22 tests)
 ✓ src/messaging/universal-message.test.ts (12 tests)

 Test Files  6 passed (6)
      Tests  142 passed (142)
```

## Lint Results

Before: ✖ 80 problems (22 errors, 58 warnings)
After: ✖ 58 problems (0 errors, 58 warnings)

Fixes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)