### PR TITLE
fix: resolve test failures in feishu-channel tests

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -39,6 +39,7 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getDebugConfig: vi.fn().mockReturnValue({}),
   },
 }));
 

--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -50,6 +50,7 @@ vi.mock('../config/index.js', () => ({
   Config: {
     FEISHU_APP_ID: 'test-app-id',
     FEISHU_APP_SECRET: 'test-app-secret',
+    getDebugConfig: vi.fn().mockReturnValue({}),
   },
 }));
 


### PR DESCRIPTION
## Summary

Fixes test failures in feishu-channel-mention.test.ts and feishu-channel-passive-mode.test.ts by adding missing \`getDebugConfig\` method to the Config mock.

## Root Cause

The Config mock in both test files was incomplete - it was missing the \`getDebugConfig\` method that \`FilteredMessageForwarder\` requires.

## Changes

| File | Change |
|-----|-------|
| feishu-channel-mention.test.ts | Add \`getDebugConfig\` to Config mock |
| feishu-channel-passive-mode.test.ts | Add \`getDebugConfig\` to Config mock |

## Test Results

- All 82 test files pass
- 1478 tests pass

## Issues Closed

- Closes #623
- Closes #624  
- Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>