### PR TITLE
feat(channel): add supportedMcpTools to ChannelCapabilities (Issue #590 Phase 1)

### DIFF
--- a/src/messaging/channel-adapter.ts
+++ b/src/messaging/channel-adapter.ts
@@ -66,6 +66,11 @@ export interface ChannelCapabilities {
   supportsMention: boolean;
   /** Whether the channel supports reactions/emoji */
   supportsReactions: boolean;
+  /**
+   * Supported MCP tools for this channel.
+   * Issue #590: MCP Tools 与 Channel 解耦
+   */
+  supportedMcpTools?: string[];
 }
 
 /**
@@ -82,6 +87,7 @@ export const DEFAULT_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: false,
   supportsMention: false,
   supportsReactions: false,
+  supportedMcpTools: [],
 };
 
 /**
@@ -98,6 +104,7 @@ export const FEISHU_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: true,
   supportsMention: true,
   supportsReactions: true,
+  supportedMcpTools: ['send_user_feedback', 'send_file_to_feishu', 'update_card', 'wait_for_interaction'],
 };
 
 /**
@@ -114,6 +121,7 @@ export const CLI_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: false,
   supportsMention: false,
   supportsReactions: false,
+  supportedMcpTools: [], // CLI mode doesn't need MCP tools
 };
 
 /**
@@ -130,6 +138,7 @@ export const REST_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: false,
   supportsMention: false,
   supportsReactions: false,
+  supportedMcpTools: ['send_user_feedback'], // REST channel only supports basic messaging
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Add supportedMcpTools field to ChannelCapabilities interface

Define supported MCP tools for each channel type

## Details
This is a foundational change that enables future work on Issue #590 (Mcp Tools 与 Channel 解耦)

- **Feishu**: send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction
- **REST**: Basic messaging only (send_user_feedback)
- **CLI**: No MCP tools needed

## Next Steps
- Phase 2: Create unified send_message MCP tool
- Phase 3: Dynamic Agent Prompt adaptation based on channel capabilities

## Test plan
- [ ] Verify TypeScript compilation passes
- [ ] Run existing unit tests
- [ ] Manual test with different channel types

🤖 Generated with [Claude Code](https://claude.com/claude-code)