### PR TITLE
fix(ruliu): resolve lint errors in message sender

### DIFF
--- a/src/platforms/ruliu/ruliu-message-sender.ts
+++ b/src/platforms/ruliu/ruliu-message-sender.ts
@@ -217,7 +217,7 @@ export class RuliuMessageSender implements IMessageSender {
 
     // Fallback to JSON if no markdown extracted
     if (!markdown.trim()) {
-      markdown = '```json\n' + JSON.stringify(card, null, 2) + '\n```';
+      markdown = `\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
     }
 
     const body: RuliuMessageBodyItem[] = [
@@ -251,8 +251,8 @@ export class RuliuMessageSender implements IMessageSender {
    * Add a reaction to a message.
    * Ruliu may not support reactions - this is a no-op.
    */
-  async addReaction(_messageId: string, _emoji: string): Promise<boolean> {
+  addReaction(_messageId: string, _emoji: string): Promise<boolean> {
     this.logger.debug('Reactions not supported in Ruliu');
-    return false;
+    return Promise.resolve(false);
   }
 }


### PR DESCRIPTION
## Summary

- Fix `prefer-template` error by using template literal instead of string concatenation
- Fix `require-await` error by removing `async` keyword and using `Promise.resolve()`

## Changes

| File | Change |
|------|--------|
| `src/platforms/ruliu/ruliu-message-sender.ts` | Fixed 2 lint errors |

## Details

### Error 1: prefer-template (line 220)
```typescript
// Before
markdown = '```json\n' + JSON.stringify(card, null, 2) + '\n```';

// After
markdown = `\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
```

### Error 2: require-await (line 254)
```typescript
// Before
async addReaction(_messageId: string, _emoji: string): Promise<boolean> {
  return false;
}

// After
addReaction(_messageId: string, _emoji: string): Promise<boolean> {
  return Promise.resolve(false);
}
```

## Test Results

| Metric | Value |
|--------|-------|
| Lint Errors | 0 (was 2) |
| Ruliu Tests | 4 passed ✅ |

## Related

- Targets PR #766 (Issue #725 - 如流平台适配器)

🤖 Generated with [Claude Code](https://claude.com/claude-code)