### PR TITLE
fix(logger): 修正日志分割结构 - 日期文件夹 + chatId 文件名

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -71,39 +71,93 @@ export class MessageLogger {
   }
 
   /**
-   * Migrate legacy flat files ({chatId}.md) to date-based structure.
-   * Moves old files to today's directory.
+   * Migrate legacy flat files ({chatId}.md) and wrong structure ({chatId}/{date}.md)
+   * to correct structure ({date}/{chatId}.md).
    */
   private async migrateLegacyFiles(): Promise<void> {
     try {
       const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
 
-      // Find legacy flat .md files (not in subdirectories)
+      // 1. Find legacy flat .md files (not in subdirectories)
       const legacyFiles = entries.filter(
         entry => entry.isFile() && entry.name.endsWith('.md')
       );
 
-      if (legacyFiles.length === 0) {
-        return;
+      if (legacyFiles.length > 0) {
+        console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy flat files...`);
+
+        const today = getDateString();
+
+        for (const file of legacyFiles) {
+          const legacyPath = path.join(this.chatDir, file.name);
+          const chatId = file.name.replace('.md', '');
+
+          // Create date directory
+          const dateDir = path.join(this.chatDir, today);
+          await fs.mkdir(dateDir, { recursive: true });
+
+          // Move to new location
+          const newPath = path.join(dateDir, `${this.sanitizeId(chatId)}.md`);
+          await fs.rename(legacyPath, newPath);
+
+          console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${chatId}.md`);
+        }
       }
 
-      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
+      // 2. Find wrong structure directories ({chatId}/{date}.md) and migrate
+      const wrongDirs = entries.filter(
+        entry => entry.isDirectory() && !/^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+      );
 
-      const today = getDateString();
+      if (wrongDirs.length > 0) {
+        console.log(`[MessageLogger] Migrating ${wrongDirs.length} wrong structure directories...`);
 
-      for (const file of legacyFiles) {
-        const legacyPath = path.join(this.chatDir, file.name);
-        const chatId = file.name.replace('.md', '');
+        for (const dir of wrongDirs) {
+          const dirPath = path.join(this.chatDir, dir.name);
+          const subEntries = await fs.readdir(dirPath, { withFileTypes: true });
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
+          for (const subFile of subEntries) {
+            if (subFile.isFile() && subFile.name.endsWith('.md')) {
+              // Extract date from filename (e.g., "2026-03-05.md" -> "2026-03-05")
+              const dateMatch = subFile.name.match(/^(\d{4}-\d{2}-\d{2})\.md$/);
+              if (dateMatch) {
+                const dateStr = dateMatch[1];
+                const chatId = dir.name;
 
-        // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
-        await fs.rename(legacyPath, newPath);
+                const oldPath = path.join(dirPath, subFile.name);
+                const dateDir = path.join(this.chatDir, dateStr);
+                await fs.mkdir(dateDir, { recursive: true });
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+                const newPath = path.join(dateDir, `${this.sanitizeId(chatId)}.md`);
+
+                // Check if target already exists
+                try {
+                  await fs.access(newPath);
+                  // Target exists, append content instead of rename
+                  const oldContent = await fs.readFile(oldPath, 'utf-8');
+                  await fs.appendFile(newPath, '\n\n' + oldContent, 'utf-8');
+                  await fs.unlink(oldPath);
+                  console.log(`[MessageLogger] Merged ${chatId}/${subFile.name} -> ${dateStr}/${chatId}.md`);
+                } catch {
+                  // Target doesn't exist, just rename
+                  await fs.rename(oldPath, newPath);
+                  console.log(`[MessageLogger] Migrated ${chatId}/${subFile.name} -> ${dateStr}/${chatId}.md`);
+                }
+              }
+            }
+          }
+
+          // Remove empty directory
+          try {
+            const remaining = await fs.readdir(dirPath);
+            if (remaining.length === 0) {
+              await fs.rmdir(dirPath);
+              console.log(`[MessageLogger] Removed empty directory: ${dir.name}`);
+            }
+          } catch {
+            // Directory not empty or already removed
+          }
+        }
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +227,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**
@@ -270,12 +324,15 @@ ${entry.content}
    * Create file header for new log files.
    */
   private createFileHeader(chatId: string): string {
-    const now = new Date().toISOString();
+    const now = new Date();
+    const dateStr = getDateString(now);
+    const isoStr = now.toISOString();
     return `# Chat Message Log: ${chatId}
 
 **Chat ID**: ${chatId}
-**Created**: ${now}
-**Last Updated**: ${now}
+**Date**: ${dateStr}
+**Created**: ${isoStr}
+**Last Updated**: ${isoStr}
 
 ---
 


### PR DESCRIPTION
## Summary

- 修正 PR #726 实现的日志分割结构，使其符合 Issue #691 的原始需求
- 修改 `getChatLogPath()` 逻辑，路径从 `{chatId}/{date}.md` 改为 `{date}/{chatId}.md`
- 更新迁移逻辑，同时处理旧版扁平文件和错误结构

## 变更详情

### 日志结构修正

**错误结构** (PR #726):
```
workspace/logs/
├── oc_abc123/           ← chatId 作为文件夹
│   ├── 2026-03-05.md    ← 日期作为文件名
│   └── 2026-03-04.md
└── ou_xyz789/
    └── 2026-03-05.md
```

**正确结构** (本 PR):
```
workspace/logs/
├── 2026-03-05/              ← 日期作为文件夹
│   ├── oc_abc123.md         ← chatId 作为文件名
│   └── ou_xyz789.md
└── 2026-03-04/
    ├── oc_abc123.md
    └── ou_xyz789.md
```

### 迁移逻辑增强

同时处理两种旧结构：
1. 旧版扁平文件 `{chatId}.md` → `{date}/{chatId}.md`
2. 错误结构 `{chatId}/{date}.md` → `{date}/{chatId}.md`

## 优势

| 方面 | 日期文件夹 | chatId 文件夹 |
|------|-----------|---------------|
| 清理旧日志 | ✅ 删除日期文件夹即可 | ❌ 需遍历每个 chatId |
| 查看某天活动 | ✅ 打开一个文件夹 | ❌ 需遍历所有 chatId |
| 日志归档 | ✅ 按日期打包 | ❌ 分散在多个文件夹 |
| 磁盘监控 | ✅ du -sh 2026-03-* | ❌ 需汇总所有 chatId |

## Test plan

- [x] 所有 23 个 message-logger 测试通过
- [x] TypeScript 编译成功
- [x] 迁移逻辑正确处理两种旧结构

Fixes #763

🤖 Generated with [Claude Code](https://claude.com/claude-code)