### PR TITLE
refactor(AgentPool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -56,15 +56,18 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent (Pilot) instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * ChatAgent is designed for long-term binding to a specific chatId,
+   * maintaining conversation context across sessions.
+   *
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
       this.log.info({ chatId }, 'Creating new Pilot instance for chatId');

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -529,7 +529,7 @@ export class PrimaryNode extends EventEmitter {
 
     try {
       // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -993,7 +993,7 @@ export class PrimaryNode extends EventEmitter {
       // Execute task using Pilot
       if (this.agentPool) {
         // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -413,7 +413,7 @@ export class WorkerNode {
 
           try {
             // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -221,7 +221,7 @@ ${task.prompt}`;
 
       // Issue #644: Get Pilot for this chatId from AgentPool
       // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary

- 将 `AgentPool.getOrCreate()` 重命名为 `getOrCreateChatAgent()`
- 更新所有调用点
- 无需向后兼容层（内部 API）

## 变更详情

| 文件 | 变更 |
|------|------|
| `src/agents/agent-pool.ts` | 方法重命名，更新注释说明 ChatAgent 的长期绑定特性 |
| `src/nodes/primary-node.ts` | 更新 2 处调用 |
| `src/nodes/worker-node.ts` | 更新 1 处调用 |
| `src/schedule/scheduler.ts` | 更新 1 处调用 |
| `src/schedule/scheduler.test.ts` | 更新 mock 和测试调用 |

## 测试结果

- ✅ `src/schedule/scheduler.test.ts` - 16 tests passed
- ✅ 全部测试通过 (1556 passed, 1 unrelated failed)

## 相关

- Fixes #711
- PR #723 已关闭（保留了不必要的向后兼容性）