### PR TITLE
feat(groups): improve groups command with API fetch and categorization (Issue #648)

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -312,29 +312,62 @@ export class ListGroupMembersCommand implements Command {
 }
 
 /**
- * List Group Command - List all managed groups.
+ * List Group Command - List all groups the bot is in.
+ * Issue #648: 改进群列表命令 - 更名 + API获取 + 分类展示
  */
 export class ListGroupCommand implements Command {
-  readonly name = 'list-group';
+  readonly name = 'groups';
   readonly category = 'group' as const;
   readonly description = '列出群';
 
-  execute(context: CommandContext): CommandResult {
-    const groups = context.services.listGroups();
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const { services } = context;
 
-    if (groups.length === 0) {
-      return { success: true, message: '📋 **管理的群列表**\n\n暂无管理的群' };
+    try {
+      const client = services.getFeishuClient();
+
+      // Get all chats from Feishu API
+      const allChats = await services.getBotChats(client);
+
+      // Get managed groups from local registry
+      const managedGroups = services.listGroups();
+      const managedChatIds = new Set(managedGroups.map(g => g.chatId));
+
+      // Categorize chats
+      const botCreatedGroups = allChats.filter(c => managedChatIds.has(c.chatId));
+      const invitedGroups = allChats.filter(c => !managedChatIds.has(c.chatId));
+
+      // Build output
+      if (allChats.length === 0) {
+        return { success: true, message: '📋 **群列表**\n\n暂无群聊' };
+      }
+
+      const lines: string[] = [`📋 **群列表** (共 ${allChats.length} 个)\n`];
+
+      // Bot created groups
+      if (botCreatedGroups.length > 0) {
+        lines.push(`🤖 **机器人创建的群** (${botCreatedGroups.length})`);
+        for (const g of botCreatedGroups) {
+          lines.push(`• ${g.name} - \`${g.chatId}\``);
+        }
+        lines.push('');
+      }
+
+      // Invited groups
+      if (invitedGroups.length > 0) {
+        lines.push(`👥 **被邀请加入的群** (${invitedGroups.length})`);
+        for (const g of invitedGroups) {
+          lines.push(`• ${g.name} - \`${g.chatId}\``);
+        }
+      }
+
+      return {
+        success: true,
+        message: lines.join('\n'),
+      };
+    } catch (error) {
+      return { success: false, error: `获取群列表失败: ${(error as Error).message}` };
     }
-
-    const groupList = groups.map(g => {
-      const createdAt = new Date(g.createdAt).toLocaleString('zh-CN');
-      return `- **${g.name}** \`${g.chatId}\`\n  创建时间: ${createdAt}\n  初始成员: ${g.initialMembers.length}`;
-    }).join('\n\n');
-
-    return {
-      success: true,
-      message: `📋 **管理的群列表**\n\n群数量: ${groups.length}\n\n${groupList}`,
-    };
   }
 }
 

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -31,6 +31,7 @@ function createMockServices(): CommandServices {
     registerGroup: () => {},
     unregisterGroup: () => false,
     listGroups: () => [],
+    getBotChats: () => Promise.resolve([]),
     setDebugGroup: () => null,
     getDebugGroup: () => null,
     clearDebugGroup: () => null,
@@ -340,7 +341,7 @@ describe('registerDefaultCommands', () => {
     expect(registry.get('add-member')).toBeDefined();
     expect(registry.get('remove-member')).toBeDefined();
     expect(registry.get('list-group-members')).toBeDefined();
-    expect(registry.get('list-group')).toBeDefined();
+    expect(registry.get('groups')).toBeDefined();  // Issue #648: renamed from list-group
     expect(registry.get('dissolve-group')).toBeDefined();
     expect(registry.get('passive')).toBeDefined();
 

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -53,6 +53,7 @@ describe('ScheduleCommand', () => {
     registerGroup: () => {},
     unregisterGroup: () => false,
     listGroups: () => [],
+    getBotChats: () => Promise.resolve([]),
     setDebugGroup: () => null,
     getDebugGroup: () => null,
     clearDebugGroup: () => null,

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -60,6 +60,15 @@ export interface ManagedGroupInfo {
 }
 
 /**
+ * Bot chat info from Feishu API.
+ * Issue #648: 改进群列表命令
+ */
+export interface BotChatInfo {
+  chatId: string;
+  name: string;
+}
+
+/**
  * Debug group info.
  */
 export interface DebugGroupInfo {
@@ -122,6 +131,9 @@ export interface CommandServices {
 
   /** List all managed groups */
   listGroups: () => ManagedGroupInfo[];
+
+  /** Get all chats the bot is in (from Feishu API) */
+  getBotChats: (client: lark.Client) => Promise<BotChatInfo[]>;
 
   /** Set debug group */
   setDebugGroup: (chatId: string, name?: string) => DebugGroupInfo | null;

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -55,6 +55,7 @@ import {
   addMembers,
   removeMembers,
   getMembers,
+  getBotChats,
 } from '../platforms/feishu/chat-ops.js';
 import { GroupService, getGroupService } from '../platforms/feishu/group-service.js';
 import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
@@ -605,6 +606,7 @@ export class PrimaryNode extends EventEmitter {
         registerGroup: (group: Parameters<typeof this.groupService.registerGroup>[0]) => this.groupService.registerGroup(group),
         unregisterGroup: (chatId: string) => this.groupService.unregisterGroup(chatId),
         listGroups: () => this.groupService.listGroups(),
+        getBotChats,
         setDebugGroup: (chatId: string, name?: string) => debugGroupService.setDebugGroup(chatId, name),
         getDebugGroup: () => debugGroupService.getDebugGroup(),
         clearDebugGroup: () => debugGroupService.clearDebugGroup(),

--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as lark from '@larksuiteoapi/node-sdk';
-import { createDiscussionChat, dissolveChat, addMembers, removeMembers, getMembers } from './chat-ops.js';
+import { createDiscussionChat, dissolveChat, addMembers, removeMembers, getMembers, getBotChats } from './chat-ops.js';
 
 // Mock lark client
 const mockClient = {
@@ -15,6 +15,7 @@ const mockClient = {
     chat: {
       create: vi.fn(),
       delete: vi.fn(),
+      list: vi.fn(),
     },
     chatMembers: {
       create: vi.fn(),
@@ -258,6 +259,73 @@ describe('ChatOps', () => {
       mockGet.mockRejectedValue(new Error('Chat not found'));
 
       await expect(getMembers(mockClient, 'oc_invalid_chat')).rejects.toThrow('Chat not found');
+    });
+  });
+
+  describe('getBotChats', () => {
+    it('should get all bot chats successfully', async () => {
+      const mockList = mockClient.im.chat.list as ReturnType<typeof vi.fn>;
+      mockList.mockResolvedValue({
+        data: {
+          items: [
+            { chat_id: 'oc_chat_1', name: 'Group 1' },
+            { chat_id: 'oc_chat_2', name: 'Group 2' },
+          ],
+        },
+      });
+
+      const chats = await getBotChats(mockClient);
+
+      expect(mockList).toHaveBeenCalledWith({
+        params: {
+          page_size: 50,
+          page_token: undefined,
+        },
+      });
+      expect(chats).toHaveLength(2);
+      expect(chats[0]).toEqual({ chatId: 'oc_chat_1', name: 'Group 1' });
+      expect(chats[1]).toEqual({ chatId: 'oc_chat_2', name: 'Group 2' });
+    });
+
+    it('should handle pagination', async () => {
+      const mockList = mockClient.im.chat.list as ReturnType<typeof vi.fn>;
+      mockList
+        .mockResolvedValueOnce({
+          data: {
+            items: [{ chat_id: 'oc_chat_1', name: 'Group 1' }],
+            page_token: 'next_page',
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            items: [{ chat_id: 'oc_chat_2', name: 'Group 2' }],
+          },
+        });
+
+      const chats = await getBotChats(mockClient);
+
+      expect(mockList).toHaveBeenCalledTimes(2);
+      expect(chats).toHaveLength(2);
+    });
+
+    it('should return empty array when no chats', async () => {
+      const mockList = mockClient.im.chat.list as ReturnType<typeof vi.fn>;
+      mockList.mockResolvedValue({
+        data: {
+          items: [],
+        },
+      });
+
+      const chats = await getBotChats(mockClient);
+
+      expect(chats).toEqual([]);
+    });
+
+    it('should throw on API error', async () => {
+      const mockList = mockClient.im.chat.list as ReturnType<typeof vi.fn>;
+      mockList.mockRejectedValue(new Error('API error'));
+
+      await expect(getBotChats(mockClient)).rejects.toThrow('API error');
     });
   });
 });

--- a/src/platforms/feishu/chat-ops.ts
+++ b/src/platforms/feishu/chat-ops.ts
@@ -199,3 +199,59 @@ export async function getMembers(
     throw error;
   }
 }
+
+/**
+ * Chat info from Feishu API.
+ */
+export interface BotChatInfo {
+  /** Chat ID */
+  chatId: string;
+  /** Chat name */
+  name: string;
+}
+
+/**
+ * Get all chats the bot is in.
+ *
+ * Uses Feishu API to get all groups where the bot is a member.
+ * This provides accurate data compared to local registry.
+ *
+ * @param client - Feishu API client
+ * @returns Array of chat info
+ */
+export async function getBotChats(
+  client: lark.Client
+): Promise<BotChatInfo[]> {
+  const chats: BotChatInfo[] = [];
+  let pageToken: string | undefined;
+
+  try {
+    // Paginate through all chats
+    do {
+      const response = await client.im.chat.list({
+        params: {
+          page_size: 50,
+          page_token: pageToken,
+        },
+      });
+
+      const items = response?.data?.items || [];
+      for (const item of items) {
+        if (item.chat_id && item.name) {
+          chats.push({
+            chatId: item.chat_id,
+            name: item.name,
+          });
+        }
+      }
+
+      pageToken = response?.data?.page_token;
+    } while (pageToken);
+
+    logger.info({ chatCount: chats.length }, 'Bot chats retrieved');
+    return chats;
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to get bot chats');
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #648 - 改进群列表命令：更名 + API获取 + 分类展示

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/chat-ops.ts` | Add `getBotChats` function to fetch all bot chats via Feishu API |
| `src/nodes/commands/types.ts` | Add `BotChatInfo` interface and `getBotChats` to `CommandServices` |
| `src/nodes/commands/builtin-commands.ts` | Rename `list-group` to `groups`, implement categorization |
| `src/nodes/primary-node.ts` | Wire up `getBotChats` in command services |
| `src/platforms/feishu/chat-ops.test.ts` | Add tests for `getBotChats` function |

## Features

### 1. Command Renamed
- `/list-group` → `/groups` (more intuitive)

### 2. API-Based Group List
- Uses Feishu API to get accurate data
- No longer relies solely on local registry

### 3. Categorized Display
Groups are now categorized into:
- **🤖 机器人创建的群** (Bot-created groups)
- **👥 被邀请加入的群** (Invited groups)

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| ESLint | ✅ Pass (0 new errors) |
| Unit Tests | 75 passed |

Fixes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)