### PR TITLE
fix: resolve ESLint errors in filtered-message-forwarder and chat-ops

### DIFF
--- a/src/feishu/filtered-message-forwarder.test.ts
+++ b/src/feishu/filtered-message-forwarder.test.ts
@@ -143,8 +143,7 @@ describe('FilteredMessageForwarder', () => {
         timestamp: Date.now(),
       });
 
-      const call = sendText.mock.calls[0];
-      const message = call[1] as string;
+      const [, message] = sendText.mock.calls[0] as [unknown, string];
       expect(message).toContain('...');
     });
   });

--- a/src/feishu/filtered-message-forwarder.ts
+++ b/src/feishu/filtered-message-forwarder.ts
@@ -146,7 +146,7 @@ export class FilteredMessageForwarder {
     const emoji = reasonEmoji[message.reason] || '🚫';
     const timestamp = new Date(message.timestamp).toISOString();
     const truncatedContent = message.content.length > 200
-      ? message.content.slice(0, 200) + '...'
+      ? `${message.content.slice(0, 200)}...`
       : message.content;
 
     return `${emoji} **被过滤消息**

--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -110,7 +110,7 @@ describe('ChatOps', () => {
         })
       );
       // Verify the name contains date pattern
-      const callArgs = mockCreate.mock.calls[0][0];
+      const [[callArgs]] = mockCreate.mock.calls as [[{ data: { name: string } }]];
       expect(callArgs.data.name).toMatch(/讨论组 \d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
     });
 


### PR DESCRIPTION
## Summary

Fixes ESLint errors that are causing CI failures on the main branch.

## Changes

| File | Change |
|------|--------|
| `src/feishu/filtered-message-forwarder.ts` | Use template literal instead of string concatenation |
| `src/feishu/filtered-message-forwarder.test.ts` | Use array destructuring |
| `src/platforms/feishu/chat-ops.test.ts` | Use nested array destructuring |

## Error Details

The following ESLint errors were blocking CI:
1. `prefer-template` - String concatenation should use template literals
2. `prefer-destructuring` - Array access should use destructuring

## Test Results

- TypeScript: ✅ Pass
- ESLint: ✅ Pass (0 errors, 70 warnings)
- Related Tests: ✅ 28 passed

## Context

These errors were introduced by recently merged PRs (#608, #610, #611, #613, #615) and were causing all CI runs on main to fail at the lint stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)