### PR TITLE
fix: commands should only work with @mention in group chats (Issue #650)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -222,54 +222,43 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       );
     });
 
-    it('should always handle control commands in group chat even without @mention', async () => {
+    it('should NOT handle control commands in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/status',
         chatId: 'oc_test_group', // Group chat ID
         mentions: undefined, // No mentions
       });
 
-      // Control handler SHOULD be called - control commands always handled
-      expect(controlHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'status',
-          chatId: 'oc_test_group',
-        })
-      );
+      // Issue #650: Control commands should NOT be handled without @mention in group chats
+      // Control handler should NOT be called
+      expect(controlHandler).not.toHaveBeenCalled();
 
       // Message should NOT be passed to agent
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should handle /reset in group chat without @mention', async () => {
+    it('should NOT handle /reset in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/reset',
         chatId: 'oc_test_group',
         mentions: undefined,
       });
 
-      expect(controlHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'reset',
-        })
-      );
+      // Issue #650: Control commands should NOT be handled without @mention in group chats
+      expect(controlHandler).not.toHaveBeenCalled();
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should skip non-control command in group chat without @mention', async () => {
+    it('should skip any command in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/custom-command',
         chatId: 'oc_test_group',
         mentions: undefined,
       });
 
-      // Control handler returns success: false for unknown commands
-      // But passive mode should still skip the message
-      expect(controlHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'custom-command',
-        })
-      );
+      // Issue #650: ALL commands should be skipped without @mention in group chats
+      // Control handler should NOT be called
+      expect(controlHandler).not.toHaveBeenCalled();
 
       // Message should NOT be passed to agent (passive mode)
       expect(messageHandler).not.toHaveBeenCalled();

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -627,6 +627,22 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
+    // Issue #460 & #511: Group chat passive mode
+    // In group chats, only respond when bot is mentioned (@bot)
+    // This allows scheduled tasks to broadcast without triggering unwanted responses
+    // Issue #511: Passive mode can be disabled per chat via /passive command
+    // Issue #650: Move passive mode check BEFORE command processing
+    const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
+    if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled) {
+      logger.debug(
+        { messageId: message_id, chatId: chat_id, chat_type },
+        'Skipped group chat message without @mention (passive mode)'
+      );
+      // Issue #597: Forward filtered message to debug chat
+      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
+      return;
+    }
+
     // Get control commands from CommandRegistry (Issue #463: removed hardcoded list)
     const commandRegistry = getCommandRegistry();
 
@@ -704,21 +720,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Log if bot is mentioned with a non-control command (for debugging)
     if (botMentioned && trimmedText.startsWith('/')) {
       logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
-    }
-
-    // Issue #460 & #511: Group chat passive mode
-    // In group chats, only respond when bot is mentioned (@bot)
-    // This allows scheduled tasks to broadcast without triggering unwanted responses
-    // Issue #511: Passive mode can be disabled per chat via /passive command
-    const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
-    if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled) {
-      logger.debug(
-        { messageId: message_id, chatId: chat_id, chat_type },
-        'Skipped group chat message without @mention (passive mode)'
-      );
-      // Issue #597: Forward filtered message to debug chat
-      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
-      return;
     }
 
     // Issue #514: Add typing reaction only for messages that will be processed


### PR DESCRIPTION
## Summary

- Move passive mode check BEFORE command processing in `feishu-channel.ts`
- Ensure all commands (including control commands like `/passive`, `/status`, `/reset`) only work when bot is @mentioned in group chats
- Update tests to reflect new expected behavior

## Problem

Previously, control commands were processed before the passive mode check, allowing users to execute commands like `/passive` without explicitly invoking (mentioning) the bot. This violated the passive mode design where the bot should only respond when explicitly mentioned in group chats.

## Solution

Move the passive mode check to execute before any command processing. This ensures:
1. In group chats without @mention: All messages (including commands) are skipped
2. In group chats with @mention: Commands work normally
3. In private chats: No change in behavior (commands work without @mention)

## Test Plan

- [x] All 25 passive mode tests pass
- [x] TypeScript type check passes
- [x] Behavior verified: `/passive` and other commands no longer work without @mention in group chats

Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)