### PR TITLE
fix(feishu): passive command requires @mention in group chats (Issue #650)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -107,6 +107,17 @@ vi.mock('../utils/task-tracker.js', () => ({
   TaskTracker: vi.fn(),
 }));
 
+vi.mock('../nodes/commands/command-registry.js', () => ({
+  getCommandRegistry: vi.fn(() => ({
+    has: (name: string) => ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
+      'create-group', 'add-member', 'remove-member', 'list-group-members', 'groups', 'dissolve-group',
+      'passive'].includes(name),
+    getAll: () => [],
+    register: vi.fn(),
+  })),
+  resetCommandRegistry: vi.fn(),
+}));
+
 import { FeishuChannel } from './feishu-channel.js';
 
 describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
@@ -525,6 +536,106 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
 
       // Reaction SHOULD be added for private chat messages
       expect(senderInstance?.addReaction).toHaveBeenCalledWith('test-msg-id', 'Typing');
+    });
+  });
+
+  /**
+   * Issue #650: /passive command should only respond when @mentioned in group chats
+   */
+  describe('/passive command requires @mention (Issue #650)', () => {
+    it('should skip /passive command in group chat without @mention', async () => {
+      await simulateMessageReceive({
+        text: '/passive status',
+        chatId: 'oc_test_group', // Group chat ID
+        mentions: undefined, // No mentions
+      });
+
+      // Control handler should NOT be called - passive command requires @mention
+      expect(controlHandler).not.toHaveBeenCalled();
+
+      // Message should NOT be passed to agent (passive mode filter)
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle /passive command in group chat WITH @mention', async () => {
+      await simulateMessageReceive({
+        text: '/passive status',
+        chatId: 'oc_test_group', // Group chat ID
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'cli_test_bot_id' }, // Bot's open_id from mock
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler SHOULD be called when @mentioned
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+          chatId: 'oc_test_group',
+        })
+      );
+
+      // Message should NOT be passed to agent (command handled)
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle /passive on/off in group chat WITH @mention', async () => {
+      await simulateMessageReceive({
+        text: '/passive off',
+        chatId: 'oc_test_group',
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'cli_test_bot_id' },
+            name: 'Bot',
+          },
+        ],
+      });
+
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+          chatId: 'oc_test_group',
+          data: expect.objectContaining({
+            args: ['off'],
+          }),
+        })
+      );
+    });
+
+    it('should handle /passive command in private chat without @mention', async () => {
+      await simulateMessageReceive({
+        text: '/passive status',
+        chatId: 'ou_user_private', // Private chat ID
+        mentions: undefined,
+      });
+
+      // Control handler SHOULD be called in private chat without @mention
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'passive',
+        })
+      );
+    });
+
+    it('should skip /passive in group chat when bot is not the one mentioned', async () => {
+      await simulateMessageReceive({
+        text: '@user1 /passive status',
+        chatId: 'oc_test_group',
+        mentions: [
+          {
+            key: '@_user1',
+            id: { open_id: 'user1-open-id' }, // Another user, not bot
+            name: 'User1',
+          },
+        ],
+      });
+
+      // Control handler should NOT be called - bot is not mentioned
+      expect(controlHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -631,6 +631,18 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       // Non-control commands with @mention show error instead of passing to agent (Issue #595)
       const isControlCommand = commandRegistry.has(cmd);
 
+      // Issue #650: passive command should only respond when @mentioned in group chats
+      // This is a special case because passive controls the bot's response behavior
+      if (cmd === 'passive' && this.isGroupChat(chat_type) && !botMentioned) {
+        logger.debug(
+          { messageId: message_id, chatId: chat_id, chat_type },
+          'Passive command skipped without @mention in group chat'
+        );
+        // Forward to passive mode filter which will handle the message
+        await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
+        return;
+      }
+
       if (isControlCommand || !botMentioned) {
         if (this.controlHandler) {
           const response = await this.emitControl({


### PR DESCRIPTION
## Summary

Fixes #650 - `/passive` command now requires @mention in group chats.

## Problem

The `/passive` command was being processed in group chats even when the bot was not @mentioned. This caused unexpected responses when users typed `/passive status` without @mentioning the bot.

## Root Cause

The command handling logic treats all control commands equally - they are "ALWAYS handled locally, regardless of @mentions". However, the `/passive` command controls the bot's response behavior in group chats, so it should only be processed when the bot is explicitly @mentioned.

## Solution

Added a special case check before processing control commands:
- In group chats, `/passive` command is only processed when bot is @mentioned
- Without @mention, the message is forwarded to the passive mode filter
- Private chat behavior is unchanged

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | Add check for `/passive` command requiring @mention in group chats |
| `src/channels/feishu-channel-passive-mode.test.ts` | Add 5 new test cases + mock for command-registry |

## New Test Cases

1. ✅ Skip `/passive` without @mention in group chat
2. ✅ Handle `/passive` with @mention in group chat
3. ✅ Handle `/passive on/off` with @mention
4. ✅ Handle `/passive` in private chat without @mention
5. ✅ Skip `/passive` when only other user is mentioned

## Test Results

| Metric | Value |
|--------|-------|
| Total Tests | 30 |
| Passed | 30 |
| Failed | 0 |

```
 ✓ src/channels/feishu-channel-passive-mode.test.ts (30 tests) 20ms
 ✓ src/channels/feishu-channel-mention.test.ts (8 tests) 4ms

 Test Files  2 passed (2)
      Tests  38 passed (38)
```

## Verification Criteria from Issue #650

- [x] passive 指令在没有被 @ 时不会响应
- [x] passive 指令在被 @ 时正常响应
- [x] 私聊中行为不变

Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)