### PR TITLE
feat(suggestions): add LLM-driven task suggestions (Issue #470)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -41,6 +41,17 @@ agent:
   # Default: 1
   maxConcurrentTasks: 1
 
+  # Task suggestions configuration
+  # When enabled, Agent will suggest follow-up actions after completing a task
+  suggestions:
+    # Enable/disable task suggestions
+    # Default: false
+    enabled: false
+
+    # Maximum number of suggestions to show
+    # Default: 4
+    maxSuggestions: 4
+
 # -----------------------------------------------------------------------------
 # Feishu/Lark Platform Configuration
 # -----------------------------------------------------------------------------

--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Pilot, type PilotCallbacks } from './pilot.js';
+import { Config } from '../config/index.js';
 
 // Mock the SDK to avoid unhandled errors
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
@@ -35,6 +36,10 @@ vi.mock('../config/index.js', () => ({
       pretty: true,
       rotate: false,
       sdkDebug: true,
+    })),
+    getSuggestionsConfig: vi.fn(() => ({
+      enabled: false,
+      maxSuggestions: 4,
     })),
   },
 }));
@@ -335,6 +340,74 @@ describe('Pilot (Streaming Input)', () => {
 
       // Should have received at least one message
       expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Task Suggestions (Issue #470)', () => {
+    it('should not include suggestions section when disabled', () => {
+      // Mock getSuggestionsConfig to return disabled
+      vi.mocked(Config.getSuggestionsConfig).mockReturnValue({
+        enabled: false,
+        maxSuggestions: 4,
+      });
+
+      // Access private method via bracket notation
+      const content = pilot['buildEnhancedContent']('chat-123', {
+        text: 'Hello',
+        messageId: 'msg-001',
+      });
+
+      // Should not include suggestions section
+      expect(content).not.toContain('Task Completion Suggestions');
+      expect(content).not.toContain('接下来你可以');
+    });
+
+    it('should include suggestions section when enabled', () => {
+      // Mock getSuggestionsConfig to return enabled
+      vi.mocked(Config.getSuggestionsConfig).mockReturnValue({
+        enabled: true,
+        maxSuggestions: 4,
+      });
+
+      const content = pilot['buildEnhancedContent']('chat-123', {
+        text: 'Hello',
+        messageId: 'msg-001',
+      });
+
+      // Should include suggestions section
+      expect(content).toContain('Task Completion Suggestions');
+      expect(content).toContain('接下来你可以');
+    });
+
+    it('should use custom maxSuggestions value', () => {
+      vi.mocked(Config.getSuggestionsConfig).mockReturnValue({
+        enabled: true,
+        maxSuggestions: 3,
+      });
+
+      const content = pilot['buildEnhancedContent']('chat-123', {
+        text: 'Hello',
+        messageId: 'msg-001',
+      });
+
+      // Should include the custom max value
+      expect(content).toContain('3');
+      expect(content).toContain('Maximum 3 suggestions');
+    });
+
+    it('should not include suggestions for skill commands', () => {
+      vi.mocked(Config.getSuggestionsConfig).mockReturnValue({
+        enabled: true,
+        maxSuggestions: 4,
+      });
+
+      const content = pilot['buildEnhancedContent']('chat-123', {
+        text: '/help',
+        messageId: 'msg-001',
+      });
+
+      // Skill commands should not include suggestions
+      expect(content).not.toContain('Task Completion Suggestions');
     });
   });
 });

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -617,6 +617,9 @@ ${msg.chatHistoryContext}
     // Build capability-aware tools section (Issue #582)
     const toolsSection = this.buildToolsSection(chatId, msg.messageId || '', capabilities, msg.senderOpenId);
 
+    // Build suggestions section if enabled (Issue #470)
+    const suggestionsSection = this.buildSuggestionsSection();
+
     // For regular messages: context FIRST, then user message
     if (msg.senderOpenId) {
       const mentionSection = capabilities?.supportsMention !== false
@@ -646,7 +649,7 @@ ${chatHistorySection}${mentionSection}
 ---
 
 ## Tools
-${toolsSection}
+${toolsSection}${suggestionsSection}
 
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
@@ -658,7 +661,7 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 **Message ID:** ${msg.messageId}
 ${chatHistorySection}
 ## Tools
-${toolsSection}
+${toolsSection}${suggestionsSection}
 
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
@@ -712,6 +715,53 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     }
 
     return parts.join('\n');
