### PR TITLE
fix(test): ensure fake timers are always restored in afterEach (Issue #740)

### DIFF
--- a/src/platforms/feishu/create-feishu-client.test.ts
+++ b/src/platforms/feishu/create-feishu-client.test.ts
@@ -50,6 +50,8 @@ describe('createFeishuClient', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // Ensure fake timers are always restored to prevent flaky tests
+    vi.useRealTimers();
   });
 
   it('should create client with correct timeout configuration', () => {


### PR DESCRIPTION
## Summary

- 在 `afterEach` 中添加 `vi.useRealTimers()` 确保 fake timers 总是被恢复
- 防止测试中途失败时 fake timers 影响后续测试导致的 flaky test

## Problem

Issue #740 报告 `create-feishu-client.test.ts` 中的重试逻辑测试在 CI 中全部超时（10s）。

## Root Cause

测试代码中使用了 `vi.useFakeTimers()` 来加速测试，但如果测试中途失败，`vi.useRealTimers()` 可能不会被执行，导致后续测试受到影响。

## Solution

在 `afterEach` 钩子中添加 `vi.useRealTimers()` 调用，确保无论测试成功还是失败，fake timers 都会被正确恢复。

## Test Plan

- [x] 本地运行 `npx vitest --run src/platforms/feishu/create-feishu-client.test.ts` - 8/8 通过
- [x] 本地多次运行测试验证稳定性 - 5次运行全部通过
- [x] 运行所有 feishu 相关测试 - 142/142 通过

Fixes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)