### PR TITLE
fix(mcp): resolve CI failures from PR #733 (Issue #743)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1107,7 +1107,7 @@ When parentMessageId is provided, the message is sent as a reply to that message
     parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. MUST match format type: string for "text", object for "card" with {config, header, elements}.'),
       format: z.enum(['text', 'card'], {
-        errorMap: () => ({ message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.' }),
+        message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.',
       }).describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies.'),
@@ -1124,9 +1124,9 @@ When parentMessageId is provided, the message is sent as a reply to that message
       if (format === 'card' && typeof content === 'object' && content !== null) {
         const obj = content as Record<string, unknown>;
         const missing: string[] = [];
-        if (!('config' in obj)) missing.push('config');
-        if (!('header' in obj)) missing.push('header');
-        if (!('elements' in obj)) missing.push('elements');
+        if (!('config' in obj)) { missing.push('config'); }
+        if (!('header' in obj)) { missing.push('header'); }
+        if (!('elements' in obj)) { missing.push('elements'); }
         if (missing.length > 0) {
           return toolSuccess(`❌ Card validation failed: missing required fields: ${missing.join(', ')}.\n\nRequired structure:\n{"config": {...}, "header": {"title": {...}, ...}, "elements": [...]}`);
         }

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -80,7 +80,7 @@ describe('Feishu MCP Server', () => {
       // Verify description mentions key features
       expect(sendFeedbackTool?.description).toContain('Send a message to a Feishu chat');
       expect(sendFeedbackTool?.description).toContain('Thread Support');
-      expect(sendFeedbackTool?.description).toContain('Card Format Requirements');
+      expect(sendFeedbackTool?.description).toContain('Card Structure Requirements');
     });
 
     it('should define send_file_to_feishu tool with correct schema', async () => {


### PR DESCRIPTION
## Summary

Fixes three issues introduced by PR #733:
1. **Type check failure**: `z.enum()` `errorMap` parameter not supported in Zod v4
2. **Lint failure**: `curly` rule violation on single-line if statements
3. **Unit test failure**: test expected "Card Format Requirements" but code used "Card Structure Requirements"

## Changes

| File | Change |
|------|--------|
| `feishu-context-mcp.ts` | Replace `errorMap` with `message` parameter for `z.enum()` |
| `feishu-context-mcp.ts` | Add braces to single-line if statements |
| `feishu-mcp-server.test.ts` | Update expected string to match new description |

## Root Cause

PR #733 used Zod v3 API (`errorMap`) but the project uses Zod v4 where `z.enum()` only accepts `{ error?, message? }` parameters.

## Solution Details

### 1. Type Check Fix
```typescript
// Before (Zod v3 API - doesn't work in Zod v4)
z.enum(['text', 'card'], {
  errorMap: () => ({ message: '...' }),
})

// After (Zod v4 API)
z.enum(['text', 'card'], {
  message: 'format is REQUIRED...',
})
```

### 2. Lint Fix (curly rule)
```typescript
// Before
if (!('config' in obj)) missing.push('config');

// After
if (!('config' in obj)) { missing.push('config'); }
```

### 3. Test Fix
```typescript
// Before
expect(sendFeedbackTool?.description).toContain('Card Format Requirements');

// After
expect(sendFeedbackTool?.description).toContain('Card Structure Requirements');
```

## Test Results

| Check | Status |
|--------|-------|
| Type check | ✅ Pass |
| ESLint | ✅ Pass |
| Unit tests | ✅ 7/7 passed |

## Verification

```bash
npm run type-check  # ✅ Pass
npx eslint src/mcp/feishu-context-mcp.ts  # ✅ No errors
npx vitest --run src/mcp/feishu-mcp-server.test.ts  # ✅ 7/7 passed
```

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)