### PR TITLE
fix(task-state): use updatedAt for stable history sorting (Issue #624)

### DIFF
--- a/src/utils/task-state-manager.ts
+++ b/src/utils/task-state-manager.ts
@@ -360,9 +360,17 @@ export class TaskStateManager {
         }
       }
 
-      // Sort by creation date (newest first) and limit
+      // Sort by update date (newest first), use id as tiebreaker for stability
+      // Issue #624: Use updatedAt for history order (most recently completed first)
       return tasks
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .sort((a, b) => {
+          const timeDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+          if (timeDiff !== 0) {
+            return timeDiff;
+          }
+          // Use id as tiebreaker (id contains timestamp: task_${Date.now()}_${random})
+          return b.id.localeCompare(a.id);
+        })
         .slice(0, limit);
     } catch {
       return [];


### PR DESCRIPTION
## Summary

Fixes unstable sorting in `listTaskHistory()` that caused intermittent test failures in CI.

## Problem

The `listTaskHistory` function sorted tasks by `createdAt`. When tasks are created in rapid succession (within the same millisecond), the sorting becomes unstable because:
1. `Date.now()` has millisecond precision
2. JavaScript's `sort()` is not guaranteed to be stable

This caused the test `should list completed tasks` to fail intermittently in CI, expecting "Task 2" (most recent) first but getting "Task 1".

## Solution

| Before | After |
|--------|-------|
| Sort by `createdAt` only | Sort by `updatedAt` (primary), `id` (tiebreaker) |

**Why `updatedAt`?**
- More semantically correct for "history" - shows most recently **completed** tasks first
- Updated when task status changes (complete/cancel/error), ensuring different timestamps

**Why `id` as tiebreaker?**
- Task IDs contain `Date.now()` timestamp: `task_${Date.now()}_${random}`
- Provides deterministic ordering even when timestamps are equal

## Changes

| File | Description |
|------|-------------|
| `src/utils/task-state-manager.ts` | Update `listTaskHistory` sorting logic |

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| ESLint | ✅ Pass |
| TaskStateManager Tests | 27 passed |
| All Tests | 1473 passed (5 pre-existing failures unrelated to this change) |

## Test Plan

- [x] Unit tests for `listTaskHistory` pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] CI passes (will verify after merge)

Fixes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)