### PR TITLE
fix(task-state): correct listTaskHistory sorting by completion time (Issue #642)

### DIFF
--- a/src/utils/task-state-manager.ts
+++ b/src/utils/task-state-manager.ts
@@ -360,9 +360,18 @@ export class TaskStateManager {
         }
       }
 
-      // Sort by creation date (newest first) and limit
+      // Sort by completion time (newest first) and limit
+      // Use updatedAt since it reflects when the task was completed/cancelled
+      // Secondary sort by createdAt for stable ordering when updatedAt is equal
       return tasks
-        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .sort((a, b) => {
+          const updatedAtDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+          if (updatedAtDiff !== 0) {
+            return updatedAtDiff;
+          }
+          // When updatedAt is equal, sort by createdAt (newest first)
+          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+        })
         .slice(0, limit);
     } catch {
       return [];


### PR DESCRIPTION
## Summary

Fixes a bug in `listTaskHistory()` where tasks were sorted by creation time (`createdAt`) instead of completion time (`updatedAt`).

Fixes #642

## Problem

The test `listTaskHistory > should list completed tasks` was failing because:

1. Tasks were sorted by `createdAt` (creation time)
2. When tasks are created and completed in rapid succession (same millisecond), the sort order was unstable
3. The expected behavior is to show most recently completed tasks first

## Root Cause

```typescript
// Before (incorrect)
.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
```

The `createdAt` field represents when the task was **started**, not when it was **completed**.

## Solution

```typescript
// After (correct)
.sort((a, b) => {
  const updatedAtDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
  if (updatedAtDiff !== 0) {
    return updatedAtDiff;
  }
  // Secondary sort for stable ordering when updatedAt is equal
  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
})
```

1. Sort by `updatedAt` (completion time) - most recent first
2. Add secondary sort by `createdAt` for stable ordering when `updatedAt` is equal

## Test Results

| Metric | Value |
|--------|-------|
| TaskStateManager Tests | 27 passed ✅ |
| TypeScript | ✅ Pass |

## Verification Criteria from Issue #642

- [x] `listTaskHistory` returns tasks in completion order (newest first)
- [x] Test `should list completed tasks` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)