### PR TITLE
fix(logger): 修正日志分割结构 - 日期文件夹 + chatId 文件名

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -71,39 +71,83 @@ export class MessageLogger {
   }
 
   /**
-   * Migrate legacy flat files ({chatId}.md) to date-based structure.
-   * Moves old files to today's directory.
+   * Migrate legacy files to new date-based structure.
+   * Handles two legacy formats:
+   * 1. Flat files: {chatId}.md -> {date}/{chatId}.md
+   * 2. Old structure: {chatId}/{date}.md -> {date}/{chatId}.md
    */
   private async migrateLegacyFiles(): Promise<void> {
     try {
       const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
+      const today = getDateString();
 
-      // Find legacy flat .md files (not in subdirectories)
+      // 1. Migrate legacy flat .md files (not in subdirectories)
       const legacyFiles = entries.filter(
         entry => entry.isFile() && entry.name.endsWith('.md')
       );
 
-      if (legacyFiles.length === 0) {
-        return;
+      if (legacyFiles.length > 0) {
+        console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy flat files...`);
+
+        for (const file of legacyFiles) {
+          const legacyPath = path.join(this.chatDir, file.name);
+          const chatId = file.name.replace('.md', '');
+          const sanitizedId = this.sanitizeId(chatId);
+
+          // Create date directory
+          const dateDir = path.join(this.chatDir, today);
+          await fs.mkdir(dateDir, { recursive: true });
+
+          // Move to new location
+          const newPath = path.join(dateDir, `${sanitizedId}.md`);
+          await fs.rename(legacyPath, newPath);
+
+          console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${sanitizedId}.md`);
+        }
       }
 
-      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
+      // 2. Migrate old structure: {chatId}/{date}.md -> {date}/{chatId}.md
+      const oldDirectories = entries.filter(
+        entry => entry.isDirectory() && !/^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+      );
 
-      const today = getDateString();
+      if (oldDirectories.length > 0) {
+        console.log(`[MessageLogger] Migrating ${oldDirectories.length} old structure directories...`);
 
-      for (const file of legacyFiles) {
-        const legacyPath = path.join(this.chatDir, file.name);
-        const chatId = file.name.replace('.md', '');
+        for (const dir of oldDirectories) {
+          const oldDirPath = path.join(this.chatDir, dir.name);
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
+          try {
+            const dateFiles = await fs.readdir(oldDirPath, { withFileTypes: true });
+            const mdFiles = dateFiles.filter(f => f.isFile() && f.name.endsWith('.md'));
 
-        // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
-        await fs.rename(legacyPath, newPath);
+            for (const dateFile of mdFiles) {
+              const dateStr = dateFile.name.replace('.md', '');
+              // Validate date format
+              if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+                continue;
+              }
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+              const oldFilePath = path.join(oldDirPath, dateFile.name);
+              const newDateDir = path.join(this.chatDir, dateStr);
+              await fs.mkdir(newDateDir, { recursive: true });
+
+              const newFilePath = path.join(newDateDir, `${dir.name}.md`);
+              await fs.rename(oldFilePath, newFilePath);
+
+              console.log(`[MessageLogger] Migrated ${dir.name}/${dateFile.name} -> ${dateStr}/${dir.name}.md`);
+            }
+
+            // Remove empty directory
+            const remaining = await fs.readdir(oldDirPath);
+            if (remaining.length === 0) {
+              await fs.rmdir(oldDirPath);
+              console.log(`[MessageLogger] Removed empty directory: ${dir.name}`);
+            }
+          } catch {
+            // Skip directories that can't be read
+          }
+        }
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +217,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**


### PR DESCRIPTION
## Summary
修正 PR #726 实现的日志结构与需求不符的问题，将日志目录结构从 `{chatId}/{date}.md` 改为 `{date}/{chatId}.md`。

## 问题
PR #726 实现的日志分割结构与 Issue #691 描述不符。

### 当前实现（错误）
```
workspace/logs/
├── oc_abc123/           ← chatId 作为文件夹
│   ├── 2026-03-05.md    ← 日期作为文件名
│   └── 2026-03-04.md
└── ou_xyz789/
    └── 2026-03-05.md
```

### 正确结构
```
workspace/logs/
├── 2026-03-05/              ← 日期作为文件夹
│   ├── oc_abc123.md         ← chatId 作为文件名
│   └── ou_xyz789.md
└── 2026-03-04/
    ├── oc_abc123.md
    └── ou_xyz789.md
```

## 优势
| 方面 | 日期文件夹 | chatId 文件夹 |
|------|-----------|---------------|
| 清理旧日志 | ✅ 删除日期文件夹即可 | ❌ 需遍历每个 chatId |
| 查看某天活动 | ✅ 打开一个文件夹 | ❌ 需遍历所有 chatId |
| 日志归档 | ✅ 按日期打包 | ❌ 分散在多个文件夹 |
| 磁盘监控 | ✅ du -sh 2026-03-* | ❌ 需汇总所有 chatId |

## Changes
| 文件 | 变更 |
|------|------|
| `src/feishu/message-logger.ts` | 修改 `getChatLogPath()` 逻辑，更新迁移逻辑 |

## 关键改动
1. **路径结构修正**: 从 `{chatId}/{date}.md` 改为 `{date}/{chatId}.md`
2. **迁移逻辑增强**: 支持两种旧格式迁移:
   - 扁平文件 `{chatId}.md` -> `{date}/{chatId}.md`
   - 旧结构 `{chatId}/{date}.md` -> `{date}/{chatId}.md`
3. **自动清理**: 迁移后删除空的旧目录

## Test Plan
- [x] 运行 `npx tsc --noEmit` 无错误
- [x] 运行 `npx vitest run src/feishu/message-logger.test.ts` 23 个测试全部通过

Fixes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)