### PR TITLE
feat(rest): implement async mode for REST Channel (Issue #738)

### DIFF
--- a/src/channels/rest-channel.test.ts
+++ b/src/channels/rest-channel.test.ts
@@ -36,6 +36,7 @@ interface ApiResponseBody {
   response?: string;
   channel?: string;
   id?: string;
+  status?: string;
   file?: {
     id?: string;
     fileName?: string;
@@ -816,6 +817,150 @@ describe('RestChannel', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
+    });
+  });
+
+  describe('Async Mode (POST /api/chat/{chatId})', () => {
+    beforeEach(async () => {
+      channel = new RestChannel({ port });
+      await channel.start();
+    });
+
+    it('should return 204 No Content when polling non-existent session', async () => {
+      const response = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/non-existent-chat-id',
+      });
+
+      expect(response.status).toBe(204);
+    });
+
+    it('should return 202 Accepted when sending a message', async () => {
+      const response = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/test-chat-123',
+        body: { message: 'Hello async' },
+      });
+
+      expect(response.status).toBe(202);
+      expect(response.body.success).toBe(true);
+      expect(response.body.chatId).toBe('test-chat-123');
+      expect(response.body.status).toBe('processing');
+      expect(response.body.messageId).toBeDefined();
+    });
+
+    it('should return 202 when polling a processing session', async () => {
+      // Send a message first
+      await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/processing-chat',
+        body: { message: 'Processing test' },
+      });
+
+      // Poll immediately - should be processing
+      const response = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/processing-chat',
+      });
+
+      expect(response.status).toBe(202);
+      expect(response.body.status).toBe('processing');
+    });
+
+    it('should return 200 with response when session is completed', async () => {
+      // Set up message handler that will respond
+      channel.onMessage(async (msg) => {
+        // Simulate agent response
+        await channel.sendMessage({
+          type: 'text',
+          text: 'Hello from agent!',
+          chatId: msg.chatId,
+        });
+        // Signal completion
+        await channel.sendMessage({
+          type: 'done',
+          chatId: msg.chatId,
+        });
+      });
+
+      // Send a message
+      const sendResponse = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/completed-chat',
+        body: { message: 'Hello' },
+      });
+
+      expect(sendResponse.status).toBe(202);
+
+      // Wait a bit for processing
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Poll - should be completed with response
+      const pollResponse = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/completed-chat',
+      });
+
+      expect(pollResponse.status).toBe(200);
+      expect(pollResponse.body.success).toBe(true);
+      expect(pollResponse.body.status).toBe('completed');
+      expect(pollResponse.body.response).toBe('Hello from agent!');
+    });
+
+    it('should support appending messages to existing session', async () => {
+      // Send first message
+      const response1 = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/append-chat',
+        body: { message: 'First message' },
+      });
+
+      expect(response1.status).toBe(202);
+
+      // Send second message (append)
+      const response2 = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/append-chat',
+        body: { message: 'Second message' },
+      });
+
+      expect(response2.status).toBe(202);
+      expect(response2.body.messageId).toBeDefined();
+      // MessageId should be different
+      expect(response2.body.messageId).not.toBe(response1.body.messageId);
+    });
+
+    it('should handle message handler errors in async mode', async () => {
+      channel.onMessage(() => {
+        throw new Error('Async handler failed');
+      });
+
+      const response = await makeRequest(port, {
+        method: 'POST',
+        path: '/api/chat/error-chat',
+        body: { message: 'This will fail' },
+      });
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBe('Failed to process message');
+    });
+
+    it('should work with custom API prefix', async () => {
+      // Stop current channel first
+      await channel.stop();
+
+      // Create new channel with custom prefix
+      channel = new RestChannel({ port, apiPrefix: '/custom' });
+      await channel.start();
+
+      const response = await makeRequest(port, {
+        method: 'POST',
+        path: '/custom/chat/custom-prefix-chat',
+        body: { message: 'Custom prefix test' },
+      });
+
+      expect(response.status).toBe(202);
+      expect(response.body.chatId).toBe('custom-prefix-chat');
     });
   });
 });

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -7,12 +7,16 @@
  * API Endpoints:
  * - POST /api/chat - Send a message and receive response (streaming)
  * - POST /api/chat/sync - Send a message and wait for complete response
+ * - POST /api/chat/{chatId} - Async mode: send message or poll for response
+ *   - With message body: returns 202 Accepted (message received)
+ *   - Without body (poll): 200 OK (completed), 202 Accepted (processing), 204 No Content (no session)
  * - GET /api/health - Health check
  * - POST /api/files/upload - Upload a file (base64 encoded)
  * - GET /api/files/:fileId - Get file metadata
  * - GET /api/files/:fileId/download - Download a file (base64 encoded)
  *
  * @see Issue #583 - REST Channel file transfer
+ * @see Issue #738 - REST async mode
  */
 
 import http from 'node:http';
