### PR TITLE
feat(mcp): add unified messaging MCP tool (Issue #590 Phase 2)

### DIFF
--- a/src/mcp/unified-messaging-mcp.test.ts
+++ b/src/mcp/unified-messaging-mcp.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Unified Messaging MCP Tools.
+ *
+ * Issue #590 Phase 2: MCP Tools 与 Channel 解耦
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectChannel, send_message } from './unified-messaging-mcp.js';
+
+describe('detectChannel', () => {
+  it('should detect CLI channel for cli- prefix', () => {
+    expect(detectChannel('cli-12345')).toBe('cli');
+    expect(detectChannel('cli-test-session')).toBe('cli');
+  });
+
+  it('should detect Feishu channel for oc_ prefix (group chat)', () => {
+    expect(detectChannel('oc_abcd1234')).toBe('feishu');
+    expect(detectChannel('oc_xxxxxxxxxxxxxxxx')).toBe('feishu');
+  });
+
+  it('should detect Feishu channel for ou_ prefix (private chat)', () => {
+    expect(detectChannel('ou_abcd1234')).toBe('feishu');
+    expect(detectChannel('ou_xxxxxxxxxxxxxxxx')).toBe('feishu');
+  });
+
+  it('should detect REST channel for other prefixes', () => {
+    expect(detectChannel('rest-123')).toBe('rest');
+    expect(detectChannel('chat-456')).toBe('rest');
+    expect(detectChannel('default')).toBe('rest');
+    expect(detectChannel('any-other-id')).toBe('rest');
+  });
+});
+
+describe('send_message', () => {
+  // Mock send_user_feedback from feishu-context-mcp
+  vi.mock('./feishu-context-mcp.js', () => ({
+    send_user_feedback: vi.fn(),
+    setMessageSentCallback: vi.fn(),
+  }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should route CLI messages correctly', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: true,
+      message: '✅ Feedback displayed (CLI mode)',
+    });
+
+    const result = await send_message({
+      content: 'Hello CLI',
+      format: 'text',
+      chatId: 'cli-test',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe('cli');
+    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+      content: 'Hello CLI',
+      format: 'text',
+      chatId: 'cli-test',
+      parentMessageId: undefined,
+    });
+  });
+
+  it('should route Feishu messages correctly', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: true,
+      message: '✅ Feedback sent',
+    });
+
+    const result = await send_message({
+      content: 'Hello Feishu',
+      format: 'text',
+      chatId: 'oc_test123',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe('feishu');
+    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+      content: 'Hello Feishu',
+      format: 'text',
+      chatId: 'oc_test123',
+      parentMessageId: undefined,
+    });
+  });
+
+  it('should route REST messages correctly', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: true,
+      message: '✅ Feedback logged (Feishu not configured)',
+    });
+
+    const result = await send_message({
+      content: 'Hello REST',
+      format: 'text',
+      chatId: 'rest-chat-1',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe('rest');
+    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+      content: 'Hello REST',
+      format: 'text',
+      chatId: 'rest-chat-1',
+      parentMessageId: undefined,
+    });
+  });
+
+  it('should pass parentMessageId for thread replies', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: true,
+      message: '✅ Feedback sent',
+    });
+
+    const result = await send_message({
+      content: 'Reply',
+      format: 'text',
+      chatId: 'oc_test',
+      parentMessageId: 'msg_parent123',
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+      content: 'Reply',
+      format: 'text',
+      chatId: 'oc_test',
+      parentMessageId: 'msg_parent123',
+    });
+  });
+
+  it('should handle card format', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: true,
+      message: '✅ Card sent',
+    });
+
+    const cardContent = {
+      config: { wide_screen_mode: true },
+      header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
+      elements: [{ tag: 'div', text: { tag: 'plain_text', content: 'Hello' } }],
+    };
+
+    const result = await send_message({
+      content: cardContent,
+      format: 'card',
+      chatId: 'oc_test',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.channel).toBe('feishu');
+  });
+
+  it('should handle errors gracefully', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockResolvedValue({
+      success: false,
+      message: '❌ Failed: Invalid card',
+      error: 'Invalid card structure',
+    });
+
+    const result = await send_message({
+      content: 'test',
+      format: 'card',
+      chatId: 'oc_test',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid card structure');
+  });
+
+  it('should handle exceptions', async () => {
+    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
+    mockSendUserFeedback.mockRejectedValue(new Error('Network error'));
+
+    const result = await send_message({
+      content: 'test',
+      format: 'text',
+      chatId: 'oc_test',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Network error');
+    expect(result.channel).toBe('feishu');
+  });
+});

--- a/src/mcp/unified-messaging-mcp.ts
+++ b/src/mcp/unified-messaging-mcp.ts
@@ -1,0 +1,247 @@
+/**
+ * Unified Messaging MCP Tools - Channel-agnostic message sending.
+ *
+ * This module provides a unified interface for sending messages across
+ * different channels (Feishu, REST, CLI). It routes messages based on
+ * chatId prefix and uses the appropriate channel adapter.
+ *
+ * Issue #590 Phase 2: MCP Tools 与 Channel 解耦
+ *
+ * Tools provided:
+ * - send_message: Unified message sending (text or card format)
+ *
+ * Architecture:
+ * ```
+ * ┌─────────────────┐
+ * │   Chat Agent    │
+ * └────────┬────────┘
+ *          │
+ * ┌────────▼────────┐
+ * │  send_message   │  ← Unified interface
+ * │  (this module)  │
+ * └────────┬────────┘
+ *          │
+ *     ┌────┴────┬──────────┐
+ *     ▼         ▼          ▼
+ *  Feishu    REST       CLI
+ * Channel  Channel    Channel
+ * ```
+ */
+
+import { z } from 'zod';
+import { createLogger } from '../utils/logger.js';
+import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
+import { send_user_feedback, setMessageSentCallback, type MessageSentCallback } from './feishu-context-mcp.js';
+
+const logger = createLogger('UnifiedMessagingMCP');
+
+// ============================================================================
+// Channel Detection
+// ============================================================================
+
+/**
+ * Channel type based on chatId prefix.
+ */
+export type ChannelType = 'feishu' | 'cli' | 'rest';
+
+/**
+ * Detect channel type from chatId.
+ *
+ * @param chatId - Chat ID to analyze
+ * @returns Detected channel type
+ */
+export function detectChannel(chatId: string): ChannelType {
+  // CLI mode: chatId starts with 'cli-'
+  if (chatId.startsWith('cli-')) {
+    return 'cli';
+  }
+
+  // Feishu: chatId starts with 'oc_' (group) or 'ou_' (private)
+  if (chatId.startsWith('oc_') || chatId.startsWith('ou_')) {
+    return 'feishu';
+  }
+
+  // REST or other: treat as REST channel
+  return 'rest';
+}
+
+// ============================================================================
+// Unified send_message Tool
+// ============================================================================
+
+/**
+ * Result from send_message tool.
+ */
+export interface SendMessageResult {
+  success: boolean;
+  message: string;
+  channel: ChannelType;
+  error?: string;
+}
+
+/**
+ * Unified message sending tool.
+ *
+ * Routes to the appropriate channel based on chatId:
+ * - Feishu (oc_*, ou_*): Uses Feishu API
+ * - CLI (cli-*): Logs to console
+ * - REST (other): Graceful degradation
+ *
+ * @param params - Tool parameters
+ * @returns Result with success status and channel info
+ */
+export async function send_message(params: {
+  content: string | Record<string, unknown>;
+  format: 'text' | 'card';
+  chatId: string;
+  parentMessageId?: string;
+}): Promise<SendMessageResult> {
+  const { content, format, chatId, parentMessageId } = params;
+
+  // Detect channel
+  const channel = detectChannel(chatId);
+
+  logger.info({
+    chatId,
+    channel,
+    format,
+    contentType: typeof content,
+    hasParent: !!parentMessageId,
+  }, 'send_message called');
+
+  try {
+    // Use the existing send_user_feedback implementation
+    // It already handles graceful degradation for non-Feishu channels
+    const result = await send_user_feedback({
+      content,
+      format,
+      chatId,
+      parentMessageId,
+    });
+
+    return {
+      success: result.success,
+      message: result.message,
+      channel,
+      error: result.error,
+    };
+
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error({
+      err: error,
+      chatId,
+      channel,
+      format,
+    }, 'send_message failed');
+
+    return {
+      success: false,
+      message: `❌ Failed to send message via ${channel}: ${errorMessage}`,
+      channel,
+      error: errorMessage,
+    };
+  }
+}
+
+// ============================================================================
+// Tool Definitions for SDK
+// ============================================================================
+
+/**
+ * Helper to create a successful tool result.
+ */
+function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{ type: 'text', text }],
+  };
+}
+
+/**
+ * Unified messaging tool definitions for Agent SDK.
+ *
+ * These tools provide a channel-agnostic interface for message sending,
+ * automatically routing to the appropriate channel based on chatId.
+ */
+export const unifiedMessagingToolDefinitions: InlineToolDefinition[] = [
+  {
+    name: 'send_message',
+    description: `Send a message to a chat. Automatically routes to the correct channel based on chatId.
+
+**Channel Detection:**
+- Feishu (oc_*, ou_*): Full support for text and cards
+- CLI (cli-*): Logs to console
+- REST (other): Graceful degradation
+
+**Format Options:**
+- "text": Plain text message
+- "card": Interactive card (Feishu only, falls back to text on other channels)
+
+**Thread Support:**
+When parentMessageId is provided, the message is sent as a reply to that message.
+
+**Card Format (Feishu only):**
+A valid card must include:
+- config: Object with optional "wide_screen_mode"
+- header: Object with "title" and "template" color
+- elements: Array of element objects
+
+**Example Card:**
+\`\`\`json
+{
+  "config": {"wide_screen_mode": true},
+  "header": {"title": {"tag": "plain_text", "content": "Title"}, "template": "blue"},
+  "elements": [
+    {"tag": "markdown", "content": "**Bold** text"},
+    {"tag": "hr"},
+    {"tag": "div", "text": {"tag": "plain_text", "content": "Content"}}
+  ]
+}
+\`\`\``,
+    parameters: z.object({
+      content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. String for text, object for cards.'),
+      format: z.enum(['text', 'card']).describe('Format: "text" for plain text, "card" for interactive cards (Feishu only).'),
+      chatId: z.string().describe('Chat ID (determines channel routing)'),
+      parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies'),
+    }),
+    handler: async ({ content, format, chatId, parentMessageId }) => {
+      try {
+        const result = await send_message({ content, format, chatId, parentMessageId });
+        if (result.success) {
+          return toolSuccess(`${result.message} (via ${result.channel})`);
+        } else {
+          return toolSuccess(`⚠️ ${result.message}`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Message failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+];
+
+/**
+ * SDK MCP Server factory for unified messaging tools.
+ *
+ * **Usage:**
+ * ```typescript
+ * query({
+ *   prompt: "...",
+ *   options: {
+ *     mcpServers: {
+ *       'unified-messaging': createUnifiedMessagingMcpServer(),
+ *     },
+ *   },
+ * })
+ * ```
+ */
+export function createUnifiedMessagingMcpServer() {
+  return getProvider().createMcpServer({
+    type: 'inline',
+    name: 'unified-messaging',
+    version: '1.0.0',
+    tools: unifiedMessagingToolDefinitions,
+  });
+}
+
+// Re-export callback setter for compatibility
+export { setMessageSentCallback, type MessageSentCallback };


### PR DESCRIPTION
## Summary

Add `send_message` tool that provides a unified, channel-agnostic interface for sending messages. This implements Phase 2 of Issue #590.

The tool automatically routes messages to the correct channel based on chatId prefix:
- Feishu (oc_*, ou_*): Full support for text and cards
- CLI (cli-*): Logs to console
- REST (other): Graceful degradation

## Changes

| File | Description |
|------|-------------|
| `src/mcp/unified-messaging-mcp.ts` | Unified messaging tool implementation |
| `src/mcp/unified-messaging-mcp.test.ts` | 11 tests for the new module |

## Architecture

```
┌─────────────────┐
│   Chat Agent    │
└────────┬────────┘
         │
┌────────▼────────┐
│  send_message   │  ← Unified interface
│  (this module)  │
└────────┬────────┘
         │
    ┌────┴────┬──────────┐
    ▼         ▼          ▼
 Feishu    REST       CLI
 Channel  Channel    Channel
```

## Features

### Channel Detection
- `cli-*` → CLI channel (console logging)
- `oc_*`, `ou_*` → Feishu channel (full API support)
- Other → REST channel (graceful degradation)

### Backward Compatibility
- Existing `send_user_feedback` tool remains unchanged
- New `send_message` tool uses existing implementation internally
- No breaking changes to existing code

## Test Results

| Metric | Value |
|--------|-------|
| New Tests | 11 passed |
| MCP Tests | 63 passed |
| All Tests | 1492 passed |

## Test Plan

- [x] Unit tests for channel detection
- [x] Unit tests for message routing
- [x] Unit tests for error handling
- [x] TypeScript type check passes (no new errors)
- [ ] Manual test: Use send_message in CLI mode
- [ ] Manual test: Use send_message in Feishu channel

Fixes #590 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)