### PR TITLE
fix(test): include all valid log levels in LOG_LEVEL test

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -296,7 +296,8 @@ describe('Config', () => {
     });
 
     it('should have default LOG_LEVEL', () => {
-      expect(['debug', 'info', 'warn', 'error']).toContain(Config.LOG_LEVEL);
+      // Valid log levels: trace, debug, info, warn, error, fatal
+      expect(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).toContain(Config.LOG_LEVEL);
     });
 
     it('should have default LOG_PRETTY as true', () => {


### PR DESCRIPTION
## Summary

- Fix test `should have default LOG_LEVEL` to include all valid log levels
- The test was missing `'trace'` and `'fatal'` which are valid according to `LoggingConfig` type

## Problem

The test expected `LOG_LEVEL` to be one of `['debug', 'info', 'warn', 'error']`, but according to the type definition in `src/config/types.ts`:

```typescript
/** Log level (trace, debug, info, warn, error, fatal) */
level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
```

All six levels are valid. When the config file sets `logging.level: "trace"`, the test would fail.

## Changes

| File | Change |
|------|--------|
| `src/config/index.test.ts` | Added `'trace'` and `'fatal'` to valid log levels |

## Test Results

| Metric | Before | After |
|--------|--------|-------|
| Test Failures | 1 | 0 |
| Total Tests | 1556 passed, 1 failed | 1557 passed |
| TypeScript | ✅ Pass | ✅ Pass |
| ESLint | ✅ Pass | ✅ Pass |

## Related

This is a bug fix for a test that was incorrectly written - it didn't account for all valid log levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)