### PR TITLE
refactor(commands): rename group member management commands (Issue #651)

### DIFF
--- a/src/channels/feishu-channel-mention.test.ts
+++ b/src/channels/feishu-channel-mention.test.ts
@@ -99,7 +99,7 @@ vi.mock('../utils/task-tracker.js', () => ({
 vi.mock('../nodes/commands/command-registry.js', () => ({
   getCommandRegistry: vi.fn(() => ({
     has: (name: string) => ['reset', 'status', 'help', 'restart', 'list-nodes', 'switch-node',
-      'create-group', 'add-member', 'remove-member', 'list-group-members', 'list-group', 'dissolve-group'].includes(name),
+      'create-group', 'add-group-member', 'remove-group-member', 'list-group-members', 'list-group', 'dissolve-group'].includes(name),
     getAll: () => [],
     register: vi.fn(),
   })),

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -118,8 +118,8 @@ export type ControlCommandType =
   | 'switch-node'
   // Group management commands (Issue #486)
   | 'create-group'
-  | 'add-member'
-  | 'remove-member'
+  | 'add-group-member'
+  | 'remove-group-member'
   | 'list-group-members'
   | 'list-group'
   | 'dissolve-group'

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -210,13 +210,13 @@ export class CreateGroupCommand implements Command {
 }
 
 /**
- * Add Member Command - Add a member to a group.
+ * Add Group Member Command - Add a member to a group.
  */
-export class AddMemberCommand implements Command {
-  readonly name = 'add-member';
+export class AddGroupMemberCommand implements Command {
+  readonly name = 'add-group-member';
   readonly category = 'group' as const;
-  readonly description = '添加成员';
-  readonly usage = 'add-member <groupId> <member>';
+  readonly description = '添加群成员';
+  readonly usage = 'add-group-member <groupId> <member>';
 
   async execute(context: CommandContext): Promise<CommandResult> {
     const { services, args } = context;
@@ -224,7 +224,7 @@ export class AddMemberCommand implements Command {
     if (args.length < 2) {
       return {
         success: false,
-        error: '用法: `/add-member <群ID> <成员ID>`\n\n示例: `/add-member oc_xxx ou_yyy`',
+        error: '用法: `/add-group-member <群ID> <成员ID>`\n\n示例: `/add-group-member oc_xxx ou_yyy`',
       };
     }
 
@@ -241,13 +241,13 @@ export class AddMemberCommand implements Command {
 }
 
 /**
- * Remove Member Command - Remove a member from a group.
+ * Remove Group Member Command - Remove a member from a group.
  */
-export class RemoveMemberCommand implements Command {
-  readonly name = 'remove-member';
+export class RemoveGroupMemberCommand implements Command {
+  readonly name = 'remove-group-member';
   readonly category = 'group' as const;
-  readonly description = '移除成员';
-  readonly usage = 'remove-member <groupId> <member>';
+  readonly description = '移除群成员';
+  readonly usage = 'remove-group-member <groupId> <member>';
 
   async execute(context: CommandContext): Promise<CommandResult> {
     const { services, args } = context;
@@ -255,7 +255,7 @@ export class RemoveMemberCommand implements Command {
     if (args.length < 2) {
       return {
         success: false,
-        error: '用法: `/remove-member <群ID> <成员ID>`\n\n示例: `/remove-member oc_xxx ou_yyy`',
+        error: '用法: `/remove-group-member <群ID> <成员ID>`\n\n示例: `/remove-group-member oc_xxx ou_yyy`',
       };
     }
 
@@ -939,8 +939,8 @@ export function registerDefaultCommands(
   registry.register(new SwitchNodeCommand());
   registry.register(new RestartCommand());
   registry.register(new CreateGroupCommand());
-  registry.register(new AddMemberCommand());
-  registry.register(new RemoveMemberCommand());
+  registry.register(new AddGroupMemberCommand());
+  registry.register(new RemoveGroupMemberCommand());
   registry.register(new ListGroupMembersCommand());
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -338,8 +338,8 @@ describe('registerDefaultCommands', () => {
 
     // Group commands
     expect(registry.get('create-group')).toBeDefined();
-    expect(registry.get('add-member')).toBeDefined();
-    expect(registry.get('remove-member')).toBeDefined();
+    expect(registry.get('add-group-member')).toBeDefined();
+    expect(registry.get('remove-group-member')).toBeDefined();
     expect(registry.get('list-group-members')).toBeDefined();
     expect(registry.get('groups')).toBeDefined();  // Issue #648: renamed from list-group
     expect(registry.get('dissolve-group')).toBeDefined();


### PR DESCRIPTION
## Summary

Renames group member management commands for better clarity and consistency with other group-related commands.

| Old Command | New Command |
|-------------|-------------|
| `/add-member` | `/add-group-member` |
| `/remove-member` | `/remove-group-member` |

## Changes

| File | Description |
|------|-------------|
| `src/channels/types.ts` | Update `ControlCommandType` with new command names |
| `src/nodes/commands/builtin-commands.ts` | Rename command classes and update names, descriptions, usage |
| `src/nodes/commands/command-registry.test.ts` | Update test expectations |
| `src/channels/feishu-channel-mention.test.ts` | Update mock command list |

## Rationale

1. **明确作用域**: `group-member` 明确表示这是群组成员管理
2. **避免歧义**: 未来可能有其他类型的成员管理（如团队、项目等）
3. **命令一致性**: 与 `/list-group-members`、`/create-group` 等群组相关命令保持命名风格一致

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| ESLint | ✅ Pass |
| Unit Tests | 25 passed |

```
 ✓ src/nodes/commands/command-registry.test.ts (17 tests)
 ✓ src/channels/feishu-channel-mention.test.ts (8 tests)
```

Fixes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)