### PR TITLE
fix(mcp): resolve Zod v4 z.enum errorMap incompatibility (Issue #744)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1106,9 +1106,7 @@ When parentMessageId is provided, the message is sent as a reply to that message
 **Reference:** https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags`,
     parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. MUST match format type: string for "text", object for "card" with {config, header, elements}.'),
-      format: z.enum(['text', 'card'], {
-        errorMap: () => ({ message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.' }),
-      }).describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
+      format: z.enum(['text', 'card'], 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.').describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies.'),
     }),
@@ -1124,9 +1122,9 @@ When parentMessageId is provided, the message is sent as a reply to that message
       if (format === 'card' && typeof content === 'object' && content !== null) {
         const obj = content as Record<string, unknown>;
         const missing: string[] = [];
-        if (!('config' in obj)) missing.push('config');
-        if (!('header' in obj)) missing.push('header');
-        if (!('elements' in obj)) missing.push('elements');
+        if (!('config' in obj)) { missing.push('config'); }
+        if (!('header' in obj)) { missing.push('header'); }
+        if (!('elements' in obj)) { missing.push('elements'); }
         if (missing.length > 0) {
           return toolSuccess(`❌ Card validation failed: missing required fields: ${missing.join(', ')}.\n\nRequired structure:\n{"config": {...}, "header": {"title": {...}, ...}, "elements": [...]}`);
         }

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -80,7 +80,7 @@ describe('Feishu MCP Server', () => {
       // Verify description mentions key features
       expect(sendFeedbackTool?.description).toContain('Send a message to a Feishu chat');
       expect(sendFeedbackTool?.description).toContain('Thread Support');
-      expect(sendFeedbackTool?.description).toContain('Card Format Requirements');
+      expect(sendFeedbackTool?.description).toContain('Card Structure Requirements');
     });
 
     it('should define send_file_to_feishu tool with correct schema', async () => {


### PR DESCRIPTION
## Summary

- Replace `z.enum` `errorMap` parameter with `message` string for Zod v4 compatibility
- Add curly braces to single-line if statements to satisfy ESLint curly rule
- Update test assertion to match actual description text

## Root Cause

PR #733 used Zod v3 API (`errorMap`) but the project uses Zod v4 where `z.enum()` only accepts string or `{ error?, message? }` parameters.

```typescript
// Before (Zod v3 API - doesn't work in Zod v4)
z.enum(['text', 'card'], {
  errorMap: () => ({ message: '...' }),
})

// After (Zod v4 API)
z.enum(['text', 'card'], 'format is REQUIRED...')
```

## Changes

| File | Change |
|------|--------|
| `feishu-context-mcp.ts` | Replace `errorMap` with string parameter for `z.enum()` |
| `feishu-context-mcp.ts` | Add braces to single-line if statements |
| `feishu-mcp-server.test.ts` | Update expected string to match actual description |

## Test Results

| Check | Status |
|--------|-------|
| Type check | ✅ Pass |
| ESLint | ✅ Pass (0 errors) |
| Unit tests | ✅ 7/7 passed |

Fixes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)