### PR TITLE
fix(lint): resolve ESLint errors in ScheduleCommand (Issue #584)

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -607,11 +607,11 @@ export class ScheduleCommand implements Command {
 
     // Handle list subcommand
     if (subCommand === 'list') {
-      return this.handleList(services);
+      return await this.handleList(services);
     }
 
     // Other subcommands require a task name
-    const taskName = context.args[1];
+    const [, taskName] = context.args;
     if (!taskName) {
       return {
         success: false,
@@ -622,13 +622,13 @@ export class ScheduleCommand implements Command {
     // Handle other subcommands
     switch (subCommand) {
       case 'status':
-        return this.handleStatus(services, taskName);
+        return await this.handleStatus(services, taskName);
       case 'enable':
-        return this.handleEnable(services, taskName);
+        return await this.handleEnable(services, taskName);
       case 'disable':
-        return this.handleDisable(services, taskName);
+        return await this.handleDisable(services, taskName);
       case 'run':
-        return this.handleRun(services, taskName);
+        return await this.handleRun(services, taskName);
       default:
         return { success: false, error: `未知子命令: ${subCommand}` };
     }


### PR DESCRIPTION
## Summary

Fix two ESLint errors in `src/nodes/commands/builtin-commands.ts` reported by CI Monitor.

## Changes

| Line | Error | Fix |
|------|-------|-----|
| 567 | `require-await` | Add `await` to async handle method calls |
| 614 | `prefer-destructuring` | Use array destructuring for args |

### Code Changes

1. **require-await fix**: Add `await` keyword when calling async handle methods:
   ```typescript
   // Before
   return this.handleList(services);
   
   // After
   return await this.handleList(services);
   ```

2. **prefer-destructuring fix**: Use array destructuring:
   ```typescript
   // Before
   const taskName = context.args[1];
   
   // After
   const [, taskName] = context.args;
   ```

## Test Results

| Metric | Value |
|--------|-------|
| ESLint Errors | ✅ 0 (was 2) |
| TypeScript | ✅ Pass |
| ScheduleCommand Tests | ✅ 24 passed |

Fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)