### PR TITLE
fix(feishu): use DebugGroupService for filtered message forwarding (Issue #652)

### DIFF
--- a/src/feishu/filtered-message-forwarder.test.ts
+++ b/src/feishu/filtered-message-forwarder.test.ts
@@ -1,30 +1,40 @@
 /**
  * Tests for FilteredMessageForwarder.
  * @see Issue #597
+ * @see Issue #652 - Uses DebugGroupService for memory-based debug group
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FilteredMessageForwarder, type MessageSender } from './filtered-message-forwarder.js';
+import { getDebugGroupService } from '../nodes/debug-group-service.js';
 import type { FilterReason } from '../config/types.js';
 
 describe('FilteredMessageForwarder', () => {
   let mockSender: MessageSender;
+  const debugGroupService = getDebugGroupService();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockSender = {
       sendText: vi.fn().mockResolvedValue(undefined),
     };
+    // Clear debug group before each test
+    debugGroupService.clearDebugGroup();
   });
 
-  describe('when disabled', () => {
+  afterEach(() => {
+    // Clean up after each test
+    debugGroupService.clearDebugGroup();
+  });
+
+  describe('when debug group is not set', () => {
     it('should not be configured', () => {
-      const forwarder = new FilteredMessageForwarder({ enabled: false });
+      const forwarder = new FilteredMessageForwarder();
       expect(forwarder.isConfigured()).toBe(false);
     });
 
     it('should not forward any messages', async () => {
-      const forwarder = new FilteredMessageForwarder({ enabled: false });
+      const forwarder = new FilteredMessageForwarder();
       forwarder.setMessageSender(mockSender);
 
       await forwarder.forward({
@@ -38,47 +48,26 @@ describe('FilteredMessageForwarder', () => {
       expect(mockSender.sendText).not.toHaveBeenCalled();
     });
 
-    it('should not forward even if reason matches includeReasons', async () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: false,
-        filterForwardChatId: 'debug-chat',
-        includeReasons: ['passive_mode'],
-      });
-      forwarder.setMessageSender(mockSender);
-
-      await forwarder.forward({
-        messageId: 'test-id',
-        chatId: 'chat-1',
-        content: 'test content',
-        reason: 'passive_mode',
-        timestamp: Date.now(),
-      });
-
-      expect(mockSender.sendText).not.toHaveBeenCalled();
+    it('shouldForward should return false', () => {
+      const forwarder = new FilteredMessageForwarder();
+      expect(forwarder.shouldForward('passive_mode')).toBe(false);
     });
   });
 
-  describe('when enabled without filterForwardChatId', () => {
-    it('should not be configured', () => {
-      const forwarder = new FilteredMessageForwarder({ enabled: true });
-      expect(forwarder.isConfigured()).toBe(false);
-    });
-  });
+  describe('when debug group is set', () => {
+    const debugChatId = 'oc_debug_chat_123';
 
-  describe('when fully configured', () => {
+    beforeEach(() => {
+      debugGroupService.setDebugGroup(debugChatId, 'Test Debug Group');
+    });
+
     it('should be configured', () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat-123',
-      });
+      const forwarder = new FilteredMessageForwarder();
       expect(forwarder.isConfigured()).toBe(true);
     });
 
-    it('should forward all reasons when includeReasons is empty', async () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat-123',
-      });
+    it('should forward all reasons', async () => {
+      const forwarder = new FilteredMessageForwarder();
       forwarder.setMessageSender(mockSender);
 
       const reasons: FilterReason[] = ['duplicate', 'bot', 'old', 'unsupported', 'empty', 'passive_mode'];
@@ -96,11 +85,8 @@ describe('FilteredMessageForwarder', () => {
       expect(mockSender.sendText).toHaveBeenCalledTimes(6);
     });
 
-    it('should format message correctly', async () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat-123',
-      });
+    it('should format message correctly with debug group info', async () => {
+      const forwarder = new FilteredMessageForwarder();
       forwarder.setMessageSender(mockSender);
 
       await forwarder.forward({
@@ -113,25 +99,27 @@ describe('FilteredMessageForwarder', () => {
       });
 
       expect(mockSender.sendText).toHaveBeenCalledWith(
-        'debug-chat-123',
+        debugChatId,
         expect.stringContaining('🔇')
       );
       expect(mockSender.sendText).toHaveBeenCalledWith(
-        'debug-chat-123',
+        debugChatId,
         expect.stringContaining('passive_mode')
       );
       expect(mockSender.sendText).toHaveBeenCalledWith(
-        'debug-chat-123',
+        debugChatId,
         expect.stringContaining('Hello world')
+      );
+      // Should contain debug group name
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        debugChatId,
+        expect.stringContaining('Test Debug Group')
       );
     });
 
     it('should truncate long content', async () => {
       const sendText = vi.fn().mockResolvedValue(undefined);
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat-123',
-      });
+      const forwarder = new FilteredMessageForwarder();
       forwarder.setMessageSender({ sendText });
 
       const longContent = 'x'.repeat(300);
@@ -146,21 +134,81 @@ describe('FilteredMessageForwarder', () => {
       const [, message] = sendText.mock.calls[0] as [unknown, string];
       expect(message).toContain('...');
     });
-  });
 
-  describe('when configured with includeReasons', () => {
-    let forwarder: FilteredMessageForwarder;
+    it('shouldForward should return true for all reasons', () => {
+      const forwarder = new FilteredMessageForwarder();
+      const reasons: FilterReason[] = ['duplicate', 'bot', 'old', 'unsupported', 'empty', 'passive_mode'];
 
-    beforeEach(() => {
-      forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat-123',
-        includeReasons: ['passive_mode', 'duplicate'],
-      });
-      forwarder.setMessageSender(mockSender);
+      for (const reason of reasons) {
+        expect(forwarder.shouldForward(reason)).toBe(true);
+      }
     });
 
-    it('should forward only included reasons', async () => {
+    it('should forward to the correct debug chat ID', async () => {
+      const forwarder = new FilteredMessageForwarder();
+      forwarder.setMessageSender(mockSender);
+
+      await forwarder.forward({
+        messageId: 'msg-123',
+        chatId: 'chat-456',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        debugChatId,
+        expect.any(String)
+      );
+    });
+  });
+
+  describe('when debug group is changed', () => {
+    it('should forward to the new debug group after change', async () => {
+      const forwarder = new FilteredMessageForwarder();
+      forwarder.setMessageSender(mockSender);
+
+      // Set first debug group
+      debugGroupService.setDebugGroup('oc_first_debug', 'First Debug');
+
+      await forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test 1',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        'oc_first_debug',
+        expect.any(String)
+      );
+
+      // Change to new debug group
+      debugGroupService.setDebugGroup('oc_second_debug', 'Second Debug');
+
+      await forwarder.forward({
+        messageId: 'msg-2',
+        chatId: 'chat-1',
+        content: 'test 2',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      expect(mockSender.sendText).toHaveBeenCalledWith(
+        'oc_second_debug',
+        expect.any(String)
+      );
+    });
+
+    it('should stop forwarding after debug group is cleared', async () => {
+      const forwarder = new FilteredMessageForwarder();
+      forwarder.setMessageSender(mockSender);
+
+      // Set debug group
+      debugGroupService.setDebugGroup('oc_debug', 'Debug');
+      debugGroupService.clearDebugGroup();
+
       await forwarder.forward({
         messageId: 'msg-1',
         chatId: 'chat-1',
@@ -169,39 +217,17 @@ describe('FilteredMessageForwarder', () => {
         timestamp: Date.now(),
       });
 
-      await forwarder.forward({
-        messageId: 'msg-2',
-        chatId: 'chat-1',
-        content: 'test',
-        reason: 'duplicate',
-        timestamp: Date.now(),
-      });
-
-      await forwarder.forward({
-        messageId: 'msg-3',
-        chatId: 'chat-1',
-        content: 'test',
-        reason: 'bot',
-        timestamp: Date.now(),
-      });
-
-      expect(mockSender.sendText).toHaveBeenCalledTimes(2);
-    });
-
-    it('should check shouldForward correctly', () => {
-      expect(forwarder.shouldForward('passive_mode')).toBe(true);
-      expect(forwarder.shouldForward('duplicate')).toBe(true);
-      expect(forwarder.shouldForward('bot')).toBe(false);
-      expect(forwarder.shouldForward('old')).toBe(false);
+      expect(mockSender.sendText).not.toHaveBeenCalled();
     });
   });
 
   describe('setMessageSender', () => {
+    beforeEach(() => {
+      debugGroupService.setDebugGroup('oc_debug', 'Debug');
+    });
+
     it('should update message sender', async () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat',
-      });
+      const forwarder = new FilteredMessageForwarder();
 
       const sendText1 = vi.fn().mockResolvedValue(undefined);
       const sendText2 = vi.fn().mockResolvedValue(undefined);
@@ -234,11 +260,12 @@ describe('FilteredMessageForwarder', () => {
   });
 
   describe('error handling', () => {
+    beforeEach(() => {
+      debugGroupService.setDebugGroup('oc_debug', 'Debug');
+    });
+
     it('should handle send errors gracefully', async () => {
-      const forwarder = new FilteredMessageForwarder({
-        enabled: true,
-        filterForwardChatId: 'debug-chat',
-      });
+      const forwarder = new FilteredMessageForwarder();
 
       const failingSender: MessageSender = {
         sendText: vi.fn().mockRejectedValue(new Error('Network error')),
@@ -255,9 +282,27 @@ describe('FilteredMessageForwarder', () => {
         timestamp: Date.now(),
       })).resolves.not.toThrow();
     });
+
+    it('should warn when MessageSender not configured', async () => {
+      const forwarder = new FilteredMessageForwarder();
+      // Don't set message sender
+
+      // Should not throw and should silently skip
+      await expect(forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      })).resolves.not.toThrow();
+    });
   });
 
   describe('formatting', () => {
+    beforeEach(() => {
+      debugGroupService.setDebugGroup('oc_debug', 'Debug Group');
+    });
+
     it('should use correct emoji for each reason', async () => {
       const emojiMap: Record<FilterReason, string> = {
         duplicate: '🔄',
@@ -270,10 +315,7 @@ describe('FilteredMessageForwarder', () => {
 
       for (const [reason, emoji] of Object.entries(emojiMap)) {
         const sendText = vi.fn().mockResolvedValue(undefined);
-        const forwarder = new FilteredMessageForwarder({
-          enabled: true,
-          filterForwardChatId: 'debug-chat',
-        });
+        const forwarder = new FilteredMessageForwarder();
         forwarder.setMessageSender({ sendText });
 
         await forwarder.forward({
@@ -284,10 +326,28 @@ describe('FilteredMessageForwarder', () => {
           timestamp: Date.now(),
         });
         expect(sendText).toHaveBeenCalledWith(
-          'debug-chat',
+          'oc_debug',
           expect.stringContaining(emoji)
         );
       }
+    });
+
+    it('should include debug group info in message', async () => {
+      const sendText = vi.fn().mockResolvedValue(undefined);
+      const forwarder = new FilteredMessageForwarder();
+      forwarder.setMessageSender({ sendText });
+
+      await forwarder.forward({
+        messageId: 'msg-1',
+        chatId: 'chat-1',
+        content: 'test',
+        reason: 'passive_mode',
+        timestamp: Date.now(),
+      });
+
+      const [, message] = sendText.mock.calls[0] as [unknown, string];
+      expect(message).toContain('调试群');
+      expect(message).toContain('Debug Group');
     });
   });
 });

--- a/src/feishu/filtered-message-forwarder.ts
+++ b/src/feishu/filtered-message-forwarder.ts
@@ -5,10 +5,11 @@
  * Useful for diagnosing why messages are being filtered in passive mode.
  *
  * @see Issue #597
+ * @see Issue #652 - Uses DebugGroupService for memory-based debug group management
  */
 
-import { Config } from '../config/index.js';
-import type { FilterReason, DebugConfig } from '../config/types.js';
+import type { FilterReason } from '../config/types.js';
+import { getDebugGroupService, type DebugGroupInfo } from '../nodes/debug-group-service.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('FilteredMessageForwarder');
@@ -43,77 +44,44 @@ export interface MessageSender {
 /**
  * FilteredMessageForwarder handles forwarding filtered messages to a debug chat.
  *
- * Configuration (in disclaude.config.yaml):
- * ```yaml
- * messaging:
- *   debug:
- *     enabled: true
- *     filterForwardChatId: "oc_xxx"  # Chat to forward filtered messages to
- *     includeReasons:                # Only forward these reasons (empty = all)
- *       - passive_mode
- *       - duplicate
- * ```
+ * Uses DebugGroupService for memory-based debug group management.
+ * The debug group is set via the `/set-debug` command in a chat.
+ *
+ * @see Issue #652 - Changed from config-based to memory-based debug group
+ * @see Issue #597 - Original filtered message forwarding feature
  */
 export class FilteredMessageForwarder {
-  private enabled: boolean;
-  private forwardChatId?: string;
-  private includeReasons: Set<FilterReason>;
   private messageSender?: MessageSender;
-
-  /**
-   * Create a new FilteredMessageForwarder.
-   * @param debugConfig - Optional debug config for testing (uses Config.getDebugConfig() by default)
-   */
-  constructor(debugConfig?: DebugConfig) {
-    const config = debugConfig ?? Config.getDebugConfig() ?? {};
-    this.enabled = config.enabled ?? false;
-    this.forwardChatId = config.filterForwardChatId;
-    this.includeReasons = new Set(config.includeReasons || []);
-
-    if (this.enabled && this.forwardChatId) {
-      logger.info(
-        { forwardChatId: this.forwardChatId, includeReasons: [...this.includeReasons] },
-        'FilteredMessageForwarder initialized'
-      );
-    } else {
-      // Issue #652: Output WARN log when not configured
-      logger.warn(
-        {
-          enabled: this.enabled,
-          hasForwardChatId: !!this.forwardChatId,
-          hint: 'Add messaging.debug section to disclaude.config.yaml to enable filtered message forwarding'
-        },
-        'FilteredMessageForwarder is not configured. Filtered messages will not be forwarded.'
-      );
-    }
-  }
 
   /**
    * Set the message sender for forwarding messages.
    */
   setMessageSender(sender: MessageSender): void {
     this.messageSender = sender;
+    logger.info('MessageSender configured for FilteredMessageForwarder');
   }
 
   /**
-   * Check if forwarding is enabled and configured.
+   * Get the current debug group from DebugGroupService.
+   * @returns The current debug group info, or null if not set
+   */
+  private getDebugGroup(): DebugGroupInfo | null {
+    return getDebugGroupService().getDebugGroup();
+  }
+
+  /**
+   * Check if forwarding is enabled (debug group is set).
    */
   isConfigured(): boolean {
-    return this.enabled && !!this.forwardChatId;
+    return this.getDebugGroup() !== null;
   }
 
   /**
    * Check if a specific filter reason should be forwarded.
+   * Always returns true if debug group is set (forwards all reasons).
    */
   shouldForward(reason: FilterReason): boolean {
-    if (!this.isConfigured()) {
-      return false;
-    }
-    // If includeReasons is empty, forward all reasons
-    if (this.includeReasons.size === 0) {
-      return true;
-    }
-    return this.includeReasons.has(reason);
+    return this.isConfigured();
   }
 
   /**
@@ -122,19 +90,25 @@ export class FilteredMessageForwarder {
    * @param message - The filtered message data
    */
   async forward(message: FilteredMessage): Promise<void> {
-    if (!this.shouldForward(message.reason)) {
+    const debugGroup = this.getDebugGroup();
+
+    if (!debugGroup) {
+      // Debug group not set, silently skip
       return;
     }
 
-    if (!this.messageSender || !this.forwardChatId) {
-      logger.warn('MessageSender or forwardChatId not configured');
+    if (!this.messageSender) {
+      logger.warn('MessageSender not configured, cannot forward filtered message');
       return;
     }
 
     try {
-      const formattedMessage = this.formatMessage(message);
-      await this.messageSender.sendText(this.forwardChatId, formattedMessage);
-      logger.debug({ messageId: message.messageId, reason: message.reason }, 'Forwarded filtered message');
+      const formattedMessage = this.formatMessage(message, debugGroup);
+      await this.messageSender.sendText(debugGroup.chatId, formattedMessage);
+      logger.debug(
+        { messageId: message.messageId, reason: message.reason, debugChatId: debugGroup.chatId },
+        'Forwarded filtered message to debug group'
+      );
     } catch (error) {
       logger.error({ err: error, messageId: message.messageId }, 'Failed to forward filtered message');
     }
@@ -142,8 +116,10 @@ export class FilteredMessageForwarder {
 
   /**
    * Format a filtered message for display.
+   * @param message - The filtered message data
+   * @param debugGroup - The debug group info (optional, for context)
    */
-  private formatMessage(message: FilteredMessage): string {
+  private formatMessage(message: FilteredMessage, debugGroup: DebugGroupInfo): string {
     const reasonEmoji: Record<FilterReason, string> = {
       duplicate: '🔄',
       bot: '🤖',
@@ -159,6 +135,8 @@ export class FilteredMessageForwarder {
       ? `${message.content.slice(0, 200)}...`
       : message.content;
 
+    const debugGroupName = debugGroup.name ? ` (${debugGroup.name})` : '';
+
     return `${emoji} **被过滤消息**
 
 | 字段 | 值 |
@@ -168,6 +146,7 @@ export class FilteredMessageForwarder {
 | 消息ID | \`${message.messageId}\` |
 | 聊天ID | \`${message.chatId}\` |
 | 用户ID | \`${message.userId || 'unknown'}\` |
+| 调试群 | \`${debugGroup.chatId}\`${debugGroupName} |
 
 **内容**:
 \`\`\`


### PR DESCRIPTION
## Summary

This PR fixes issue #652 by changing `FilteredMessageForwarder` to use memory-based `DebugGroupService` instead of reading from config file.

## Problem

The original implementation read `filterForwardChatId` from config file (`messaging.debug.filterForwardChatId`), but as noted in [issue comment](https://github.com/hs3180/disclaude/issues/652#issuecomment-xxx):

> "这个 chatid 应该在 primary node 的内存中维护，不应该从配置文件读取"

(The chatId should be maintained in primary node memory, not read from config file)

## Solution

Changed `FilteredMessageForwarder` to:
- Use `DebugGroupService.getDebugGroup()` to get the current debug chat ID dynamically
- This aligns with the existing `/set-debug` command which already manages debug group in primary node memory
- Removed config-based initialization (`enabled`, `filterForwardChatId`, `includeReasons`)
- Now forwards all filter reasons when debug group is set

## Key Changes

1. **filtered-message-forwarder.ts**:
   - Removed dependency on `Config.getDebugConfig()`
   - Added dependency on `getDebugGroupService()` from `debug-group-service.ts`
   - `isConfigured()` now checks if `DebugGroupService.getDebugGroup()` returns a value
   - `forward()` gets chatId dynamically from `DebugGroupService`
   - Added debug group info to the forwarded message format

2. **filtered-message-forwarder.test.ts**:
   - Updated all tests to use `DebugGroupService` for setting up debug group
   - Added `beforeEach`/`afterEach` to manage debug group state
   - Removed tests for config-based features (includeReasons filtering)

## Usage

Users can now use the `/set-debug` command in any chat to set it as the debug group. Filtered messages will automatically be forwarded to that chat. No config file changes needed.

## Test Plan

- [x] All 16 tests in `filtered-message-forwarder.test.ts` pass
- [x] All 10 tests in `debug-group-service.test.ts` pass
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)