+  }
+
+  /**
+   * Build suggestions section for the prompt.
+   * When enabled, Agent will suggest follow-up actions after completing a task.
+   * @see Issue #470
+   *
+   * @returns Suggestions section string for the prompt, or empty string if disabled
+   */
+  private buildSuggestionsSection(): string {
+    const suggestionsConfig = Config.getSuggestionsConfig();
+
+    if (!suggestionsConfig.enabled) {
+      return '';
+    }
+
+    const maxSuggestions = suggestionsConfig.maxSuggestions ?? 4;
+
+    return `
+
+---
+
+## Task Completion Suggestions
+
+After completing the user's task, suggest ${maxSuggestions} relevant follow-up actions based on:
+- The task you just completed
+- The context of the conversation
+- What would be most helpful for the user
+
+Format your suggestions at the end of your response:
+
+\`\`\`
+─────────────
+💡 接下来你可以：
+
+1. [emoji] [操作描述]
+2. [emoji] [操作描述]
+3. [emoji] [操作描述]
+4. [emoji] [操作描述]
+\`\`\`
+
+**Guidelines:**
+- Analyze the task context to generate relevant suggestions
+- Each suggestion should be actionable and specific
+- Use appropriate emojis for visual clarity
+- Maximum ${maxSuggestions} suggestions
+- Only show suggestions after completing a meaningful task, not for simple queries`;
   }
 
   /**

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -346,4 +346,18 @@ export class Config {
   static getDebugConfig(): import('./types.js').DebugConfig {
     return fileConfigOnly.messaging?.debug || {};
   }
+
+  /**
+   * Get task suggestions configuration.
+   * @see Issue #470
+   *
+   * @returns Suggestions configuration object with defaults
+   */
+  static getSuggestionsConfig(): import('./types.js').SuggestionsConfig {
+    const config = fileConfigOnly.agent?.suggestions;
+    return {
+      enabled: config?.enabled ?? false,
+      maxSuggestions: config?.maxSuggestions ?? 4,
+    };
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -44,6 +44,8 @@ export interface AgentConfig {
   maxConcurrentTasks?: number;
   /** Model identifier for Anthropic/Claude (only used when provider is 'anthropic') */
   model?: string;
+  /** Task suggestions configuration */
+  suggestions?: SuggestionsConfig;
 }
 
 /**
@@ -214,6 +216,18 @@ export interface DebugConfig {
   filterForwardChatId?: string;
   /** Filter reasons to include in forwarding (empty = all) */
   includeReasons?: FilterReason[];
+}
+
+/**
+ * Task suggestion configuration.
+ * When enabled, Agent will suggest follow-up actions after completing a task.
+ * @see Issue #470
+ */
+export interface SuggestionsConfig {
+  /** Enable/disable task suggestions */
+  enabled?: boolean;
+  /** Maximum number of suggestions to show (default: 4) */
+  maxSuggestions?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Reimplements task suggestions using LLM context analysis instead of preset rules. When enabled, the Agent analyzes the task context and generates relevant follow-up action suggestions.

This addresses the feedback from PR #629 that preset rules should be replaced with LLM-generated context-aware suggestions.

## Changes

| File | Description |
|------|-------------|
| `src/config/types.ts` | Add `SuggestionsConfig` interface |
| `src/config/index.ts` | Add `getSuggestionsConfig` method |
| `src/agents/pilot.ts` | Add `buildSuggestionsSection` method |
| `src/agents/pilot.test.ts` | Add 4 tests for suggestions |
| `disclaude.config.example.yaml` | Add suggestions config example |

## Key Features

- **Context-aware**: Suggestions are generated by LLM based on task context
- **Configurable**: Enable/disable via `agent.suggestions` in config file
- **Opt-in**: Disabled by default
- **Smart exclusion**: Does not apply to skill commands (starting with `/`)

## Configuration

```yaml
agent:
  suggestions:
    enabled: true
    maxSuggestions: 4
```

## How It Works

When suggestions are enabled, the Agent's system prompt includes instructions to:

1. Analyze the completed task and conversation context
2. Generate relevant follow-up actions
3. Present suggestions in a consistent format:

```
─────────────
💡 接下来你可以：

1. 📝 生成代码结构文档
2. 🔍 分析某个模块的依赖关系
3. 📊 统计代码行数和文件分布
4. 🐛 检查代码风格问题
```

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| ESLint | ✅ Pass |
| New Tests | 4 |
| All Pilot Tests | 32 passed |

## Comparison with PR #629

| Aspect | PR #629 (Closed) | This PR |
|--------|------------------|---------|
| Approach | Preset rules | LLM context analysis |
| Flexibility | Low | High |
| User feedback | Rejected | Addresses feedback |
| Code complexity | +345 lines | +54 lines |

Fixes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)