### PR TITLE
fix(mcp): improve send_user_feedback parameter validation error message

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1106,9 +1106,7 @@ When parentMessageId is provided, the message is sent as a reply to that message
 **Reference:** https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags`,
     parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. MUST match format type: string for "text", object for "card" with {config, header, elements}.'),
-      format: z.enum(['text', 'card'], {
-        errorMap: () => ({ message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.' }),
-      }).describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
+      format: z.enum(['text', 'card'], 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.').describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies.'),
     }),

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -80,7 +80,7 @@ describe('Feishu MCP Server', () => {
       // Verify description mentions key features
       expect(sendFeedbackTool?.description).toContain('Send a message to a Feishu chat');
       expect(sendFeedbackTool?.description).toContain('Thread Support');
-      expect(sendFeedbackTool?.description).toContain('Card Format Requirements');
+      expect(sendFeedbackTool?.description).toContain('Card Structure Requirements');
     });
 
     it('should define send_file_to_feishu tool with correct schema', async () => {


### PR DESCRIPTION
## Summary

- Fix Zod v4 enum error message format (`errorMap` -> string param)
- Update test to match actual description text ("Card Format" -> "Card Structure")

The error message is now more user-friendly when format parameter is missing or invalid:

**Before:** `Invalid option: expected one of "text"|"card"`

**After:** `format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.`

## Root Cause

Zod v4 changed the enum API. The `errorMap` option is no longer supported; instead, pass a string as the second parameter to customize the error message.

```typescript
// Before (ignored in Zod v4)
z.enum(['text', 'card'], {
  errorMap: () => ({ message: '...' })
})

// After (works in Zod v4)
z.enum(['text', 'card'], 'format is REQUIRED...')
```

## Test Results

| Metric | Value |
|--------|-------|
| MCP Tests | 63 passed ✅ |
| TypeScript | ✅ Pass |

Fixes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)