### PR TITLE
feat(suggestions): add interactive suggestion cards after task completion (Issue #470)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -41,7 +41,20 @@ agent:
   # Default: 1
   maxConcurrentTasks: 1
 
-# -----------------------------------------------------------------------------
+  # Task completion suggestions ( Issue #470)
+  # Show follow-up suggestions after a task is completed
+  suggestions:
+    # Enable/disable suggestion feature
+    # Default: true
+    enabled: true
+
+    # Maximum number of suggestions to show
+    # default: 4
+    maxSuggestions: 4
+
+    # Show suggestions after all tasks
+    # default: true
+    showAfterTasks: true# -----------------------------------------------------------------------------
 # Feishu/Lark Platform Configuration
 # -----------------------------------------------------------------------------
 feishu:

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -47,6 +47,10 @@ import { MessageChannel } from './message-channel.js';
 import { SessionManager } from './session-manager.js';
 import { RestartManager } from './restart-manager.js';
 import { ConversationOrchestrator } from '../conversation/index.js';
+import {
+  initTaskSuggestionService,
+  getTaskSuggestionService,
+} from './task-suggestion.js';
 
 /**
  * Callback functions for platform-specific operations.
@@ -159,6 +163,15 @@ export class Pilot extends BaseAgent implements ChatAgent {
       initialBackoffMs: 5000,  // Start with 5 seconds
       maxBackoffMs: 60000,     // Max 1 minute
     });
+
+    // Initialize task suggestion service (Issue #470)
+    const suggestionConfig = Config.getSuggestionsConfig();
+    if (suggestionConfig.enabled) {
+      // Only initialize if not already initialized (singleton)
+      if (!getTaskSuggestionService()) {
+        initTaskSuggestionService(suggestionConfig);
+      }
+    }
   }
 
   protected getAgentName(): string {
@@ -481,6 +494,16 @@ export class Pilot extends BaseAgent implements ChatAgent {
 
           // Record success to reset restart state
           this.restartManager.recordSuccess(chatId);
+
+          // Generate task suggestions card (Issue #470)
+          const suggestionService = getTaskSuggestionService();
+          if (suggestionService && suggestionService.isEnabled() && parsed.content) {
+            const suggestionCard = suggestionService.generateFromResult(parsed.content);
+            if (suggestionCard) {
+              const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);
+              await this.callbacks.sendCard(chatId, suggestionCard, 'Task suggestions', threadRoot);
+            }
+          }
 
           if (this.callbacks.onDone) {
             const threadRoot = this.conversationOrchestrator.getThreadRoot(chatId);

--- a/src/agents/task-suggestion.test.ts
+++ b/src/agents/task-suggestion.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for Task Suggestion Service.
+ *
+ * Issue #470: Task completion follow-up suggestions
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  TaskSuggestionService,
+  initTaskSuggestionService,
+  getTaskSuggestionService,
+  resetTaskSuggestionService,
+  isSuggestionAction,
+  type SuggestionActionValue,
+} from './task-suggestion.js';
+
+describe('TaskSuggestionService', () => {
+  let service: TaskSuggestionService;
+
+  beforeEach(() => {
+    resetTaskSuggestionService();
+    service = new TaskSuggestionService();
+  });
+
+  afterEach(() => {
+    resetTaskSuggestionService();
+  });
+
+  describe('constructor', () => {
+    it('should use default config when no config provided', () => {
+      expect(service.isEnabled()).toBe(true);
+    });
+
+    it('should merge custom config with defaults', () => {
+      const customService = new TaskSuggestionService({ maxSuggestions: 2 });
+      expect(customService.isEnabled()).toBe(true);
+    });
+
+    it('should respect enabled: false', () => {
+      const disabledService = new TaskSuggestionService({ enabled: false });
+      expect(disabledService.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('detectTaskType', () => {
+    it('should detect file-analysis task type', () => {
+      expect(service.detectTaskType('分析了 src 目录的代码结构')).toBe('file-analysis');
+      expect(service.detectTaskType('Analyzed the directory structure')).toBe('file-analysis');
+    });
+
+    it('should detect code-modification task type', () => {
+      expect(service.detectTaskType('修改了配置文件')).toBe('code-modification');
+      expect(service.detectTaskType('Updated the module')).toBe('code-modification');
+      expect(service.detectTaskType('重构了代码')).toBe('code-modification');
+    });
+
+    it('should detect bug-fix task type', () => {
+      expect(service.detectTaskType('修复了登录 bug')).toBe('bug-fix');
+      expect(service.detectTaskType('Fixed the error in parser')).toBe('bug-fix');
+      expect(service.detectTaskType('解决了问题')).toBe('bug-fix');
+    });
+
+    it('should detect information-query task type', () => {
+      expect(service.detectTaskType('查询了用户信息')).toBe('information-query');
+      expect(service.detectTaskType('Search for related files')).toBe('information-query');
+      expect(service.detectTaskType('查找到了配置')).toBe('information-query');
+    });
+
+    it('should detect file-operation task type', () => {
+      expect(service.detectTaskType('创建了新配置')).toBe('file-operation');
+      expect(service.detectTaskType('Deleted the temp')).toBe('file-operation');
+      expect(service.detectTaskType('Copy config file')).toBe('file-operation');
+    });
+
+    it('should detect test-execution task type', () => {
+      expect(service.detectTaskType('运行了测试')).toBe('test-execution');
+      expect(service.detectTaskType('Test passed')).toBe('test-execution');
+      expect(service.detectTaskType('vitest results')).toBe('test-execution');
+    });
+
+    it('should detect documentation task type', () => {
+      expect(service.detectTaskType('生成了说明文档')).toBe('documentation');
+      expect(service.detectTaskType('Generated readme.md')).toBe('documentation');
+    });
+
+    it('should return general for unknown content', () => {
+      expect(service.detectTaskType('Hello world')).toBe('general');
+      expect(service.detectTaskType('')).toBe('general');
+    });
+  });
+
+  describe('generateSuggestionCard', () => {
+    it('should return null when disabled', () => {
+      const disabledService = new TaskSuggestionService({ enabled: false });
+      const result = disabledService.generateSuggestionCard({ taskType: 'file-analysis' });
+      expect(result).toBeNull();
+    });
+
+    it('should generate card for file-analysis', () => {
+      const result = service.generateSuggestionCard({ taskType: 'file-analysis' });
+      expect(result).not.toBeNull();
+      expect(result?.header?.title?.content).toContain('接下来你可以');
+      expect(result?.elements.length).toBeGreaterThan(0);
+    });
+
+    it('should generate card for code-modification', () => {
+      const result = service.generateSuggestionCard({ taskType: 'code-modification' });
+      expect(result).not.toBeNull();
+      expect(result?.header?.title?.content).toContain('接下来你可以');
+    });
+
+    it('should generate card for bug-fix', () => {
+      const result = service.generateSuggestionCard({ taskType: 'bug-fix' });
+      expect(result).not.toBeNull();
+      expect(result?.header?.title?.content).toContain('接下来你可以');
+    });
+
+    it('should respect maxSuggestions config', () => {
+      const customService = new TaskSuggestionService({ maxSuggestions: 2 });
+      const result = customService.generateSuggestionCard({ taskType: 'file-analysis' });
+
+      // Count the number of buttons in the card
+      let buttonCount = 0;
+      for (const element of result?.elements || []) {
+        if (element.tag === 'action') {
+          buttonCount += element.actions.length;
+        }
+      }
+      expect(buttonCount).toBeLessThanOrEqual(2);
+    });
+
+    it('should generate card with correct structure', () => {
+      const result = service.generateSuggestionCard({ taskType: 'general' });
+
+      // Check card structure
+      expect(result?.config?.wide_screen_mode).toBe(true);
+      expect(result?.header?.template).toBe('blue');
+
+      // Should have divider and action groups
+      const hasDivider = result?.elements.some((e) => e.tag === 'hr');
+      expect(hasDivider).toBe(true);
+
+      const hasAction = result?.elements.some((e) => e.tag === 'action');
+      expect(hasAction).toBe(true);
+    });
+  });
+
+  describe('generateFromResult', () => {
+    it('should return null when disabled', () => {
+      const disabledService = new TaskSuggestionService({ enabled: false });
+      const result = disabledService.generateFromResult('分析完成');
+      expect(result).toBeNull();
+    });
+
+    it('should auto-detect task type and generate card', () => {
+      const result = service.generateFromResult('分析了 src 目录结构');
+      expect(result).not.toBeNull();
+      expect(result?.header?.title?.content).toContain('接下来你可以');
+    });
+
+    it('should generate card for general content', () => {
+      const result = service.generateFromResult('一些随机内容');
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe('button value format', () => {
+    it('should contain action and prompt in button value', () => {
+      const result = service.generateSuggestionCard({ taskType: 'file-analysis' });
+      expect(result).not.toBeNull();
+
+      // Find an action element
+      const actionElement = result?.elements.find((e) => e.tag === 'action');
+      expect(actionElement).toBeDefined();
+
+      if (actionElement && actionElement.tag === 'action') {
+        const button = actionElement.actions[0];
+        if (button.tag === 'button') {
+          // Button value is a JSON string
+          const valueStr = button.value as unknown as string;
+          expect(typeof valueStr).toBe('string');
+          const value = JSON.parse(valueStr as string) as { action?: string; prompt?: string };
+          expect(value.action).toBe('suggestion');
+          expect(typeof value.prompt).toBe('string');
+        }
+      }
+    });
+  });
+
+  describe('Global Instance Management', () => {
+    it('should initialize and get global service', () => {
+      resetTaskSuggestionService();
+      expect(getTaskSuggestionService()).toBeNull();
+
+      const svc = initTaskSuggestionService({ maxSuggestions: 3 });
+      expect(getTaskSuggestionService()).toBe(svc);
+      expect(svc).toBeInstanceOf(TaskSuggestionService);
+    });
+
+    it('should reset global service', () => {
+      initTaskSuggestionService();
+      expect(getTaskSuggestionService()).not.toBeNull();
+
+      resetTaskSuggestionService();
+      expect(getTaskSuggestionService()).toBeNull();
+    });
+  });
+});
+
+describe('isSuggestionAction', () => {
+  it('should return true for valid suggestion action', () => {
+    const value: SuggestionActionValue = {
+      action: 'suggestion',
+      prompt: 'test prompt',
+      description: 'test description',
+    };
+    expect(isSuggestionAction(value)).toBe(true);
+  });
+
+  it('should return false for non-suggestion action', () => {
+    expect(isSuggestionAction({ action: 'other' })).toBe(false);
+    expect(isSuggestionAction(null)).toBe(false);
+    expect(isSuggestionAction(undefined)).toBe(false);
+    expect(isSuggestionAction('string')).toBe(false);
+    expect(isSuggestionAction(123)).toBe(false);
+  });
+
+  it('should return false for object without prompt', () => {
+    expect(isSuggestionAction({ action: 'suggestion' })).toBe(false);
+  });
+});

--- a/src/agents/task-suggestion.ts
+++ b/src/agents/task-suggestion.ts
@@ -1,0 +1,345 @@
+/**
+ * Task Suggestion Service - Generates interactive suggestion cards after task completion.
+ *
+ * Issue #470: Task completion follow-up suggestions
+ *
+ * Instead of text suggestions, this service generates interactive cards with buttons.
+ * When a user clicks a button, the associated prompt is sent to the Agent for execution.
+ */
+
+import { createLogger } from '../utils/logger.js';
+import {
+  buildCard,
+  buildDiv,
+  buildDivider,
+  buildActionGroup,
+  buildButton,
+  type BuiltCard,
+  type ButtonAction,
+} from '../platforms/feishu/card-builders/interactive-card-builder.js';
+
+const logger = createLogger('TaskSuggestion');
+
+/**
+ * Task types that can be detected from result content.
+ */
+export type TaskType =
+  | 'file-analysis'
+  | 'code-modification'
+  | 'bug-fix'
+  | 'information-query'
+  | 'file-operation'
+  | 'test-execution'
+  | 'documentation'
+  | 'general';
+
+/**
+ * A single suggestion with prompt to execute.
+ */
+export interface Suggestion {
+  /** Emoji icon for the suggestion */
+  emoji: string;
+  /** Short description */
+  description: string;
+  /** Prompt to send to Agent when clicked */
+  prompt: string;
+}
+
+/**
+ * Task suggestion configuration.
+ */
+export interface TaskSuggestionConfig {
+  /** Enable/disable suggestion feature */
+  enabled?: boolean;
+  /** Maximum number of suggestions to show (default: 4) */
+  maxSuggestions?: number;
+  /** Show suggestions after all tasks (default: true) */
+  showAfterTasks?: boolean;
+}
+
+/**
+ * Context for generating suggestions.
+ */
+export interface SuggestionContext {
+  /** Detected task type */
+  taskType: TaskType;
+  /** Original result content (for context-aware suggestions) */
+  context?: string;
+}
+
+/**
+ * Keywords for detecting task types.
+ */
+const TASK_TYPE_KEYWORDS: Record<TaskType, string[]> = {
+  'file-analysis': ['分析', '结构', '目录', '代码结构', 'analyze', 'structure', 'directory'],
+  'code-modification': ['修改', '更新', '重构', 'modify', 'update', 'refactor', 'edit'],
+  'bug-fix': ['修复', 'fix', 'bug', '问题', 'error', '解决'],
+  'information-query': ['查询', '搜索', '查找', 'query', 'search', 'find', '获取'],
+  'file-operation': ['创建', '删除', '移动', '复制', 'create', 'delete', 'move', 'copy'],
+  'test-execution': ['测试', 'test', 'spec', 'vitest', 'jest'],
+  documentation: ['文档', 'document', 'readme', 'md', '说明'],
+  general: [],
+};
+
+/**
+ * Suggestion rules per task type.
+ * Each suggestion includes an emoji, description, and the prompt to execute.
+ */
+const SUGGESTION_RULES: Record<TaskType, Suggestion[]> = {
+  'file-analysis': [
+    { emoji: '📝', description: '生成代码结构文档', prompt: '请为刚才分析的代码结构生成一份文档' },
+    { emoji: '🔍', description: '分析依赖关系', prompt: '请分析这些文件的依赖关系' },
+    { emoji: '📊', description: '统计代码行数', prompt: '请统计刚才分析的代码的行数和文件分布' },
+    { emoji: '🐛', description: '检查代码问题', prompt: '请检查刚才分析的代码是否存在潜在问题' },
+  ],
+  'code-modification': [
+    { emoji: '🧪', description: '运行测试验证', prompt: '请运行相关测试来验证修改' },
+    { emoji: '📝', description: '提交更改', prompt: '请帮我提交这些更改' },
+    { emoji: '📄', description: '更新文档', prompt: '请更新相关文档以反映这些修改' },
+    { emoji: '🔍', description: '检查影响范围', prompt: '请分析这些修改可能影响的其他代码' },
+  ],
+  'bug-fix': [
+    { emoji: '✅', description: '验证修复', prompt: '请验证这个修复是否解决了问题' },
+    { emoji: '🧪', description: '添加测试用例', prompt: '请为这个修复添加测试用例以防止回归' },
+    { emoji: '📄', description: '更新变更日志', prompt: '请更新变更日志记录这个修复' },
+    { emoji: '🔍', description: '检查类似问题', prompt: '请检查代码中是否存在类似的问题' },
+  ],
+  'information-query': [
+    { emoji: '💾', description: '保存结果', prompt: '请将查询结果保存到文件' },
+    { emoji: '📊', description: '生成报告', prompt: '请根据查询结果生成一份报告' },
+    { emoji: '📤', description: '分享结果', prompt: '请帮我分享这些查询结果' },
+    { emoji: '🔍', description: '深入分析', prompt: '请对查询结果进行更深入的分析' },
+  ],
+  'file-operation': [
+    { emoji: '✅', description: '验证操作', prompt: '请验证文件操作是否成功完成' },
+    { emoji: '📝', description: '更新相关引用', prompt: '请检查并更新相关的文件引用' },
+    { emoji: '🧪', description: '运行测试', prompt: '请运行测试确保操作没有破坏其他功能' },
+    { emoji: '📄', description: '提交更改', prompt: '请帮我提交这些文件操作' },
+  ],
+  'test-execution': [
+    { emoji: '🐛', description: '分析失败用例', prompt: '请分析失败的测试用例' },
+    { emoji: '📊', description: '生成测试报告', prompt: '请生成测试结果报告' },
+    { emoji: '🔧', description: '修复失败测试', prompt: '请帮我修复失败的测试' },
+    { emoji: '🚀', description: '运行全部测试', prompt: '请运行完整的测试套件' },
+  ],
+  documentation: [
+    { emoji: '📤', description: '发布文档', prompt: '请帮我发布这份文档' },
+    { emoji: '🔍', description: '检查完整性', prompt: '请检查文档是否完整' },
+    { emoji: '🌐', description: '翻译文档', prompt: '请将文档翻译成英文' },
+    { emoji: '✏️', description: '改进文档', prompt: '请改进文档的可读性' },
+  ],
+  general: [
+    { emoji: '🔄', description: '继续执行', prompt: '请继续执行' },
+    { emoji: '📝', description: '总结结果', prompt: '请总结刚才的操作结果' },
+    { emoji: '💾', description: '保存结果', prompt: '请保存操作结果' },
+    { emoji: '❓', description: '提供帮助', prompt: '请告诉我接下来可以做什么' },
+  ],
+};
+
+/**
+ * Action value for suggestion button clicks.
+ * This is serialized as JSON in the button's value field.
+ */
+export interface SuggestionActionValue {
+  /** Action type: 'suggestion' */
+  action: 'suggestion';
+  /** The prompt to send to the Agent */
+  prompt: string;
+  /** The description of the suggestion (for logging) */
+  description: string;
+}
+
+/**
+ * Task Suggestion Service - Generates follow-up suggestions after task completion.
+ *
+ * This service:
+ * 1. Detects task type from result content
+ * 2. Generates an interactive card with suggestion buttons
+ * 3. Each button contains a prompt that will be sent to the Agent when clicked
+ */
+export class TaskSuggestionService {
+  private readonly config: Required<TaskSuggestionConfig>;
+
+  constructor(config?: TaskSuggestionConfig) {
+    this.config = {
+      enabled: config?.enabled ?? true,
+      maxSuggestions: config?.maxSuggestions ?? 4,
+      showAfterTasks: config?.showAfterTasks ?? true,
+    };
+    logger.info({ config: this.config }, 'TaskSuggestionService initialized');
+  }
+
+  /**
+   * Check if suggestions are enabled.
+   */
+  isEnabled(): boolean {
+    return this.config.enabled && this.config.showAfterTasks;
+  }
+
+  /**
+   * Detect task type from message content.
+   *
+   * @param content - The result message content
+   * @returns Detected task type
+   */
+  detectTaskType(content: string): TaskType {
+    const lowerContent = content.toLowerCase();
+
+    // Check each task type's keywords
+    for (const [type, keywords] of Object.entries(TASK_TYPE_KEYWORDS)) {
+      if (type === 'general') {
+        continue; // Skip general, it's the fallback
+      }
+
+      for (const keyword of keywords) {
+        if (lowerContent.includes(keyword.toLowerCase())) {
+          return type as TaskType;
+        }
+      }
+    }
+
+    return 'general';
+  }
+
+  /**
+   * Build suggestion buttons for a card.
+   *
+   * @param suggestions - Suggestions to build buttons for
+   * @returns Array of button actions
+   */
+  private buildSuggestionButtons(suggestions: Suggestion[]): ButtonAction[] {
+    return suggestions.map((s) => {
+      const actionValue: SuggestionActionValue = {
+        action: 'suggestion',
+        prompt: s.prompt,
+        description: s.description,
+      };
+
+      // Build button directly to control the value format
+      // The value needs to be a JSON string for the interaction handler to parse
+      const button: ButtonAction = {
+        tag: 'button',
+        text: { tag: 'plain_text', content: `${s.emoji} ${s.description}` },
+        type: 'default',
+        value: JSON.stringify(actionValue),
+      };
+
+      return button;
+    });
+  }
+
+  /**
+   * Generate an interactive suggestion card based on task completion context.
+   *
+   * @param context - Context about the completed task
+   * @returns Built card object, or null if disabled
+   */
+  generateSuggestionCard(context: SuggestionContext): BuiltCard | null {
+    if (!this.config.enabled) {
+      return null;
+    }
+
+    const suggestions = SUGGESTION_RULES[context.taskType] || SUGGESTION_RULES.general;
+    const limitedSuggestions = suggestions.slice(0, this.config.maxSuggestions);
+
+    if (limitedSuggestions.length === 0) {
+      return null;
+    }
+
+    // Build buttons in groups of 2 (for better layout)
+    const buttons = this.buildSuggestionButtons(limitedSuggestions);
+
+    // Create card with title, divider, and action buttons
+    const card = buildCard({
+      header: {
+        title: '💡 接下来你可以',
+        template: 'blue',
+      },
+      elements: [
+        buildDivider(),
+        // Add buttons as action groups (2 per row for better mobile experience)
+        ...this.groupButtons(buttons),
+      ],
+    });
+
+    logger.debug(
+      { taskType: context.taskType, suggestionCount: limitedSuggestions.length },
+      'Generated suggestion card'
+    );
+
+    return card;
+  }
+
+  /**
+   * Group buttons into action groups (2 per row).
+   *
+   * @param buttons - Buttons to group
+   * @returns Array of action group elements
+   */
+  private groupButtons(buttons: ButtonAction[]): ReturnType<typeof buildActionGroup>[] {
+    const groups: ReturnType<typeof buildActionGroup>[] = [];
+
+    for (let i = 0; i < buttons.length; i += 2) {
+      const rowButtons = buttons.slice(i, i + 2);
+      groups.push(buildActionGroup(rowButtons));
+    }
+
+    return groups;
+  }
+
+  /**
+   * Generate suggestions from result content (auto-detect task type).
+   *
+   * @param resultContent - The result message content
+   * @returns Built card object, or null if disabled
+   */
+  generateFromResult(resultContent: string): BuiltCard | null {
+    if (!this.config.enabled) {
+      return null;
+    }
+
+    const taskType = this.detectTaskType(resultContent);
+    return this.generateSuggestionCard({ taskType, context: resultContent });
+  }
+}
+
+// ============================================================================
+// Global Instance Management
+// ============================================================================
+
+let globalTaskSuggestionService: TaskSuggestionService | null = null;
+
+/**
+ * Initialize the global task suggestion service.
+ */
+export function initTaskSuggestionService(config?: TaskSuggestionConfig): TaskSuggestionService {
+  globalTaskSuggestionService = new TaskSuggestionService(config);
+  logger.info('Global TaskSuggestionService initialized');
+  return globalTaskSuggestionService;
+}
+
+/**
+ * Get the global task suggestion service.
+ * Returns null if not initialized (suggestions disabled).
+ */
+export function getTaskSuggestionService(): TaskSuggestionService | null {
+  return globalTaskSuggestionService;
+}
+
+/**
+ * Reset the global task suggestion service (for testing).
+ */
+export function resetTaskSuggestionService(): void {
+  globalTaskSuggestionService = null;
+}
+
+/**
+ * Check if an action value is a suggestion action.
+ */
+export function isSuggestionAction(value: unknown): value is SuggestionActionValue {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return v.action === 'suggestion' && typeof v.prompt === 'string';
+}

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -817,23 +817,48 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     try {
       // Try to handle via InteractionManager
       const handled = await this.interactionManager.handleAction(event, async (defaultEvent) => {
-        // Default handler: emit as interaction message
-        // Issue #525: Use button text to generate user-friendly prompt
-        const buttonText = defaultEvent.action.text || defaultEvent.action.value;
-        const messageContent = `The user clicked '${buttonText}' button`;
+        // Check if this is a suggestion action (Issue #470)
+        const actionValue = defaultEvent.action.value;
+        let suggestionAction: { action: string; prompt?: string } | null = null;
 
-        await this.emitMessage({
-          messageId: `${defaultEvent.message_id}-${defaultEvent.action.value}`,
-          chatId: defaultEvent.chat_id,
-          userId: defaultEvent.user?.sender_id?.open_id,
-          content: messageContent,
-          messageType: 'card',
-          timestamp: Date.now(),
-          metadata: {
-            cardAction: defaultEvent.action,
-            cardMessageId: defaultEvent.message_id,
-          },
-        });
+        // Try to parse the action value as JSON (suggestion buttons use JSON)
+        if (typeof actionValue === 'string' && actionValue.startsWith('{')) {
+          try {
+            suggestionAction = JSON.parse(actionValue);
+          } catch {
+            // Not JSON, use default handling
+          }
+        }
+
+        // If this is a suggestion action, send the prompt as user message
+        if (suggestionAction?.action === 'suggestion' && suggestionAction.prompt) {
+          await this.emitMessage({
+            messageId: `${defaultEvent.message_id}-suggestion`,
+            chatId: defaultEvent.chat_id,
+            userId: defaultEvent.user?.sender_id?.open_id,
+            content: suggestionAction.prompt,
+            messageType: 'text',
+            timestamp: Date.now(),
+          });
+        } else {
+          // Default handler: emit as interaction message
+          // Issue #525: Use button text to generate user-friendly prompt
+          const buttonText = defaultEvent.action.text || defaultEvent.action.value;
+          const messageContent = `The user clicked '${buttonText}' button`;
+
+          await this.emitMessage({
+            messageId: `${defaultEvent.message_id}-${defaultEvent.action.value}`,
+            chatId: defaultEvent.chat_id,
+            userId: defaultEvent.user?.sender_id?.open_id,
+            content: messageContent,
+            messageType: 'card',
+            timestamp: Date.now(),
+            metadata: {
+              cardAction: defaultEvent.action,
+              cardMessageId: defaultEvent.message_id,
+            },
+          });
+        }
       });
 
       if (!handled) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createLogger } from '../utils/logger.js';
 import { loadConfigFile, getConfigFromFile, validateConfig, getPreloadedConfig } from './loader.js';
-import type { DisclaudeConfig, ConfigValidationError } from './types.js';
+import type { DisclaudeConfig, ConfigValidationError, SuggestionsConfig } from './types.js';
 
 // Export constants and types
 export * from './constants.js';
@@ -345,5 +345,18 @@ export class Config {
    */
   static getDebugConfig(): import('./types.js').DebugConfig {
     return fileConfigOnly.messaging?.debug || {};
+  }
+
+  /**
+   * Get task suggestions configuration (Issue #470).
+   *
+   * @returns Suggestions configuration or default config
+   */
+  static getSuggestionsConfig(): SuggestionsConfig {
+    return fileConfigOnly.agent?.suggestions || {
+      enabled: true,
+      maxSuggestions: 4,
+      showAfterTasks: true,
+    };
   }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -30,6 +30,18 @@ export interface WorkspaceConfig {
 }
 
 /**
+ * Task suggestion configuration (Issue #470).
+ */
+export interface SuggestionsConfig {
+  /** Enable/disable suggestion feature */
+  enabled?: boolean;
+  /** Maximum number of suggestions to show (default: 4) */
+  maxSuggestions?: number;
+  /** Show suggestions after all tasks (default: true) */
+  showAfterTasks?: boolean;
+}
+
+/**
  * Agent configuration section.
  *
  * Note: model is configured per-provider (glm.model for GLM, agent.model for Anthropic).
@@ -44,6 +56,8 @@ export interface AgentConfig {
   maxConcurrentTasks?: number;
   /** Model identifier for Anthropic/Claude (only used when provider is 'anthropic') */
   model?: string;
+  /** Task completion suggestions configuration (Issue #470) */
+  suggestions?: SuggestionsConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces text-based suggestions with interactive card buttons.
When a task completes, users see a card with clickable suggestion buttons.
Clicking a button sends the associated prompt to the Agent for execution.

## Changes

| File | Description |
|------|-------------|
| src/agents/task-suggestion.ts | TaskSuggestionService for generating cards |
| src/agents/task-suggestion.test.ts | 26 tests for the service |
| src/agents/pilot.ts | Integration with task completion flow |
| src/channels/feishu-channel.ts | Handle suggestion button clicks |
| src/config/types.ts | Add SuggestionsConfig interface |
| src/config/index.ts | Add getSuggestionsConfig method |
| disclaude.config.example.yaml | Add suggestions config example |

## Key features

- Detects task type from result content (file-analysis, bug-fix, etc.)
- Generates interactive card with suggestion buttons
- Each button has a prompt that is sent to Agent when clicked
- Configurable via agent.suggestions in config file

## Test Results

| Metric | Value |
|--------|-------|
| New Tests | 26 |
| All Task Suggestion Tests | ✅ Pass |
| Pre-existing Failures | 5 (unrelated to this change) |

## Test Plan

- [x] Unit tests for TaskSuggestionService (26 tests)
- [x] Unit tests for task type detection
- [x] Unit tests for card generation
- [x] Unit tests for button value format
- [x] Manual test: Task completion shows suggestion card
- [ ] Manual test: Clicking button sends prompt to Agent

This addresses the feedback from PR #577 that text suggestions should be replaced with interactive card buttons.

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)