### PR TITLE
feat(logger): split chat logs by date with auto-migration (Issue #691)

### DIFF
--- a/src/feishu/message-logger.test.ts
+++ b/src/feishu/message-logger.test.ts
@@ -28,6 +28,8 @@ vi.mock('fs/promises', () => ({
     writeFile: vi.fn().mockResolvedValue(undefined),
     appendFile: vi.fn().mockResolvedValue(undefined),
     access: vi.fn().mockRejectedValue(new Error('File not found')),
+    rename: vi.fn().mockResolvedValue(undefined),
+    unlink: vi.fn().mockResolvedValue(undefined),
   },
   mkdir: vi.fn().mockResolvedValue(undefined),
   readdir: vi.fn().mockResolvedValue([]),
@@ -35,6 +37,8 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(undefined),
   appendFile: vi.fn().mockResolvedValue(undefined),
   access: vi.fn().mockRejectedValue(new Error('File not found')),
+  rename: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('MessageLogger', () => {
@@ -57,6 +61,8 @@ describe('MessageLogger', () => {
     vi.mocked(mockFs.writeFile).mockClear().mockResolvedValue(undefined);
     vi.mocked(mockFs.appendFile).mockClear().mockResolvedValue(undefined);
     vi.mocked(mockFs.access).mockClear().mockRejectedValue(new Error('File not found'));
+    vi.mocked(mockFs.rename).mockClear().mockResolvedValue(undefined);
+    vi.mocked(mockFs.unlink).mockClear().mockResolvedValue(undefined);
 
     // Also reset default exports if they exist
     if (mockFs.default) {
@@ -66,6 +72,8 @@ describe('MessageLogger', () => {
       vi.mocked(mockFs.default.writeFile).mockClear().mockResolvedValue(undefined);
       vi.mocked(mockFs.default.appendFile).mockClear().mockResolvedValue(undefined);
       vi.mocked(mockFs.default.access).mockClear().mockRejectedValue(new Error('File not found'));
+      vi.mocked(mockFs.default.rename).mockClear().mockResolvedValue(undefined);
+      vi.mocked(mockFs.default.unlink).mockClear().mockResolvedValue(undefined);
     }
 
     // Re-import to get fresh instance
@@ -326,6 +334,123 @@ describe('MessageLogger', () => {
 
       expect(messageLogger.isMessageProcessed('msg-a1')).toBe(true);
       expect(messageLogger.isMessageProcessed('msg-b1')).toBe(true);
+    });
+  });
+
+  describe('Date-based storage', () => {
+    it('should create log files in date-based directory', async () => {
+      await messageLogger.logIncomingMessage('msg-date', 'user-1', 'chat-date', 'Test', 'text');
+
+      // Check that mkdir was called with a date-based path
+      const mkdirCalls = vi.mocked(mockFs.mkdir).mock.calls;
+      const hasDateDir = mkdirCalls.some(call => {
+        const pathArg = String(call[0]);
+        return pathArg.includes('2026-') || /\d{4}-\d{2}-\d{2}/.test(pathArg);
+      });
+      expect(hasDateDir).toBe(true);
+    });
+
+    it('should use date directory in file path', async () => {
+      await messageLogger.logIncomingMessage('msg-path', 'user-1', 'chat-path', 'Test', 'text');
+
+      // writeFile should be called with a path containing date directory
+      const writeCalls = vi.mocked(mockFs.writeFile).mock.calls;
+      expect(writeCalls.length).toBeGreaterThan(0);
+
+      const filePath = String(writeCalls[0][0]);
+      // Path should match pattern: .../chat-logs/YYYY-MM-DD/chatId.md
+      expect(filePath).toMatch(/\d{4}-\d{2}-\d{2}/);
+    });
+  });
+
+  describe('Legacy file migration', () => {
+    it('should migrate legacy flat files on init', async () => {
+      // Mock readdir to return legacy files
+      const mockDirent = (name: string, isFile: boolean) => ({
+        name,
+        isFile: () => isFile,
+        isDirectory: () => !isFile,
+      });
+
+      const entries = [
+        mockDirent('chat-legacy.md', true),
+        mockDirent('2026-03-05', false), // existing date dir
+      ];
+      vi.mocked(mockFs.readdir).mockResolvedValueOnce(
+        // @ts-expect-error - Mock Dirent type mismatch is expected in tests
+        entries
+      );
+
+      await messageLogger.init();
+
+      // Should have called rename to move the file
+      expect(mockFs.rename).toHaveBeenCalled();
+    });
+
+    it('should handle no legacy files gracefully', async () => {
+      // Mock readdir to return only directories
+      const mockDirent = (name: string, isFile: boolean) => ({
+        name,
+        isFile: () => isFile,
+        isDirectory: () => !isFile,
+      });
+
+      const entries = [
+        mockDirent('2026-03-05', false),
+        mockDirent('2026-03-04', false),
+      ];
+      vi.mocked(mockFs.readdir).mockResolvedValueOnce(
+        // @ts-expect-error - Mock Dirent type mismatch is expected in tests
+        entries
+      );
+
+      await messageLogger.init();
+
+      // Should not have called rename
+      expect(mockFs.rename).not.toHaveBeenCalled();
+    });
+
+    it('should remove duplicate legacy files if migrated file exists', async () => {
+      const mockDirent = (name: string, isFile: boolean) => ({
+        name,
+        isFile: () => isFile,
+        isDirectory: () => !isFile,
+      });
+
+      const entries = [mockDirent('chat-dup.md', true)];
+      vi.mocked(mockFs.readdir).mockResolvedValueOnce(
+        // @ts-expect-error - Mock Dirent type mismatch is expected in tests
+        entries
+      );
+
+      // Mock access to succeed (file exists in new location)
+      vi.mocked(mockFs.access).mockResolvedValueOnce(undefined);
+
+      await messageLogger.init();
+
+      // Should have called unlink to remove duplicate
+      expect(mockFs.unlink).toHaveBeenCalled();
+    });
+  });
+
+  describe('In-memory deduplication only', () => {
+    it('should not load message IDs from files at startup', () => {
+      // This test verifies that we only use in-memory deduplication
+      // The logger should start with an empty cache
+
+      expect(messageLogger.isMessageProcessed('old-msg-id')).toBe(false);
+    });
+
+    it('should track messages in memory during session', async () => {
+      const messageId = 'session-msg';
+
+      await messageLogger.logIncomingMessage(messageId, 'user-1', 'chat-1', 'Test', 'text');
+
+      expect(messageLogger.isMessageProcessed(messageId)).toBe(true);
+
+      messageLogger.clearCache();
+
+      expect(messageLogger.isMessageProcessed(messageId)).toBe(false);
     });
   });
 });

--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -1,9 +1,10 @@
 /**
  * Message logger for persistent message history.
  *
- * Logs all user and bot messages to chat-specific MD files.
- * Provides message ID-based deduplication by parsing MD files.
- * Replaces in-memory MessageHistoryManager and task directory deduplication.
+ * Logs all user and bot messages to chat-specific MD files organized by date.
+ * File structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
+ * Provides in-memory message ID-based deduplication.
+ * Automatically migrates legacy flat files to date-based structure.
  */
 
 import fs from 'fs/promises';
@@ -21,11 +22,18 @@ interface LogEntry {
   direction: 'incoming' | 'outgoing';
 }
 
+/**
+ * Get today's date string in YYYY-MM-DD format.
+ */
+function getTodayDateDir(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
 export class MessageLogger {
   private chatDir: string;
 
   // In-memory cache for immediate deduplication (no size limit)
-  // Loaded at startup from all existing MD files
+  // Only stores message IDs from current session
   private processedMessageIds = new Set<string>();
   private initialized = false;
 
@@ -37,7 +45,7 @@ export class MessageLogger {
 
   /**
    * Explicit initialization method that must be called and awaited before using the logger.
-   * This ensures the chat directory exists and message IDs are loaded.
+   * This ensures the chat directory exists and legacy files are migrated.
    */
   async init(): Promise<void> {
     if (this.initialized) {
@@ -56,44 +64,59 @@ export class MessageLogger {
       // Then create chat subdirectory
       await fs.mkdir(this.chatDir, { recursive: true });
 
-      // Load all existing message IDs from MD files at startup
-      await this.loadAllMessageIds();
+      // Migrate legacy flat files to date-based structure
+      await this.migrateLegacyFiles();
     } catch (error) {
       console.error('[MessageLogger] Failed to initialize:', error);
     }
   }
 
   /**
-   * Load all message IDs from existing MD files at startup.
-   * One-time operation to populate the in-memory cache.
+   * Migrate legacy flat files ({chatId}.md) to date-based structure ({date}/{chatId}.md).
+   * Legacy files are moved to today's directory.
    */
-  private async loadAllMessageIds(): Promise<void> {
+  private async migrateLegacyFiles(): Promise<void> {
     try {
-      const files = await fs.readdir(this.chatDir);
-      const mdFiles = files.filter(f => f.endsWith('.md'));
+      const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
+      const legacyFiles = entries.filter(
+        entry => entry.isFile() && entry.name.endsWith('.md')
+      );
 
-      console.log(`[MessageLogger] Loading message IDs from ${mdFiles.length} chat files...`);
+      if (legacyFiles.length === 0) {
+        return;
+      }
 
-      for (const file of mdFiles) {
-        const filePath = path.join(this.chatDir, file);
+      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
+
+      const todayDir = getTodayDateDir();
+      const todayPath = path.join(this.chatDir, todayDir);
+      await fs.mkdir(todayPath, { recursive: true });
+
+      for (const file of legacyFiles) {
+        const oldPath = path.join(this.chatDir, file.name);
+        const newPath = path.join(todayPath, file.name);
+
         try {
-          const content = await fs.readFile(filePath, 'utf-8');
-          const regex = MESSAGE_LOGGING.MD_PARSE_REGEX;
-
-          let match;
-          regex.lastIndex = 0;
-          while ((match = regex.exec(content)) !== null) {
-            this.processedMessageIds.add(match[1].trim());
+          // Check if file already exists in new location
+          try {
+            await fs.access(newPath);
+            // File exists, delete the legacy file
+            await fs.unlink(oldPath);
+            console.log(`[MessageLogger] Removed duplicate legacy file: ${file.name}`);
+          } catch {
+            // File doesn't exist in new location, move it
+            await fs.rename(oldPath, newPath);
+            console.log(`[MessageLogger] Migrated: ${file.name} -> ${todayDir}/${file.name}`);
           }
-        } catch (_error) {
-          console.error(`[MessageLogger] Failed to read ${file}:`, _error);
+        } catch (error) {
+          console.error(`[MessageLogger] Failed to migrate ${file.name}:`, error);
         }
       }
 
-      console.log(`[MessageLogger] Loaded ${this.processedMessageIds.size} message IDs into memory`);
+      console.log('[MessageLogger] Legacy file migration completed');
     } catch (_error) {
       // Directory doesn't exist yet, that's fine
-      console.log('[MessageLogger] No existing chat files found, starting fresh');
+      console.log('[MessageLogger] No legacy files to migrate');
     }
   }
 
@@ -158,11 +181,13 @@ export class MessageLogger {
   }
 
   /**
-   * Get chat log file path.
+   * Get chat log file path with date-based directory.
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string): string {
     const sanitizedId = this.sanitizeId(chatId);
-    return path.join(this.chatDir, `${sanitizedId}.md`);
+    const dateDir = getTodayDateDir();
+    return path.join(this.chatDir, dateDir, `${sanitizedId}.md`);
   }
 
   /**
@@ -255,9 +280,11 @@ ${entry.content}
    */
   private createFileHeader(chatId: string): string {
     const now = new Date().toISOString();
+    const dateDir = getTodayDateDir();
     return `# Chat Message Log: ${chatId}
 
 **Chat ID**: ${chatId}
+**Date**: ${dateDir}
 **Created**: ${now}
 **Last Updated**: ${now}
 


### PR DESCRIPTION
## Summary

Implements Issue #691 - 聊天日志按天分割存储

Changes the chat log storage structure from flat files to date-based directories for better organization and management.

## Changes

| File | Description |
|------|-------------|
| `src/feishu/message-logger.ts` | Add date-based directory structure and migration |
| `src/feishu/message-logger.test.ts` | Add tests for new functionality |

## New Features

### Date-based Storage Structure
- **Before**: `workspace/chat/{chatId}.md` (flat files)
- **After**: `workspace/chat/{YYYY-MM-DD}/{chatId}.md` (date directories)

### Key Changes

1. **`getChatLogPath()`**: Now includes date directory in the path
2. **`migrateLegacyFiles()`**: Auto-migrates legacy flat files to date structure
3. **In-memory deduplication**: Removed file-based message ID loading per user request

### Migration Behavior

- Legacy flat files are automatically moved to today's directory on startup
- If a file already exists in the target location, the legacy file is removed
- Migration is non-blocking and logs progress

## Test Results

| Metric | Value |
|--------|-------|
| Tests | 28 passed |
| TypeScript | ✅ Pass |
| ESLint | ✅ Pass |

## Verification Criteria from Issue #691

- [x] 按天来建文件夹
- [x] chat id 来建文件
- [x] 自动迁移旧日志到新结构
- [x] 移除从文件加载 message IDs（只用内存去重）

Fixes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)