### PR TITLE
fix(feishu): show error for unknown commands instead of passing to agent (Issue #698)

### DIFF
--- a/src/channels/feishu-channel-passive-mode.test.ts
+++ b/src/channels/feishu-channel-passive-mode.test.ts
@@ -337,6 +337,31 @@ describe('FeishuChannel - Group Chat Passive Mode (Issue #460)', () => {
       );
       expect(messageHandler).not.toHaveBeenCalled();
     });
+
+    it('should show error for unknown command in private chat (Issue #698)', async () => {
+      // Mock controlHandler to return failure for unknown command
+      controlHandler.mockResolvedValueOnce({
+        success: false,
+        error: 'Unknown command: unknown-command',
+      });
+
+      await simulateMessageReceive({
+        text: '/unknown-command',
+        chatId: 'ou_user_private',
+        mentions: undefined,
+      });
+
+      // Control handler should be called (to check if command exists)
+      expect(controlHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'unknown-command',
+        })
+      );
+
+      // Issue #698: Unknown commands should NOT be passed to agent
+      // Instead, an error message is shown to the user
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
   });
 
   describe('Edge cases', () => {

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -725,7 +725,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           });
 
           // Only return if command was successfully handled
-          // Unknown commands (success: false) will fall through to normal message processing
           if (response.success) {
             if (response.message) {
               await this.sendMessage({
@@ -736,16 +735,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
             }
             return;
           }
-          // Without @mention: unknown commands fall through to agent (original behavior)
-          // With @mention: show error instead of passing to agent (Issue #595)
-          if (botMentioned) {
-            await this.sendMessage({
-              chatId: chat_id,
-              type: 'text',
-              text: `❓ **未知命令**: /${cmd}\n\n使用 /help 查看可用命令列表。`,
-            });
-            return;
-          }
+          // Issue #698: Unknown commands should show error instead of passing to agent
+          // This ensures /-prefixed messages are always treated as system commands
+          await this.sendMessage({
+            chatId: chat_id,
+            type: 'text',
+            text: `❓ **未知命令**: /${cmd}\n\n使用 /help 查看可用命令列表。`,
+          });
+          return;
         }
 
         // Default command handling if no control handler registered
@@ -767,8 +764,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           return;
         }
       } else {
-        // Unknown command with @mention: show error instead of passing to agent
-        // Issue #595: Control commands not parsed when bot is @mentioned in group chat
+        // Issue #698: Unknown command without control handler
+        // Show error instead of passing to agent
         await this.sendMessage({
           chatId: chat_id,
           type: 'text',


### PR DESCRIPTION
## Summary
- Modified `feishu-channel.ts` to always show "未知命令" error for unknown commands, regardless of whether the bot is mentioned or not
- Added test case for unknown command handling in private chat
- Simplified command handling logic by removing the `botMentioned` check for unknown commands

## Problem
When users send messages starting with `/` that are not registered commands, the bot was passing them to the agent as regular prompts instead of showing an error message.

## Solution
Changed the behavior so that:
- Messages starting with `/` are always treated as system commands
- Unknown commands return a clear "❓ **未知命令**: /xxx" error message
- Unknown commands are never passed to the agent

## Test plan
- [x] All existing feishu-channel tests pass (37 tests)
- [x] All command-registry tests pass (41 tests)
- [x] Added new test for unknown command in private chat

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)