### PR TITLE
fix(feishu): 修复群聊成员加入时帮助消息不发送的问题 (Issue #676)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -934,6 +934,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
    * Handle chat member added event.
    * Triggered when members are added to a chat.
    * Issue #463: Send welcome message when new members join a group.
+   * Issue #676: Send help message when users join a group that already has the bot.
    */
   private async handleChatMemberAdded(data: FeishuChatMemberAddedEventData): Promise<void> {
     if (!this.isRunning || !this.welcomeService) {
@@ -947,7 +948,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     }
 
     // Only send welcome to group chats
-    if (!this.isGroupChat(event.chat_id)) {
+    // Use welcomeService.isGroupChat() which checks chat_id prefix (oc_)
+    // Note: this.isGroupChat() expects chat_type string, not chat_id
+    if (!this.welcomeService.isGroupChat(event.chat_id)) {
       logger.debug({ chatId: event.chat_id }, 'Member added to non-group chat, skipping welcome');
       return;
     }


### PR DESCRIPTION
## Summary
- 修复 `handleChatMemberAdded()` 中的 bug：错误使用 `this.isGroupChat(event.chat_id)` 判断群聊
- `this.isGroupChat()` 方法期望 `chat_type` 字符串（如 'group'），但传入的是 `chat_id`（如 'oc_xxx'）
- 改用 `welcomeService.isGroupChat(event.chat_id)` 方法，正确检查 chat_id 是否以 'oc_' 开头

## 问题分析
原代码中的 bug 导致：
1. 当新成员加入群聊时，`this.isGroupChat(event.chat_id)` 始终返回 `false`（因为 chat_id 不是有效的 chat_type）
2. 因此帮助消息永远不会发送给新加入的用户

## 修复内容
- 使用 `welcomeService.isGroupChat(chatId)` 方法，该方法通过检查 chatId 前缀 'oc_' 来正确判断是否为群聊

## Test plan
- [x] 代码编译通过 (`npm run build`)
- [x] TypeScript 类型检查通过 (`npm run type-check`)
- [x] 单元测试通过 (1517 passed)
- [ ] 手动测试：用户加入群聊时收到帮助消息

Fixes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)