### PR TITLE
feat(debug): add filtered message forwarding to debug channel (Issue #597)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -19,6 +19,8 @@ import type { WelcomeService } from '../platforms/feishu/welcome-service.js';
 import { getCommandRegistry } from '../nodes/commands/command-registry.js';
 import { resolvePendingInteraction } from '../mcp/feishu-context-mcp.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
+import { filteredMessageForwarder } from '../feishu/filtered-message-forwarder.js';
+import type { FilterReason } from '../config/types.js';
 import { TaskTracker } from '../utils/task-tracker.js';
 import { BaseChannel } from './base-channel.js';
 import type {
@@ -275,6 +277,12 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
         client: this.client,
         logger,
       });
+      // Initialize filtered message forwarder (Issue #597)
+      filteredMessageForwarder.setMessageSender({
+        sendText: async (chatId: string, text: string) => {
+          await this.messageSender!.sendText(chatId, text);
+        },
+      });
     }
     return this.client;
   }
@@ -382,6 +390,36 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
+   * Forward a filtered message to the debug chat.
+   * @see Issue #597
+   *
+   * @param reason - The reason the message was filtered
+   * @param messageId - The message ID
+   * @param chatId - The chat ID
+   * @param content - The message content
+   * @param userId - The user ID (optional)
+   * @param metadata - Additional metadata (optional)
+   */
+  private async forwardFilteredMessage(
+    reason: FilterReason,
+    messageId: string,
+    chatId: string,
+    content: string,
+    userId?: string,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    await filteredMessageForwarder.forward({
+      messageId,
+      chatId,
+      userId,
+      content,
+      reason,
+      metadata,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
    * Handle incoming message event from WebSocket.
    */
   private async handleMessageReceive(data: FeishuEventData): Promise<void> {
@@ -408,12 +446,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Deduplication
     if (messageLogger.isMessageProcessed(message_id)) {
       logger.debug({ messageId: message_id }, 'Skipped duplicate message');
+      await this.forwardFilteredMessage('duplicate', message_id, chat_id, content, this.extractOpenId(sender));
       return;
     }
 
     // Ignore bot messages
     if (sender?.sender_type === 'app') {
       logger.debug('Skipped bot message');
+      await this.forwardFilteredMessage('bot', message_id, chat_id, content);
       return;
     }
 
@@ -422,6 +462,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       const messageAge = Date.now() - create_time;
       if (messageAge > this.MAX_MESSAGE_AGE) {
         logger.debug({ messageId: message_id }, 'Skipped old message');
+        await this.forwardFilteredMessage('old', message_id, chat_id, content, this.extractOpenId(sender), { age: messageAge });
         return;
       }
     }
@@ -474,6 +515,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Handle text and post messages
     if (message_type !== 'text' && message_type !== 'post') {
       logger.debug({ messageType: message_type }, 'Skipped unsupported message type');
+      await this.forwardFilteredMessage('unsupported', message_id, chat_id, content, this.extractOpenId(sender), { messageType: message_type });
       return;
     }
 
@@ -502,6 +544,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     if (!text) {
       logger.debug('Skipped empty text');
+      await this.forwardFilteredMessage('empty', message_id, chat_id, content, this.extractOpenId(sender));
       return;
     }
 
@@ -594,6 +637,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
         { messageId: message_id, chatId: chat_id, chat_type },
         'Skipped group chat message without @mention (passive mode)'
       );
+      // Issue #597: Forward filtered message to debug chat
+      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
       return;
     }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -336,4 +336,14 @@ export class Config {
   static getGlobalEnv(): Record<string, string> {
     return fileConfigOnly.env || {};
   }
+
+  /**
+   * Get debug configuration for filtered message forwarding.
+   * @see Issue #597
+   *
+   * @returns Debug configuration object
+   */
+  static getDebugConfig(): import('./types.js').DebugConfig {
+    return fileConfigOnly.messaging?.debug || {};
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -192,6 +192,31 @@ export interface ChannelsConfig {
 }
 
 /**
+ * Filter reason types for message filtering.
+ * @see Issue #597
+ */
+export type FilterReason =
+  | 'duplicate'
+  | 'bot'
+  | 'old'
+  | 'unsupported'
+  | 'empty'
+  | 'passive_mode';
+
+/**
+ * Debug configuration for filtered message forwarding.
+ * @see Issue #597
+ */
+export interface DebugConfig {
+  /** Enable filtered message forwarding */
+  enabled?: boolean;
+  /** Chat ID to forward filtered messages to */
+  filterForwardChatId?: string;
+  /** Filter reasons to include in forwarding (empty = all) */
+  includeReasons?: FilterReason[];
+}
+
+/**
  * Messaging routing configuration section.
  *
  * Controls how messages are routed between admin and user chats.
@@ -226,6 +251,8 @@ export interface MessagingConfig {
       showDetails?: 'admin' | 'all';
     };
   };
+  /** Debug configuration for filtered message forwarding */
+  debug?: DebugConfig;
 }
 
 /**

--- a/src/feishu/filtered-message-forwarder.test.ts
+++ b/src/feishu/filtered-message-forwarder.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for FilteredMessageForwarder.
+ * @see Issue #597
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FilteredMessageForwarder, type MessageSender } from './filtered-message-forwarder.js';
+import type { FilterReason } from '../config/types.js';
+
+describe('FilteredMessageForwarder', () => {
+  let mockSender: MessageSender;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSender = {
+      sendText: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  describe('when disabled', () => {
+    it('should not be configured', () => {
+      const forwarder = new FilteredMessageForwarder({ enabled: false });
+      expect(forwarder.isConfigured()).toBe(false);
+    });
+
+    it('should not forward any messages', async () => {
+      const forwarder = new FilteredMessageForwarder({ enabled: false });
+      forwarder.setMessageSender(mockSender);
+
+      await forwarder.forward({
+        messageId: 'test-id',
+        chatId: 'chat-1',
+        content: 'test content',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).not.toHaveBeenCalled();
+    });
+
+    it('should not forward even if reason matches includeReasons', async () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: false,
+        filterForwardChatId: 'debug-chat',
+        includeReasons: ['passive_mode'],
+      });
+      forwarder.setMessageSender(mockSender);
+
+      await forwarder.forward({
+        messageId: 'test-id',
+        chatId: 'chat-1',
+        content: 'test content',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when enabled without filterForwardChatId', () => {
+    it('should not be configured', () => {
+      const forwarder = new FilteredMessageForwarder({ enabled: true });
+      expect(forwarder.isConfigured()).toBe(false);
+    });
+  });
+
+  describe('when fully configured', () => {
+    it('should be configured', () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat-123',
+      });
+      expect(forwarder.isConfigured()).toBe(true);
+    });
+
+    it('should forward all reasons when includeReasons is empty', async () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat-123',
+      });
+      forwarder.setMessageSender(mockSender);
+
+      const reasons: FilterReason[] = ['duplicate', 'bot', 'old', 'unsupported', 'empty', 'passive_mode'];
+
+      for (const reason of reasons) {
+        await forwarder.forward({
+          messageId: `test-${reason}`,
+          chatId: 'chat-1',
+          content: 'test content',
+          reason,
+          timestamp: Date.now(),
+        });
+      }
+
+      expect(mockSender.sendText).toHaveBeenCalledTimes(6);
+    });
+
+    it('should format message correctly', async () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat-123',
+      });
+      forwarder.setMessageSender(mockSender);
+
+      await forwarder.forward({
+        messageId: 'msg-123',
+        chatId: 'chat-456',
+        userId: 'user-789',
+        content: 'Hello world',
+        reason: 'passive_mode',
+        timestamp: 1709565600000,
+      });
+
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        'debug-chat-123',
+        expect.stringContaining('🔇')
+      );
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        'debug-chat-123',
+        expect.stringContaining('passive_mode')
+      );
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        'debug-chat-123',
+        expect.stringContaining('Hello world')
+      );
+    });
+
+    it('should truncate long content', async () => {
+      const sendText = vi.fn().mockResolvedValue(undefined);
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat-123',
+      });
+      forwarder.setMessageSender({ sendText });
+
+      const longContent = 'x'.repeat(300);
+      await forwarder.forward({
+        messageId: 'msg-123',
+        chatId: 'chat-456',
+        content: longContent,
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      const call = sendText.mock.calls[0];
+      const message = call[1] as string;
+      expect(message).toContain('...');
+    });
+  });
+
+  describe('when configured with includeReasons', () => {
+    let forwarder: FilteredMessageForwarder;
+
+    beforeEach(() => {
+      forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat-123',
+        includeReasons: ['passive_mode', 'duplicate'],
+      });
+      forwarder.setMessageSender(mockSender);
+    });
+
+    it('should forward only included reasons', async () => {
+      await forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      await forwarder.forward({
+        messageId: 'msg-2',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'duplicate',
+        timestamp: Date.now(),
+      });
+
+      await forwarder.forward({
+        messageId: 'msg-3',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'bot',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
+    });
+
+    it('should check shouldForward correctly', () => {
+      expect(forwarder.shouldForward('passive_mode')).toBe(true);
+      expect(forwarder.shouldForward('duplicate')).toBe(true);
+      expect(forwarder.shouldForward('bot')).toBe(false);
+      expect(forwarder.shouldForward('old')).toBe(false);
+    });
+  });
+
+  describe('setMessageSender', () => {
+    it('should update message sender', async () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat',
+      });
+
+      const sendText1 = vi.fn().mockResolvedValue(undefined);
+      const sendText2 = vi.fn().mockResolvedValue(undefined);
+
+      const sender1: MessageSender = { sendText: sendText1 };
+      const sender2: MessageSender = { sendText: sendText2 };
+
+      forwarder.setMessageSender(sender1);
+      await forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(sendText1).toHaveBeenCalled();
+
+      forwarder.setMessageSender(sender2);
+      await forwarder.forward({
+        messageId: 'msg-2',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(sendText2).toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle send errors gracefully', async () => {
+      const forwarder = new FilteredMessageForwarder({
+        enabled: true,
+        filterForwardChatId: 'debug-chat',
+      });
+
+      const failingSender: MessageSender = {
+        sendText: vi.fn().mockRejectedValue(new Error('Network error')),
+      };
+
+      forwarder.setMessageSender(failingSender);
+
+      // Should not throw
+      await expect(forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      })).resolves.not.toThrow();
+    });
+  });
+
+  describe('formatting', () => {
+    it('should use correct emoji for each reason', async () => {
+      const emojiMap: Record<FilterReason, string> = {
+        duplicate: '🔄',
+        bot: '🤖',
+        old: '⏰',
+        unsupported: '❓',
+        empty: '📭',
+        passive_mode: '🔇',
+      };
+
+      for (const [reason, emoji] of Object.entries(emojiMap)) {
+        const sendText = vi.fn().mockResolvedValue(undefined);
+        const forwarder = new FilteredMessageForwarder({
+          enabled: true,
+          filterForwardChatId: 'debug-chat',
+        });
+        forwarder.setMessageSender({ sendText });
+
+        await forwarder.forward({
+          messageId: `msg-${reason}`,
+          chatId: 'chat-1',
+          content: 'test',
+          reason: reason as FilterReason,
+          timestamp: Date.now(),
+        });
+        expect(sendText).toHaveBeenCalledWith(
+          'debug-chat',
+          expect.stringContaining(emoji)
+        );
+      }
+    });
+  });
+});

--- a/src/feishu/filtered-message-forwarder.ts
+++ b/src/feishu/filtered-message-forwarder.ts
@@ -1,0 +1,170 @@
+/**
+ * Filtered Message Forwarder.
+ *
+ * Forwards filtered messages to a debug chat for visibility.
+ * Useful for diagnosing why messages are being filtered in passive mode.
+ *
+ * @see Issue #597
+ */
+
+import { Config } from '../config/index.js';
+import type { FilterReason, DebugConfig } from '../config/types.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('FilteredMessageForwarder');
+
+/**
+ * Filtered message data.
+ */
+export interface FilteredMessage {
+  /** Original message ID */
+  messageId: string;
+  /** Chat ID where message was sent */
+  chatId: string;
+  /** User ID who sent the message */
+  userId?: string;
+  /** Message content (truncated for display) */
+  content: string;
+  /** Reason the message was filtered */
+  reason: FilterReason;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+  /** Timestamp of the message */
+  timestamp: number;
+}
+
+/**
+ * Message sender interface for forwarding messages.
+ */
+export interface MessageSender {
+  sendText(chatId: string, text: string): Promise<void>;
+}
+
+/**
+ * FilteredMessageForwarder handles forwarding filtered messages to a debug chat.
+ *
+ * Configuration (in disclaude.config.yaml):
+ * ```yaml
+ * messaging:
+ *   debug:
+ *     enabled: true
+ *     filterForwardChatId: "oc_xxx"  # Chat to forward filtered messages to
+ *     includeReasons:                # Only forward these reasons (empty = all)
+ *       - passive_mode
+ *       - duplicate
+ * ```
+ */
+export class FilteredMessageForwarder {
+  private enabled: boolean;
+  private forwardChatId?: string;
+  private includeReasons: Set<FilterReason>;
+  private messageSender?: MessageSender;
+
+  /**
+   * Create a new FilteredMessageForwarder.
+   * @param debugConfig - Optional debug config for testing (uses Config.getDebugConfig() by default)
+   */
+  constructor(debugConfig?: DebugConfig) {
+    const config = debugConfig ?? Config.getDebugConfig() ?? {};
+    this.enabled = config.enabled ?? false;
+    this.forwardChatId = config.filterForwardChatId;
+    this.includeReasons = new Set(config.includeReasons || []);
+
+    if (this.enabled && this.forwardChatId) {
+      logger.info(
+        { forwardChatId: this.forwardChatId, includeReasons: [...this.includeReasons] },
+        'FilteredMessageForwarder initialized'
+      );
+    }
+  }
+
+  /**
+   * Set the message sender for forwarding messages.
+   */
+  setMessageSender(sender: MessageSender): void {
+    this.messageSender = sender;
+  }
+
+  /**
+   * Check if forwarding is enabled and configured.
+   */
+  isConfigured(): boolean {
+    return this.enabled && !!this.forwardChatId;
+  }
+
+  /**
+   * Check if a specific filter reason should be forwarded.
+   */
+  shouldForward(reason: FilterReason): boolean {
+    if (!this.isConfigured()) {
+      return false;
+    }
+    // If includeReasons is empty, forward all reasons
+    if (this.includeReasons.size === 0) {
+      return true;
+    }
+    return this.includeReasons.has(reason);
+  }
+
+  /**
+   * Forward a filtered message to the debug chat.
+   *
+   * @param message - The filtered message data
+   */
+  async forward(message: FilteredMessage): Promise<void> {
+    if (!this.shouldForward(message.reason)) {
+      return;
+    }
+
+    if (!this.messageSender || !this.forwardChatId) {
+      logger.warn('MessageSender or forwardChatId not configured');
+      return;
+    }
+
+    try {
+      const formattedMessage = this.formatMessage(message);
+      await this.messageSender.sendText(this.forwardChatId, formattedMessage);
+      logger.debug({ messageId: message.messageId, reason: message.reason }, 'Forwarded filtered message');
+    } catch (error) {
+      logger.error({ err: error, messageId: message.messageId }, 'Failed to forward filtered message');
+    }
+  }
+
+  /**
+   * Format a filtered message for display.
+   */
+  private formatMessage(message: FilteredMessage): string {
+    const reasonEmoji: Record<FilterReason, string> = {
+      duplicate: '🔄',
+      bot: '🤖',
+      old: '⏰',
+      unsupported: '❓',
+      empty: '📭',
+      passive_mode: '🔇',
+    };
+
+    const emoji = reasonEmoji[message.reason] || '🚫';
+    const timestamp = new Date(message.timestamp).toISOString();
+    const truncatedContent = message.content.length > 200
+      ? message.content.slice(0, 200) + '...'
+      : message.content;
+
+    return `${emoji} **被过滤消息**
+
+| 字段 | 值 |
+|------|-----|
+| 原因 | \`${message.reason}\` |
+| 时间 | ${timestamp} |
+| 消息ID | \`${message.messageId}\` |
+| 聊天ID | \`${message.chatId}\` |
+| 用户ID | \`${message.userId || 'unknown'}\` |
+
+**内容**:
+\`\`\`
+${truncatedContent}
+\`\`\``;
+  }
+}
+
+// Singleton instance
+export const filteredMessageForwarder = new FilteredMessageForwarder();


### PR DESCRIPTION
## Summary

Add visibility for filtered messages in group chat passive mode by forwarding them to a configurable debug chat.

Fixes #597

## Changes

| File | Description |
|------|-------------|
| `src/config/types.ts` | Add `DebugConfig` and `FilterReason` types |
| `src/config/index.ts` | Add `getDebugConfig()` method |
| `src/feishu/filtered-message-forwarder.ts` | New FilteredMessageForwarder class |
| `src/feishu/filtered-message-forwarder.test.ts` | 13 tests for FilteredMessageForwarder |
| `src/channels/feishu-channel.ts` | Integrate forwarder at all filter points |

## New Configuration

```yaml
messaging:
  debug:
    enabled: true                    # Enable filtered message forwarding
    filterForwardChatId: "oc_xxx"    # Chat to forward filtered messages to
    includeReasons:                  # Only forward these reasons (empty = all)
      - passive_mode
      - duplicate
```

## Supported Filter Reasons

| Reason | Emoji | Description |
|--------|-------|-------------|
| `duplicate` | 🔄 | Duplicate message |
| `bot` | 🤖 | Bot message |
| `old` | ⏰ | Message too old |
| `unsupported` | ❓ | Unsupported message type |
| `empty` | 📭 | Empty text content |
| `passive_mode` | 🔇 | Group chat passive mode filter |

## Example Forwarded Message

```
🔇 **被过滤消息**

| 字段 | 值 |
|------|-----|
| 原因 | `passive_mode` |
| 时间 | 2026-03-04T10:43:00.000Z |
| 消息ID | `msg_123` |
| 聊天ID | `oc_xxx` |
| 用户ID | `ou_yyy` |

**内容**:
```
Hello world
```
```

## Test Results

| Metric | Value |
|--------|-------|
| New Tests | 13 passed |
| All Tests | 1464 passed |

## Test Plan

- [x] Unit tests for FilteredMessageForwarder (13 tests)
- [x] TypeScript type check passes (no new errors)
- [ ] Manual test: Configure debug forwarding and verify messages appear in debug chat
- [ ] Manual test: Verify only configured reasons are forwarded

🤖 Generated with [Claude Code](https://claude.com/claude-code)