### PR TITLE
fix(lint): resolve lint errors in multimodal image support

### DIFF
--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -649,7 +649,7 @@ ${msg.chatHistoryContext}
 
     // If we have images and vision is enabled, build multimodal content
     if (imageAttachments.length > 0 && Config.isVisionEnabled()) {
-      return this.buildMultimodalContent(msg, imageAttachments, chatId, capabilities, chatHistorySection);
+      return await this.buildMultimodalContent(msg, imageAttachments, chatId, capabilities, chatHistorySection);
     }
 
     // Build text-only content (original behavior)
@@ -795,7 +795,9 @@ ${msg.text}`;
 
     // Encode and add image blocks
     for (const image of imageAttachments) {
-      if (!image.localPath) continue;
+      if (!image.localPath) {
+        continue;
+      }
 
       try {
         const encoded = await encodeImageToBase64(image.localPath);

--- a/src/utils/image-encoder.ts
+++ b/src/utils/image-encoder.ts
@@ -74,7 +74,9 @@ function getMimeTypeFromExtension(filePath: string): SupportedImageFormat | null
  * Check if a MIME type is supported for multimodal input.
  */
 export function isSupportedImageFormat(mimeType: string | undefined): mimeType is SupportedImageFormat {
-  if (!mimeType) return false;
+  if (!mimeType) {
+    return false;
+  }
   return SUPPORTED_IMAGE_FORMATS.includes(mimeType as SupportedImageFormat);
 }
 


### PR DESCRIPTION
## Summary

- Add missing `await` for async `buildMultimodalContent` call in `pilot.ts`
- Add curly braces to if statements for `curly` rule compliance

This PR fixes the lint errors blocking PR #765 from passing CI.

## Changes

| File | Change |
|------|--------|
| `src/agents/pilot.ts` | Added `await` to async call, added curly braces |
| `src/utils/image-encoder.ts` | Added curly braces to if statement |

## Lint Errors Fixed

| Error | File | Line | Fix |
|-------|------|------|-----|
| `require-await` | pilot.ts | 652 | Added `await` |
| `curly` | pilot.ts | 798 | Added `{ }` |
| `curly` | image-encoder.ts | 77 | Added `{ }` |

## Test Results

| Metric | Value |
|--------|-------|
| Lint | 0 errors ✅ |
| TypeScript | ✅ Pass |
| Pilot Tests | 12 passed ✅ |
| Image Encoder Tests | 15 passed ✅ |

## Related

- Targets PR #765 (Issue #656 - Multimodal Image Support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)