### PR TITLE
fix(test): add wait between async and sync tests (Issue #644)

### DIFF
--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -617,6 +617,24 @@ parse_common_args() {
 }
 
 # =============================================================================
+# Wait for Background Sessions (Issue #644)
+# =============================================================================
+
+# Wait for background agent sessions to complete.
+# This is needed after REST Channel Tests which use async mode.
+# The async tests leave agent sessions running in background, and
+# GLM SDK may route messages to wrong sessions if we don't wait.
+#
+# Usage: wait_for_background_sessions [seconds]
+# Default wait time: 5 seconds
+wait_for_background_sessions() {
+    local wait_seconds="${1:-5}"
+    log_info "Waiting ${wait_seconds}s for background agent sessions to complete (Issue #644)..."
+    sleep "$wait_seconds"
+    log_debug "Wait complete"
+}
+
+# =============================================================================
 # Test Summary
 # =============================================================================
 

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -142,6 +142,12 @@ main() {
         failed=$((failed + 1))
     fi
 
+    # Wait for background agent sessions to complete (Issue #644)
+    # REST Channel Tests use async mode, leaving agent sessions running in background.
+    # We need to wait for these sessions to complete before running sync tests
+    # to avoid SDK message routing issues.
+    wait_for_background_sessions 5
+
     # Run Use Case 1 Tests
     if ! run_test_script "$SCRIPT_DIR/use-case-1-basic-reply.sh" "Use Case 1 - Basic Reply"; then
         failed=$((failed + 1))


### PR DESCRIPTION
## Summary
- Add `wait_for_background_sessions()` function to handle SDK concurrency issues
- Wait 5 seconds between REST Channel Tests (async) and Use Case tests (sync)
- Prevents GLM SDK message routing confusion when multiple sessions run concurrently

## Problem
Integration tests randomly fail with HTTP 000 (connection timeout) in Use Case 1 Test 3. The root cause is GLM SDK message routing confusion when multiple agent sessions run concurrently.

### Timeline
```
T1: REST Channel Tests send async requests (chatId: A) → Agent starts background processing
T2: REST Channel Tests complete (but Agent session A still running)
T3: Use Case 1 Test 2 completes (chatId: B)
T4: Use Case 1 Test 3 starts (chatId: C)
T5: Test 3 receives SDK init message (session_id: X)
T6: SDK message wrongly routed to chatId: A session (instead of C)
T7: Session A completes
T8: Test 3 never completes → HTTP timeout (HTTP 000)
```

## Solution
Add a wait period between async tests and sync tests to allow background sessions to complete.

## Changes

| File | Description |
|------|-------------|
| `tests/integration/common.sh` | Add `wait_for_background_sessions()` function |
| `tests/integration/run-all-tests.sh` | Call wait function after REST Channel Tests |

## Test Results
- All existing tests pass (2 pre-existing failures unrelated to this change)
- Build: ✅ Pass
- Shell syntax: ✅ Pass

Fixes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)