### PR TITLE
feat(feishu): split chat logs by date with legacy migration (Issue #691)

### DIFF
--- a/src/feishu/message-logger.test.ts
+++ b/src/feishu/message-logger.test.ts
@@ -15,7 +15,7 @@ vi.mock('../config/index.js', () => ({
 vi.mock('../config/constants.js', () => ({
   MESSAGE_LOGGING: {
     LOGS_DIR: 'chat-logs',
-    MD_PARSE_REGEX: /message_id:\s*([^\n\]]+)/g,
+    MD_PARSE_REGEX: /message_id:\s*([^\)]+)/g,
   },
 }));
 
@@ -28,6 +28,7 @@ vi.mock('fs/promises', () => ({
     writeFile: vi.fn().mockResolvedValue(undefined),
     appendFile: vi.fn().mockResolvedValue(undefined),
     access: vi.fn().mockRejectedValue(new Error('File not found')),
+    rename: vi.fn().mockResolvedValue(undefined),
   },
   mkdir: vi.fn().mockResolvedValue(undefined),
   readdir: vi.fn().mockResolvedValue([]),
@@ -35,6 +36,7 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
   appendFile: vi.fn().mockResolvedValue(undefined),
   access: vi.fn().mockRejectedValue(new Error('File not found')),
+  rename: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('MessageLogger', () => {
@@ -57,6 +59,7 @@ describe('MessageLogger', () => {
     vi.mocked(mockFs.writeFile).mockClear().mockResolvedValue(undefined);
     vi.mocked(mockFs.appendFile).mockClear().mockResolvedValue(undefined);
     vi.mocked(mockFs.access).mockClear().mockRejectedValue(new Error('File not found'));
+    vi.mocked(mockFs.rename).mockClear().mockResolvedValue(undefined);
 
     // Also reset default exports if they exist
     if (mockFs.default) {
@@ -66,6 +69,7 @@ describe('MessageLogger', () => {
       vi.mocked(mockFs.default.writeFile).mockClear().mockResolvedValue(undefined);
       vi.mocked(mockFs.default.appendFile).mockClear().mockResolvedValue(undefined);
       vi.mocked(mockFs.default.access).mockClear().mockRejectedValue(new Error('File not found'));
+      vi.mocked(mockFs.default.rename).mockClear().mockResolvedValue(undefined);
     }
 
     // Re-import to get fresh instance
@@ -213,8 +217,8 @@ describe('MessageLogger', () => {
   });
 
   describe('getChatHistory', () => {
-    it('should return empty string when file not found', async () => {
-      vi.mocked(mockFs.readFile).mockRejectedValueOnce(new Error('File not found'));
+    it('should return empty string when no files exist', async () => {
+      vi.mocked(mockFs.readFile).mockRejectedValue(new Error('File not found'));
 
       const history = await messageLogger.getChatHistory('nonexistent');
 
@@ -225,9 +229,23 @@ describe('MessageLogger', () => {
       const mockContent = '# Chat Log\nContent here';
       vi.mocked(mockFs.readFile).mockResolvedValueOnce(mockContent);
 
-      const history = await messageLogger.getChatHistory('chat-1');
+      const history = await messageLogger.getChatHistory('chat-1', 1);
 
       expect(history).toBe(mockContent);
+    });
+
+    it('should read multiple days of logs', async () => {
+      const day1Content = '# Day 1';
+      const day2Content = '# Day 2';
+
+      vi.mocked(mockFs.readFile)
+        .mockResolvedValueOnce(day1Content) // Today
+        .mockResolvedValueOnce(day2Content); // Yesterday
+
+      const history = await messageLogger.getChatHistory('chat-1', 2);
+
+      // Should be in chronological order (oldest first)
+      expect(history).toBe(`${day2Content}\n\n${day1Content}`);
     });
   });
 
@@ -326,6 +344,21 @@ describe('MessageLogger', () => {
 
       expect(messageLogger.isMessageProcessed('msg-a1')).toBe(true);
       expect(messageLogger.isMessageProcessed('msg-b1')).toBe(true);
+    });
+  });
+
+  describe('Date-based structure', () => {
+    it('should create date-based directory structure', async () => {
+      await messageLogger.logIncomingMessage(
+        'msg-date',
+        'user-1',
+        'chat-date',
+        'Test',
+        'text'
+      );
+
+      // Verify mkdir was called for the chat directory
+      expect(mockFs.mkdir).toHaveBeenCalled();
     });
   });
 });

--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,8 +2,8 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Provides message ID-based deduplication by parsing MD files.
- * Replaces in-memory MessageHistoryManager and task directory deduplication.
+ * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Provides message ID-based deduplication via in-memory cache only.
  */
 
 import fs from 'fs/promises';
@@ -21,11 +21,18 @@ interface LogEntry {
   direction: 'incoming' | 'outgoing';
 }
 
+/**
+ * Get today's date string in YYYY-MM-DD format
+ */
+function getDateString(date: Date = new Date()): string {
+  return date.toISOString().split('T')[0];
+}
+
 export class MessageLogger {
   private chatDir: string;
 
   // In-memory cache for immediate deduplication (no size limit)
-  // Loaded at startup from all existing MD files
+  // Only tracks message IDs seen in current session
   private processedMessageIds = new Set<string>();
   private initialized = false;
 
@@ -37,7 +44,7 @@ export class MessageLogger {
 
   /**
    * Explicit initialization method that must be called and awaited before using the logger.
-   * This ensures the chat directory exists and message IDs are loaded.
+   * This ensures the chat directory exists and migrates legacy files.
    */
   async init(): Promise<void> {
     if (this.initialized) {
@@ -56,44 +63,51 @@ export class MessageLogger {
       // Then create chat subdirectory
       await fs.mkdir(this.chatDir, { recursive: true });
 
-      // Load all existing message IDs from MD files at startup
-      await this.loadAllMessageIds();
+      // Migrate legacy flat files to date-based structure
+      await this.migrateLegacyFiles();
     } catch (error) {
       console.error('[MessageLogger] Failed to initialize:', error);
     }
   }
 
   /**
-   * Load all message IDs from existing MD files at startup.
-   * One-time operation to populate the in-memory cache.
+   * Migrate legacy flat files ({chatId}.md) to date-based structure.
+   * Moves old files to today's directory.
    */
-  private async loadAllMessageIds(): Promise<void> {
+  private async migrateLegacyFiles(): Promise<void> {
     try {
-      const files = await fs.readdir(this.chatDir);
-      const mdFiles = files.filter(f => f.endsWith('.md'));
+      const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
 
-      console.log(`[MessageLogger] Loading message IDs from ${mdFiles.length} chat files...`);
+      // Find legacy flat .md files (not in subdirectories)
+      const legacyFiles = entries.filter(
+        entry => entry.isFile() && entry.name.endsWith('.md')
+      );
 
-      for (const file of mdFiles) {
-        const filePath = path.join(this.chatDir, file);
-        try {
-          const content = await fs.readFile(filePath, 'utf-8');
-          const regex = MESSAGE_LOGGING.MD_PARSE_REGEX;
-
-          let match;
-          regex.lastIndex = 0;
-          while ((match = regex.exec(content)) !== null) {
-            this.processedMessageIds.add(match[1].trim());
-          }
-        } catch (_error) {
-          console.error(`[MessageLogger] Failed to read ${file}:`, _error);
-        }
+      if (legacyFiles.length === 0) {
+        return;
       }
 
-      console.log(`[MessageLogger] Loaded ${this.processedMessageIds.size} message IDs into memory`);
+      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
+
+      const today = getDateString();
+
+      for (const file of legacyFiles) {
+        const legacyPath = path.join(this.chatDir, file.name);
+        const chatId = file.name.replace('.md', '');
+
+        // Create chat directory
+        const chatDir = path.join(this.chatDir, chatId);
+        await fs.mkdir(chatDir, { recursive: true });
+
+        // Move to new location
+        const newPath = path.join(chatDir, `${today}.md`);
+        await fs.rename(legacyPath, newPath);
+
+        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+      }
     } catch (_error) {
-      // Directory doesn't exist yet, that's fine
-      console.log('[MessageLogger] No existing chat files found, starting fresh');
+      // Directory doesn't exist or migration failed, that's fine
+      console.log('[MessageLogger] No legacy files to migrate');
     }
   }
 
@@ -151,18 +165,20 @@ export class MessageLogger {
 
   /**
    * Check if message was already processed.
-   * All message IDs are loaded at startup, so this is just an in-memory lookup.
+   * Uses in-memory cache only (no file reading).
    */
   isMessageProcessed(messageId: string): boolean {
     return this.processedMessageIds.has(messageId);
   }
 
   /**
-   * Get chat log file path.
+   * Get chat log file path for a specific date.
+   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
    */
-  private getChatLogPath(chatId: string): string {
+  private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
-    return path.join(this.chatDir, `${sanitizedId}.md`);
+    const dateStr = getDateString(date);
+    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
   }
 
   /**
@@ -267,13 +283,32 @@ ${entry.content}
   }
 
   /**
-   * Get message history for a chat.
+   * Get message history for a chat, reading from the last N days.
+   * @param chatId Chat ID
+   * @param days Number of days to look back (default: 7)
    */
-  async getChatHistory(chatId: string): Promise<string> {
-    const logPath = this.getChatLogPath(chatId);
+  async getChatHistory(chatId: string, days: number = 7): Promise<string> {
+    const contents: string[] = [];
 
     try {
-      return await fs.readFile(logPath, 'utf-8');
+      // Read logs from the last N days
+      for (let i = 0; i < days; i++) {
+        const date = new Date();
+        date.setDate(date.getDate() - i);
+        const logPath = this.getChatLogPath(chatId, date);
+
+        try {
+          const content = await fs.readFile(logPath, 'utf-8');
+          if (content.trim()) {
+            contents.push(content);
+          }
+        } catch {
+          // File doesn't exist for this day, continue
+        }
+      }
+
+      // Reverse to get chronological order (oldest first)
+      return contents.reverse().join('\n\n');
     } catch (_error) {
       return '';
     }
@@ -281,7 +316,6 @@ ${entry.content}
 
   /**
    * Clear in-memory cache (useful for testing).
-   * Note: This will require a restart to reload message IDs from MD files.
    */
   clearCache(): void {
     this.processedMessageIds.clear();


### PR DESCRIPTION
## Summary

将聊天日志从扁平文件结构改为按日期分割的目录结构，并自动迁移旧格式文件。

## Changes

| 文件 | 变更 |
|------|------|
| `src/feishu/message-logger.ts` | 修改文件路径结构，添加迁移逻辑 |
| `src/feishu/message-logger.test.ts` | 更新测试以适应新结构 |

## 新结构

```
workspace/logs/
├── oc_abc123/
│   ├── 2026-03-05.md
│   ├── 2026-03-04.md
│   └── 2026-03-03.md
└── ou_xyz789/
    └── 2026-03-05.md
```

## 关键改动

1. **移除 `loadAllMessageIds()`** - 去重仅使用内存哈希表，不再从文件加载
2. **日期目录结构** - 从 `{chatId}.md` 改为 `{chatId}/{YYYY-MM-DD}.md`
3. **旧日志迁移** - init 时自动将旧格式文件移动到今日目录
4. **多天读取** - `getChatHistory()` 可读取最近 N 天的日志（默认 7 天）

## Benefits

- ✅ 按天分割日志，便于管理和清理
- ✅ 自动迁移旧格式，无需手动干预
- ✅ 支持读取多天历史记录

## Test Plan

- [x] 运行 `npx tsc --noEmit` 无错误
- [x] 运行 `npx vitest run src/feishu/message-logger.test.ts` 23 个测试全部通过

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)