### PR TITLE
fix(logger): 修正日志分割结构 - 日期文件夹 + chatId 文件名

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -71,39 +71,94 @@ export class MessageLogger {
   }
 
   /**
-   * Migrate legacy flat files ({chatId}.md) to date-based structure.
-   * Moves old files to today's directory.
+   * Migrate legacy files to date-based structure.
+   * Handles two legacy formats:
+   * 1. Flat files: {chatId}.md -> {today}/{chatId}.md
+   * 2. Wrong structure: {chatId}/{date}.md -> {date}/{chatId}.md
    */
   private async migrateLegacyFiles(): Promise<void> {
     try {
       const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
 
       // Find legacy flat .md files (not in subdirectories)
-      const legacyFiles = entries.filter(
+      const legacyFlatFiles = entries.filter(
         entry => entry.isFile() && entry.name.endsWith('.md')
       );
 
-      if (legacyFiles.length === 0) {
+      // Find legacy directories with wrong structure ({chatId}/{date}.md)
+      const legacyDirectories = entries.filter(
+        entry => entry.isDirectory() && !/^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+      );
+
+      if (legacyFlatFiles.length === 0 && legacyDirectories.length === 0) {
         return;
       }
 
-      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
-
       const today = getDateString();
 
-      for (const file of legacyFiles) {
-        const legacyPath = path.join(this.chatDir, file.name);
-        const chatId = file.name.replace('.md', '');
+      // Migrate flat files
+      if (legacyFlatFiles.length > 0) {
+        console.log(`[MessageLogger] Migrating ${legacyFlatFiles.length} legacy flat files...`);
+        for (const file of legacyFlatFiles) {
+          const legacyPath = path.join(this.chatDir, file.name);
+          const chatId = file.name.replace('.md', '');
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
+          // Create date directory
+          const dateDir = path.join(this.chatDir, today);
+          await fs.mkdir(dateDir, { recursive: true });
 
-        // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
-        await fs.rename(legacyPath, newPath);
+          // Move to new location
+          const newPath = path.join(dateDir, `${chatId}.md`);
+          await fs.rename(legacyPath, newPath);
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+          console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${chatId}.md`);
+        }
+      }
+
+      // Migrate wrong structure directories ({chatId}/{date}.md -> {date}/{chatId}.md)
+      if (legacyDirectories.length > 0) {
+        console.log(`[MessageLogger] Migrating ${legacyDirectories.length} legacy directories...`);
+        for (const dir of legacyDirectories) {
+          const chatId = dir.name;
+          const chatDirPath = path.join(this.chatDir, chatId);
+
+          try {
+            const dateFiles = await fs.readdir(chatDirPath, { withFileTypes: true });
+            const mdFiles = dateFiles.filter(
+              entry => entry.isFile() && entry.name.endsWith('.md')
+            );
+
+            for (const mdFile of mdFiles) {
+              const dateStr = mdFile.name.replace('.md', '');
+
+              // Skip if not a valid date format
+              if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+                continue;
+              }
+
+              const legacyPath = path.join(chatDirPath, mdFile.name);
+
+              // Create date directory
+              const dateDir = path.join(this.chatDir, dateStr);
+              await fs.mkdir(dateDir, { recursive: true });
+
+              // Move to new location
+              const newPath = path.join(dateDir, `${chatId}.md`);
+              await fs.rename(legacyPath, newPath);
+
+              console.log(`[MessageLogger] Migrated ${chatId}/${dateStr}.md -> ${dateStr}/${chatId}.md`);
+            }
+
+            // Remove empty chat directory
+            const remaining = await fs.readdir(chatDirPath);
+            if (remaining.length === 0) {
+              await fs.rmdir(chatDirPath);
+              console.log(`[MessageLogger] Removed empty directory: ${chatId}`);
+            }
+          } catch {
+            // Failed to process directory, continue
+          }
+        }
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +228,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**


### PR DESCRIPTION
## Summary

将日志文件结构从 `{chatId}/{YYYY-MM-DD}.md` 修正为 `{YYYY-MM-DD}/{chatId}.md`。

## Changes

| 文件 | 变更 |
|------|------|
| `src/feishu/message-logger.ts` | 修改路径结构，增强迁移逻辑 |

## 新结构

```
workspace/logs/
├── 2026-03-05/              ← 日期作为文件夹
│   ├── oc_abc123.md         ← chatId 作为文件名
│   └── ou_xyz789.md
└── 2026-03-04/
    ├── oc_abc123.md
    └── ou_xyz789.md
```

## 修改内容

1. **`getChatLogPath()`**: 交换日期和 chatId 的位置
2. **`migrateLegacyFiles()`**: 支持迁移两种旧格式
   - 扁平文件: `{chatId}.md` -> `{today}/{chatId}.md`
   - 错误结构: `{chatId}/{date}.md` -> `{date}/{chatId}.md`

## 优势

| 方面 | 日期文件夹 | chatId 文件夹 |
|------|-----------|---------------|
| 清理旧日志 | ✅ 删除日期文件夹即可 | ❌ 需遍历每个 chatId |
| 查看某天活动 | ✅ 打开一个文件夹 | ❌ 需遍历所有 chatId |
| 日志归档 | ✅ 按日期打包 | ❌ 分散在多个文件夹 |
| 磁盘监控 | ✅ du -sh 2026-03-* | ❌ 需汇总所有 chatId |

## Test Plan

- [x] 运行 `npx tsc --noEmit` 无错误
- [x] 运行 `npx vitest run src/feishu/message-logger.test.ts` 23 个测试全部通过

Fixes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)