### PR TITLE
test(mcp): add graceful degradation tests for Feishu tools (Issue #581)

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -424,6 +424,78 @@ describe('Feishu Context MCP Tools', () => {
     });
   });
 
+  describe('Graceful Degradation (No Feishu Credentials)', () => {
+    // These tests verify the fix for Issue #581
+    // When Feishu credentials are not configured, tools should handle gracefully
+
+    // Temporarily override the Config mock for these tests
+    let originalConfig: typeof import('../config/index.js').Config;
+
+    beforeAll(async () => {
+      // Save original config
+      originalConfig = (await import('../config/index.js')).Config;
+      // Re-mock Config without credentials
+      vi.resetModules();
+      vi.doMock('../config/index.js', () => ({
+        Config: {
+          FEISHU_APP_ID: '',
+          FEISHU_APP_SECRET: '',
+          getWorkspaceDir: vi.fn(() => '/test/workspace'),
+        },
+      }));
+    });
+
+    afterAll(() => {
+      vi.doUnmock('../config/index.js');
+    });
+
+    it('send_user_feedback should gracefully handle missing credentials', async () => {
+      // Re-import to get the mocked version
+      const { send_user_feedback: sendFeedbackNoCreds } = await import('./feishu-context-mcp.js');
+
+      const result = await sendFeedbackNoCreds({
+        content: 'Test message',
+        format: 'text',
+        chatId: 'chat-no-creds',
+      });
+
+      // Should succeed with graceful degradation message
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Feishu not configured');
+    });
+
+    it('send_file_to_feishu should return soft error when credentials missing', async () => {
+      const { send_file_to_feishu: sendFileNoCreds } = await import('./feishu-context-mcp.js');
+
+      const result = await sendFileNoCreds({
+        filePath: '/test/file.txt',
+        chatId: 'chat-no-creds',
+      });
+
+      // Should return soft error (not throw)
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Feishu credentials not configured');
+    });
+
+    it('update_card should return soft error when credentials missing', async () => {
+      const { update_card: updateCardNoCreds } = await import('./feishu-context-mcp.js');
+
+      const result = await updateCardNoCreds({
+        messageId: 'msg-123',
+        card: {
+          config: { wide_screen_mode: true },
+          header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
+          elements: [],
+        },
+        chatId: 'chat-no-creds',
+      });
+
+      // Should return soft error (not throw)
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Feishu credentials not configured');
+    });
+  });
+
   describe('send_file_to_feishu', () => {
     it('should require chatId', async () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);


### PR DESCRIPTION
## Summary

Add tests to verify that Feishu MCP tools handle missing credentials gracefully. These tests confirm the fix implemented in PR #579.

## Test Cases Added

- **send_user_feedback**: Verifies that the tool succeeds with a graceful degradation message when Feishu credentials are not configured
- **send_file_to_feishu**: Verifies that the tool returns a soft error instead of throwing when credentials are missing
- **update_card**: Verifies that the tool returns a soft error instead of throwing when credentials are missing

## Related Issues

- Closes #581 - The original issue was caused by `send_user_feedback` throwing errors when Feishu credentials were not configured, which led to HTTP 000 errors in integration tests
- PR #579 implemented the graceful degradation fix

## Root Cause Analysis (from Issue #581)

The integration test for Use Case 2 (calculation task) was intermittently returning HTTP 000 because:

1. Test configuration (`disclaude.config.test.yaml`) intentionally has empty Feishu credentials
2. Agent attempted to call `send_user_feedback` MCP tool
3. Tool threw error: "FEISHU_APP_ID and FEISHU_APP_SECRET must be configured in Config"
4. This caused a cascade failure, resulting in HTTP 000 (connection failure)

## Solution (implemented in PR #579)

The fix adds graceful degradation:
- When Feishu credentials are not configured, tools log the message and return success/soft error instead of throwing
- This allows REST channel and test environments to work without Feishu credentials

## Test Plan

- [x] All new tests pass (48 tests in feishu-context-mcp.test.ts)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)