### PR TITLE
fix(lint): use array destructuring in rest-channel.ts

### DIFF
--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -456,7 +456,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
     // Async mode: POST /api/chat/{chatId}
     const asyncChatMatch = url.match(new RegExp(`^${this.apiPrefix}/chat/([^/]+)$`));
     if (asyncChatMatch && req.method === 'POST') {
-      const chatId = asyncChatMatch[1];
+      const [, chatId] = asyncChatMatch;
       await this.handleAsyncChat(req, res, chatId);
       return;
     }


### PR DESCRIPTION
## Summary
- Fix ESLint `prefer-destructuring` error at line 459 in `src/channels/rest-channel.ts`
- Replace `const chatId = asyncChatMatch[1];` with `const [, chatId] = asyncChatMatch;`

## Test plan
- [x] Run `npm run lint` - passes without errors
- [x] Run `npx tsc --noEmit` - type check passes

Fixes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)