### PR TITLE
feat(feishu): add GroupService.createGroup() method (Issue #692)

### DIFF
--- a/src/platforms/feishu/group-service.test.ts
+++ b/src/platforms/feishu/group-service.test.ts
@@ -2,13 +2,28 @@
  * Tests for GroupService.
  *
  * @see Issue #486 - Group management commands
+ * @see Issue #692 - GroupService.createGroup() method
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type * as lark from '@larksuiteoapi/node-sdk';
 import { GroupService, type GroupInfo } from './group-service.js';
+
+// Mock lark Client
+const createMockClient = (chatId: string = 'oc_new123'): lark.Client => {
+  return {
+    im: {
+      chat: {
+        create: vi.fn().mockResolvedValue({
+          data: { chat_id: chatId },
+        }),
+      },
+    },
+  } as unknown as lark.Client;
+};
 
 describe('GroupService', () => {
   let tempDir: string;
@@ -198,6 +213,86 @@ describe('GroupService', () => {
   describe('getFilePath', () => {
     it('should return the configured file path', () => {
       expect(service.getFilePath()).toBe(testFilePath);
+    });
+  });
+
+  describe('createGroup', () => {
+    it('should create a group and auto-register', async () => {
+      const mockClient = createMockClient('oc_created123');
+
+      const groupInfo = await service.createGroup(mockClient, {
+        topic: 'Test Discussion',
+        members: ['ou_user1', 'ou_user2'],
+      });
+
+      expect(groupInfo.chatId).toBe('oc_created123');
+      expect(groupInfo.name).toBe('Test Discussion');
+      expect(groupInfo.initialMembers).toEqual(['ou_user1', 'ou_user2']);
+      expect(groupInfo.createdAt).toBeDefined();
+
+      // Verify auto-registration
+      expect(service.isManaged('oc_created123')).toBe(true);
+      expect(service.getGroup('oc_created123')).toEqual(groupInfo);
+    });
+
+    it('should use creatorId when no members provided', async () => {
+      const mockClient = createMockClient('oc_created456');
+
+      const groupInfo = await service.createGroup(mockClient, {
+        topic: 'Creator Only',
+        creatorId: 'ou_creator',
+      });
+
+      expect(groupInfo.initialMembers).toEqual(['ou_creator']);
+      expect(groupInfo.createdBy).toBe('ou_creator');
+    });
+
+    it('should use members over creatorId', async () => {
+      const mockClient = createMockClient('oc_created789');
+
+      const groupInfo = await service.createGroup(mockClient, {
+        topic: 'With Members',
+        members: ['ou_member1'],
+        creatorId: 'ou_creator',
+      });
+
+      expect(groupInfo.initialMembers).toEqual(['ou_member1']);
+      expect(groupInfo.createdBy).toBe('ou_creator');
+    });
+
+    it('should use default name when topic not provided', async () => {
+      const mockClient = createMockClient('oc_created000');
+
+      const groupInfo = await service.createGroup(mockClient, {});
+
+      expect(groupInfo.name).toBe('自动命名');
+    });
+
+    it('should throw error if chat creation fails', async () => {
+      const mockClient = {
+        im: {
+          chat: {
+            create: vi.fn().mockRejectedValue(new Error('API Error')),
+          },
+        },
+      } as unknown as lark.Client;
+
+      await expect(service.createGroup(mockClient, { topic: 'Test' })).rejects.toThrow('API Error');
+
+      // Verify no registration happened
+      expect(service.listGroups()).toEqual([]);
+    });
+
+    it('should throw error if response has no chat_id', async () => {
+      const mockClient = {
+        im: {
+          chat: {
+            create: vi.fn().mockResolvedValue({ data: {} }),
+          },
+        },
+      } as unknown as lark.Client;
+
+      await expect(service.createGroup(mockClient, { topic: 'Test' })).rejects.toThrow('Failed to get chat_id');
     });
   });
 });

--- a/src/platforms/feishu/group-service.ts
+++ b/src/platforms/feishu/group-service.ts
@@ -5,11 +5,14 @@
  * Stores group metadata in workspace/groups.json.
  *
  * @see Issue #486 - Group management commands
+ * @see Issue #692 - GroupService.createGroup() method
  */
 
+import type * as lark from '@larksuiteoapi/node-sdk';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createLogger } from '../../utils/logger.js';
+import { createDiscussionChat } from './chat-ops.js';
 
 const logger = createLogger('GroupService');
 
@@ -45,6 +48,18 @@ interface GroupRegistry {
 export interface GroupServiceConfig {
   /** Storage file path (default: workspace/groups.json) */
   filePath?: string;
+}
+
+/**
+ * Options for creating a new group.
+ */
+export interface CreateGroupOptions {
+  /** Group topic/name (optional, auto-generated if not provided) */
+  topic?: string;
+  /** Initial member open_ids */
+  members?: string[];
+  /** Creator open_id (will be auto-added if no members) */
+  creatorId?: string;
 }
 
 /**
@@ -150,6 +165,66 @@ export class GroupService {
    */
   listGroups(): GroupInfo[] {
     return Object.values(this.registry.groups);
+  }
+
+  /**
+   * Options for creating a group.
+   */
+  createGroup(client: lark.Client, options: CreateGroupOptions = {}): Promise<GroupInfo> {
+    return this.createGroupWithClient(client, options);
+  }
+
+  /**
+   * Create a group with Feishu client and auto-register.
+   *
+   * This method combines group creation and registration in one operation,
+   * making it easier for agents to create groups without going through
+   * the command system.
+   *
+   * @param client - Feishu API client
+   * @param options - Group creation options
+   * @returns Created group info
+   * @throws Error if group creation fails
+   *
+   * @example
+   * ```typescript
+   * const groupInfo = await groupService.createGroup(client, {
+   *   topic: '讨论组',
+   *   members: ['ou_user1', 'ou_user2'],
+   *   creatorId: 'ou_creator'
+   * });
+   * console.log(groupInfo.chatId); // New group chat ID
+   * ```
+   */
+  async createGroupWithClient(
+    client: lark.Client,
+    options: CreateGroupOptions = {}
+  ): Promise<GroupInfo> {
+    const { topic, members, creatorId } = options;
+
+    // Create the chat using ChatOps
+    const chatId = await createDiscussionChat(client, { topic, members }, creatorId);
+
+    // Determine actual members for registration
+    const actualMembers = members && members.length > 0
+      ? members
+      : (creatorId ? [creatorId] : []);
+
+    // Build group info
+    const groupInfo: GroupInfo = {
+      chatId,
+      name: topic || '自动命名',
+      createdAt: Date.now(),
+      createdBy: creatorId,
+      initialMembers: actualMembers,
+    };
+
+    // Auto-register the group
+    this.registerGroup(groupInfo);
+
+    logger.info({ chatId, topic, memberCount: actualMembers.length }, 'Group created and registered');
+
+    return groupInfo;
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements Issue #692 - GroupService 支持创建群聊

Add `createGroup()` method to GroupService that allows agents to create group chats directly without going through the command system.

## Changes

| File | Description |
|------|-------------|
| `src/platforms/feishu/group-service.ts` | Add `createGroup()` method and `CreateGroupOptions` interface |
| `src/platforms/feishu/group-service.test.ts` | Add 5 tests for `createGroup()` |

## New Features

### `GroupService.createGroup()`

```typescript
const groupInfo = await groupService.createGroup(client, {
  topic: '讨论组',
  members: ['ou_user1', 'ou_user2'],
  creatorId: 'ou_creator'
});
```

Features:
- Calls `ChatOps.createDiscussionChat()` to create the group via Feishu API
- Auto-registers the created group in GroupService
- Returns `GroupInfo` with chat ID, name, and metadata

## Why This Change?

Previously, only `/create-group` command could create groups. Agents (e.g., in scheduled tasks) could not create groups programmatically without:
1. Calling the command system (not elegant)
2. Directly calling Feishu API (bypassing GroupService)

Now agents can directly use `GroupService.createGroup()` for a clean, unified approach.

## Test Results

| Metric | Value |
|--------|-------|
| TypeScript | ✅ Pass |
| Unit Tests | 21 passed (GroupService) |
| Feishu Tests | 144 passed |
| Command Tests | 41 passed |

## Verification Criteria from Issue #692

- [x] GroupService.createGroup() method available
- [x] Created groups are auto-registered
- [x] Implementation shared with CreateGroupCommand (both use ChatOps.createDiscussionChat)

Fixes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)