### PR TITLE
fix: admin chat should receive all messages for monitoring (Issue #675)

### DIFF
--- a/src/nodes/unified-message-router.ts
+++ b/src/nodes/unified-message-router.ts
@@ -6,16 +6,18 @@
  * - Supports admin chat for debug/progress messages
  * - Handles feedback messages (text, card, file, done, error)
  *
- * Routing Rules (Issue #659):
+ * Routing Rules (Issue #659, Issue #675):
  * ```
  * Message Type          →    Target Channel
  * ────────────────────────────────────────────
- * text/result/complete  →    user chat
- * card/file             →    user chat
+ * text/result/complete  →    admin + user chat
+ * card/file             →    admin + user chat
  * error/critical        →    admin + user chat
  * debug/progress        →    admin chat only
- * done                  →    user chat (triggers onTaskDone)
+ * done                  →    admin + user chat (triggers onTaskDone)
  * ```
+ *
+ * Note: Admin chat receives ALL messages for system monitoring (Issue #675).
  *
  * Architecture:
  * ```
@@ -245,11 +247,11 @@ export class UnifiedMessageRouter {
       case 'card':
       case 'file':
       case 'done':
-        // User-facing messages → user chat only (unless level-based override)
+        // User-facing messages → admin + user chat (admin receives all for monitoring)
+        decision.toAdmin = !!this.adminChatId;
         decision.toUser = true;
         if (level && !this.userLevels.has(level)) {
           decision.toUser = false;
-          decision.toAdmin = !!this.adminChatId;
         }
         break;
     }


### PR DESCRIPTION
## Summary

- Modify `UnifiedMessageRouter.determineRouting()` to send all message types to admin chat
- Admin chat now receives ALL messages for complete system monitoring
- User-facing messages still go to user chat as expected

## Problem

Admin/debug chat was only receiving debug/progress level messages, not all messages as expected for system monitoring. This made it difficult to use admin chat as a complete monitoring window.

## Solution

Update routing rules so admin chat receives all message types:

| Message Type | Before | After |
|--------------|--------|-------|
| text/result/complete | user only | admin + user |
| card/file | user only | admin + user |
| error/critical | admin + user | admin + user (unchanged) |
| debug/progress | admin only | admin only (unchanged) |
| done | user only | admin + user |

## Changes

| File | Description |
|------|-------------|
| `src/nodes/unified-message-router.ts` | Update `determineRouting()` to send all types to admin |

## Test Results

| Metric | Value |
|--------|-------|
| Build | ✅ Pass |
| Tests | 1518/1519 passed |
| Pre-existing failure | `src/config/index.test.ts` (unrelated) |

## Verification Criteria from Issue #675

- [x] Admin chat receives text/result messages
- [x] Admin chat receives card/file messages
- [x] Admin chat receives error messages
- [x] Admin chat receives debug/progress messages
- [x] Admin chat receives done messages
- [x] User chat behavior unchanged

Fixes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)