### PR TITLE
feat(schedules): add defaultChatId configuration support (Issue #357)

### DIFF
--- a/examples/schedules/recommend-analysis.example.md
+++ b/examples/schedules/recommend-analysis.example.md
@@ -3,7 +3,10 @@ name: "智能推荐分析"
 cron: "0 3 * * *"
 enabled: false
 blocking: true
-chatId: "REPLACE_WITH_ACTUAL_CHAT_ID"
+# chatId 可通过以下两种方式配置：
+# 1. 在此文件中直接设置 chatId（优先级更高）
+# 2. 在 disclaude.config.yaml 中设置 schedules.defaultChatId（全局默认值）
+# chatId: "oc_your_chat_id"
 createdAt: "2026-03-01T00:00:00.000Z"
 ---
 
@@ -13,7 +16,30 @@ createdAt: "2026-03-01T00:00:00.000Z"
 
 ## 配置说明
 
-**重要**: 使用前请将 `chatId` 替换为实际的飞书 Chat ID，并将 `enabled` 设为 `true`。
+有两种方式配置消息发送目标：
+
+### 方式 1: 全局默认 chatId（推荐）
+
+在 `disclaude.config.yaml` 中添加：
+
+```yaml
+schedules:
+  defaultChatId: "oc_your_chat_id"
+```
+
+这样所有定时任务都会使用这个默认 chatId，无需在每个任务文件中单独配置。
+
+### 方式 2: 任务级 chatId
+
+在任务的 frontmatter 中直接设置 `chatId`：
+
+```yaml
+---
+chatId: "oc_your_chat_id"
+---
+```
+
+**启用任务**: 将 `enabled` 设为 `true`。
 
 ## 执行步骤
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -336,4 +336,13 @@ export class Config {
   static getGlobalEnv(): Record<string, string> {
     return fileConfigOnly.env || {};
   }
+
+  /**
+   * Get schedules configuration.
+   *
+   * @returns Schedules configuration object
+   */
+  static getSchedulesConfig(): import('./types.js').SchedulesConfig {
+    return fileConfigOnly.schedules || {};
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -229,6 +229,17 @@ export interface MessagingConfig {
 }
 
 /**
+ * Scheduled tasks configuration section.
+ *
+ * Controls default behavior for scheduled tasks.
+ * @see Issue #357
+ */
+export interface SchedulesConfig {
+  /** Default chat ID for scheduled tasks without explicit chatId */
+  defaultChatId?: string;
+}
+
+/**
  * Run mode for the application.
  * - comm: Communication Node (Feishu WebSocket handler)
  * - exec: Execution Node (Pilot/Agent handler)
@@ -260,6 +271,8 @@ export interface DisclaudeConfig {
   channels?: ChannelsConfig;
   /** Message routing configuration */
   messaging?: MessagingConfig;
+  /** Scheduled tasks configuration */
+  schedules?: SchedulesConfig;
   /** Global environment variables applied to all agent processes */
   env?: Record<string, string>;
 }

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -78,7 +78,11 @@ export class SchedulerService {
    * Start the scheduler service.
    */
   async start(): Promise<void> {
-    const scheduleManager = new ScheduleManager({ schedulesDir: this.schedulesDir });
+    const schedulesConfig = Config.getSchedulesConfig();
+    const scheduleManager = new ScheduleManager({
+      schedulesDir: this.schedulesDir,
+      defaultChatId: schedulesConfig.defaultChatId,
+    });
 
     this.scheduler = new Scheduler({
       scheduleManager,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -192,7 +192,11 @@ export class WorkerNode {
     // Initialize Schedule Manager and Scheduler
     const workspaceDir = Config.getWorkspaceDir();
     const schedulesDir = path.join(workspaceDir, 'schedules');
-    const scheduleManager = new ScheduleManager({ schedulesDir });
+    const schedulesConfig = Config.getSchedulesConfig();
+    const scheduleManager = new ScheduleManager({
+      schedulesDir,
+      defaultChatId: schedulesConfig.defaultChatId,
+    });
     this.scheduler = new Scheduler({
       scheduleManager,
       pilot: this.sharedPilot,

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -51,6 +51,8 @@ export interface ScheduledTask {
 export interface ScheduleManagerOptions {
   /** Directory for schedule files */
   schedulesDir: string;
+  /** Default chat ID for tasks without explicit chatId */
+  defaultChatId?: string;
 }
 
 /**
@@ -74,8 +76,11 @@ export class ScheduleManager {
   private fileScanner: ScheduleFileScanner;
 
   constructor(options: ScheduleManagerOptions) {
-    this.fileScanner = new ScheduleFileScanner({ schedulesDir: options.schedulesDir });
-    logger.info({ schedulesDir: options.schedulesDir }, 'ScheduleManager initialized (no cache)');
+    this.fileScanner = new ScheduleFileScanner({
+      schedulesDir: options.schedulesDir,
+      defaultChatId: options.defaultChatId,
+    });
+    logger.info({ schedulesDir: options.schedulesDir, defaultChatId: options.defaultChatId }, 'ScheduleManager initialized (no cache)');
   }
 
   /**

--- a/src/schedule/schedule-watcher.ts
+++ b/src/schedule/schedule-watcher.ts
@@ -127,6 +127,8 @@ function generateTaskId(fileName: string): string {
 export interface ScheduleFileScannerOptions {
   /** Directory to scan for schedule files */
   schedulesDir: string;
+  /** Default chat ID for tasks without explicit chatId */
+  defaultChatId?: string;
 }
 
 /**
@@ -134,10 +136,12 @@ export interface ScheduleFileScannerOptions {
  */
 export class ScheduleFileScanner {
   private schedulesDir: string;
+  private defaultChatId?: string;
 
   constructor(options: ScheduleFileScannerOptions) {
     this.schedulesDir = options.schedulesDir;
-    logger.info({ schedulesDir: this.schedulesDir }, 'ScheduleFileScanner initialized');
+    this.defaultChatId = options.defaultChatId;
+    logger.info({ schedulesDir: this.schedulesDir, defaultChatId: this.defaultChatId }, 'ScheduleFileScanner initialized');
   }
 
   /**
@@ -191,10 +195,28 @@ export class ScheduleFileScanner {
       const stats = await fsPromises.stat(filePath);
       const { frontmatter, contentStart } = parseScheduleFrontmatter(content);
 
-      // Validate required fields
-      if (!frontmatter['name'] || !frontmatter['cron'] || !frontmatter['chatId']) {
-        logger.warn({ filePath }, 'Schedule file missing required fields (name, cron, chatId)');
+      // Validate required fields (chatId is optional if defaultChatId is set)
+      if (!frontmatter['name'] || !frontmatter['cron']) {
+        logger.warn({ filePath }, 'Schedule file missing required fields (name, cron)');
         return null;
+      }
+
+      // Resolve chatId: use frontmatter value, or defaultChatId, or reject
+      let chatId = frontmatter['chatId'] as string | undefined;
+      const isPlaceholder = chatId && (
+        chatId === 'REPLACE_WITH_ACTUAL_CHAT_ID' ||
+        chatId.startsWith('REPLACE_') ||
+        chatId === 'YOUR_CHAT_ID'
+      );
+
+      if (isPlaceholder || !chatId) {
+        if (this.defaultChatId) {
+          chatId = this.defaultChatId;
+          logger.debug({ filePath, defaultChatId: this.defaultChatId }, 'Using default chatId for schedule file');
+        } else {
+          logger.warn({ filePath }, 'Schedule file has placeholder chatId and no defaultChatId configured');
+          return null;
+        }
       }
 
       const prompt = content.slice(contentStart).trim();
@@ -204,7 +226,7 @@ export class ScheduleFileScanner {
         id: generateTaskId(fileName),
         name: frontmatter['name'] as string,
         cron: frontmatter['cron'] as string,
-        chatId: frontmatter['chatId'] as string,
+        chatId,
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
         blocking: (frontmatter['blocking'] as boolean) ?? true,


### PR DESCRIPTION
## Summary

- Add `SchedulesConfig` interface with `defaultChatId` option
- Add `getSchedulesConfig()` method to Config class
- Update `ScheduleFileScanner` to use default chatId for placeholder values
- Update `ScheduleManager` to pass defaultChatId to scanner
- Update `SchedulerService` and `WorkerNode` to use config
- Update `recommend-analysis.example.md` with configuration instructions

This allows users to set a global default chat ID for scheduled tasks in `disclaude.config.yaml` instead of configuring it per task file.

## Problem

Issue #357 智能定时任务推荐系统的基础设施已经存在（send_user_feedback MCP 工具、Scheduler、schedule-recommend skill），但示例文件 `recommend-analysis.example.md` 需要手动替换 `chatId` 占位符才能使用。

## Solution

添加 `schedules.defaultChatId` 配置选项，让用户可以在配置文件中设置默认的 chat ID，无需在每个定时任务文件中单独配置。

## Configuration

在 `disclaude.config.yaml` 中添加：

```yaml
schedules:
  defaultChatId: "oc_your_chat_id"
```

## Placeholder Detection

以下占位符值会自动使用 `defaultChatId`：
- `REPLACE_WITH_ACTUAL_CHAT_ID`
- 以 `REPLACE_` 开头的值
- `YOUR_CHAT_ID`

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Schedule Tests | ✅ 59 passed |
| Config Tests | ✅ 90 passed (1 pre-existing failure) |

## Test Plan

- [x] TypeScript type check passes
- [x] Unit tests for schedule module pass
- [ ] Manual test: Set defaultChatId in config → task uses it
- [ ] Manual test: Task with explicit chatId → uses task's chatId

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)