### PR TITLE
fix(logger): correct log directory structure - date folder + chatId filename

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -91,19 +91,18 @@ export class MessageLogger {
 
       const today = getDateString();
 
+      // Create today's directory
+      const todayDir = path.join(this.chatDir, today);
+      await fs.mkdir(todayDir, { recursive: true });
+
       for (const file of legacyFiles) {
         const legacyPath = path.join(this.chatDir, file.name);
-        const chatId = file.name.replace('.md', '');
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
-
-        // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
+        // Move to new location: {date}/{chatId}.md
+        const newPath = path.join(todayDir, file.name);
         await fs.rename(legacyPath, newPath);
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+        console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${file.name}`);
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +172,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #763

The log directory structure implemented in PR #726 was inverted from the original requirement in Issue #691. This PR corrects the structure.

### Before (incorrect)
```
workspace/logs/
├── oc_abc123/           ← chatId as folder
│   ├── 2026-03-05.md    ← date as filename
│   └── 2026-03-04.md
└── ou_xyz789/
    └── 2026-03-05.md
```

### After (correct)
```
workspace/logs/
├── 2026-03-05/              ← date as folder
│   ├── oc_abc123.md         ← chatId as filename
│   └── ou_xyz789.md
└── 2026-03-04/
    ├── oc_abc123.md
    └── ou_xyz789.md
```

### Benefits of the correct structure
| Aspect | Date folder | chatId folder |
|--------|-------------|---------------|
| Cleanup old logs | ✅ Delete date folder | ❌ Need to traverse all chatIds |
| View day's activity | ✅ Open one folder | ❌ Need to traverse all chatIds |
| Log archiving | ✅ Pack by date | ❌ Scattered in multiple folders |
| Disk monitoring | ✅ `du -sh 2026-03-*` | ❌ Need to aggregate all chatIds |

### Changes
- Updated `getChatLogPath()` to use date as directory and chatId as filename
- Updated `migrateLegacyFiles()` for the new structure
- Updated documentation comments

## Test plan
- [x] All existing unit tests pass (23 tests)
- [x] Lint check passes
- [x] Verified the path structure change is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)