### PR TITLE
fix(mcp): replace Zod v3 errorMap with v4 message parameter (Issue #744)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1107,7 +1107,7 @@ When parentMessageId is provided, the message is sent as a reply to that message
     parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. MUST match format type: string for "text", object for "card" with {config, header, elements}.'),
       format: z.enum(['text', 'card'], {
-        errorMap: () => ({ message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.' }),
+        message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.',
       }).describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies.'),


### PR DESCRIPTION
## Summary

- Replace `z.enum()` `errorMap` parameter (Zod v3 API) with `message` parameter (Zod v4 API)
- Fix TypeScript compilation error: `TS2769: No overload matches this call`

## Changes

**File:** `src/mcp/feishu-context-mcp.ts` (line 1109)

**Before (Zod v3):**
```typescript
format: z.enum(['text', 'card'], {
  errorMap: () => ({ message: 'format is REQUIRED...' }),
})
```

**After (Zod v4):**
```typescript
format: z.enum(['text', 'card'], {
  message: 'format is REQUIRED...',
})
```

## Root Cause

The project uses Zod v4, which changed the `z.enum()` second parameter type:
- Zod v3: accepts `{ errorMap?: ... }`
- Zod v4: only accepts `{ error?: string | ..., message?: string }`, no longer supports `errorMap`

This issue was introduced in PR #733 (commit 57ee520).

## Test Results

- ✅ TypeScript type-check: **passed**
- ⚠️ Unit tests: 3 pre-existing failures (unrelated to this fix)
  - `cli-args.test.ts`: environment-specific (localhost vs 192.168.x.x)
  - `feishu-mcp-server.test.ts`: description content mismatch from PR #733

Fixes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)