### PR TITLE
refactor(agent-pool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -56,15 +56,17 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * ChatAgents are long-lived and bound to specific chatIds.
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
+   * @see Issue #711 - Renamed from getOrCreate to getOrCreateChatAgent
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
       this.log.info({ chatId }, 'Creating new Pilot instance for chatId');

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -529,7 +529,7 @@ export class PrimaryNode extends EventEmitter {
 
     try {
       // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -993,7 +993,7 @@ export class PrimaryNode extends EventEmitter {
       // Execute task using Pilot
       if (this.agentPool) {
         // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -413,7 +413,7 @@ export class WorkerNode {
 
           try {
             // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -221,7 +221,7 @@ ${task.prompt}`;
 
       // Issue #644: Get Pilot for this chatId from AgentPool
       // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary

- Rename `AgentPool.getOrCreate()` to `getOrCreateChatAgent()` as part of Issue #711
- This change distinguishes ChatAgent from other Agent types by lifecycle management

## Problem

Issue #711 requires distinguishing ChatAgent (long-lived, bound to chatId) from other Agent types (ScheduleAgent, TaskAgent, SkillAgent - short-lived, not bound to chatId).

The first step is to rename the method to be more explicit about what type of agent it creates.

## Changes

| File | Change |
|------|--------|
| `src/agents/agent-pool.ts` | Rename `getOrCreate()` to `getOrCreateChatAgent()` |
| `src/schedule/scheduler.ts` | Update call site |
| `src/schedule/scheduler.test.ts` | Update mock and call sites |
| `src/nodes/primary-node.ts` | Update 2 call sites |
| `src/nodes/worker-node.ts` | Update call site |

## Notes

- No backward compatibility maintained as requested in [issue comments](https://github.com/hs3180/disclaude/issues/711)
- Previous PR #723 was closed because it kept unnecessary backward compatibility

## Test Results

| Test Suite | Result |
|------------|--------|
| TypeScript | ✅ Pass |
| scheduler.test.ts | ✅ 16 tests passed |
| agents/*.test.ts | ✅ 159 tests passed |
| nodes/*.test.ts | ✅ 98 tests passed |

Fixes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)