### PR TITLE
feat(feishu): send help message when users join group (Issue #676)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -341,6 +341,19 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   }
 
   /**
+   * Check if a chat ID is a group chat based on ID prefix.
+   * In Feishu, group chat IDs start with 'oc_' and private chat IDs start with 'ou_'.
+   *
+   * Issue #676: Used in handleChatMemberAdded where chat_type is not available.
+   *
+   * @param chatId - Chat ID to check
+   * @returns true if it's a group chat ID
+   */
+  private isGroupChatId(chatId: string): boolean {
+    return chatId.startsWith('oc_');
+  }
+
+  /**
    * Fetch bot's open_id from Feishu API.
    * This is used to correctly identify when the bot is mentioned.
    *
@@ -933,7 +946,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   /**
    * Handle chat member added event.
    * Triggered when members are added to a chat.
-   * Issue #463: Send welcome message when new members join a group.
+   * Issue #463: Send welcome message when bot is added to a group.
+   * Issue #676: Send help message when users join a group that already has the bot.
    */
   private async handleChatMemberAdded(data: FeishuChatMemberAddedEventData): Promise<void> {
     if (!this.isRunning || !this.welcomeService) {
@@ -946,15 +960,36 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    // Only send welcome to group chats
-    if (!this.isGroupChat(event.chat_id)) {
-      logger.debug({ chatId: event.chat_id }, 'Member added to non-group chat, skipping welcome');
+    // Only send messages to group chats
+    if (!this.isGroupChatId(event.chat_id)) {
+      logger.debug({ chatId: event.chat_id }, 'Member added to non-group chat, skipping');
       return;
     }
 
-    logger.info({ chatId: event.chat_id, memberCount: event.members.length }, 'New members joined group, sending welcome message');
+    // Check if the bot is among the added members
+    // Bot's member_id_type is "app_id" and member_id is the bot's app_id
+    const botMemberAdded = event.members.some(
+      (member) => member.member_id_type === 'app_id' && member.member_id === this.appId
+    );
 
-    await this.welcomeService.handleBotAddedToGroup(event.chat_id);
+    // Get non-bot members (users who joined)
+    const userMembers = event.members.filter(
+      (member) => !(member.member_id_type === 'app_id' && member.member_id === this.appId)
+    );
+
+    if (botMemberAdded) {
+      // Bot was added to the group -> send welcome message
+      logger.info({ chatId: event.chat_id }, 'Bot added to group, sending welcome message');
+      await this.welcomeService.handleBotAddedToGroup(event.chat_id);
+    } else if (userMembers.length > 0) {
+      // Users joined a group that already has the bot -> send help message
+      logger.info(
+        { chatId: event.chat_id, userCount: userMembers.length },
+        'New users joined group, sending help message'
+      );
+      const userIds = userMembers.map((m) => m.member_id);
+      await this.welcomeService.handleUserJoinedGroup(event.chat_id, userIds);
+    }
   }
 
   /**

--- a/src/platforms/feishu/welcome-service.test.ts
+++ b/src/platforms/feishu/welcome-service.test.ts
@@ -79,6 +79,49 @@ describe('WelcomeService', () => {
     });
   });
 
+  describe('handleUserJoinedGroup', () => {
+    it('should send help message to group when users join', async () => {
+      await service.handleUserJoinedGroup('oc_test123', ['ou_user1', 'ou_user2']);
+
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageMock).toHaveBeenCalledWith('oc_test123', '👋 Welcome!');
+    });
+
+    it('should use custom help message if provided', async () => {
+      const customService = new WelcomeService({
+        generateWelcomeMessage: () => '👋 Welcome!',
+        generateHelpMessage: () => '📖 Help info for new users',
+        sendMessage: sendMessageMock,
+      });
+
+      await customService.handleUserJoinedGroup('oc_test123', ['ou_user1']);
+
+      expect(sendMessageMock).toHaveBeenCalledWith('oc_test123', '📖 Help info for new users');
+    });
+
+    it('should not send message to non-group chat', async () => {
+      await service.handleUserJoinedGroup('ou_test123', ['ou_user1']);
+
+      expect(sendMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle send message error', async () => {
+      sendMessageMock.mockRejectedValueOnce(new Error('Send failed'));
+
+      // Should not throw
+      await service.handleUserJoinedGroup('oc_test123', ['ou_user1']);
+
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should work without user IDs parameter', async () => {
+      await service.handleUserJoinedGroup('oc_test123');
+
+      expect(sendMessageMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageMock).toHaveBeenCalledWith('oc_test123', '👋 Welcome!');
+    });
+  });
+
   describe('handleFirstPrivateChat', () => {
     it('should send welcome message on first private chat', async () => {
       const result = await service.handleFirstPrivateChat('ou_user123');

--- a/src/platforms/feishu/welcome-service.ts
+++ b/src/platforms/feishu/welcome-service.ts
@@ -4,9 +4,11 @@
  * Provides:
  * - Welcome message when bot enters a new P2P chat
  * - Welcome message when bot is added to a group
+ * - Help message when users join a group that already has the bot
  * - Tracks first-time private chats in memory
  *
  * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
+ * Issue #676: 新用户加入群聊时发送 /help 信息
  */
 
 import { createLogger } from '../../utils/logger.js';
@@ -20,6 +22,9 @@ export interface WelcomeServiceConfig {
   /** Function to generate welcome message */
   generateWelcomeMessage: () => string;
 
+  /** Function to generate help message for new users joining group */
+  generateHelpMessage?: () => string;
+
   /** Function to send a message */
   sendMessage: (chatId: string, text: string) => Promise<void>;
 }
@@ -29,6 +34,7 @@ export interface WelcomeServiceConfig {
  */
 export class WelcomeService {
   private generateWelcomeMessage: () => string;
+  private generateHelpMessage?: () => string;
   private sendMessage: (chatId: string, text: string) => Promise<void>;
 
   /** Track first-time private chats (memory-only, resets on restart) */
@@ -36,6 +42,7 @@ export class WelcomeService {
 
   constructor(config: WelcomeServiceConfig) {
     this.generateWelcomeMessage = config.generateWelcomeMessage;
+    this.generateHelpMessage = config.generateHelpMessage;
     this.sendMessage = config.sendMessage;
   }
 
@@ -72,6 +79,36 @@ export class WelcomeService {
       logger.info({ chatId }, 'Welcome message sent to group');
     } catch (error) {
       logger.error({ err: error, chatId }, 'Failed to send welcome message to group');
+    }
+  }
+
+  /**
+   * Handle users joining a group chat that already has the bot.
+   * Sends help message to introduce bot capabilities to new users.
+   *
+   * Issue #676: 新用户加入群聊时发送 /help 信息
+   *
+   * @param chatId - The group chat ID
+   * @param userIds - Array of user open_ids who joined (optional, for future use)
+   */
+  async handleUserJoinedGroup(chatId: string, userIds?: string[]): Promise<void> {
+    if (!this.isGroupChat(chatId)) {
+      logger.warn({ chatId }, 'handleUserJoinedGroup called with non-group chat ID');
+      return;
+    }
+
+    // Use help message if available, otherwise use welcome message
+    const message = this.generateHelpMessage
+      ? this.generateHelpMessage()
+      : this.generateWelcomeMessage();
+
+    logger.info({ chatId, userCount: userIds?.length }, 'Users joined group, sending help message');
+
+    try {
+      await this.sendMessage(chatId, message);
+      logger.info({ chatId }, 'Help message sent to group for new users');
+    } catch (error) {
+      logger.error({ err: error, chatId }, 'Failed to send help message to group');
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `handleUserJoinedGroup` method to WelcomeService
- Update `handleChatMemberAdded` in FeishuChannel to distinguish between:
  - Bot being added to group -> send welcome message (existing)
  - Users joining existing group -> send help message (new)
- Add `isGroupChatId` helper method to check chat type by ID prefix
- Add 5 new tests for `handleUserJoinedGroup`

## Problem
When new users join a group chat that already has the bot, they don't receive any guidance on how to use the bot's features.

## Solution
1. Detect when non-bot users join a group (not when bot itself is added)
2. Send help/welcome message to introduce bot capabilities to new users
3. Support optional custom help message via `generateHelpMessage` config

## Changes

| File | Description |
|------|-------------|
| src/platforms/feishu/welcome-service.ts | Add `handleUserJoinedGroup` method |
| src/channels/feishu-channel.ts | Update `handleChatMemberAdded` logic |
| src/platforms/feishu/welcome-service.test.ts | Add 5 tests |

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Feishu Tests | ✅ 171 passed |
| New Tests | ✅ 5 passed |

## Verification Criteria from Issue #676

- [x] Detect when users join group chat
- [x] Send /help information to the group
- [x] Only trigger for group chats (not private chats)
- [x] Distinguish between bot being added vs users joining

Fixes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)