### PR TITLE
feat(groups): add topic group infrastructure for BBS mode (Issue #721)

### DIFF
--- a/src/platforms/feishu/group-service.test.ts
+++ b/src/platforms/feishu/group-service.test.ts
@@ -3,6 +3,7 @@
  *
  * @see Issue #486 - Group management commands
  * @see Issue #692 - GroupService.createGroup() method
+ * @see Issue #721 - Topic Group Infrastructure
  */
 
 import * as fs from 'fs';
@@ -288,6 +289,113 @@ describe('GroupService', () => {
       await expect(service.createGroup(mockClient, {
         topic: 'Test Group',
       })).rejects.toThrow('API Error');
+    });
+  });
+
+  describe('Topic Group', () => {
+    it('should set a group as topic group', () => {
+      service.registerGroup({
+        chatId: 'oc_topic1',
+        name: 'Topic Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const result = service.setTopicGroup('oc_topic1', true);
+
+      expect(result).toBe(true);
+      expect(service.isTopicGroup('oc_topic1')).toBe(true);
+      expect(service.getGroup('oc_topic1')?.isTopicGroup).toBe(true);
+    });
+
+    it('should unset a topic group', () => {
+      service.registerGroup({
+        chatId: 'oc_topic2',
+        name: 'Topic Group 2',
+        createdAt: Date.now(),
+        initialMembers: [],
+        isTopicGroup: true,
+      });
+
+      const result = service.setTopicGroup('oc_topic2', false);
+
+      expect(result).toBe(true);
+      expect(service.isTopicGroup('oc_topic2')).toBe(false);
+      expect(service.getGroup('oc_topic2')?.isTopicGroup).toBeUndefined();
+    });
+
+    it('should return false when setting topic group for non-existent group', () => {
+      const result = service.setTopicGroup('oc_nonexistent', true);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-topic group', () => {
+      service.registerGroup({
+        chatId: 'oc_regular',
+        name: 'Regular Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      expect(service.isTopicGroup('oc_regular')).toBe(false);
+    });
+
+    it('should return false for non-existent group when checking isTopicGroup', () => {
+      expect(service.isTopicGroup('oc_nonexistent')).toBe(false);
+    });
+
+    it('should list only topic groups', () => {
+      service.registerGroup({
+        chatId: 'oc_regular',
+        name: 'Regular Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.registerGroup({
+        chatId: 'oc_topic1',
+        name: 'Topic Group 1',
+        createdAt: Date.now(),
+        initialMembers: [],
+        isTopicGroup: true,
+      });
+      service.registerGroup({
+        chatId: 'oc_topic2',
+        name: 'Topic Group 2',
+        createdAt: Date.now(),
+        initialMembers: [],
+        isTopicGroup: true,
+      });
+
+      const topicGroups = service.listTopicGroups();
+
+      expect(topicGroups.length).toBe(2);
+      expect(topicGroups.map(g => g.chatId).sort()).toEqual(['oc_topic1', 'oc_topic2']);
+    });
+
+    it('should return empty array when no topic groups', () => {
+      service.registerGroup({
+        chatId: 'oc_regular',
+        name: 'Regular Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      expect(service.listTopicGroups()).toEqual([]);
+    });
+
+    it('should persist topic group status', () => {
+      service.registerGroup({
+        chatId: 'oc_topic',
+        name: 'Topic Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.setTopicGroup('oc_topic', true);
+
+      // Create a new service instance to verify persistence
+      const newService = new GroupService({ filePath: testFilePath });
+      expect(newService.isTopicGroup('oc_topic')).toBe(true);
+      expect(newService.getGroup('oc_topic')?.isTopicGroup).toBe(true);
     });
   });
 });

--- a/src/platforms/feishu/group-service.ts
+++ b/src/platforms/feishu/group-service.ts
@@ -30,6 +30,12 @@ export interface GroupInfo {
   createdBy?: string;
   /** Initial members */
   initialMembers: string[];
+  /**
+   * Whether this is a topic group (BBS mode).
+   * Topic groups are used for one-way broadcasts like daily reflections.
+   * @see Issue #721 - Topic Group Infrastructure
+   */
+  isTopicGroup?: boolean;
 }
 
 /**
@@ -167,6 +173,60 @@ export class GroupService {
    */
   listGroups(): GroupInfo[] {
     return Object.values(this.registry.groups);
+  }
+
+  /**
+   * Set or unset a group as a topic group.
+   *
+   * Topic groups are used for BBS-mode communication where the agent
+   * can push messages without expecting immediate responses.
+   *
+   * @param chatId - Group chat ID
+   * @param isTopicGroup - Whether to mark as topic group
+   * @returns Whether the operation was successful
+   *
+   * @see Issue #721 - Topic Group Infrastructure
+   */
+  setTopicGroup(chatId: string, isTopicGroup: boolean): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group) {
+      logger.warn({ chatId }, 'Cannot set topic group: group not found');
+      return false;
+    }
+
+    if (isTopicGroup) {
+      group.isTopicGroup = true;
+    } else {
+      delete group.isTopicGroup;
+    }
+    this.save();
+
+    logger.info({ chatId, name: group.name, isTopicGroup }, 'Topic group status updated');
+    return true;
+  }
+
+  /**
+   * Check if a group is a topic group.
+   *
+   * @param chatId - Group chat ID
+   * @returns Whether the group is a topic group
+   *
+   * @see Issue #721 - Topic Group Infrastructure
+   */
+  isTopicGroup(chatId: string): boolean {
+    const group = this.registry.groups[chatId];
+    return group?.isTopicGroup === true;
+  }
+
+  /**
+   * List all topic groups.
+   *
+   * @returns Array of topic group info
+   *
+   * @see Issue #721 - Topic Group Infrastructure
+   */
+  listTopicGroups(): GroupInfo[] {
+    return Object.values(this.registry.groups).filter(g => g.isTopicGroup === true);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add support for "topic groups" - groups used for one-way broadcasts like daily reflections
- Topic groups enable BBS-style communication where the agent pushes messages without expecting immediate responses

## Changes

### GroupInfo Interface
- Add `isTopicGroup?: boolean` field to mark groups as topic groups

### New Methods
- `setTopicGroup(chatId, isTopicGroup)` - Set or unset a group as a topic group
- `isTopicGroup(chatId)` - Check if a group is a topic group
- `listTopicGroups()` - List all topic groups

### Tests
- 8 new test cases covering all topic group functionality
- All 27 tests pass ✅

## API Usage

```typescript
const groupService = getGroupService();

// Register a group
groupService.registerGroup({
  chatId: 'oc_topic_123',
  name: 'Daily Discussion',
  createdAt: Date.now(),
  initialMembers: [],
});

// Mark as topic group
groupService.setTopicGroup('oc_topic_123', true);

// Check if topic group
if (groupService.isTopicGroup('oc_topic_123')) {
  // Send scheduled broadcast
}

// List all topic groups
const topicGroups = groupService.listTopicGroups();
```

## Verification

| Metric | Value |
|--------|-------|
| Unit Tests | 27 passed ✅ |
| TypeScript | ✅ Pass |

## Related

- Closes #721
- Milestone: 0.4.2 BBS话题群

🤖 Generated with [Claude Code](https://claude.com/claude-code)