### PR TITLE
fix(feishu): show error for unknown commands when bot is @mentioned (Issue #595)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -284,8 +284,8 @@ describe('FeishuChannel - Control Command Handling (Issue #387)', () => {
     });
   });
 
-  describe('Non-control commands with @mention should be passed to agent', () => {
-    it('should pass unknown commands directly to agent when bot is mentioned', async () => {
+  describe('Unknown commands with @mention should show error (Issue #595)', () => {
+    it('should show error for unknown commands when bot is mentioned', async () => {
       await simulateMessageReceive({
         text: '/unknown-command',
         mentions: [
@@ -297,16 +297,12 @@ describe('FeishuChannel - Control Command Handling (Issue #387)', () => {
         ],
       });
 
-      // Control handler should NOT be called for unknown commands with @mention
-      // (unknown commands with @mention are passed directly to agent)
+      // Control handler should NOT be called for unknown commands
       expect(controlHandler).not.toHaveBeenCalled();
 
-      // Message should be passed to agent
-      expect(messageHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: '/unknown-command',
-        })
-      );
+      // Message should NOT be passed to agent (Issue #595 fix)
+      // Instead, an error message is sent to the user
+      expect(messageHandler).not.toHaveBeenCalled();
     });
 
     it('should handle regular messages normally (without / prefix)', async () => {

--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -265,7 +265,7 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should process non-control command in group chat WITH @mention', async () => {
+    it('should show error for unknown command in group chat WITH @mention (Issue #595)', async () => {
       await simulateMessageReceive({
         text: '/custom-command',
         chatId: 'oc_test_group',
@@ -278,15 +278,12 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
         ],
       });
 
-      // Control handler should NOT be called (unknown command with @mention goes to agent)
+      // Control handler should NOT be called (unknown command)
       expect(controlHandler).not.toHaveBeenCalled();
 
-      // Message SHOULD be passed to agent
-      expect(messageHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: '/custom-command',
-        })
-      );
+      // Message should NOT be passed to agent (Issue #595 fix)
+      // Instead, an error message is shown to the user
+      expect(messageHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -532,7 +532,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
       // Handle control commands through the control channel
       // Control commands are ALWAYS handled locally, regardless of @mentions
-      // Non-control commands with @mention are passed to agent
+      // Non-control commands with @mention show error instead of passing to agent (Issue #595)
       const isControlCommand = commandRegistry.has(cmd);
 
       if (isControlCommand || !botMentioned) {
@@ -555,7 +555,16 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
             }
             return;
           }
-          // Unknown command: fall through to emitMessage for Agent to handle
+          // Without @mention: unknown commands fall through to agent (original behavior)
+          // With @mention: show error instead of passing to agent (Issue #595)
+          if (botMentioned) {
+            await this.sendMessage({
+              chatId: chat_id,
+              type: 'text',
+              text: `❓ **未知命令**: /${cmd}\n\n使用 /help 查看可用命令列表。`,
+            });
+            return;
+          }
         }
 
         // Default command handling if no control handler registered
@@ -576,6 +585,15 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           });
           return;
         }
+      } else {
+        // Unknown command with @mention: show error instead of passing to agent
+        // Issue #595: Control commands not parsed when bot is @mentioned in group chat
+        await this.sendMessage({
+          chatId: chat_id,
+          type: 'text',
+          text: `❓ **未知命令**: /${cmd}\n\n使用 /help 查看可用命令列表。`,
+        });
+        return;
       }
     }
 


### PR DESCRIPTION
## Summary

When a user sends an unknown command with @mention in a group chat (e.g., `@bot /list-groups`), the command was incorrectly passed to the Agent instead of showing a helpful error message.

Fixes #595

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | Show error for unknown commands when bot is @mentioned |
| `src/channels/feishu-channel-mention.test.ts` | Update test for new behavior |
| `src/channels/feishu-channel-passive-mode.test.ts` | Update test for new behavior |

## Root Cause

In `feishu-channel.ts`, the condition `isControlCommand || !botMentioned` was false when:
- `isControlCommand = false` (command not in registry)
- `botMentioned = true` (bot was @mentioned)

This caused the message to be passed to the Agent instead of being handled locally.

## Fix

Added handling for unknown commands when bot is @mentioned:

1. **Inside existing block**: After `emitControl` returns `success: false`, check if `botMentioned` and show error
2. **Outside existing block**: Handle case where `isControlCommand=false` AND `botMentioned=true`

## Behavior Changes

| Scenario | Before | After |
|----------|--------|-------|
| `/unknown` without @mention | Pass to agent | Pass to agent (unchanged) |
| `/unknown` with @mention | Pass to agent | Show error message ✅ |
| `/reset` with @mention | Handle locally | Handle locally (unchanged) |

## Error Message

```
❓ **未知命令**: /list-groups

使用 /help 查看可用命令列表。
```

## Test Results

| Metric | Value |
|--------|-------|
| Mention Tests | ✅ 8 passed |
| Passive Mode Tests | ✅ 22 passed |
| Total | ✅ 30 passed |

## Test Plan

- [x] Unit tests for unknown command with @mention
- [x] Unit tests for unknown command without @mention
- [x] Unit tests for known command with @mention
- [ ] Manual test: `@bot /list-groups` shows error message
- [ ] Manual test: `/list-groups` without @mention passes to agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)