### PR TITLE
fix(feishu): recognize commands in @mentioned messages (Issue #698)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -22,6 +22,7 @@ import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { filteredMessageForwarder } from '../feishu/filtered-message-forwarder.js';
 import type { FilterReason } from '../config/types.js';
 import { TaskTracker } from '../utils/task-tracker.js';
+import { stripMentions } from '../utils/mention-parser.js';
 import { BaseChannel } from './base-channel.js';
 import type {
   FeishuEventData,
@@ -685,6 +686,10 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
+    // Issue #698: Strip @mentions to detect commands in mentioned messages
+    // e.g., "@bot /list-nodes" should be treated as "/list-nodes" for command detection
+    const strippedText = botMentioned ? stripMentions(trimmedText, mentions) : trimmedText;
+
     // Get control commands from CommandRegistry (Issue #463: removed hardcoded list)
     const commandRegistry = getCommandRegistry();
 
@@ -695,7 +700,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #650: Move passive mode check BEFORE command processing
     // Issue #677: Allow /passive command to bypass passive mode check to avoid deadlock
     // (when mention detection fails, users still need a way to disable passive mode)
-    const isPassiveCommand = trimmedText.startsWith('/passive');
+    // Issue #698: Use strippedText to detect commands in @mentioned messages
+    const isPassiveCommand = strippedText.startsWith('/passive');
     const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
     if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled && !isPassiveCommand) {
       logger.debug(
@@ -707,8 +713,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    if (trimmedText.startsWith('/')) {
-      const [command, ...args] = trimmedText.slice(1).split(/\s+/);
+    // Issue #698: Use strippedText to detect commands in @mentioned messages
+    if (strippedText.startsWith('/')) {
+      const [command, ...args] = strippedText.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
 
       // Handle control commands through the control channel
@@ -779,8 +786,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     }
 
     // Log if bot is mentioned with a non-control command (for debugging)
-    if (botMentioned && trimmedText.startsWith('/')) {
-      logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
+    // Issue #698: Use strippedText for consistent logging
+    if (botMentioned && strippedText.startsWith('/')) {
+      logger.debug({ messageId: message_id, chatId: chat_id, command: strippedText }, 'Bot mentioned with non-control command, passing to agent');
     }
 
     // Issue #514: Add typing reaction only for messages that will be processed

--- a/src/utils/mention-parser.test.ts
+++ b/src/utils/mention-parser.test.ts
@@ -10,6 +10,7 @@ import {
   isUserMentioned,
   extractMentionedOpenIds,
   normalizeMentionPlaceholders,
+  stripMentions,
 } from './mention-parser.js';
 import type { FeishuMessageEvent } from '../types/platform.js';
 
@@ -204,5 +205,76 @@ describe('normalizeMentionPlaceholders', () => {
     const mentions = [createMockMention('@_user.test', 'ou_abc123', 'Alice')];
     const result = normalizeMentionPlaceholders(text, mentions);
     expect(result).toBe('Hello @Alice how are you?');
+  });
+});
+
+describe('stripMentions', () => {
+  it('should return original text for undefined mentions', () => {
+    const text = '/list-nodes';
+    expect(stripMentions(text, undefined)).toBe('/list-nodes');
+  });
+
+  it('should return original text when no mentions', () => {
+    const text = '/list-nodes';
+    expect(stripMentions(text, [])).toBe('/list-nodes');
+  });
+
+  it('should strip placeholder format and reveal command (Issue #698)', () => {
+    const text = '${@_bot} /list-nodes';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/list-nodes');
+  });
+
+  it('should strip @Name format and reveal command (Issue #698)', () => {
+    const text = '@Bot /list-nodes';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/list-nodes');
+  });
+
+  it('should strip <at> format and reveal command (Issue #698)', () => {
+    const text = '<at user_id="cli_bot_id">@Bot</at> /list-nodes';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/list-nodes');
+  });
+
+  it('should handle multiple mentions', () => {
+    const text = '@User1 @Bot /list-nodes';
+    const mentions = [
+      createMockMention('@_user1', 'ou_user1', 'User1'),
+      createMockMention('@_bot', 'cli_bot_id', 'Bot'),
+    ];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/list-nodes');
+  });
+
+  it('should handle text without mentions', () => {
+    const text = 'Hello world';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('Hello world');
+  });
+
+  it('should handle empty text with mentions', () => {
+    const text = '@Bot';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('');
+  });
+
+  it('should handle command with arguments after mention', () => {
+    const text = '@Bot /reset force';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/reset force');
+  });
+
+  it('should preserve command when bot is not mentioned', () => {
+    const text = '/list-nodes';
+    const mentions = [createMockMention('@_bot', 'cli_bot_id', 'Bot')];
+    const result = stripMentions(text, mentions);
+    expect(result).toBe('/list-nodes');
   });
 });

--- a/src/utils/mention-parser.ts
+++ b/src/utils/mention-parser.ts
@@ -156,6 +156,58 @@ export function normalizeMentionPlaceholders(
 }
 
 /**
+ * Strip all @mentions from text to get the actual content.
+ *
+ * Issue #698: 正确识别 @消息中的系统指令
+ *
+ * This function removes all mention patterns from text:
+ * - `${key}` - placeholder format (e.g., `${@_user}`)
+ * - `<at user_id="xxx">@Name</at>` - normalized format
+ * - `@Name` - simple mention format
+ *
+ * @param text - Text content with mentions
+ * @param mentions - Mentions array from Feishu message
+ * @returns Text with all mentions stripped and trimmed
+ */
+export function stripMentions(
+  text: string,
+  mentions: MentionsArray | undefined | null
+): string {
+  let result = text;
+
+  // First, handle placeholder format: ${key}
+  if (mentions && mentions.length > 0) {
+    for (const mention of mentions) {
+      if (mention.key) {
+        const placeholderPattern = new RegExp(`\\$\\{${escapeRegExp(mention.key)}\\}`, 'g');
+        result = result.replace(placeholderPattern, '');
+      }
+    }
+  }
+
+  // Remove <at user_id="xxx">@Name</at> format
+  result = result.replace(/<at[^>]*>@[^<]*<\/at>/gi, '');
+
+  // Remove @Name format (simple mention at start of line or after whitespace)
+  // This handles cases like "@Bot /command" -> "/command"
+  if (mentions && mentions.length > 0) {
+    for (const mention of mentions) {
+      if (mention.name) {
+        // Match @Name at start of line or after whitespace
+        const mentionPattern = new RegExp(`(^|\\s)@${escapeRegExp(mention.name)}(\\s|$)`, 'g');
+        result = result.replace(mentionPattern, '$1$2');
+        // Also match @Name at the very start
+        const startPattern = new RegExp(`^@${escapeRegExp(mention.name)}\\s*`, 'g');
+        result = result.replace(startPattern, '');
+      }
+    }
+  }
+
+  // Clean up multiple spaces and trim
+  return result.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Escape special regex characters in a string.
  */
 function escapeRegExp(string: string): string {


### PR DESCRIPTION
## Summary
- Added `stripMentions()` function to mention-parser.ts to remove @mentions from text
- Updated feishu-channel.ts to use stripped text for command detection when bot is mentioned
- When bot is mentioned with a command (e.g., "@bot /list-nodes"), the system now correctly identifies and executes the command instead of passing it to the agent

## Problem
When users send messages like "@bot /list-nodes", the bot was passing them to the agent as regular prompts instead of recognizing them as system commands. This happened because the command detection checked if the raw text started with '/', which failed when @mentions were present.

## Solution
1. Added `stripMentions()` function that removes all mention formats:
   - Placeholder format: `${@_user}`
   - AT tag format: `<at user_id="xxx">@Name</at>`
   - Simple format: `@Name`

2. Modified command detection to use stripped text when bot is mentioned, so "@bot /list-nodes" is correctly identified as "/list-nodes" command

## Test plan
- [x] All mention-parser tests pass (32 tests)
- [x] All feishu-channel passive mode tests pass (25 tests)
- [x] Added new test cases for stripMentions function

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)