### PR TITLE
fix(feishu): pass senderOpenId in control commands for group creation (Issue #647)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -636,7 +636,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           const response = await this.emitControl({
             type: cmd as any,
             chatId: chat_id,
-            data: { args, rawText: trimmedText },
+            data: { args, rawText: trimmedText, senderOpenId: this.extractOpenId(sender) },
           });
 
           // Only return if command was successfully handled


### PR DESCRIPTION
## Summary

Fixes an issue where the `/create-group` command was not adding the creator to the newly created group.

## Problem

When creating a group via `/create-group` command, the creator was not being added to the group. This is because `senderOpenId` was not being passed in the `emitControl` call, causing `userId` to be `undefined` in `CreateGroupCommand`, which prevented the auto-add creator logic from working.

## Root Cause

In `feishu-channel.ts`, the `emitControl` call for handling control commands was not including `senderOpenId` in the data payload.

## Fix

Added `senderOpenId` to the control command data payload so that commands like `create-group` can properly identify and add the creator to the newly created group.

```typescript
// Before
data: { args, rawText: trimmedText }

// After
data: { args, rawText: trimmedText, senderOpenId: this.extractOpenId(sender) }
```

## Changes

| File | Description |
|------|-------------|
| src/channels/feishu-channel.ts | Add senderOpenId to emitControl data payload |

## Test Results

| Test File | Status |
|-----------|--------|
| feishu-channel-mention.test.ts | 8 passed |
| chat-ops.test.ts | 15 passed |
| commands tests | 41 passed |

Fixes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)