### PR TITLE
refactor(commands): rename list-member to list-group-members (Issue #596)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -98,7 +98,7 @@ vi.mock('../utils/task-tracker.js', () => ({
 vi.mock('../nodes/commands/command-registry.js', () => ({
   getCommandRegistry: vi.fn(() => ({
     has: (name: string) => ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
-      'create-group', 'add-member', 'remove-member', 'list-member', 'list-group', 'dissolve-group'].includes(name),
+      'create-group', 'add-member', 'remove-member', 'list-group-members', 'list-group', 'dissolve-group'].includes(name),
     getAll: () => [],
     register: vi.fn(),
   })),

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -120,7 +120,7 @@ export type ControlCommandType =
   | 'create-group'
   | 'add-member'
   | 'remove-member'
-  | 'list-member'
+  | 'list-group-members'
   | 'list-group'
   | 'dissolve-group'
   // Debug group commands (Issue #487)

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -265,13 +265,13 @@ export class RemoveMemberCommand implements Command {
 }
 
 /**
- * List Member Command - List members of a group.
+ * List Group Members Command - List members of a group.
  */
-export class ListMemberCommand implements Command {
-  readonly name = 'list-member';
+export class ListGroupMembersCommand implements Command {
+  readonly name = 'list-group-members';
   readonly category = 'group' as const;
-  readonly description = '列出成员';
-  readonly usage = 'list-member <groupId>';
+  readonly description = '列出群成员';
+  readonly usage = 'list-group-members <groupId>';
 
   async execute(context: CommandContext): Promise<CommandResult> {
     const { services, args } = context;
@@ -279,7 +279,7 @@ export class ListMemberCommand implements Command {
     if (args.length < 1) {
       return {
         success: false,
-        error: '用法: `/list-member <群ID>`\n\n示例: `/list-member oc_xxx`',
+        error: '用法: `/list-group-members <群ID>`\n\n示例: `/list-group-members oc_xxx`',
       };
     }
 
@@ -970,7 +970,7 @@ export function registerDefaultCommands(
   registry.register(new CreateGroupCommand());
   registry.register(new AddMemberCommand());
   registry.register(new RemoveMemberCommand());
-  registry.register(new ListMemberCommand());
+  registry.register(new ListGroupMembersCommand());
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());
   registry.register(new PassiveCommand());

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -340,7 +340,7 @@ describe('registerDefaultCommands', () => {
     expect(registry.get('create-group')).toBeDefined();
     expect(registry.get('add-member')).toBeDefined();
     expect(registry.get('remove-member')).toBeDefined();
-    expect(registry.get('list-member')).toBeDefined();
+    expect(registry.get('list-group-members')).toBeDefined();
     expect(registry.get('list-group')).toBeDefined();
     expect(registry.get('dissolve-group')).toBeDefined();
     expect(registry.get('passive')).toBeDefined();


### PR DESCRIPTION
## Summary

Rename the `/list-member` command to `/list-group-members` for better clarity and consistency.

Fixes #596

## Changes

| File | Description |
|------|-------------|
| `src/channels/types.ts` | Update type definition from `'list-member'` to `'list-group-members'` |
| `src/nodes/commands/builtin-commands.ts` | Rename `ListMemberCommand` to `ListGroupMembersCommand` |
| `src/channels/feishu-channel-mention.test.ts` | Update mock to use new command name |
| `src/nodes/commands/command-registry.test.ts` | Update test assertion |

## Details

- Command name: `list-member` → `list-group-members`
- Class name: `ListMemberCommand` → `ListGroupMembersCommand`
- Description: `列出成员` → `列出群成员`
- Usage: `list-member <groupId>` → `list-group-members <groupId>`

## Test Results

| Test File | Status |
|-----------|--------|
| command-registry.test.ts | ✅ 17 passed |
| feishu-channel-mention.test.ts | ✅ 8 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)