### PR TITLE
feat: implement next-step recommendations after task completion

### DIFF
--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: next-step
+description: Analyze completed task and recommend follow-up actions
+allowed-tools: [send_user_feedback, update_card, wait_for_interaction]
+---
+
+# Next Step Recommender
+
+You are a follow-up action recommendation specialist. When a task completes, analyze the chat history and suggest relevant next steps to the user.
+
+## Input Context
+
+You will receive:
+- **Chat History**: Recent conversation showing what was accomplished
+- **Task Type**: The category of the completed task
+- **Chat ID**: For sending interactive cards
+
+## Workflow
+
+1. **Analyze** the chat history to understand what was done
+2. **Identify** the task type (coding, research, bug fix, documentation, etc.)
+3. **Generate** 2-4 relevant follow-up actions
+4. **Send** an interactive card with quick-action buttons
+
+## Task Type Detection
+
+Identify the task type from patterns in the conversation:
+
+| Task Type | Patterns |
+|-----------|----------|
+| **Bug Fix** | "fix", "bug", "error", "issue", "crash" |
+| **Feature** | "implement", "add", "create", "feature" |
+| **Refactor** | "refactor", "clean up", "restructure" |
+| **Research** | "analyze", "investigate", "research", "explore" |
+| **Documentation** | "document", "readme", "docs", "comment" |
+| **Test** | "test", "coverage", "spec", "verify" |
+| **GitHub** | "issue", "pr", "commit", "merge" |
+| **General** | Default if no specific pattern |
+
+## Recommendation Rules
+
+Based on task type, suggest relevant follow-ups:
+
+### Bug Fix
+- 📋 Create GitHub issue for tracking
+- 📝 Document the fix in changelog
+- 🧪 Add regression tests
+
+### Feature Implementation
+- 📋 Create GitHub issue/PR
+- 📝 Update documentation
+- 🧪 Add unit tests
+- 🔄 Code review request
+
+### Refactor
+- 🧪 Run test suite to verify
+- 📊 Check code coverage
+- 📝 Update related docs
+
+### Research/Analysis
+- 📝 Create summary document
+- 📋 Create GitHub issue with findings
+- 🔄 Share with team
+
+### GitHub Related
+- 🔄 Check PR status
+- 📝 Update issue comments
+- 🏷️ Add labels/milestones
+
+### General
+- 📋 Create GitHub issue
+- 📝 Summarize changes
+- 🔄 Continue with related work
+
+## Output Format
+
+Send an interactive card using `send_user_feedback`:
+
+```json
+{
+  "config": {"wide_screen_mode": true},
+  "header": {
+    "title": {"tag": "plain_text", "content": "✅ 任务完成"},
+    "template": "blue"
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "接下来您可以："
+    },
+    {
+      "tag": "action",
+      "actions": [
+        {
+          "tag": "button",
+          "text": {"tag": "plain_text", "content": "📋 提交 GitHub Issue"},
+          "type": "default",
+          "value": "create_github_issue"
+        },
+        {
+          "tag": "button",
+          "text": {"tag": "plain_text", "content": "📝 总结文档"},
+          "type": "default",
+          "value": "create_summary"
+        },
+        {
+          "tag": "button",
+          "text": {"tag": "plain_text", "content": "🔄 继续优化"},
+          "type": "default",
+          "value": "continue_improve"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## 🚨 CRITICAL: Button Click Handling
+
+When user clicks a button, the system will send a message to the agent:
+- The agent will receive: `User clicked '📋 提交 GitHub Issue'`
+- The agent should then process the request accordingly
+
+**DO NOT** use `wait_for_interaction` to block - let the system handle clicks asynchronously.
+
+## Chat ID
+
+The Chat ID is ALWAYS provided in the prompt. Look for:
+
+```
+**Chat ID for Feishu tools**: `oc_xxx`
+```
+
+Use this exact value for `send_user_feedback`.
+
+## DO NOT
+
+- ❌ Just output text without sending a card
+- ❌ Forget to include the Chat ID
+- ❌ Block waiting for button clicks
+- ❌ Suggest actions unrelated to the completed task

--- a/src/nodes/feedback-router.ts
+++ b/src/nodes/feedback-router.ts
@@ -29,6 +29,12 @@ export interface FeedbackRouterConfig {
   fileStorageService?: FileStorageService;
   /** Function to send file to user */
   sendFileToUser: (chatId: string, filePath: string, threadId?: string) => Promise<void>;
+  /**
+   * Callback when task completes (done event).
+   * Used to trigger follow-up actions like next-step recommendations.
+   * Issue #657: Smart next-step recommendations
+   */
+  onTaskDone?: (chatId: string, threadId?: string) => Promise<void>;
 }
 
 /**
@@ -43,11 +49,13 @@ export interface FeedbackRouterConfig {
 export class FeedbackRouter {
   private readonly fileStorageService?: FileStorageService;
   private readonly sendFileToUser: (chatId: string, filePath: string, threadId?: string) => Promise<void>;
+  private readonly onTaskDone?: (chatId: string, threadId?: string) => Promise<void>;
   private readonly channels: Map<string, IChannel> = new Map();
 
   constructor(config: FeedbackRouterConfig) {
     this.fileStorageService = config.fileStorageService;
     this.sendFileToUser = config.sendFileToUser;
+    this.onTaskDone = config.onTaskDone;
   }
 
   /**
@@ -119,6 +127,13 @@ export class FeedbackRouter {
         case 'done':
           logger.info({ chatId }, 'Execution completed');
           await this.broadcastToChannels({ type: 'done', chatId, threadId });
+          // Issue #657: Trigger next-step recommendations after task completion
+          if (this.onTaskDone) {
+            // Fire and forget - don't block the done signal
+            void this.onTaskDone(chatId, threadId).catch((err) => {
+              logger.warn({ err, chatId }, 'Failed to trigger next-step recommendations');
+            });
+          }
           break;
         case 'error':
           logger.error({ chatId, error }, 'Execution error');

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -34,6 +34,7 @@ import * as path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
 import { Config } from '../config/index.js';
 import { AgentFactory } from '../agents/index.js';
+import { messageLogger } from '../feishu/message-logger.js';
 import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
@@ -160,6 +161,7 @@ export class PrimaryNode extends EventEmitter {
     // Initialize FeedbackRouter
     this.feedbackRouter = new FeedbackRouter({
       sendFileToUser: this.sendFileToUser.bind(this),
+      onTaskDone: this.triggerNextStepRecommendation.bind(this),
     });
 
     // Issue #463: Initialize CommandRegistry with default commands
@@ -986,6 +988,57 @@ export class PrimaryNode extends EventEmitter {
     } catch (error) {
       logger.error({ err: error, taskId: task.id }, 'Failed to run schedule manually');
       return false;
+    }
+  }
+
+  // ============================================================================
+  // Next Step Recommendations (Issue #657)
+  // ============================================================================
+
+  /**
+   * Trigger next-step recommendations after task completion.
+   * Uses SkillAgent to analyze chat history and suggest follow-up actions.
+   *
+   * @param chatId - Chat ID to get history from
+   * @param threadId - Optional thread ID for reply
+   */
+  private async triggerNextStepRecommendation(chatId: string, threadId?: string): Promise<void> {
+    try {
+      logger.info({ chatId }, 'Triggering next-step recommendations');
+
+      // Get chat history for context
+      const chatHistory = await messageLogger.getChatHistory(chatId);
+
+      if (!chatHistory || chatHistory.trim().length === 0) {
+        logger.debug({ chatId }, 'No chat history available for recommendations');
+        return;
+      }
+
+      // Create SkillAgent for next-step recommendations using AgentFactory
+      const nextStepAgent = await AgentFactory.createSkillAgent('next-step');
+
+      // Build prompt with chat history
+      const prompt = `## Context
+
+**Chat ID for Feishu tools**: \`${chatId}\`
+${threadId ? `**Thread ID**: \`${threadId}\`` : ''}
+
+## Chat History
+
+${chatHistory}`;
+
+      // Execute skill and handle responses
+      for await (const message of nextStepAgent.execute(prompt)) {
+        if (message.type === 'tool_use' || message.metadata?.toolName) {
+          logger.debug({ toolName: message.metadata?.toolName }, 'Next-step skill using tool');
+        } else if ((message.type === 'text' || message.messageType === 'text') && message.content) {
+          logger.debug({ contentLength: typeof message.content === 'string' ? message.content.length : 0 }, 'Next-step skill output');
+        }
+      }
+
+      logger.info({ chatId }, 'Next-step recommendations completed');
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to trigger next-step recommendations');
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements Issue #657 - Smart next-step recommendations after task completion.

### Changes

1. **Create `skills/next-step/SKILL.md`**
   - Analyzes completed task type (bug fix, feature, refactor, etc.)
   - Generates relevant follow-up recommendations
   - Sends interactive card with quick-action buttons

2. **Add done event callback in FeedbackRouter**
   - New `onTaskDone` callback option
   - Triggers after broadcasting done signal (non-blocking)

3. **Implement `triggerNextStepRecommendation` in PrimaryNode**
   - Gets chat history for context
   - Creates SkillAgent via AgentFactory
   - Executes next-step skill asynchronously

## Flow

```
Task complete → FeedbackRouter broadcasts 'done'
                       ↓
              onTaskDone callback triggered
                       ↓
              PrimaryNode.triggerNextStepRecommendation()
                       ↓
              SkillAgent executes next-step skill
                       ↓
              Interactive card with recommendations sent
```

## Test Plan

- [ ] Complete a task and verify next-step recommendations appear
- [ ] Verify recommendations match task type
- [ ] Test button clicks trigger agent actions

Fixes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)