### PR TITLE
fix(logger): correct log directory structure to date/chatId format

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -95,15 +95,15 @@ export class MessageLogger {
         const legacyPath = path.join(this.chatDir, file.name);
         const chatId = file.name.replace('.md', '');
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
+        // Create date directory
+        const dateDir = path.join(this.chatDir, today);
+        await fs.mkdir(dateDir, { recursive: true });
 
         // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
+        const newPath = path.join(dateDir, `${chatId}.md`);
         await fs.rename(legacyPath, newPath);
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+        console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${chatId}.md`);
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +173,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**


### PR DESCRIPTION
## Summary

修正 PR #726 中实现的日志分割结构，将路径从 `{chatId}/{date}.md` 改为 `{date}/{chatId}.md`。

## 问题

PR #726 实现的日志结构与 Issue #691 描述不符：

| 方面 | 当前实现（错误） | 正确实现 |
|------|-----------------|---------|
| 结构 | `{chatId}/{date}.md` | `{date}/{chatId}.md` |
| 示例 | `oc_abc123/2026-03-05.md` | `2026-03-05/oc_abc123.md` |

## 正确结构的优势

| 方面 | 日期文件夹 | chatId 文件夹 |
|------|-----------|---------------|
| 清理旧日志 | ✅ 删除日期文件夹即可 | ❌ 需遍历每个 chatId |
| 查看某天活动 | ✅ 打开一个文件夹 | ❌ 需遍历所有 chatId |
| 日志归档 | ✅ 按日期打包 | ❌ 分散在多个文件夹 |
| 磁盘监控 | ✅ du -sh 2026-03-* | ❌ 需汇总所有 chatId |

## Changes

| 文件 | 变更 |
|------|------|
| `src/feishu/message-logger.ts` | 修改 `getChatLogPath()` 和 `migrateLegacyFiles()` |

### 代码改动

```typescript
// Before (错误)
private getChatLogPath(chatId: string, date?: Date): string {
  const sanitizedId = this.sanitizeId(chatId);
  const dateStr = (date || new Date()).toISOString().split('T')[0];
  return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
}

// After (正确)
private getChatLogPath(chatId: string, date: Date = new Date()): string {
  const sanitizedId = this.sanitizeId(chatId);
  const dateStr = getDateString(date);
  return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
}
```

## Test Plan

- [x] 运行 `npx tsc --noEmit` 无错误
- [x] 运行 `npx vitest run src/feishu/message-logger.test.ts` 23 个测试全部通过

Fixes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)