### PR TITLE
fix(agent-pool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -56,15 +56,17 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
+   *
+   * Issue #711: Renamed from getOrCreate() to clarify this is for ChatAgent only.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
       this.log.info({ chatId }, 'Creating new Pilot instance for chatId');

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -529,7 +529,8 @@ export class PrimaryNode extends EventEmitter {
 
     try {
       // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      // Issue #711: Use getOrCreateChatAgent() for ChatAgent lifecycle management
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -993,7 +994,8 @@ export class PrimaryNode extends EventEmitter {
       // Execute task using Pilot
       if (this.agentPool) {
         // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        // Issue #711: Use getOrCreateChatAgent() for ChatAgent lifecycle management
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -413,7 +413,8 @@ export class WorkerNode {
 
           try {
             // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            // Issue #711: Use getOrCreateChatAgent() for ChatAgent lifecycle management
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -220,8 +220,9 @@ ${task.prompt}`;
       const wrappedPrompt = this.buildScheduledTaskPrompt(task);
 
       // Issue #644: Get Pilot for this chatId from AgentPool
+      // Issue #711: Use getOrCreateChatAgent() for ChatAgent lifecycle management
       // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary
- 将 `AgentPool.getOrCreate()` 重命名为 `getOrCreateChatAgent()` 以明确该方法专门用于 ChatAgent 的生命周期管理
- 直接删除旧方法，不保留向后兼容性（按 Issue #711 要求）
- 更新所有调用点

## 修改文件
- `src/agents/agent-pool.ts` - 重命名方法并更新注释
- `src/nodes/primary-node.ts` - 更新调用
- `src/nodes/worker-node.ts` - 更新调用
- `src/schedule/scheduler.ts` - 更新调用
- `src/schedule/scheduler.test.ts` - 更新测试 mock

## 测试结果
- TypeScript 编译通过 ✓
- Scheduler 单元测试全部通过 (16 tests) ✓

Fixes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)