### PR TITLE
fix(feishu): detect commands after stripping leading mentions (Issue #698)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -22,6 +22,7 @@ import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { filteredMessageForwarder } from '../feishu/filtered-message-forwarder.js';
 import type { FilterReason } from '../config/types.js';
 import { TaskTracker } from '../utils/task-tracker.js';
+import { stripLeadingMentions } from '../utils/mention-parser.js';
 import { BaseChannel } from './base-channel.js';
 import type {
   FeishuEventData,
@@ -682,11 +683,14 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Check for control commands
     // Control commands should ALWAYS be handled through the control channel, regardless of mentions
     // This ensures /reset, /status, etc. work correctly even when bot is @mentioned
-    const trimmedText = text.trim();
     const botMentioned = this.isBotMentioned(mentions);
 
     // Get control commands from CommandRegistry (Issue #463: removed hardcoded list)
     const commandRegistry = getCommandRegistry();
+
+    // Issue #698: Strip leading mentions to detect commands in messages like "@bot /help"
+    // After stripping, we can check if the remaining text starts with '/'
+    const textWithoutMentions = stripLeadingMentions(text, mentions);
 
     // Issue #460 & #511: Group chat passive mode
     // In group chats, only respond when bot is mentioned (@bot)
@@ -695,7 +699,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #650: Move passive mode check BEFORE command processing
     // Issue #677: Allow /passive command to bypass passive mode check to avoid deadlock
     // (when mention detection fails, users still need a way to disable passive mode)
-    const isPassiveCommand = trimmedText.startsWith('/passive');
+    const isPassiveCommand = textWithoutMentions.startsWith('/passive');
     const passiveModeDisabled = this.isPassiveModeDisabled(chat_id);
     if (this.isGroupChat(chat_type) && !botMentioned && !passiveModeDisabled && !isPassiveCommand) {
       logger.debug(
@@ -707,8 +711,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       return;
     }
 
-    if (trimmedText.startsWith('/')) {
-      const [command, ...args] = trimmedText.slice(1).split(/\s+/);
+    if (textWithoutMentions.startsWith('/')) {
+      const [command, ...args] = textWithoutMentions.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
 
       // Handle control commands through the control channel
@@ -721,7 +725,7 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
           const response = await this.emitControl({
             type: cmd as any,
             chatId: chat_id,
-            data: { args, rawText: trimmedText, senderOpenId: this.extractOpenId(sender) },
+            data: { args, rawText: textWithoutMentions, senderOpenId: this.extractOpenId(sender) },
           });
 
           // Only return if command was successfully handled
@@ -779,8 +783,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     }
 
     // Log if bot is mentioned with a non-control command (for debugging)
-    if (botMentioned && trimmedText.startsWith('/')) {
-      logger.debug({ messageId: message_id, chatId: chat_id, command: trimmedText }, 'Bot mentioned with non-control command, passing to agent');
+    if (botMentioned && textWithoutMentions.startsWith('/')) {
+      logger.debug({ messageId: message_id, chatId: chat_id, command: textWithoutMentions }, 'Bot mentioned with non-control command, passing to agent');
     }
 
     // Issue #514: Add typing reaction only for messages that will be processed

--- a/src/utils/mention-parser.test.ts
+++ b/src/utils/mention-parser.test.ts
@@ -10,6 +10,7 @@ import {
   isUserMentioned,
   extractMentionedOpenIds,
   normalizeMentionPlaceholders,
+  stripLeadingMentions,
 } from './mention-parser.js';
 import type { FeishuMessageEvent } from '../types/platform.js';
 
@@ -204,5 +205,87 @@ describe('normalizeMentionPlaceholders', () => {
     const mentions = [createMockMention('@_user.test', 'ou_abc123', 'Alice')];
     const result = normalizeMentionPlaceholders(text, mentions);
     expect(result).toBe('Hello @Alice how are you?');
+  });
+});
+
+describe('stripLeadingMentions', () => {
+  it('should return original text for undefined mentions', () => {
+    const text = '/help';
+    expect(stripLeadingMentions(text, undefined)).toBe('/help');
+  });
+
+  it('should return original text when no mentions', () => {
+    const text = '/help';
+    expect(stripLeadingMentions(text, [])).toBe('/help');
+  });
+
+  it('should strip <at> tag format at the start', () => {
+    const text = '<at user_id="ou_bot">@Bot</at> /help';
+    const mentions = [createMockMention('@_bot', 'ou_bot', 'Bot')];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('/help');
+  });
+
+  it('should strip placeholder format at the start', () => {
+    const text = '${@_bot} /help';
+    const mentions = [createMockMention('@_bot', 'ou_bot', 'Bot')];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('/help');
+  });
+
+  it('should strip simple @mention format at the start', () => {
+    const text = '@Bot /help';
+    const mentions = [createMockMention('@_bot', 'ou_bot', 'Bot')];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('/help');
+  });
+
+  it('should strip multiple leading mentions', () => {
+    const text = '@Bot @User /help';
+    const mentions = [
+      createMockMention('@_bot', 'ou_bot', 'Bot'),
+      createMockMention('@_user', 'ou_user', 'User'),
+    ];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('/help');
+  });
+
+  it('should not strip mentions in the middle of text', () => {
+    const text = 'Hello @Bot how are you?';
+    const mentions = [createMockMention('@_bot', 'ou_bot', 'Bot')];
+    const result = stripLeadingMentions(text, mentions);
+    // Only strips leading mentions, not middle ones
+    expect(result).toBe('Hello @Bot how are you?');
+  });
+
+  it('should handle text without any mention', () => {
+    const text = 'This is a regular message';
+    const mentions: never[] = [];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('This is a regular message');
+  });
+
+  it('should handle empty text', () => {
+    expect(stripLeadingMentions('', undefined)).toBe('');
+  });
+
+  it('should handle text with only mentions', () => {
+    const text = '@Bot @User';
+    const mentions = [
+      createMockMention('@_bot', 'ou_bot', 'Bot'),
+      createMockMention('@_user', 'ou_user', 'User'),
+    ];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('');
+  });
+
+  it('should handle mixed mention formats in sequence', () => {
+    const text = '<at user_id="ou_bot">@Bot</at> @User /command arg1';
+    const mentions = [
+      createMockMention('@_bot', 'ou_bot', 'Bot'),
+      createMockMention('@_user', 'ou_user', 'User'),
+    ];
+    const result = stripLeadingMentions(text, mentions);
+    expect(result).toBe('/command arg1');
   });
 });

--- a/src/utils/mention-parser.ts
+++ b/src/utils/mention-parser.ts
@@ -161,3 +161,80 @@ export function normalizeMentionPlaceholders(
 function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Strip leading mentions from text.
+ *
+ * This is used to detect commands in messages that start with @mentions.
+ * For example: "@bot /help" should be recognized as a command "/help".
+ *
+ * Handles multiple mention formats:
+ * - `<at user_id="xxx">@Name</at>` - normalized format
+ * - `${key}` - placeholder format (key is from mentions array)
+ * - `@Name` - simple @mention format
+ *
+ * Issue #698: Commands should be detected after stripping leading mentions
+ *
+ * @param text - Text content with potential leading mentions
+ * @param mentions - Mentions array from Feishu message
+ * @returns Text with leading mentions stripped
+ */
+export function stripLeadingMentions(
+  text: string,
+  mentions: MentionsArray | undefined | null
+): string {
+  if (!text) {
+    return text;
+  }
+
+  let result = text.trim();
+
+  // Build a map of key -> name for placeholder replacement
+  const keyToName = new Map<string, string>();
+  if (mentions) {
+    for (const mention of mentions) {
+      if (mention.key && mention.name) {
+        keyToName.set(mention.key, mention.name);
+      }
+    }
+  }
+
+  // Keep stripping leading mentions until no more are found
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    // Pattern 1: <at user_id="xxx">@Name</at> at the start
+    const atTagMatch = result.match(/^<at[^>]*>@[^<]+<\/at>\s*/i);
+    if (atTagMatch) {
+      result = result.slice(atTagMatch[0].length).trim();
+      changed = true;
+      continue;
+    }
+
+    // Pattern 2: ${key} at the start (placeholder format)
+    if (keyToName.size > 0) {
+      for (const [key] of keyToName) {
+        const placeholderPattern = new RegExp(`^\\$\\{${escapeRegExp(key)}\\}\\s*`);
+        if (placeholderPattern.test(result)) {
+          result = result.replace(placeholderPattern, '').trim();
+          changed = true;
+          break;
+        }
+      }
+      if (changed) {
+        continue;
+      }
+    }
+
+    // Pattern 3: @Name at the start (simple format)
+    // Match @ followed by non-whitespace characters
+    const simpleMentionMatch = result.match(/^@[^\s]+\s*/);
+    if (simpleMentionMatch) {
+      result = result.slice(simpleMentionMatch[0].length).trim();
+      changed = true;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

When users send messages like `@bot /help` in Feishu, the command was not recognized because the text starts with `@` instead of `/`. This fix strips leading @mentions before checking if the message is a command.

## Changes

| File | Description |
|------|-------------|
| `src/utils/mention-parser.ts` | Add `stripLeadingMentions()` function |
| `src/utils/mention-parser.test.ts` | Add 11 tests for the new function |
| `src/channels/feishu-channel.ts` | Use stripped text for command detection |

## Implementation Details

### stripLeadingMentions() Function
Handles multiple mention formats:
- `<at user_id="xxx">@Name</at>` - normalized format
- `${key}` - placeholder format (key from mentions array)
- `@Name` - simple @mention format

Strips all leading mentions until non-mention text is found.

### Command Detection Update
- Previously: `trimmedText.startsWith('/')`
- Now: `stripLeadingMentions(text, mentions).startsWith('/')`

This allows commands like `/help` to be recognized in messages like:
- `@bot /help`
- `${@_bot} /help`
- `<at user_id="ou_xxx">@bot</at> /help`

## Test Results

| Metric | Value |
|--------|-------|
| mention-parser tests | 33 passed |
| feishu-channel tests | 36 passed |

## Verification Criteria from Issue #698

- [x] Messages starting with `/` are recognized as commands
- [x] Messages like `@bot /help` are recognized as commands
- [x] Unknown commands show clear error message
- [x] Commands are prioritized over normal prompts when @mentioned

Fixes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)