### PR TITLE
feat(logger): split chat logs by date (Issue #691)

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -33,6 +33,12 @@ export const MESSAGE_LOGGING = {
 
   /** Regex to extract message IDs from MD files */
   MD_PARSE_REGEX: /message_id:\s*([^\)]+)/g,
+
+  /** Number of days to keep in memory for deduplication (default: 7) */
+  DEDUP_DAYS: 7,
+
+  /** Number of days of history to return by default in getChatHistory (default: 3) */
+  HISTORY_DAYS: 3,
 } as const;
 
 /**

--- a/src/feishu/message-logger.test.ts
+++ b/src/feishu/message-logger.test.ts
@@ -16,6 +16,8 @@ vi.mock('../config/constants.js', () => ({
   MESSAGE_LOGGING: {
     LOGS_DIR: 'chat-logs',
     MD_PARSE_REGEX: /message_id:\s*([^\n\]]+)/g,
+    DEDUP_DAYS: 7,
+    HISTORY_DAYS: 3,
   },
 }));
 
@@ -213,21 +215,61 @@ describe('MessageLogger', () => {
   });
 
   describe('getChatHistory', () => {
-    it('should return empty string when file not found', async () => {
-      vi.mocked(mockFs.readFile).mockRejectedValueOnce(new Error('File not found'));
+    it('should return empty string when all files not found', async () => {
+      const impl = async () => {
+        throw new Error('File not found');
+      };
+      vi.mocked(mockFs.readFile).mockImplementation(impl);
+      if (mockFs.default) {
+        vi.mocked(mockFs.default.readFile).mockImplementation(impl);
+      }
 
       const history = await messageLogger.getChatHistory('nonexistent');
 
       expect(history).toBe('');
     });
 
-    it('should return file content when file exists', async () => {
+    it('should return file content when today\'s file exists', async () => {
       const mockContent = '# Chat Log\nContent here';
-      vi.mocked(mockFs.readFile).mockResolvedValueOnce(mockContent);
+      let callCount = 0;
+
+      const impl = async () => {
+        callCount++;
+        if (callCount === 1) return mockContent; // Today
+        throw new Error('Not found'); // Other days
+      };
+      vi.mocked(mockFs.readFile).mockImplementation(impl);
+      if (mockFs.default) {
+        vi.mocked(mockFs.default.readFile).mockImplementation(impl);
+      }
 
       const history = await messageLogger.getChatHistory('chat-1');
 
-      expect(history).toBe(mockContent);
+      // History should contain the content
+      expect(history).toContain(mockContent);
+    });
+
+    it('should combine history from multiple days', async () => {
+      const todayContent = '# Chat Log Today';
+      const yesterdayContent = '# Chat Log Yesterday';
+      let callCount = 0;
+
+      const impl = async () => {
+        callCount++;
+        if (callCount === 1) return todayContent; // Today
+        if (callCount === 2) return yesterdayContent; // Yesterday
+        throw new Error('Not found'); // Other days
+      };
+      vi.mocked(mockFs.readFile).mockImplementation(impl);
+      if (mockFs.default) {
+        vi.mocked(mockFs.default.readFile).mockImplementation(impl);
+      }
+
+      const history = await messageLogger.getChatHistory('chat-1');
+
+      // Both contents should be present (reversed to chronological order)
+      expect(history).toContain(todayContent);
+      expect(history).toContain(yesterdayContent);
     });
   });
 

--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -65,28 +65,48 @@ export class MessageLogger {
 
   /**
    * Load all message IDs from existing MD files at startup.
-   * One-time operation to populate the in-memory cache.
+   * Only loads from recent days (configurable via MESSAGE_LOGGING.DEDUP_DAYS).
+   * Structure: {chatDir}/{date}/{chatId}.md
    */
   private async loadAllMessageIds(): Promise<void> {
     try {
-      const files = await fs.readdir(this.chatDir);
-      const mdFiles = files.filter(f => f.endsWith('.md'));
+      // Get list of date directories
+      const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
+      const dateDirs = entries.filter(e => e.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(e.name));
 
-      console.log(`[MessageLogger] Loading message IDs from ${mdFiles.length} chat files...`);
+      // Calculate cutoff date for deduplication
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - MESSAGE_LOGGING.DEDUP_DAYS);
+      const cutoffStr = this.formatDate(cutoffDate);
 
-      for (const file of mdFiles) {
-        const filePath = path.join(this.chatDir, file);
+      // Filter to only recent directories
+      const recentDirs = dateDirs.filter(d => d.name >= cutoffStr).map(d => d.name);
+
+      console.log(`[MessageLogger] Loading message IDs from ${recentDirs.length} recent date directories...`);
+
+      for (const dateDir of recentDirs) {
+        const datePath = path.join(this.chatDir, dateDir);
         try {
-          const content = await fs.readFile(filePath, 'utf-8');
-          const regex = MESSAGE_LOGGING.MD_PARSE_REGEX;
+          const files = await fs.readdir(datePath);
+          const mdFiles = files.filter(f => f.endsWith('.md'));
 
-          let match;
-          regex.lastIndex = 0;
-          while ((match = regex.exec(content)) !== null) {
-            this.processedMessageIds.add(match[1].trim());
+          for (const file of mdFiles) {
+            const filePath = path.join(datePath, file);
+            try {
+              const content = await fs.readFile(filePath, 'utf-8');
+              const regex = MESSAGE_LOGGING.MD_PARSE_REGEX;
+
+              let match;
+              regex.lastIndex = 0;
+              while ((match = regex.exec(content)) !== null) {
+                this.processedMessageIds.add(match[1].trim());
+              }
+            } catch (_error) {
+              console.error(`[MessageLogger] Failed to read ${dateDir}/${file}:`, _error);
+            }
           }
         } catch (_error) {
-          console.error(`[MessageLogger] Failed to read ${file}:`, _error);
+          console.error(`[MessageLogger] Failed to read directory ${dateDir}:`, _error);
         }
       }
 
@@ -159,10 +179,20 @@ export class MessageLogger {
 
   /**
    * Get chat log file path.
+   * Structure: {chatDir}/{date}/{chatId}.md
+   * Example: workspace/chat/2026-03-05/oc_abc123.md
    */
-  private getChatLogPath(chatId: string): string {
+  private getChatLogPath(chatId: string, date?: Date): string {
     const sanitizedId = this.sanitizeId(chatId);
-    return path.join(this.chatDir, `${sanitizedId}.md`);
+    const dateStr = this.formatDate(date || new Date());
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
+  }
+
+  /**
+   * Format date as YYYY-MM-DD string.
+   */
+  private formatDate(date: Date): string {
+    return date.toISOString().split('T')[0];
   }
 
   /**
@@ -255,9 +285,11 @@ ${entry.content}
    */
   private createFileHeader(chatId: string): string {
     const now = new Date().toISOString();
+    const dateStr = this.formatDate(new Date());
     return `# Chat Message Log: ${chatId}
 
 **Chat ID**: ${chatId}
+**Date**: ${dateStr}
 **Created**: ${now}
 **Last Updated**: ${now}
 
@@ -267,16 +299,35 @@ ${entry.content}
   }
 
   /**
-   * Get message history for a chat.
+   * Get message history for a chat from recent days.
+   * Reads from multiple date directories and combines them.
+   * @param chatId The chat ID to get history for
+   * @param days Number of days to look back (default: MESSAGE_LOGGING.HISTORY_DAYS)
    */
-  async getChatHistory(chatId: string): Promise<string> {
-    const logPath = this.getChatLogPath(chatId);
+  async getChatHistory(chatId: string, days?: number): Promise<string> {
+    const lookbackDays = days ?? MESSAGE_LOGGING.HISTORY_DAYS;
+    const sanitizedId = this.sanitizeId(chatId);
+    const historyParts: string[] = [];
 
-    try {
-      return await fs.readFile(logPath, 'utf-8');
-    } catch (_error) {
-      return '';
+    // Collect history from most recent to oldest
+    for (let i = 0; i < lookbackDays; i++) {
+      const date = new Date();
+      date.setDate(date.getDate() - i);
+      const dateStr = this.formatDate(date);
+      const logPath = path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
+
+      try {
+        const content = await fs.readFile(logPath, 'utf-8');
+        if (content.trim()) {
+          historyParts.push(`\n\n## [${dateStr}]\n\n${content}`);
+        }
+      } catch {
+        // File doesn't exist for this date, skip
+      }
     }
+
+    // Reverse to get chronological order (oldest first)
+    return historyParts.reverse().join('\n');
   }
 
   /**


### PR DESCRIPTION
## Summary
- 按日期分割聊天日志存储结构
- 修改文件路径从 `{chatId}.md` 改为 `{date}/{chatId}.md`
- 添加 `DEDUP_DAYS` 和 `HISTORY_DAYS` 配置选项

## 变更详情

### 文件结构变更
- **之前**: `workspace/chat/{chatId}.md`
- **之后**: `workspace/chat/2026-03-05/{chatId}.md`

### 代码变更
1. **constants.ts**: 添加 `DEDUP_DAYS` (默认7天) 和 `HISTORY_DAYS` (默认3天) 配置
2. **message-logger.ts**:
   - `getChatLogPath()`: 按日期创建子目录
   - `loadAllMessageIds()`: 只扫描最近 N 天的日志目录
   - `getChatHistory()`: 读取最近 N 天的历史记录并合并
3. **message-logger.test.ts**: 更新测试以适配新的文件结构

## 优势
- **性能提升**: 去重时只加载最近几天的日志
- **易于管理**: 可以按日期清理旧日志
- **结构清晰**: 每天一个目录，便于查找

## 测试
- ✅ 所有单元测试通过 (22/22)

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)