### PR TITLE
docs: add GitHub installation support in Quick Start (Issue #587)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A multi-platform AI agent bot that bridges messaging platforms (Feishu/Lark) wit
 
 ## Version
 
-**v0.0.1** - Initial Feishu/Lark Release
+**v0.3.2** - Multi-platform Agent Bot
 
 ### Implementation Status
 
@@ -62,10 +62,61 @@ claude --version
 
 ## Quick Start
 
-### 1. Install Dependencies
+### Option A: Install from GitHub (Recommended for Users)
+
+Install directly from GitHub without cloning the repository:
 
 ```bash
-git clone <repo-url>
+# Install globally from GitHub
+npm install -g hs3180/disclaude
+
+# Or using SSH
+npm install -g git+ssh://git@github.com:hs3180/disclaude.git
+```
+
+After installation, you can use the `disclaude` command directly:
+
+```bash
+# Show help
+disclaude --help
+
+# Start Feishu bot
+disclaude start --mode feishu
+```
+
+#### Configuration for Global Install
+
+Create a configuration file in your working directory:
+
+```bash
+# Create config directory
+mkdir -p ~/.disclaude
+
+# Copy example config (if you have the repo cloned)
+cp disclaude.config.example.yaml ~/.disclaude/disclaude.config.yaml
+
+# Or download from GitHub
+curl -o ~/.disclaude/disclaude.config.yaml https://raw.githubusercontent.com/hs3180/disclaude/main/disclaude.config.example.yaml
+```
+
+Edit `~/.disclaude/disclaude.config.yaml` with your credentials.
+
+#### Update to Latest Version
+
+```bash
+# Update to latest version
+npm update -g hs3180/disclaude
+
+# Or reinstall for a clean update
+npm install -g hs3180/disclaude
+```
+
+### Option B: Clone for Development
+
+For development or customization, clone the repository:
+
+```bash
+git clone https://github.com/hs3180/disclaude.git
 cd disclaude
 npm install
 ```
@@ -76,7 +127,7 @@ The project includes an `.npmrc` file that ensures devDependencies are installed
 npm install --production=false
 ```
 
-### 2. Install Claude CLI (Required)
+### Install Claude CLI (Required)
 
 Make sure Claude CLI is installed (see [Requirements](#requirements) for installation instructions). Without it, you'll encounter errors like:
 


### PR DESCRIPTION
## Summary

Adds GitHub installation support to README.md Quick Start section, allowing users to install disclaude directly from GitHub without npm registry distribution.

## Changes

| File | Description |
|------|-------------|
| `README.md` | Add GitHub installation instructions |

## New Quick Start Options

### Option A: Install from GitHub (Recommended for Users)
```bash
npm install -g hs3180/disclaude
```

### Option B: Clone for Development
```bash
git clone https://github.com/hs3180/disclaude.git
```

## Features Added

- ✅ Direct GitHub installation instructions
- ✅ SSH installation option
- ✅ Configuration instructions for global install
- ✅ Update instructions (`npm update -g hs3180/disclaude`)
- ✅ Updated version number to v0.3.2

## Test Plan

- [x] README.md renders correctly
- [ ] `npm install -g hs3180/disclaude` works (requires merge first)
- [ ] `npm update -g hs3180/disclaude` works (requires merge first)

## Related

- Closes #587
- Replaces #592 (docs-only approach, no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)