### PR TITLE
fix(mcp): resolve type check, lint and test failures from PR #733 (Issue #743)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1069,7 +1069,7 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
 
 ---
 
-## Card Structure Requirements
+## Card Format Requirements
 
 When \`format: "card"\`, content MUST include:
 - \`config\`: Object (e.g., \`{"wide_screen_mode": true}\`)
@@ -1107,7 +1107,7 @@ When parentMessageId is provided, the message is sent as a reply to that message
     parameters: z.object({
       content: z.union([z.string(), z.object({}).passthrough()]).describe('The content to send. MUST match format type: string for "text", object for "card" with {config, header, elements}.'),
       format: z.enum(['text', 'card'], {
-        errorMap: () => ({ message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.' }),
+        message: 'format is REQUIRED. Use "text" for plain text messages or "card" for interactive cards.',
       }).describe('REQUIRED: "text" for plain text, "card" for interactive cards. This parameter is mandatory.'),
       chatId: z.string().describe('Feishu chat ID (get this from the task context/metadata)'),
       parentMessageId: z.string().optional().describe('Optional parent message ID for thread replies.'),
@@ -1124,9 +1124,9 @@ When parentMessageId is provided, the message is sent as a reply to that message
       if (format === 'card' && typeof content === 'object' && content !== null) {
         const obj = content as Record<string, unknown>;
         const missing: string[] = [];
-        if (!('config' in obj)) missing.push('config');
-        if (!('header' in obj)) missing.push('header');
-        if (!('elements' in obj)) missing.push('elements');
+        if (!('config' in obj)) { missing.push('config'); }
+        if (!('header' in obj)) { missing.push('header'); }
+        if (!('elements' in obj)) { missing.push('elements'); }
         if (missing.length > 0) {
           return toolSuccess(`❌ Card validation failed: missing required fields: ${missing.join(', ')}.\n\nRequired structure:\n{"config": {...}, "header": {"title": {...}, ...}, "elements": [...]}`);
         }


### PR DESCRIPTION
## Summary

This PR fixes three issues introduced by PR #733:

1. **Type check failure** - `z.enum()` in Zod v4 does not support `errorMap` parameter
   - Changed from `errorMap` to `message` parameter for z.enum validation

2. **Lint failure** - `curly` rule requires braces for if statements
   - Added braces to single-line if statements

3. **Unit test failure** - test expected `'Card Format Requirements'`
   - Changed `'Card Structure Requirements'` to `'Card Format Requirements'` in description

## Changes

| File | Change |
|------|--------|
| `src/mcp/feishu-context-mcp.ts` | - Replaced `errorMap` with `message` in z.enum()<br>- Added braces to if statements<br>- Fixed description string |

## Test Results

- ✅ Type check passes (`npm run type-check`)
- ✅ Lint passes (0 errors, only warnings)
- ✅ All 7 feishu-mcp-server tests pass

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)