### PR TITLE
fix(card): emit card action as message to agent (Issue #657)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -818,6 +818,41 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     if (resolved) {
       logger.debug({ messageId: message_id }, 'Card action resolved pending interaction');
+      // Issue #657: Continue to emit message to agent instead of returning early
+      // This allows the agent to handle the interaction and decide what to do next
+    }
+
+    // Issue #657: Always emit card action as a message to the agent
+    // This enables the agent to handle user interactions and take appropriate actions
+    try {
+      // Get button text for user-friendly message
+      const buttonText = action.text || action.value;
+      const messageContent = `User clicked '${buttonText}' button`;
+
+      await this.emitMessage({
+        messageId: `${message_id}-${action.value}`,
+        chatId: chat_id,
+        userId: user?.sender_id?.open_id,
+        content: messageContent,
+        messageType: 'card',
+        timestamp: Date.now(),
+        metadata: {
+          cardAction: action,
+          cardMessageId: message_id,
+          wasPendingInteraction: resolved,
+        },
+      });
+
+      logger.debug(
+        { messageId: message_id, chatId: chat_id, actionValue: action.value },
+        'Card action emitted as message to agent'
+      );
+    } catch (error) {
+      logger.error({ err: error, messageId: message_id, chatId: chat_id }, 'Failed to emit card action message');
+    }
+
+    // Return early if resolved - the wait_for_interaction tool already returned the result
+    if (resolved) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #657 - 卡片点击事件应触发 Agent 处理

## Problem

当用户点击交互卡片上的按钮时，`wait_for_interaction` 工具只返回点击值，**没有将点击事件转化为 agent 消息**。这意味着 agent 无法处理用户交互并决定下一步操作。

### 之前的行为
```
用户点击按钮 → handleCardAction
                    ↓
          resolvePendingInteraction 返回 true
                    ↓
          直接返回，不发送消息给 agent
```

## Solution

修改 `feishu-channel.ts` 中的 `handleCardAction` 方法，在 `resolvePendingInteraction` 成功后仍然发送消息给 agent。

### 现在的行为
```
用户点击按钮 → handleCardAction
                    ↓
          resolvePendingInteraction
                    ↓
          emitMessage({ content: "User clicked '提交 Issue'" })
                    ↓
          Agent 收到消息 → 决定如何处理
```

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | 在 resolvePendingInteraction 后继续发送消息给 agent |

## Message Format

发送给 agent 的消息格式：
```
User clicked '{buttonText}' button
```

包含 metadata：
- `cardAction`: 原始 action 对象
- `cardMessageId`: 卡片消息 ID
- `wasPendingInteraction`: 是否是 wait_for_interaction 的响应

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Unit Tests | 1514 passed |
| Failed Tests | 2 (pre-existing, unrelated) |

## Verification Criteria from Issue #657

- [x] 用户点击按钮后，发送消息给 agent
- [x] Agent 收到消息后可以决定如何处理
- [x] wait_for_interaction 仍然正常返回结果

Fixes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)