### PR TITLE
fix: use array destructuring in chat-ops.test.ts

### DIFF
--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -110,7 +110,7 @@ describe('ChatOps', () => {
         })
       );
       // Verify the name contains date pattern
-      const callArgs = mockCreate.mock.calls[0][0];
+      const [[callArgs]] = mockCreate.mock.calls;
       expect(callArgs.data.name).toMatch(/讨论组 \d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
     });
 


### PR DESCRIPTION
## Summary
- Fix ESLint `prefer-destructuring` error at line 113 in `chat-ops.test.ts`
- Changed `const callArgs = mockCreate.mock.calls[0][0]` to `const [[callArgs]] = mockCreate.mock.calls`

## Test plan
- [x] ESLint 检查通过
- [x] 所有 15 个单元测试通过 (`vitest run src/platforms/feishu/chat-ops.test.ts`)

Fixes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)