### PR TITLE
fix(commands): /passive command now returns actual status instead of stuck on "设置中"

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -372,6 +372,7 @@ export class DissolveGroupCommand implements Command {
 /**
  * Passive Command - Control passive mode for group chats.
  * Issue #511: Group chat passive mode control
+ * Issue #601: Fix passive command not returning status
  */
 export class PassiveCommand implements Command {
   readonly name = 'passive';
@@ -380,6 +381,7 @@ export class PassiveCommand implements Command {
   readonly usage = 'passive [on|off|status]';
 
   execute(context: CommandContext): CommandResult {
+    const { services, chatId } = context;
     // Default to status if no args
     const subCommand = context.args[0]?.toLowerCase() || 'status';
 
@@ -391,13 +393,34 @@ export class PassiveCommand implements Command {
       };
     }
 
-    // Actual implementation is handled by PrimaryNode
-    return {
-      success: true,
-      message: '🔄 **被动模式设置中...**',
-      // Signal that this needs special handling
-      data: { subCommand, needsSpecialHandling: true },
-    };
+    // Handle subcommands directly (Issue #601: fix missing status response)
+    if (subCommand === 'status') {
+      const isDisabled = services.getPassiveMode(chatId);
+      const statusText = isDisabled ? '关闭（响应所有消息）' : '开启（仅响应 @提及）';
+      return {
+        success: true,
+        message: `📋 **被动模式状态**\n\n当前状态: ${statusText}\n\n- 开启时，仅响应 @提及的消息\n- 关闭时，响应所有消息`,
+      };
+    }
+
+    if (subCommand === 'on') {
+      services.setPassiveMode(chatId, false); // false = passive mode enabled = only @mention
+      return {
+        success: true,
+        message: '✅ **被动模式已开启**\n\nBot 将仅响应 @提及的消息',
+      };
+    }
+
+    if (subCommand === 'off') {
+      services.setPassiveMode(chatId, true); // true = passive mode disabled = respond to all
+      return {
+        success: true,
+        message: '✅ **被动模式已关闭**\n\nBot 将响应所有消息',
+      };
+    }
+
+    // This should never be reached due to validation above
+    return { success: false, error: '未知子命令' };
   }
 }
 

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -52,6 +52,9 @@ function createMockServices(): CommandServices {
     completeTask: () => Promise.resolve(null),
     setTaskError: () => Promise.resolve(null),
     listTaskHistory: () => Promise.resolve([]),
+    // Passive mode management (Issue #601)
+    setPassiveMode: () => {},
+    getPassiveMode: () => false,
   };
 }
 

--- a/src/nodes/commands/node-command.test.ts
+++ b/src/nodes/commands/node-command.test.ts
@@ -50,6 +50,9 @@ describe('NodeCommand', () => {
     completeTask: () => Promise.resolve(null),
     setTaskError: () => Promise.resolve(null),
     listTaskHistory: () => Promise.resolve([]),
+    // Passive mode management (Issue #601)
+    setPassiveMode: () => {},
+    getPassiveMode: () => false,
   };
 
   describe('metadata', () => {

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -76,6 +76,9 @@ describe('ScheduleCommand', () => {
     completeTask: () => Promise.resolve(null),
     setTaskError: () => Promise.resolve(null),
     listTaskHistory: () => Promise.resolve([]),
+    // Passive mode management (Issue #601)
+    setPassiveMode: () => {},
+    getPassiveMode: () => false,
   });
 
   const createContext = (args: string[], services: CommandServices = createMockServices()): CommandContext => ({

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -182,6 +182,13 @@ export interface CommandServices {
 
   /** List task history */
   listTaskHistory: (limit?: number) => Promise<import('../../utils/task-state-manager.js').TaskState[]>;
+
+  // Passive mode management (Issue #601)
+  /** Set passive mode for a chat (true = respond to all, false = only @mention) */
+  setPassiveMode: (chatId: string, disabled: boolean) => void;
+
+  /** Get passive mode status for a chat (true = respond to all, false = only @mention) */
+  getPassiveMode: (chatId: string) => boolean;
 }
 
 /**

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -584,6 +584,20 @@ export class PrimaryNode extends EventEmitter {
         completeTask: () => taskStateManager.completeTask(),
         setTaskError: (error: string) => taskStateManager.setTaskError(error),
         listTaskHistory: (limit?: number) => taskStateManager.listTaskHistory(limit),
+        // Passive mode management (Issue #601)
+        setPassiveMode: (chatId: string, disabled: boolean) => {
+          const feishuChannel = this.feedbackRouter.getChannels().find(c => c.name === 'Feishu');
+          if (feishuChannel && 'setPassiveModeDisabled' in feishuChannel) {
+            (feishuChannel as any).setPassiveModeDisabled(chatId, disabled);
+          }
+        },
+        getPassiveMode: (chatId: string) => {
+          const feishuChannel = this.feedbackRouter.getChannels().find(c => c.name === 'Feishu');
+          if (feishuChannel && 'isPassiveModeDisabled' in feishuChannel) {
+            return (feishuChannel as any).isPassiveModeDisabled(chatId);
+          }
+          return false; // Default: passive mode enabled (only @mention)
+        },
       },
     };
 


### PR DESCRIPTION
## Summary

- `/passive` command now correctly shows status instead of stuck on "设置中..."
- Fixed `PassiveCommand` to implement actual logic directly

## Problem

When users execute `/passive off`, `/passive on`, or `/passive status`, the bot only responds with "🔄 **被动模式设置中...**" but never shows the actual result.

## Root Cause

The `PassiveCommand` class returned `needsSpecialHandling: true` in its response, expecting `PrimaryNode` to handle the actual logic. However, no code was implemented to process this signal, leaving the command incomplete.

## Solution

1. Add `setPassiveMode` and `getPassiveMode` methods to `CommandServices` interface
2. Implement these methods in `PrimaryNode.handleControlCommand()` to access `FeishuChannel` methods
3. Refactor `PassiveCommand.execute()` to directly implement the logic instead of relying on external handling

## Changes

| File | Description |
|------|-------------|
| `src/nodes/commands/types.ts` | Add `setPassiveMode` and `getPassiveMode` to `CommandServices` |
| `src/nodes/commands/builtin-commands.ts` | Refactor `PassiveCommand` to implement logic directly |
| `src/nodes/primary-node.ts` | Implement passive mode methods in command context |
| Test files | Add mock implementations for new methods |

## Test Results

- Passive mode tests: 22 passed
- Command registry tests: 17 passed
- All tests: 1480 passed (6 pre-existing failures unrelated to this PR)

Fixes #601

## Test Plan

- [x] Unit tests for passive mode pass
- [x] TypeScript type check passes (no new errors)
- [ ] Manual test: `/passive on` shows "被动模式已开启"
- [ ] Manual test: `/passive off` shows "被动模式已关闭"
- [ ] Manual test: `/passive status` shows current status

🤖 Generated with [Claude Code](https://claude.com/claude-code)