### PR TITLE
fix(test): add getDebugConfig mock to fix test failures (Issue #626)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -39,6 +39,7 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getDebugConfig: vi.fn().mockReturnValue({}),
   },
 }));
 

--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -50,6 +50,7 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getDebugConfig: vi.fn().mockReturnValue({}),
   },
 }));
 


### PR DESCRIPTION
## Summary
- 修复了两个测试文件中 Config mock 缺少 `getDebugConfig` 方法的问题
- PR #614 引入的 `FilteredMessageForwarder` 在模块初始化时调用 `Config.getDebugConfig()`
- 测试文件 mock 了 Config 类但缺少此方法，导致 "Config.getDebugConfig is not a function" 错误

## Changes
- `src/channels/feishu-channel-mention.test.ts`: 添加 `getDebugConfig: vi.fn().mockReturnValue({})`
- `src/channels/feishu-channel-passive-mode.test.ts`: 添加 `getDebugConfig: vi.fn().mockReturnValue({})`

## Test Results
```
 ✓ src/channels/feishu-channel-passive-mode.test.ts (25 tests) 14ms
 ✓ src/channels/feishu-channel-mention.test.ts (8 tests) 4ms

 Test Files  2 passed (2)
      Tests  33 passed (33)
```

Fixes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)