### PR TITLE
docs(schedule): add Phase 2 interactive example for PR Scanner (Issue #532)

### DIFF
--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -6,9 +6,9 @@ blocking: true
 chatId: "oc_REPLACE_WITH_YOUR_CHAT_ID"
 ---
 
-# PR Scanner - Phase 1
+# PR Scanner - Phase 1 & 2
 
-定期扫描仓库的 open PR，发现新 PR 时发送通知到指定群聊。
+定期扫描仓库的 open PR，发现新 PR 时发送通知并支持交互式处理。
 
 ## 配置
 
@@ -50,20 +50,21 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
    gh pr view {number} --repo hs3180/disclaude
    ```
 
-2. 使用 `send_user_feedback` 发送通知：
-   - PR 标题和编号
-   - 作者
-   - 状态（可合并/有冲突）
-   - CI 检查状态
-   - 链接
+2. 使用 `send_user_feedback` 发送带交互按钮的卡片（Phase 2）
 
-3. 更新历史记录
+3. 使用 `wait_for_interaction` 等待用户操作（Phase 2）
+
+4. 根据用户选择执行操作（Phase 2）
+
+5. 更新历史记录
 
 ### 5. 更新历史文件
 
 将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳。
 
-## 通知消息模板
+## Phase 1: 通知模式（基本）
+
+仅发送通知，无交互：
 
 ```
 🔔 新 PR 检测到
@@ -80,11 +81,120 @@ PR #{number}: {title}
 🔗 链接: https://github.com/hs3180/disclaude/pull/{number}
 ```
 
+## Phase 2: 交互模式（Human-in-the-Loop）
+
+使用 `send_user_feedback` 发送带按钮的卡片，然后使用 `wait_for_interaction` 等待用户操作：
+
+### 2.1 发送交互式卡片
+
+```json
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {
+      "title": {"tag": "plain_text", "content": "🔔 新 PR 检测到"},
+      "template": "blue"
+    },
+    "elements": [
+      {
+        "tag": "div",
+        "text": {
+          "tag": "lark_md",
+          "content": "**PR #{number}: {title}**\n\n👤 作者: {author}\n📊 状态: {status}\n🔍 检查: {ciStatus}\n\n[查看 PR](https://github.com/hs3180/disclaude/pull/{number})"
+        }
+      },
+      {
+        "tag": "action",
+        "actions": [
+          {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "✅ 合并"},
+            "type": "primary",
+            "value": "merge_{number}"
+          },
+          {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "💬 评论"},
+            "type": "default",
+            "value": "comment_{number}"
+          },
+          {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "⏳ 稍后"},
+            "type": "default",
+            "value": "later_{number}"
+          },
+          {
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": "❌ 关闭"},
+            "type": "danger",
+            "value": "close_{number}"
+          }
+        ]
+      }
+    ]
+  },
+  "format": "card",
+  "chatId": "当前聊天的 chatId"
+}
+```
+
+**重要**: 记录返回的 `messageId`，用于后续的 `wait_for_interaction` 调用。
+
+### 2.2 等待用户交互
+
+```json
+{
+  "messageId": "发送卡片后返回的消息 ID",
+  "chatId": "当前聊天的 chatId",
+  "timeoutSeconds": 300
+}
+```
+
+### 2.3 根据用户选择执行操作
+
+`wait_for_interaction` 返回的 `actionValue` 格式为 `{action}_{pr_number}`，解析后执行对应操作：
+
+| actionValue | 操作 |
+|-------------|------|
+| `merge_{number}` | 合并 PR |
+| `comment_{number}` | 请求用户输入评论内容 |
+| `later_{number}` | 跳过，稍后处理 |
+| `close_{number}` | 关闭 PR |
+
+### 2.4 更新卡片状态（可选）
+
+操作完成后，使用 `update_card` 更新卡片显示结果：
+
+```json
+{
+  "messageId": "卡片消息 ID",
+  "card": {
+    "config": {"wide_screen_mode": true},
+    "header": {
+      "title": {"tag": "plain_text", "content": "✅ PR 已处理"},
+      "template": "green"
+    },
+    "elements": [
+      {
+        "tag": "div",
+        "text": {
+          "tag": "lark_md",
+          "content": "**PR #{number}** 已被 {action}\n\n处理人: {userId}"
+        }
+      }
+    ]
+  },
+  "chatId": "当前聊天的 chatId"
+}
+```
+
 ## 错误处理
 
 - 如果 `gh` 命令失败，记录错误并发送错误通知
 - 如果历史文件损坏，重置并重新开始
 - 如果发送通知失败，记录错误但继续处理其他 PR
+- 如果 `wait_for_interaction` 超时，记录并跳过该 PR
 
 ## 使用说明
 
@@ -93,7 +203,10 @@ PR #{number}: {title}
 3. 设置 `enabled: true`
 4. 调度器将自动加载并执行
 
-## 未来扩展 (Phase 2 & 3)
+## 实现状态
 
-- **Phase 2**: 为每个 PR 创建独立群聊（需要 PR #423 ChatOps）
-- **Phase 3**: 支持交互式操作按钮（需要 PR #412 FeedbackController）
+| Phase | 功能 | 状态 |
+|-------|------|------|
+| Phase 1 | 基本扫描 + 通知 | ✅ 可用 |
+| Phase 2 | 交互式操作按钮 | ✅ 可用 (Issue #532 已实现) |
+| Phase 3 | 为每个 PR 创建独立群聊 | ⏳ 需要 ChatOps API |


### PR DESCRIPTION
## Summary

- Update `pr-scanner.example.md` to demonstrate Human-in-the-Loop functionality
- Add Phase 2 interactive mode with button cards example
- Document `send_user_feedback` card format with action buttons
- Document `wait_for_interaction` tool usage
- Document `update_card` for status updates
- Update implementation status table

## Background

Issue #532 (Human-in-the-Loop 交互系统) 的核心功能已经完全实现：
- ✅ Agent 能发送带选项的提问卡片 (`send_user_feedback` card 格式)
- ✅ 用户选择后 Agent 能收到回复 (`wait_for_interaction`)
- ✅ Agent 能根据用户选择继续执行 (返回 `actionValue`)

但示例文件 `pr-scanner.example.md` 没有演示如何使用这些功能，只描述了 Phase 1 的基本通知模式。

## Changes

更新示例文件，添加 Phase 2 的完整交互流程演示：

1. **发送交互式卡片**: 使用 `send_user_feedback` 发送带按钮的 Feishu 卡片
2. **等待用户交互**: 使用 `wait_for_interaction` 阻塞等待用户点击
3. **根据选择执行操作**: 解析 `actionValue` 执行合并/评论/关闭等操作
4. **更新卡片状态**: 使用 `update_card` 显示处理结果

## Implementation Status

| Phase | 功能 | 状态 |
|-------|------|------|
| Phase 1 | 基本扫描 + 通知 | ✅ 可用 |
| Phase 2 | 交互式操作按钮 | ✅ 可用 (Issue #532 已实现) |
| Phase 3 | 为每个 PR 创建独立群聊 | ⏳ 需要 ChatOps API |

Fixes #532

## Test plan

- [ ] 验证示例文件格式正确
- [ ] 验证 JSON 示例语法正确
- [ ] 手动测试：使用示例创建定时任务，验证交互流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)