### PR TITLE
fix(feishu): apply passive mode to control commands in group chats (Issue #650)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -107,6 +107,16 @@ vi.mock('../utils/task-tracker.js', () => ({
   TaskTracker: vi.fn(),
 }));
 
+vi.mock('../nodes/commands/command-registry.js', () => ({
+  getCommandRegistry: vi.fn(() => ({
+    register: vi.fn(),
+    // Only recognize known control commands (status, reset, help, passive, etc.)
+    // Unknown commands like 'custom-command' will return false
+    has: vi.fn((name: string) => ['status', 'reset', 'help', 'passive', 'groups', 'debug', 'schedule', 'task', 'expert', 'budget'].includes(name)),
+    get: vi.fn(),
+  })),
+}));
+
 import { FeishuChannel } from './feishu-channel.js';
 
 describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
@@ -222,14 +232,34 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       );
     });
 
-    it('should always handle control commands in group chat even without @mention', async () => {
+    it('should skip control commands in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/status',
         chatId: 'oc_test_group', // Group chat ID
         mentions: undefined, // No mentions
       });
 
-      // Control handler SHOULD be called - control commands always handled
+      // Control handler should NOT be called - passive mode applies to all messages (Issue #650)
+      expect(controlHandler).not.toHaveBeenCalled();
+
+      // Message should NOT be passed to agent
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('should handle control commands in group chat WITH @mention', async () => {
+      await simulateMessageReceive({
+        text: '/status',
+        chatId: 'oc_test_group', // Group chat ID
+        mentions: [
+          {
+            key: '@_bot',
+            id: { open_id: 'cli_test_bot_id' }, // Bot's open_id from mock
+            name: 'Bot',
+          },
+        ],
+      });
+
+      // Control handler SHOULD be called when bot is mentioned
       expect(controlHandler).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'status',
@@ -241,35 +271,27 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should handle /reset in group chat without @mention', async () => {
+    it('should skip /reset in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/reset',
         chatId: 'oc_test_group',
         mentions: undefined,
       });
 
-      expect(controlHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'reset',
-        })
-      );
+      // Control handler should NOT be called - passive mode applies to all messages (Issue #650)
+      expect(controlHandler).not.toHaveBeenCalled();
       expect(messageHandler).not.toHaveBeenCalled();
     });
 
-    it('should skip non-control command in group chat without @mention', async () => {
+    it('should skip non-control command in group chat without @mention (Issue #650)', async () => {
       await simulateMessageReceive({
         text: '/custom-command',
         chatId: 'oc_test_group',
         mentions: undefined,
       });
 
-      // Control handler returns success: false for unknown commands
-      // But passive mode should still skip the message
-      expect(controlHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'custom-command',
-        })
-      );
+      // Control handler should NOT be called - passive mode applies to all messages (Issue #650)
+      expect(controlHandler).not.toHaveBeenCalled();
 
       // Message should NOT be passed to agent (passive mode)
       expect(messageHandler).not.toHaveBeenCalled();

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -621,11 +621,27 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       create_time
     );
 
-    // Check for control commands
-    // Control commands should ALWAYS be handled through the control channel, regardless of mentions
-    // This ensures /reset, /status, etc. work correctly even when bot is @mentioned
+    // Check for passive mode first (Issue #650)
+    // In group chats, only respond when bot is mentioned (@bot)
+    // This applies to ALL messages including control commands
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
+    const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
+
+    // Issue #460 & #511: Group chat passive mode
+    // In group chats, only respond when bot is mentioned (@bot)
+    // This allows scheduled tasks to broadcast without triggering unwanted responses
+    // Issue #511: Passive mode can be disabled per chat via /passive command
+    // Issue #650: Passive mode should also apply to control commands
+    if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled) {
+      logger.debug(
+        { messageId: message_id, chatId: chat_id, chat_type },
+        'Skipped group chat message without @mention (passive mode)'
+      );
+      // Issue #597: Forward filtered message to debug chat
+      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
+      return;
+    }
 
     // Get control commands from CommandRegistry (Issue #463: removed hardcoded list)
     const commandRegistry = getCommandRegistry();
@@ -704,21 +720,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Log if bot is mentioned with a non-control command (for debugging)
     if (botMentioned && trimmedText.startsWith('/')) {
       logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
-    }
-
-    // Issue #460 & #511: Group chat passive mode
-    // In group chats, only respond when bot is mentioned (@bot)
-    // This allows scheduled tasks to broadcast without triggering unwanted responses
-    // Issue #511: Passive mode can be disabled per chat via /passive command
-    const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
-    if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled) {
-      logger.debug(
-        { messageId: message_id, chatId: chat_id, chat_type },
-        'Skipped group chat message without @mention (passive mode)'
-      );
-      // Issue #597: Forward filtered message to debug chat
-      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
-      return;
     }
 
     // Issue #514: Add typing reaction only for messages that will be processed


### PR DESCRIPTION
## Summary

Fixes #650 - 在群聊中，控制命令现在也需要 @bot 才能被处理

## Problem

在群聊中，控制命令（如 `/reset`, `/status`) 即使没有 @bot 也会被响应。这导致了不必要的 bot 响应噪音。

## Solution

将 passive 模式检查移到控制命令处理之前执行。这确保在群聊中,所有消息(包括控制命令)都会被跳过,除非 bot 被提及或者 passive 模式被禁用。

## Changes

| File | Description |
|------|-------------|
| `src/channels/feishu-channel.ts` | 将 passive 模式检查移到控制命令处理之前 |
| `src/channels/feishu-channel-passive-mode.test.ts` | 更新测试以反映新行为 |

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Unit Tests | 26 passed (feishu-channel-passive-mode.test.ts) |

## Verification Criteria from Issue #650

- [x] 群聊中没有 @bot 时,控制命令被跳过
- [x] 群聊中有 @bot 时,控制命令被处理
- [x] 私聊中,控制命令仍然正常工作

Fixes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)