### PR TITLE
feat(task-flow): add next-step recommendation after task completion (Issue #680)

### DIFF
--- a/src/feishu/task-flow-orchestrator.test.ts
+++ b/src/feishu/task-flow-orchestrator.test.ts
@@ -84,6 +84,10 @@ vi.mock('../config/constants.js', () => ({
   DIALOGUE: {
     MAX_ITERATIONS: 10,
   },
+  MESSAGE_LOGGING: {
+    LOGS_DIR: 'chat',
+    MD_PARSE_REGEX: /message_id:\s*([^\]]+)/g,
+  },
 }));
 
 // Mock Config
@@ -139,6 +143,14 @@ vi.mock('../utils/task-tracker.js', () => ({
   TaskTracker: vi.fn().mockImplementation(() => ({
     getDialogueTaskPath: vi.fn(() => '/test/workspace/tasks/test-task.md'),
   })),
+}));
+
+// Mock messageLogger
+vi.mock('./message-logger.js', () => ({
+  messageLogger: {
+    getChatHistory: vi.fn().mockResolvedValue('## Test chat history'),
+    init: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 describe('TaskFlowOrchestrator', () => {

--- a/src/feishu/task-flow-orchestrator.ts
+++ b/src/feishu/task-flow-orchestrator.ts
@@ -38,6 +38,7 @@ import type { ReflectionContext } from '../task/reflection.js';
 import { SkillAgent } from '../agents/skill-agent.js';
 import { TaskFileManager } from '../task/task-files.js';
 import { DIALOGUE } from '../config/constants.js';
+import { messageLogger } from './message-logger.js';
 
 export interface MessageCallbacks {
   sendMessage: (chatId: string, text: string, parentMessageId?: string) => Promise<void>;
@@ -328,6 +329,104 @@ export class TaskFlowOrchestrator {
         this.logger.info({ chatId, completionReason }, 'Sending no-message warning to user');
         await this.messageCallbacks.sendMessage(chatId, warning, messageId);
       }
+
+      // Run next-step skill when task is complete (Issue #680)
+      if (completionReason === 'task_done') {
+        await this.runNextStep(chatId, messageId, agentConfig);
+      }
     }
+  }
+
+  /**
+   * Run next-step skill to recommend follow-up actions after task completion.
+   *
+   * This method executes the next-step skill agent with recent chat history
+   * to suggest relevant follow-up actions to the user.
+   *
+   * @param chatId - Feishu chat ID
+   * @param messageId - Parent message ID for thread replies
+   * @param agentConfig - Agent configuration
+   */
+  private async runNextStep(
+    chatId: string,
+    messageId: string,
+    agentConfig: { apiKey: string; model: string; apiBaseUrl?: string }
+  ): Promise<void> {
+    this.logger.info({ chatId }, 'Running next-step skill after task completion');
+
+    try {
+      // Get recent chat history (limited to avoid context overflow)
+      const fullHistory = await messageLogger.getChatHistory(chatId);
+      const recentHistory = this.extractRecentMessages(fullHistory, 10);
+
+      // Build input context for next-step skill
+      const inputContext = `## Chat History (Recent Messages)
+
+${recentHistory}
+
+---
+
+**Chat ID for Feishu tools**: \`${chatId}\`
+`;
+
+      // Create and execute next-step skill agent
+      const nextStepAgent = new SkillAgent(
+        {
+          apiKey: agentConfig.apiKey,
+          model: agentConfig.model,
+          apiBaseUrl: agentConfig.apiBaseUrl,
+          permissionMode: 'bypassPermissions',
+        },
+        'skills/next-step/SKILL.md'
+      );
+
+      try {
+        for await (const message of nextStepAgent.execute(inputContext)) {
+          const content = typeof message.content === 'string' ? message.content : '';
+          if (content) {
+            // Send as card if it looks like JSON, otherwise as text
+            if (content.includes('"config"') && content.includes('"elements"')) {
+              try {
+                const card = JSON.parse(content);
+                await this.messageCallbacks.sendCard(chatId, card, undefined, messageId);
+              } catch {
+                // Not valid JSON, send as text
+                await this.messageCallbacks.sendMessage(chatId, content, messageId);
+              }
+            } else {
+              await this.messageCallbacks.sendMessage(chatId, content, messageId);
+            }
+          }
+        }
+      } finally {
+        nextStepAgent.dispose();
+      }
+
+      this.logger.info({ chatId }, 'Next-step skill completed');
+    } catch (error) {
+      // Log error but don't throw - next-step is a nice-to-have feature
+      this.logger.error({ err: error, chatId }, 'Next-step skill failed');
+    }
+  }
+
+  /**
+   * Extract recent messages from chat history.
+   *
+   * @param history - Full chat history
+   * @param maxMessages - Maximum number of message blocks to extract
+   * @returns Truncated chat history
+   */
+  private extractRecentMessages(history: string, maxMessages: number): string {
+    if (!history) {
+      return '(No chat history available)';
+    }
+
+    // Split by message blocks (## [timestamp] pattern)
+    const messageBlocks = history.split(/(?=## \[)/);
+
+    // Take the last N message blocks
+    const recentBlocks = messageBlocks.slice(-maxMessages);
+
+    return recentBlocks.join('').trim() || '(No recent messages)';
   }
 }


### PR DESCRIPTION
## Summary

Implements Issue #680 - 在任务完成后调用 `next-step` 技能，向用户推荐后续操作。

When a task completes successfully (`completionReason === 'task_done'`), automatically invoke the next-step skill to recommend follow-up actions to the user via interactive cards.

## Changes

| File | Description |
|------|-------------|
| `src/feishu/task-flow-orchestrator.ts` | Add runNextStep() method and call in finally block |
| `src/feishu/task-flow-orchestrator.test.ts` | Add mocks for messageLogger and MESSAGE_LOGGING |

## Implementation Details

### 1. runNextStep() Method
- Executes the `next-step` skill agent after task completion
- Extracts recent chat history (last 10 messages) as context
- Passes chat ID for sending interactive cards
- Handles both JSON cards and text responses

### 2. Context Control
- Limits chat history to 10 recent messages to avoid context overflow
- Builds structured input with chat history and chat ID

### 3. Error Handling
- Errors in next-step are logged but don't block the main flow
- next-step is a nice-to-have feature, failures are gracefully handled

## Workflow Example

```
Task completes (task_done)
    ↓
runNextStep() called in finally block
    ↓
Get recent chat history
    ↓
Execute next-step skill agent
    ↓
Send interactive card with recommendations
    ↓
User can click buttons for follow-up actions
```

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ⚠️ 1 pre-existing error (Issue #702) |
| Unit Tests | 52 passed (feishu module) |
| Build | ✅ Success |

## Verification Criteria from Issue #680

- [x] Use SkillAgent directly (no ReflectionController)
- [x] Control context size (last 10 messages)
- [x] Call in finally block when task_done
- [x] Non-blocking execution
- [x] Pass Chat ID for interactive cards

Fixes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)