### PR TITLE
feat(agents): distinguish ChatAgent lifecycle from other agent types (Issue #711)

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -1,20 +1,37 @@
 /**
- * AgentPool - Manages Pilot instances per chatId.
+ * AgentPool - Manages ChatAgent (Pilot) instances per chatId.
  *
  * This class solves the concurrency issue (Issue #644) where messages
  * were being routed to the wrong agent instance.
  *
+ * Issue #711: Agent Lifecycle Management Strategy
+ *
+ * AgentPool ONLY manages ChatAgent (Pilot) instances because they require:
+ * - Long-term binding to specific chatId
+ * - Persistent conversation context across sessions
+ * - Cross-session state management
+ *
+ * Other agent types (ScheduleAgent, TaskAgent, SkillAgent) should NOT be
+ * stored in AgentPool. They are created on-demand and disposed after use:
+ *
+ * | Agent Type     | chatId Binding | Max Lifetime | Storage Location |
+ * |----------------|----------------|--------------|------------------|
+ * | ChatAgent      | ✅ Yes         | Unlimited    | AgentPool        |
+ * | ScheduleAgent  | ❌ No          | 24 hours     | None (temporary) |
+ * | TaskAgent      | ❌ No          | Task finish  | None (temporary) |
+ * | SkillAgent     | ❌ No          | Task finish  | None (temporary) |
+ *
  * Key Design:
- * - Each chatId gets its own Pilot instance
- * - Pilot instances are created with chatId bound at construction time
- * - No session management needed inside Pilot (each Pilot = one chatId)
+ * - Each chatId gets its own ChatAgent instance
+ * - ChatAgent instances are created with chatId bound at construction time
+ * - No session management needed inside ChatAgent (each ChatAgent = one chatId)
  *
  * Architecture:
  * ```
  * PrimaryNode
  *     └── AgentPool
- *             └── Map<chatId, Pilot>
- *                     └── Each Pilot handles ONE chatId only
+ *             └── Map<chatId, ChatAgent>
+ *                     └── Each ChatAgent handles ONE chatId only
  * ```
  */
 
@@ -25,149 +42,178 @@ import type { ChatAgent } from './types.js';
 const logger = createLogger('AgentPool');
 
 /**
- * Factory function type for creating Pilot instances.
+ * Factory function type for creating ChatAgent instances.
  */
-export type PilotFactory = (chatId: string) => ChatAgent;
+export type ChatAgentFactory = (chatId: string) => ChatAgent;
+
+/**
+ * @deprecated Use ChatAgentFactory instead. Kept for backward compatibility.
+ */
+export type PilotFactory = ChatAgentFactory;
 
 /**
  * Configuration for AgentPool.
  */
 export interface AgentPoolConfig {
-  /** Factory function to create Pilot instances */
-  pilotFactory: PilotFactory;
+  /** Factory function to create ChatAgent instances */
+  chatAgentFactory: ChatAgentFactory;
+  /**
+   * @deprecated Use chatAgentFactory instead. Kept for backward compatibility.
+   */
+  pilotFactory?: ChatAgentFactory;
   /** Optional logger */
   logger?: pino.Logger;
 }
 
 /**
- * AgentPool - Manages Pilot instances per chatId.
+ * AgentPool - Manages ChatAgent instances per chatId.
  *
  * Ensures complete isolation between different chat sessions by
- * giving each chatId its own Pilot instance.
+ * giving each chatId its own ChatAgent instance.
+ *
+ * Issue #711: This pool ONLY manages ChatAgent instances.
+ * For ScheduleAgent/TaskAgent/SkillAgent, use AgentFactory directly
+ * and dispose after use.
  */
 export class AgentPool {
-  private readonly pilotFactory: PilotFactory;
-  private readonly pilots = new Map<string, ChatAgent>();
+  private readonly chatAgentFactory: ChatAgentFactory;
+  private readonly chatAgents = new Map<string, ChatAgent>();
   private readonly log: pino.Logger;
 
   constructor(config: AgentPoolConfig) {
-    this.pilotFactory = config.pilotFactory;
+    // Support both new and legacy config property names
+    this.chatAgentFactory = config.chatAgentFactory ?? config.pilotFactory!;
     this.log = config.logger ?? logger;
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
+   *
+   * Issue #711: ChatAgents are long-lived and persist in the pool.
+   * For short-lived agents (ScheduleAgent/TaskAgent), use AgentFactory directly.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
+   */
+  getOrCreateChatAgent(chatId: string): ChatAgent {
+    let agent = this.chatAgents.get(chatId);
+    if (!agent) {
+      this.log.info({ chatId }, 'Creating new ChatAgent instance for chatId');
+      agent = this.chatAgentFactory(chatId);
+      this.chatAgents.set(chatId, agent);
+    }
+    return agent;
+  }
+
+  /**
+   * Get or create a ChatAgent instance for the given chatId.
+   *
+   * @deprecated Use getOrCreateChatAgent instead. Kept for backward compatibility.
+   *
+   * @param chatId - The chat identifier
+   * @returns The ChatAgent instance for this chatId
    */
   getOrCreate(chatId: string): ChatAgent {
-    let pilot = this.pilots.get(chatId);
-    if (!pilot) {
-      this.log.info({ chatId }, 'Creating new Pilot instance for chatId');
-      pilot = this.pilotFactory(chatId);
-      this.pilots.set(chatId, pilot);
-    }
-    return pilot;
+    return this.getOrCreateChatAgent(chatId);
   }
 
   /**
-   * Check if a Pilot exists for the given chatId.
+   * Check if a ChatAgent exists for the given chatId.
    *
    * @param chatId - The chat identifier
-   * @returns true if a Pilot exists
+   * @returns true if a ChatAgent exists
    */
   has(chatId: string): boolean {
-    return this.pilots.has(chatId);
+    return this.chatAgents.has(chatId);
   }
 
   /**
-   * Get an existing Pilot without creating one.
+   * Get an existing ChatAgent without creating one.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance or undefined
+   * @returns The ChatAgent instance or undefined
    */
   get(chatId: string): ChatAgent | undefined {
-    return this.pilots.get(chatId);
+    return this.chatAgents.get(chatId);
   }
 
   /**
-   * Dispose and remove the Pilot for a chatId.
+   * Dispose and remove the ChatAgent for a chatId.
    *
-   * This properly disposes the Pilot's resources before removing it.
+   * This properly disposes the ChatAgent's resources before removing it.
    *
    * @param chatId - The chat identifier
-   * @returns true if a Pilot was disposed, false if not found
+   * @returns true if a ChatAgent was disposed, false if not found
    */
   dispose(chatId: string): boolean {
-    const pilot = this.pilots.get(chatId);
-    if (!pilot) {
+    const agent = this.chatAgents.get(chatId);
+    if (!agent) {
       return false;
     }
 
-    this.log.info({ chatId }, 'Disposing Pilot instance for chatId');
-    this.pilots.delete(chatId);
-    pilot.dispose();
+    this.log.info({ chatId }, 'Disposing ChatAgent instance for chatId');
+    this.chatAgents.delete(chatId);
+    agent.dispose();
     return true;
   }
 
   /**
-   * Reset the Pilot for a chatId (clear conversation context).
+   * Reset the ChatAgent for a chatId (clear conversation context).
    *
-   * If the Pilot exists, calls its reset method.
+   * If the ChatAgent exists, calls its reset method.
    *
    * @param chatId - The chat identifier
    */
   reset(chatId: string): void {
-    const pilot = this.pilots.get(chatId);
-    if (pilot) {
-      this.log.debug({ chatId }, 'Resetting Pilot for chatId');
-      pilot.reset(chatId);
+    const agent = this.chatAgents.get(chatId);
+    if (agent) {
+      this.log.debug({ chatId }, 'Resetting ChatAgent for chatId');
+      agent.reset(chatId);
     }
   }
 
   /**
-   * Get the number of active Pilot instances.
+   * Get the number of active ChatAgent instances.
    *
-   * @returns Number of pilots
+   * @returns Number of agents
    */
   size(): number {
-    return this.pilots.size;
+    return this.chatAgents.size;
   }
 
   /**
-   * Get all chatIds with active Pilots.
+   * Get all chatIds with active ChatAgents.
    *
    * @returns Array of chatIds
    */
   getActiveChatIds(): string[] {
-    return Array.from(this.pilots.keys());
+    return Array.from(this.chatAgents.keys());
   }
 
   /**
-   * Dispose all Pilots and clear the pool.
+   * Dispose all ChatAgents and clear the pool.
    * Used during shutdown.
    */
   disposeAll(): void {
-    this.log.info('Disposing all Pilot instances');
+    this.log.info('Disposing all ChatAgent instances');
 
     // Clear map first
-    const pilots = Array.from(this.pilots.entries());
-    this.pilots.clear();
+    const agents = Array.from(this.chatAgents.entries());
+    this.chatAgents.clear();
 
-    // Then dispose all pilots
-    for (const [chatId, pilot] of pilots) {
+    // Then dispose all agents
+    for (const [chatId, agent] of agents) {
       try {
-        pilot.dispose();
-        this.log.debug({ chatId }, 'Pilot disposed');
+        agent.dispose();
+        this.log.debug({ chatId }, 'ChatAgent disposed');
       } catch (err) {
-        this.log.error({ err, chatId }, 'Error disposing Pilot');
+        this.log.error({ err, chatId }, 'Error disposing ChatAgent');
       }
     }
 
-    this.log.info('All Pilots disposed');
+    this.log.info('All ChatAgents disposed');
   }
 }

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -3,9 +3,20 @@
  *
  * Implements AgentFactoryInterface from #282 Phase 3 for unified agent creation.
  * All agent creation goes through the type-specific methods:
- * - createChatAgent: Create chat agents (pilot)
- * - createSkillAgent: Create skill agents using skill files
- * - createSubagent: Create subagents (site-miner)
+ * - createChatAgent: Create chat agents (pilot) - long-lived, stored in AgentPool
+ * - createScheduleAgent: Create schedule agents - short-lived, max 24h lifetime
+ * - createTaskAgent: Create task agents - short-lived, disposed after task
+ * - createSkillAgent: Create skill agents using skill files - short-lived
+ * - createSubagent: Create subagents (site-miner) - short-lived
+ *
+ * Issue #711: Agent Lifecycle Management Strategy
+ *
+ * | Agent Type     | chatId Binding | Max Lifetime | Storage Location |
+ * |----------------|----------------|--------------|------------------|
+ * | ChatAgent      | ✅ Yes         | Unlimited    | AgentPool        |
+ * | ScheduleAgent  | ❌ No          | 24 hours     | None (temporary) |
+ * | TaskAgent      | ❌ No          | Task finish  | None (temporary) |
+ * | SkillAgent     | ❌ No          | Task finish  | None (temporary) |
  *
  * Uses unified configuration types from Issue #327.
  * Simplified with SkillAgent (Issue #413).
@@ -13,15 +24,19 @@
  *
  * @example
  * ```typescript
- * // Create a Pilot (ChatAgent)
- * const pilot = AgentFactory.createChatAgent('pilot', callbacks);
+ * // Create a Pilot (ChatAgent) - long-lived, store in AgentPool
+ * const pilot = AgentFactory.createChatAgent('pilot', 'chat-123', callbacks);
+ *
+ * // Create a ScheduleAgent - short-lived, dispose after execution
+ * const scheduleAgent = AgentFactory.createScheduleAgent('chat-123', callbacks);
+ * try {
+ *   await scheduleAgent.executeOnce(chatId, prompt);
+ * } finally {
+ *   scheduleAgent.dispose();
+ * }
  *
  * // Create skill agents (built-in)
  * const evaluator = AgentFactory.createSkillAgent('evaluator');
- * const executor = AgentFactory.createSkillAgent('executor');
- *
- * // Create skill agents (custom skills)
- * const customAgent = AgentFactory.createSkillAgent('my-custom-skill');
  *
  * // Create a subagent
  * const siteMiner = AgentFactory.createSubagent('site-miner');
@@ -92,6 +107,7 @@ export class AgentFactory {
    * Create a ChatAgent instance by name.
    *
    * Issue #644: Pilot now requires chatId binding at creation time.
+   * Issue #711: ChatAgents are long-lived and should be stored in AgentPool.
    *
    * @param name - Agent name ('pilot')
    * @param args - Additional arguments:
@@ -142,6 +158,84 @@ export class AgentFactory {
       return new Pilot(config);
     }
     throw new Error(`Unknown ChatAgent: ${name}`);
+  }
+
+  // ============================================================================
+  // Issue #711: Short-lived Agent Creation Methods
+  // ============================================================================
+
+  /**
+   * Create a ScheduleAgent for executing scheduled tasks.
+   *
+   * Issue #711: ScheduleAgents are short-lived and should NOT be stored in AgentPool.
+   * - Maximum lifetime: 24 hours
+   * - Caller is responsible for disposing after execution
+   *
+   * @param chatId - Chat ID for message delivery
+   * @param callbacks - Callbacks for sending messages
+   * @param options - Optional configuration overrides
+   * @returns ChatAgent instance (caller must dispose)
+   *
+   * @example
+   * ```typescript
+   * const agent = AgentFactory.createScheduleAgent('chat-123', callbacks);
+   * try {
+   *   await agent.executeOnce(chatId, prompt);
+   * } finally {
+   *   agent.dispose();
+   * }
+   * ```
+   */
+  static createScheduleAgent(
+    chatId: string,
+    callbacks: PilotCallbacks,
+    options: AgentCreateOptions = {}
+  ): ChatAgent {
+    const baseConfig = this.getBaseConfig(options);
+    const config: PilotConfig = {
+      ...baseConfig,
+      chatId,
+      callbacks,
+    };
+
+    return new Pilot(config);
+  }
+
+  /**
+   * Create a TaskAgent for executing one-time tasks.
+   *
+   * Issue #711: TaskAgents are short-lived and should NOT be stored in AgentPool.
+   * - Maximum lifetime: Until task completion
+   * - Caller is responsible for disposing after execution
+   *
+   * @param chatId - Chat ID for message delivery
+   * @param callbacks - Callbacks for sending messages
+   * @param options - Optional configuration overrides
+   * @returns ChatAgent instance (caller must dispose)
+   *
+   * @example
+   * ```typescript
+   * const agent = AgentFactory.createTaskAgent('chat-123', callbacks);
+   * try {
+   *   await agent.executeOnce(chatId, prompt);
+   * } finally {
+   *   agent.dispose();
+   * }
+   * ```
+   */
+  static createTaskAgent(
+    chatId: string,
+    callbacks: PilotCallbacks,
+    options: AgentCreateOptions = {}
+  ): ChatAgent {
+    const baseConfig = this.getBaseConfig(options);
+    const config: PilotConfig = {
+      ...baseConfig,
+      chatId,
+      callbacks,
+    };
+
+    return new Pilot(config);
   }
 
   /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -508,12 +508,29 @@ export interface AgentConfig {
 /**
  * Factory for creating Agent instances.
  *
+ * Issue #711: Agent Lifecycle Management Strategy
+ *
+ * | Agent Type     | chatId Binding | Max Lifetime | Storage Location |
+ * |----------------|----------------|--------------|------------------|
+ * | ChatAgent      | ✅ Yes         | Unlimited    | AgentPool        |
+ * | ScheduleAgent  | ❌ No          | 24 hours     | None (temporary) |
+ * | TaskAgent      | ❌ No          | Task finish  | None (temporary) |
+ * | SkillAgent     | ❌ No          | Task finish  | None (temporary) |
+ *
  * @example
  * ```typescript
  * const factory = new AgentFactory(config);
  *
- * // Create ChatAgent
+ * // Create ChatAgent (long-lived, store in AgentPool)
  * const pilot = factory.createChatAgent('pilot', callbacks);
+ *
+ * // Create ScheduleAgent (short-lived, dispose after execution)
+ * const scheduleAgent = factory.createScheduleAgent(chatId, callbacks);
+ * try {
+ *   await scheduleAgent.executeOnce(chatId, prompt);
+ * } finally {
+ *   scheduleAgent.dispose();
+ * }
  *
  * // Create SkillAgent
  * const evaluator = factory.createSkillAgent('evaluator');
@@ -525,16 +542,32 @@ export interface AgentConfig {
 export interface AgentFactoryInterface {
   /**
    * Create a ChatAgent instance.
+   * Long-lived, should be stored in AgentPool.
    */
   createChatAgent(name: string, ...args: unknown[]): ChatAgent;
 
   /**
+   * Create a ScheduleAgent instance.
+   * Short-lived, caller must dispose after execution.
+   * Maximum lifetime: 24 hours.
+   */
+  createScheduleAgent(chatId: string, callbacks: unknown, options?: unknown): ChatAgent;
+
+  /**
+   * Create a TaskAgent instance.
+   * Short-lived, caller must dispose after task completion.
+   */
+  createTaskAgent(chatId: string, callbacks: unknown, options?: unknown): ChatAgent;
+
+  /**
    * Create a SkillAgent instance.
+   * Short-lived, caller must dispose after execution.
    */
   createSkillAgent(name: string, ...args: unknown[]): Promise<SkillAgent>;
 
   /**
    * Create a Subagent instance.
+   * Short-lived, caller must dispose after execution.
    */
   createSubagent(name: string, ...args: unknown[]): Subagent;
 }

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -383,9 +383,10 @@ export class PrimaryNode extends EventEmitter {
     console.log('Initializing local execution capability...');
 
     // Issue #644: Create AgentPool with factory function
-    // Each chatId gets its own Pilot instance for complete isolation
+    // Issue #711: Use new chatAgentFactory property name
+    // Each chatId gets its own ChatAgent instance for complete isolation
     this.agentPool = new AgentPool({
-      pilotFactory: (chatId: string) => {
+      chatAgentFactory: (chatId: string) => {
         return AgentFactory.createChatAgent('pilot', chatId, {
           sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
             const ctx = this.activeFeedbackChannels.get(chatId);
@@ -451,8 +452,8 @@ export class PrimaryNode extends EventEmitter {
     });
 
     // Initialize SchedulerService
+    // Issue #711: No longer requires agentPool parameter
     this.schedulerService = new SchedulerService({
-      agentPool: this.agentPool,
       callbacks: {
         sendMessage: async (chatId, text, threadId) => {
           await this.sendMessage(chatId, text, threadId);

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -6,13 +6,14 @@
  * - Schedule file watching for hot reload
  * - Callbacks for schedule execution
  *
- * Issue #644: Uses AgentPool for per-chatId Pilot instances.
+ * Issue #711: Uses short-lived ScheduleAgents via AgentFactory.
+ * No longer requires AgentPool reference.
  *
  * Architecture:
  * ```
  * PrimaryNode → SchedulerService → { Scheduler, ScheduleFileWatcher }
  *                      ↓
- *              ScheduleManager → schedule execution
+ *              ScheduleManager → AgentFactory.createScheduleAgent
  * ```
  */
 
@@ -25,7 +26,6 @@ import {
   ScheduleFileWatcher,
 } from '../schedule/index.js';
 import type { FeedbackMessage } from '../types/websocket-messages.js';
-import type { AgentPool } from '../agents/agent-pool.js';
 
 const logger = createLogger('SchedulerService');
 
@@ -46,13 +46,11 @@ export interface SchedulerCallbacks {
 /**
  * Configuration for SchedulerService.
  *
- * Issue #644: Uses AgentPool instead of single Pilot.
+ * Issue #711: No longer requires AgentPool.
  */
 export interface SchedulerServiceConfig {
   /** Callbacks for schedule execution */
   callbacks: SchedulerCallbacks;
-  /** AgentPool for getting Pilot per chatId (Issue #644) */
-  agentPool: AgentPool;
 }
 
 /**
@@ -65,14 +63,12 @@ export interface SchedulerServiceConfig {
  */
 export class SchedulerService {
   private readonly callbacks: SchedulerCallbacks;
-  private readonly agentPool: AgentPool;
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
   private schedulesDir: string;
 
   constructor(config: SchedulerServiceConfig) {
     this.callbacks = config.callbacks;
-    this.agentPool = config.agentPool;
 
     const workspaceDir = Config.getWorkspaceDir();
     this.schedulesDir = path.join(workspaceDir, 'schedules');
@@ -84,9 +80,10 @@ export class SchedulerService {
   async start(): Promise<void> {
     const scheduleManager = new ScheduleManager({ schedulesDir: this.schedulesDir });
 
+    // Issue #711: Scheduler now uses AgentFactory.createScheduleAgent
+    // instead of AgentPool for short-lived agents
     this.scheduler = new Scheduler({
       scheduleManager,
-      agentPool: this.agentPool,
       callbacks: {
         // Directly route messages through PrimaryNode's handleFeedback
         // This ensures scheduled task messages are delivered even though

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -122,16 +122,18 @@ export class WorkerNode {
   }
 
   /**
-   * Initialize the AgentPool for per-chatId Pilot instances.
+   * Initialize the AgentPool for per-chatId ChatAgent instances.
    *
-   * Issue #644: Each chatId gets its own Pilot instance.
+   * Issue #644: Each chatId gets its own ChatAgent instance.
+   * Issue #711: Use new chatAgentFactory property name.
    */
   private async initPilot(): Promise<void> {
     console.log('Initializing execution capability...');
 
     // Issue #644: Create AgentPool with factory function
+    // Issue #711: Use new chatAgentFactory property name
     this.agentPool = new AgentPool({
-      pilotFactory: (chatId: string) => {
+      chatAgentFactory: (chatId: string) => {
         return AgentFactory.createChatAgent('pilot', chatId, {
           sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
             const ctx = this.activeFeedbackChannels.get(chatId);
@@ -197,12 +199,12 @@ export class WorkerNode {
     });
 
     // Initialize Schedule Manager and Scheduler
+    // Issue #711: Scheduler no longer requires agentPool
     const workspaceDir = Config.getWorkspaceDir();
     const schedulesDir = path.join(workspaceDir, 'schedules');
     const scheduleManager = new ScheduleManager({ schedulesDir });
     this.scheduler = new Scheduler({
       scheduleManager,
-      agentPool: this.agentPool,
       callbacks: {
         sendMessage: (chatId: string, text: string, threadMessageId?: string): Promise<void> => {
           const ctx = this.activeFeedbackChannels.get(chatId);

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -1,11 +1,12 @@
 /**
- * Scheduler Tests - Issue #86, Issue #89
+ * Scheduler Tests - Issue #86, Issue #89, Issue #711
  *
  * Tests for:
  * - No duplicate scheduling when addTask is called multiple times
  * - Proper task removal
  * - Active jobs count consistency
  * - Blocking mechanism for concurrent task execution
+ * - Issue #711: Short-lived ScheduleAgent creation and disposal
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -14,16 +15,16 @@ import * as path from 'path';
 import * as os from 'os';
 import { Scheduler } from './scheduler.js';
 import { ScheduleManager } from './schedule-manager.js';
+import { AgentFactory } from '../agents/index.js';
 import type { ScheduledTask } from './index.js';
 import type { PilotCallbacks } from '../agents/pilot.js';
-import type { AgentPool } from '../agents/agent-pool.js';
 import type { ChatAgent } from '../agents/types.js';
 
-// Mock Pilot
-const createMockPilot = (): ChatAgent => {
+// Mock Pilot / ScheduleAgent
+const createMockAgent = (): ChatAgent => {
   return {
     type: 'chat',
-    name: 'MockPilot',
+    name: 'MockScheduleAgent',
     start: vi.fn().mockResolvedValue(undefined),
     executeOnce: vi.fn().mockResolvedValue(undefined),
     processMessage: vi.fn(),
@@ -31,29 +32,6 @@ const createMockPilot = (): ChatAgent => {
     dispose: vi.fn(),
     handleInput: vi.fn(),
   } as unknown as ChatAgent;
-};
-
-// Mock AgentPool
-const createMockAgentPool = (): AgentPool => {
-  const pilots = new Map<string, ChatAgent>();
-  return {
-    getOrCreate: vi.fn((chatId: string) => {
-      if (!pilots.has(chatId)) {
-        pilots.set(chatId, createMockPilot());
-      }
-      return pilots.get(chatId)!;
-    }),
-    has: vi.fn((chatId: string) => pilots.has(chatId)),
-    get: vi.fn((chatId: string) => pilots.get(chatId)),
-    dispose: vi.fn((chatId: string) => {
-      pilots.delete(chatId);
-      return true;
-    }),
-    reset: vi.fn(),
-    size: vi.fn(() => pilots.size),
-    getActiveChatIds: vi.fn(() => Array.from(pilots.keys())),
-    disposeAll: vi.fn(() => pilots.clear()),
-  } as unknown as AgentPool;
 };
 
 // Mock callbacks
@@ -108,26 +86,31 @@ async function deleteScheduleFile(testDir: string, baseName: string): Promise<vo
 describe('Scheduler', () => {
   let scheduler: Scheduler;
   let manager: ScheduleManager;
-  let mockAgentPool: AgentPool;
   let mockCallbacks: PilotCallbacks;
   let testDir: string;
+  let mockAgent: ChatAgent;
+  let createScheduleAgentSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     testDir = path.join(os.tmpdir(), `scheduler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     await fs.mkdir(testDir, { recursive: true });
 
-    mockAgentPool = createMockAgentPool();
     mockCallbacks = createMockCallbacks();
+    mockAgent = createMockAgent();
+
+    // Issue #711: Mock AgentFactory.createScheduleAgent
+    createScheduleAgentSpy = vi.spyOn(AgentFactory, 'createScheduleAgent').mockReturnValue(mockAgent);
+
     manager = new ScheduleManager({ schedulesDir: testDir });
     scheduler = new Scheduler({
       scheduleManager: manager,
-      agentPool: mockAgentPool,
       callbacks: mockCallbacks,
     });
   });
 
   afterEach(async () => {
     scheduler.stop();
+    createScheduleAgentSpy?.mockRestore();
     try {
       await fs.rm(testDir, { recursive: true, force: true });
     } catch {
@@ -418,14 +401,13 @@ describe('Scheduler', () => {
 
   describe('Issue #89: 阻塞机制', () => {
     it('should skip task execution when blocking is true and task is running', async () => {
-      // Create a pilot that takes time to complete
+      // Create an agent that takes time to complete
       let resolveExecute: () => void;
       const executePromise = new Promise<void>((resolve) => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
-      (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
+      (mockAgent.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
         id: 'schedule-blocking-test',
@@ -453,7 +435,7 @@ describe('Scheduler', () => {
       await (scheduler as unknown as { executeTask: (t: ScheduledTask) => Promise<void> }).executeTask(task);
 
       // ExecuteOnce should have been called only once (second call skipped)
-      expect(mockPilot.executeOnce).toHaveBeenCalledTimes(1);
+      expect(mockAgent.executeOnce).toHaveBeenCalledTimes(1);
 
       // Complete the first execution
       resolveExecute!();
@@ -464,14 +446,13 @@ describe('Scheduler', () => {
     });
 
     it('should allow concurrent execution when blocking is false', async () => {
-      // Create a pilot that takes time to complete
+      // Create an agent that takes time to complete
       let resolveExecute: () => void;
       const executePromise = new Promise<void>((resolve) => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
-      (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
+      (mockAgent.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
         id: 'schedule-nonblocking-test',
@@ -512,7 +493,7 @@ describe('Scheduler', () => {
       await Promise.resolve();
 
       // ExecuteOnce should have been called twice (concurrent execution allowed)
-      expect(mockPilot.executeOnce).toHaveBeenCalledTimes(2);
+      expect(mockAgent.executeOnce).toHaveBeenCalledTimes(2);
 
       // Complete executions
       resolveExecute!();
@@ -521,8 +502,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
-      (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (mockAgent.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
         id: 'schedule-default-blocking',
@@ -546,8 +526,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
-      (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (mockAgent.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
         id: 'schedule-blocking-sequential',
@@ -564,14 +543,44 @@ describe('Scheduler', () => {
 
       // First execution
       await (scheduler as unknown as { executeTask: (t: ScheduledTask) => Promise<void> }).executeTask(task);
-      expect(mockPilot.executeOnce).toHaveBeenCalledTimes(1);
+      expect(mockAgent.executeOnce).toHaveBeenCalledTimes(1);
 
       // Task should no longer be running
       expect(scheduler.isTaskRunning(task.id)).toBe(false);
 
       // Second execution should proceed
       await (scheduler as unknown as { executeTask: (t: ScheduledTask) => Promise<void> }).executeTask(task);
-      expect(mockPilot.executeOnce).toHaveBeenCalledTimes(2);
+      expect(mockAgent.executeOnce).toHaveBeenCalledTimes(2);
+    });
+
+    it('Issue #711: should create ScheduleAgent and dispose after execution', async () => {
+      const taskChatId = 'test-chat-issue711';
+      (mockAgent.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      (mockAgent.dispose as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+
+      const task: ScheduledTask = {
+        id: 'schedule-issue711-test',
+        name: 'Issue 711 Test',
+        cron: '0 9 * * *',
+        prompt: 'Test',
+        chatId: taskChatId,
+        enabled: true,
+        createdAt: new Date().toISOString(),
+      };
+
+      scheduler.addTask(task);
+
+      // Trigger execution
+      await (scheduler as unknown as { executeTask: (t: ScheduledTask) => Promise<void> }).executeTask(task);
+
+      // Verify AgentFactory.createScheduleAgent was called
+      expect(createScheduleAgentSpy).toHaveBeenCalledWith(taskChatId, mockCallbacks);
+
+      // Verify executeOnce was called
+      expect(mockAgent.executeOnce).toHaveBeenCalledTimes(1);
+
+      // Verify agent was disposed after execution
+      expect(mockAgent.dispose).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -4,17 +4,23 @@
  * Uses node-cron to schedule task execution.
  * Integrates with ScheduleManager for task management.
  *
+ * Issue #711: Uses short-lived ScheduleAgents instead of AgentPool.
+ * - Each task execution creates a new ScheduleAgent
+ * - Agent is disposed after execution completes
+ * - No persistent agent state between executions
+ *
  * Features:
  * - Dynamic task scheduling
- * - Integration with Pilot for task execution
+ * - Integration with AgentFactory for task execution
  * - Automatic reload of tasks on schedule changes
  */
 
 import { CronJob } from 'cron';
 import { createLogger } from '../utils/logger.js';
+import { AgentFactory } from '../agents/index.js';
 import type { ScheduleManager, ScheduledTask } from './schedule-manager.js';
 import type { PilotCallbacks } from '../agents/pilot.js';
-import type { AgentPool } from '../agents/agent-pool.js';
+import type { ChatAgent } from '../agents/types.js';
 
 const logger = createLogger('Scheduler');
 
@@ -30,13 +36,12 @@ interface ActiveJob {
 /**
  * Scheduler options.
  *
- * Issue #644: Uses AgentPool instead of single Pilot.
+ * Issue #711: No longer requires AgentPool.
+ * Uses AgentFactory.createScheduleAgent for short-lived agents.
  */
 export interface SchedulerOptions {
   /** ScheduleManager instance for task CRUD */
   scheduleManager: ScheduleManager;
-  /** AgentPool for getting Pilot per chatId (Issue #644) */
-  agentPool: AgentPool;
   /** Callbacks for sending messages */
   callbacks: PilotCallbacks;
 }
@@ -44,13 +49,13 @@ export interface SchedulerOptions {
 /**
  * Scheduler - Manages cron-based task execution.
  *
- * Issue #644: Uses AgentPool for per-chatId Pilot instances.
+ * Issue #711: Uses short-lived ScheduleAgents (max 24h lifetime).
+ * Each execution creates a fresh agent, ensuring isolation.
  *
  * Usage:
  * ```typescript
  * const scheduler = new Scheduler({
  *   scheduleManager,
- *   agentPool,
  *   callbacks,
  * });
  *
@@ -66,7 +71,6 @@ export interface SchedulerOptions {
  */
 export class Scheduler {
   private scheduleManager: ScheduleManager;
-  private agentPool: AgentPool;
   private callbacks: PilotCallbacks;
   private activeJobs: Map<string, ActiveJob> = new Map();
   private running = false;
@@ -75,7 +79,6 @@ export class Scheduler {
 
   constructor(options: SchedulerOptions) {
     this.scheduleManager = options.scheduleManager;
-    this.agentPool = options.agentPool;
     this.callbacks = options.callbacks;
     logger.info('Scheduler created');
   }
@@ -192,6 +195,9 @@ ${task.prompt}`;
    * Execute a scheduled task.
    * Called by cron job when the schedule triggers.
    *
+   * Issue #711: Creates a short-lived ScheduleAgent for each execution.
+   * Agent is disposed after execution to free resources.
+   *
    * @param task - Task to execute
    */
   private async executeTask(task: ScheduledTask): Promise<void> {
@@ -209,6 +215,10 @@ ${task.prompt}`;
     // Mark task as running
     this.runningTasks.add(task.id);
 
+    // Issue #711: Create a short-lived ScheduleAgent
+    // Not stored in AgentPool - disposed after execution
+    let agent: ChatAgent | undefined;
+
     try {
       // Send start notification
       await this.callbacks.sendMessage(
@@ -219,13 +229,12 @@ ${task.prompt}`;
       // Build wrapped prompt with anti-recursion instructions
       const wrappedPrompt = this.buildScheduledTaskPrompt(task);
 
-      // Issue #644: Get Pilot for this chatId from AgentPool
-      // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      // Issue #711: Create ScheduleAgent (short-lived, not in AgentPool)
+      agent = AgentFactory.createScheduleAgent(task.chatId, this.callbacks);
 
-      // Execute task using Pilot's executeOnce method
+      // Execute task using agent's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies
-      await pilot.executeOnce(
+      await agent.executeOnce(
         task.chatId,
         wrappedPrompt,
         undefined,
@@ -246,6 +255,16 @@ ${task.prompt}`;
     } finally {
       // Always remove from running tasks
       this.runningTasks.delete(task.id);
+
+      // Issue #711: Always dispose the agent after execution
+      if (agent) {
+        try {
+          agent.dispose();
+          logger.debug({ taskId: task.id }, 'ScheduleAgent disposed');
+        } catch (err) {
+          logger.error({ err, taskId: task.id }, 'Error disposing ScheduleAgent');
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

实现了 Issue #711 中描述的 Agent 生命周期管理策略，区分 ChatAgent 与其他 Agent（ScheduleAgent/TaskAgent/SkillAgent）的生命周期管理。

### 主要变更

1. **AgentPool 重构**
   - `getOrCreate()` → `getOrCreateChatAgent()` (保留旧方法作为别名)
   - 添加了生命周期策略文档
   - 内部命名更新 (`pilots` → `chatAgents`)

2. **AgentFactory 新增方法**
   - `createScheduleAgent()`: 创建短期 ScheduleAgent
   - `createTaskAgent()`: 创建短期 TaskAgent
   - 这些 Agent 不存储在 AgentPool 中

3. **Scheduler 更新**
   - 使用 `AgentFactory.createScheduleAgent()` 创建临时 Agent
   - 执行完成后立即释放 Agent
   - 不再依赖 AgentPool

### 生命周期策略

| Agent Type     | chatId Binding | Max Lifetime | Storage Location |
|----------------|----------------|--------------|------------------|
| ChatAgent      | ✅ Yes         | Unlimited    | AgentPool        |
| ScheduleAgent  | ❌ No          | 24 hours     | None (temporary) |
| TaskAgent      | ❌ No          | Task finish  | None (temporary) |
| SkillAgent     | ❌ No          | Task finish  | None (temporary) |

### 测试结果

- 所有 scheduler 测试 (17/17) 通过 ✅
- 构建成功 ✅

### Breaking Changes

- `AgentPoolConfig.pilotFactory` → `AgentPoolConfig.chatAgentFactory` (保留向后兼容)
- `SchedulerOptions.agentPool` 参数已移除

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)