### PR TITLE
fix(utils): add stable sorting for listTaskHistory when timestamps are equal (Issue #734)

### DIFF
--- a/src/utils/task-state-manager.ts
+++ b/src/utils/task-state-manager.ts
@@ -363,6 +363,8 @@ export class TaskStateManager {
       // Sort by completion time (newest first) and limit
       // Use updatedAt since it reflects when the task was completed/cancelled
       // Secondary sort by createdAt for stable ordering when updatedAt is equal
+      // Tertiary sort by id (descending) for stable ordering when all timestamps are equal
+      // Note: Task IDs contain timestamps, so higher ID = more recent
       return tasks
         .sort((a, b) => {
           const updatedAtDiff = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
@@ -370,7 +372,12 @@ export class TaskStateManager {
             return updatedAtDiff;
           }
           // When updatedAt is equal, sort by createdAt (newest first)
-          return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          const createdAtDiff = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          if (createdAtDiff !== 0) {
+            return createdAtDiff;
+          }
+          // When all timestamps are equal, sort by id (higher ID = more recent)
+          return b.id.localeCompare(a.id);
         })
         .slice(0, limit);
     } catch {


### PR DESCRIPTION
## Summary

- Fix flaky test in `TaskStateManager > listTaskHistory` where tasks created in the same millisecond would have non-deterministic ordering
- Add tertiary sort by task ID (descending) for stable ordering when all timestamps are equal

## Root Cause

The test `should list completed tasks` was failing intermittently because:
- When tasks are created and completed within the same millisecond, both `updatedAt` and `createdAt` timestamps are identical
- The sort function had no tie-breaker, resulting in unstable ordering based on `fs.readdir` return order

## Solution

Add tertiary sort condition using `localeCompare` on task IDs:
- Task IDs follow the pattern `task_{timestamp}_{random}`
- Higher timestamp prefix = more recent task
- This ensures stable, deterministic ordering

## Changes

| File | Description |
|------|-------------|
| `src/utils/task-state-manager.ts` | Add tertiary sort by task ID in `listTaskHistory()` |

## Test Results

| Metric | Value |
|--------|-------|
| TaskStateManager Tests | 27 passed ✅ |
| All Tests | 1546 passed |
| Pre-existing Failures | 2 (unrelated to this change) |

## Verification

```bash
npx vitest run src/utils/task-state-manager.test.ts
# ✓ 27 tests passed
```

## Related Issue

Fixes #734 (unit test failure - TaskStateManager.listTaskHistory sorting)

## Note on Integration Test Failure

Issue #734 also mentions an integration test failure (HTTP 000). This appears to be an environment issue (API rate limiting or timeout) rather than a code bug, and is not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)