@@ -147,11 +151,39 @@ interface PendingResponse {
 }
 
 /**
+ * Session status for async mode.
+ */
+type SessionStatus = 'pending' | 'processing' | 'completed' | 'error';
+
+/**
+ * Stored message in session.
+ */
+interface SessionMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+/**
+ * Session state for async mode.
+ */
+interface SessionState {
+  chatId: string;
+  status: SessionStatus;
+  messages: SessionMessage[];
+  lastMessageId?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
  * REST Channel - Provides RESTful API for agent interaction.
  *
  * Features:
  * - POST /api/chat - Send message (streaming response)
  * - POST /api/chat/sync - Send message (synchronous response)
+ * - POST /api/chat/{chatId} - Async mode: send message or poll for response
  * - GET /api/health - Health check
  * - POST /api/files/upload - Upload a file
  * - GET /api/files/:fileId - Get file metadata
@@ -179,6 +211,8 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
   private chatToMessage = new Map<string, string>();
   // File ID to Chat ID mapping (for file uploads)
   private fileToChat = new Map<string, string>();
+  // Session states for async mode (chatId -> SessionState)
+  private sessionStates = new Map<string, SessionState>();
 
   constructor(config: RestChannelConfig = {}) {
     super(config, 'rest', 'REST');
@@ -232,6 +266,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     this.responseBuffers.clear();
     this.chatToMessage.clear();
     this.fileToChat.clear();
+    this.sessionStates.clear();
 
     // Shutdown file storage
     if (this.fileStorage) {
@@ -255,8 +290,9 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
   protected doSendMessage(message: OutgoingMessage): Promise<void> {
     const messageId = this.chatToMessage.get(message.chatId);
 
-    // Handle 'done' type - task completion signal for sync mode
+    // Handle 'done' type - task completion signal
     if (message.type === 'done') {
+      // Sync mode: resolve pending response
       const pending = this.pendingResponses.get(message.chatId);
       if (pending) {
         // Get buffered response
@@ -278,24 +314,65 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
           this.responseBuffers.delete(messageId);
         }
         this.chatToMessage.delete(message.chatId);
-      } else {
+      }
+
+      // Async mode: update session status
+      const session = this.sessionStates.get(message.chatId);
+      if (session) {
+        session.status = 'completed';
+        session.updatedAt = Date.now();
+        logger.info(
+          { chatId: message.chatId, messageId },
+          'Task completed, async session updated'
+        );
+
+        // Cleanup response buffers for async mode
+        if (messageId) {
+          this.responseBuffers.delete(messageId);
+        }
+        this.chatToMessage.delete(message.chatId);
+      }
+
+      if (!pending && !session) {
         logger.warn(
           { chatId: message.chatId, messageId },
-          'Received done but no pending response found'
+          'Received done but no pending response or session found'
         );
       }
       return Promise.resolve();
     }
 
-    // For sync mode: buffer text responses
-    if (messageId && message.type === 'text') {
-      const buffer = this.responseBuffers.get(messageId);
-      if (buffer) {
-        buffer.push(message.text || '');
-      } else {
-        logger.warn(
-          { chatId: message.chatId, messageId },
-          'No buffer found for text message'
+    // For text responses
+    if (message.type === 'text' && message.text) {
+      // Sync mode: buffer text responses
+      if (messageId) {
+        const buffer = this.responseBuffers.get(messageId);
+        if (buffer) {
+          buffer.push(message.text);
+        } else {
+          logger.warn(
+            { chatId: message.chatId, messageId },
+            'No buffer found for text message'
+          );
+        }
+      }
+
+      // Async mode: add to session messages
+      const session = this.sessionStates.get(message.chatId);
+      if (session) {
+        const now = Date.now();
+        const assistantMessageId = `resp_${now}_${Math.random().toString(36).slice(2, 8)}`;
+        session.messages.push({
+          id: assistantMessageId,
+          role: 'assistant',
+          content: message.text,
+          timestamp: now,
+        });
+        session.lastMessageId = assistantMessageId;
+        session.updatedAt = now;
+        logger.debug(
+          { chatId: message.chatId, messageId: assistantMessageId },
+          'Async session: added assistant message'
         );
       }
     }
@@ -373,6 +450,14 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
 
     if (url === `${this.apiPrefix}/chat/sync` && req.method === 'POST') {
       await this.handleChat(req, res, true);
+      return;
+    }
+
+    // Async mode: POST /api/chat/{chatId}
+    const asyncChatMatch = url.match(new RegExp(`^${this.apiPrefix}/chat/([^/]+)$`));
+    if (asyncChatMatch && req.method === 'POST') {
+      const chatId = asyncChatMatch[1];
+      await this.handleAsyncChat(req, res, chatId);
       return;
     }
 
@@ -499,6 +584,148 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(response));
+  }
+
+  /**
+   * Handle async chat request (non-blocking mode).
+   *
+   * POST /api/chat/{chatId}
+   *
+   * Behavior:
+   * - With message body: Create/update session, return 202 Accepted
+   * - Without message body (poll):
+   *   - Session completed: 200 OK + response content
+   *   - Session processing: 202 Accepted
+   *   - No session: 204 No Content
+   *
+   * @see Issue #738 - REST async mode
+   */
+  private async handleAsyncChat(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    chatId: string
+  ): Promise<void> {
+    // Read request body
+    const body = await this.readBody(req);
+
+    // Parse request if body exists
+    let chatRequest: { message?: string; userId?: string } | null = null;
+    if (body) {
+      try {
+        chatRequest = JSON.parse(body) as { message?: string; userId?: string };
+      } catch {
+        this.sendError(res, 400, 'Invalid JSON');
+        return;
+      }
+    }
+
+    // Get or create session state
+    let session = this.sessionStates.get(chatId);
+
+    // Poll mode: no message in request
+    if (!chatRequest?.message) {
+      if (!session) {
+        // No session exists
+        logger.info({ chatId }, 'Async poll: no session');
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      // Session exists, check status
+      if (session.status === 'completed') {
+        // Get assistant messages as response
+        const assistantMessages = session.messages.filter(m => m.role === 'assistant');
+        const responseText = assistantMessages.map(m => m.content).join('\n');
+
+        logger.info({ chatId, responseLength: responseText.length }, 'Async poll: completed');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          success: true,
+          chatId,
+          status: session.status,
+          response: responseText,
+          messageId: session.lastMessageId,
+        }));
+        return;
+      }
+
+      // Still processing
+      logger.info({ chatId, status: session.status }, 'Async poll: processing');
+      res.writeHead(202, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        success: true,
+        chatId,
+        status: session.status,
+        messageId: session.lastMessageId,
+      }));
+      return;
+    }
+
+    // Send message mode: has message in request
+    const messageId = uuidv4();
+    const { userId } = chatRequest;
+    const now = Date.now();
+
+    // Create new session or update existing
+    if (!session) {
+      session = {
+        chatId,
+        status: 'pending',
+        messages: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.sessionStates.set(chatId, session);
+    }
+
+    // Add user message
+    session.messages.push({
+      id: messageId,
+      role: 'user',
+      content: chatRequest.message,
+      timestamp: now,
+    });
+    session.lastMessageId = messageId;
+    session.status = 'processing';
+    session.updatedAt = now;
+
+    // Set up response buffer for this message
+    this.responseBuffers.set(messageId, []);
+    this.chatToMessage.set(chatId, messageId);
+
+    logger.info({ chatId, messageId, userId }, 'Async chat: message received');
+
+    // Emit as incoming message
+    if (this.messageHandler) {
+      try {
+        await this.messageHandler({
+          messageId,
+          chatId,
+          userId,
+          content: chatRequest.message,
+          messageType: 'text',
+          timestamp: now,
+        });
+      } catch (error) {
+        logger.error({ err: error, messageId }, 'Failed to handle async message');
+        session.status = 'error';
+        session.updatedAt = Date.now();
+        this.sendError(res, 500, 'Failed to process message');
+        return;
+      }
+    } else {
+      logger.warn({ chatId, messageId }, 'No messageHandler registered');
+    }
+
+    // Return 202 Accepted immediately
+    res.writeHead(202, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({
+      success: true,
+      messageId,
+      chatId,
+      status: 'processing',
+    }));
   }
 
   /**


### PR DESCRIPTION
## Summary

- Implement non-blocking async mode for REST Channel API
- Add new endpoint: `POST /api/chat/{chatId}`
- Use HTTP status codes to indicate session state:
  - `202 Accepted`: Message received, Agent is processing
  - `200 OK`: Response ready, body contains complete message
  - `204 No Content`: No session found (for polling)

## Changes

### New Features
- **Session State Management**: In-memory storage of session states and messages
- **Async Endpoint**: `POST /api/chat/{chatId}` supports both sending messages and polling
- **Message Storage**: Each session stores user and assistant messages

### API Usage

```bash
# Send a message (non-blocking)
curl -X POST http://localhost:3000/api/chat/chat_123 \
  -H "Content-Type: application/json" \
  -d '{"message": "Hello"}'
# Returns: 202 Accepted

# Poll for response
curl -X POST http://localhost:3000/api/chat/chat_123
# Processing: 202 Accepted
# Completed: 200 OK + response content

# Append message (continue conversation)
curl -X POST http://localhost:3000/api/chat/chat_123 \
  -d '{"message": "Continue"}'
# Returns: 202 Accepted
```

## Test Results

| Metric | Value |
|--------|-------|
| Unit Tests | 45 passed ✅ |
| TypeScript | ✅ Pass |

## Related

- Issue #738: REST Channel async mode design
- Maintains backward compatibility with existing `/api/chat` and `/api/chat/sync` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)