### PR TITLE
feat(mcp): add create_group_chat tool for PR discussion groups (Issue #393)

### DIFF
--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -6,15 +6,15 @@ blocking: true
 chatId: "oc_REPLACE_WITH_YOUR_CHAT_ID"
 ---
 
-# PR Scanner - Phase 1
+# PR Scanner - Phase 2
 
-定期扫描仓库的 open PR，发现新 PR 时发送通知到指定群聊。
+定期扫描仓库的 open PR，为每个新 PR 创建独立的讨论群聊。
 
 ## 配置
 
 - **仓库**: hs3180/disclaude
 - **扫描间隔**: 每 30 分钟
-- **通知目标**: 配置的 chatId
+- **模式**: 为每个 PR 创建独立群聊
 
 ## 执行步骤
 
@@ -37,6 +37,16 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
 }
 ```
 
+其中 `prChats` 字段记录 PR 编号到群聊 ID 的映射：
+```json
+{
+  "prChats": {
+    "123": "oc_xxx",
+    "456": "oc_yyy"
+  }
+}
+```
+
 ### 3. 识别新 PR
 
 对比当前 open PR 与历史记录，找出新增的 PR。
@@ -45,55 +55,95 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
 
 对于每个新 PR：
 
-1. 获取详细信息：
-   ```bash
-   gh pr view {number} --repo hs3180/disclaude
-   ```
+#### 4.1 获取 PR 详细信息
 
-2. 使用 `send_user_feedback` 发送通知：
-   - PR 标题和编号
-   - 作者
-   - 状态（可合并/有冲突）
-   - CI 检查状态
-   - 链接
+```bash
+gh pr view {number} --repo hs3180/disclaude --json title,author,body,state,mergeable,mergeStateStatus,statusCheckRollup
+```
 
-3. 更新历史记录
+#### 4.2 创建讨论群聊
+
+使用 `create_group_chat` 工具创建专属讨论群：
+
+```json
+{
+  "topic": "PR #{number}: {title}",
+  "members": ["{author_open_id}"]
+}
+```
+
+记录返回的 `chatId` 到 `prChats` 映射中。
+
+#### 4.3 发送 PR 信息到群聊
+
+使用 `send_user_feedback` 发送 PR 详情卡片：
+
+```json
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {
+      "title": {"tag": "plain_text", "content": "PR #{number}"},
+      "template": "{mergeable ? 'blue' : 'orange'}"
+    },
+    "elements": [
+      {"tag": "div", "text": {"tag": "lark_md", "content": "**{title}**"}},
+      {"tag": "hr"},
+      {"tag": "div", "text": {"tag": "lark_md", "content": "👤 作者: {author}\n📊 状态: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}\n🔍 检查: {ciStatus}"}},
+      {"tag": "hr"},
+      {"tag": "div", "text": {"tag": "lark_md", "content": "📋 **描述:**\n{description}"}},
+      {"tag": "action", "actions": [
+        {"tag": "button", "text": {"tag": "plain_text", "content": "查看 PR"}, "url": "https://github.com/hs3180/disclaude/pull/{number}", "type": "primary"}
+      ]}
+    ]
+  },
+  "format": "card",
+  "chatId": "{created_chat_id}"
+}
+```
 
 ### 5. 更新历史文件
 
-将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `lastScan` 时间戳。
+将处理过的 PR 编号添加到 `processedPRs` 数组，更新 `prChats` 映射和 `lastScan` 时间戳。
 
-## 通知消息模板
+## 示例输出
 
 ```
-🔔 新 PR 检测到
+✅ PR #784 检测到
+✅ 创建讨论群: PR #784: fix(logger): 修正日志分割结构
+   群聊 ID: oc_abc123
+✅ PR 信息已发送到群聊
 
-PR #{number}: {title}
-
-👤 作者: {author}
-📊 状态: {mergeable ? '✅ 可合并' : '⚠️ 有冲突'}
-🔍 检查: {ciStatus}
-
-📋 描述:
-{description}
-
-🔗 链接: https://github.com/hs3180/disclaude/pull/{number}
+✅ PR #783 检测到
+✅ 创建讨论群: PR #783: feat(expert): 专家注册
+   群聊 ID: oc_def456
+✅ PR 信息已发送到群聊
 ```
 
 ## 错误处理
 
-- 如果 `gh` 命令失败，记录错误并发送错误通知
+- 如果 `gh` 命令失败，记录错误并发送错误通知到主群聊
 - 如果历史文件损坏，重置并重新开始
-- 如果发送通知失败，记录错误但继续处理其他 PR
+- 如果创建群聊失败，记录错误并回退到发送通知到主群聊
+- 如果发送到群聊失败，记录错误但继续处理其他 PR
 
 ## 使用说明
 
 1. 复制此文件到 `workspace/schedules/pr-scanner.md`
-2. 替换 `chatId` 为实际的飞书群聊 ID
+2. 替换 `chatId` 为实际的飞书群聊 ID（用于错误通知）
 3. 设置 `enabled: true`
 4. 调度器将自动加载并执行
 
-## 未来扩展 (Phase 2 & 3)
+## 功能对比
 
-- **Phase 2**: 为每个 PR 创建独立群聊（需要 PR #423 ChatOps）
-- **Phase 3**: 支持交互式操作按钮（需要 PR #412 FeedbackController）
+| 特性 | Phase 1 | Phase 2 (当前) |
+|------|---------|----------------|
+| 通知方式 | 单一群聊通知 | 每PR独立群聊 |
+| 讨论隔离 | ❌ | ✅ |
+| 作者邀请 | ❌ | ✅ 自动邀请 |
+| 群聊管理 | 不需要 | 自动创建和记录 |
+
+## 未来扩展 (Phase 3)
+
+- **Phase 3**: 支持交互式操作按钮（合并、关闭、请求修改）
+- **Phase 4**: PR 关闭/合并后自动解散讨论群

--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -61,6 +61,15 @@ vi.mock('../file-transfer/outbound/feishu-uploader.js', () => ({
   uploadAndSendFile: vi.fn(),
 }));
 
+// Mock GroupService
+const mockGroupService = {
+  createGroup: vi.fn(),
+};
+
+vi.mock('../platforms/feishu/group-service.js', () => ({
+  getGroupService: vi.fn(() => mockGroupService),
+}));
+
 // Import after mocks
 import * as fs from 'fs/promises';
 import type * as fsStats from 'fs';
@@ -72,6 +81,7 @@ import {
   resolvePendingInteraction,
   setMessageSentCallback,
   feishuContextTools,
+  create_group_chat,
 } from './feishu-context-mcp.js';
 import { uploadAndSendFile } from '../file-transfer/outbound/feishu-uploader.js';
 
@@ -755,6 +765,75 @@ describe('Feishu Context MCP Tools', () => {
       // Clean up first wait
       resolvePendingInteraction('msg-dup', 'cancel', 'button', 'user-1');
       await firstWait;
+    });
+  });
+
+  describe('create_group_chat', () => {
+    it('should have create_group_chat tool definition', () => {
+      expect(feishuContextTools.create_group_chat).toBeDefined();
+      expect(feishuContextTools.create_group_chat.description).toContain('Create a new Feishu group chat');
+      expect(feishuContextTools.create_group_chat.handler).toBe(create_group_chat);
+    });
+
+    it('should require topic', async () => {
+      const result = await create_group_chat({
+        topic: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('topic is required');
+    });
+
+    it('should create group chat successfully', async () => {
+      mockGroupService.createGroup.mockResolvedValueOnce({
+        chatId: 'oc_new_chat_123',
+        name: 'Test Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const result = await create_group_chat({
+        topic: 'Test Group',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.chatId).toBe('oc_new_chat_123');
+      expect(result.message).toContain('Group chat created');
+    });
+
+    it('should create group chat with members', async () => {
+      mockGroupService.createGroup.mockResolvedValueOnce({
+        chatId: 'oc_new_chat_456',
+        name: 'PR #123 Discussion',
+        createdAt: Date.now(),
+        initialMembers: ['ou_user1', 'ou_user2'],
+      });
+
+      const result = await create_group_chat({
+        topic: 'PR #123 Discussion',
+        members: ['ou_user1', 'ou_user2'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.chatId).toBe('oc_new_chat_456');
+      expect(mockGroupService.createGroup).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          topic: 'PR #123 Discussion',
+          members: ['ou_user1', 'ou_user2'],
+        })
+      );
+    });
+
+    it('should handle creation failure', async () => {
+      mockGroupService.createGroup.mockRejectedValueOnce(new Error('API error'));
+
+      const result = await create_group_chat({
+        topic: 'Test Group',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('API error');
     });
   });
 });

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -20,6 +20,7 @@ import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { Config } from '../config/index.js';
 import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
+import { getGroupService } from '../platforms/feishu/group-service.js';
 
 const logger = createLogger('FeishuContextMCP');
 
@@ -843,6 +844,94 @@ export async function wait_for_interaction(params: {
 }
 
 /**
+ * Create a new group chat for discussion.
+ *
+ * This tool allows agents to create new group chats for discussions,
+ * such as PR review discussions, topic groups, etc.
+ *
+ * @param params - Tool parameters
+ * @returns Result object with the created chat ID
+ */
+export async function create_group_chat(params: {
+  /** Chat topic/name */
+  topic: string;
+  /** Initial member open_ids (optional) */
+  members?: string[];
+}): Promise<{
+  success: boolean;
+  message: string;
+  chatId?: string;
+  error?: string;
+}> {
+  const { topic, members } = params;
+
+  logger.info({
+    topic,
+    memberCount: members?.length || 0,
+  }, 'create_group_chat called');
+
+  try {
+    if (!topic || topic.trim().length === 0) {
+      return {
+        success: false,
+        error: 'topic is required',
+        message: '❌ topic is required for creating a group chat',
+      };
+    }
+
+    // Read credentials from Config
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    // Graceful degradation: When Feishu credentials are not configured,
+    // return a helpful message instead of throwing an error.
+    if (!appId || !appSecret) {
+      return {
+        success: false,
+        error: 'Feishu credentials not configured',
+        message: '❌ Feishu credentials not configured. Set FEISHU appId and appSecret in config.',
+      };
+    }
+
+    const client = createFeishuClient(appId, appSecret, {
+      domain: lark.Domain.Feishu,
+    });
+
+    // Create group via GroupService
+    const groupService = getGroupService();
+    const groupInfo = await groupService.createGroup(client, {
+      topic,
+      members,
+    });
+
+    logger.info({
+      chatId: groupInfo.chatId,
+      topic: groupInfo.name,
+    }, 'Group chat created successfully');
+
+    return {
+      success: true,
+      message: `✅ Group chat created: ${topic}`,
+      chatId: groupInfo.chatId,
+    };
+
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    logger.error({
+      err: error,
+      topic,
+    }, 'create_group_chat failed');
+
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ Failed to create group chat: ${errorMessage}`,
+    };
+  }
+}
+
+/**
  * Tool definitions for Agent SDK integration.
  *
  * Export tools in a format compatible with inline MCP servers.
@@ -992,6 +1081,25 @@ export const feishuContextTools = {
       required: ['messageId', 'chatId'],
     },
     handler: wait_for_interaction,
+  },
+  create_group_chat: {
+    description: 'Create a new Feishu group chat for discussions. Use this to create discussion groups for PR reviews, topic-specific chats, etc. Returns the chatId of the newly created group.',
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: {
+          type: 'string',
+          description: 'The name/topic for the group chat (required)',
+        },
+        members: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Optional array of member open_ids to add to the group',
+        },
+      },
+      required: ['topic'],
+    },
+    handler: create_group_chat,
   },
 };
 
@@ -1213,6 +1321,45 @@ When parentMessageId is provided, the message is sent as a reply to that message
         }
       } catch (error) {
         return toolSuccess(`⚠️ Wait failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'create_group_chat',
+    description: `Create a new Feishu group chat for discussions.
+
+**Use Cases:**
+- Create discussion groups for PR reviews
+- Create topic-specific chat groups
+- Set up ad-hoc discussion channels
+
+**Returns:**
+- chatId: The ID of the newly created group chat
+- The bot is automatically added to the new group
+
+**Example:**
+\`\`\`json
+{
+  "topic": "PR #123 Discussion",
+  "members": ["ou_user1", "ou_user2"]
+}
+\`\`\`
+
+**Note:** Members are optional. If not provided, only the bot will be in the group.`,
+    parameters: z.object({
+      topic: z.string().describe('The name/topic for the group chat (required)'),
+      members: z.array(z.string()).optional().describe('Optional array of member open_ids to add to the group'),
+    }),
+    handler: async ({ topic, members }) => {
+      try {
+        const result = await create_group_chat({ topic, members });
+        if (result.success) {
+          return toolSuccess(`${result.message}\nChat ID: ${result.chatId}`);
+        } else {
+          return toolSuccess(`⚠️ ${result.message}`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Group creation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },


### PR DESCRIPTION
## Summary

Implements Issue #393 Phase 2 - PR Scanner with individual discussion groups.

### New MCP Tool: create_group_chat

Adds a new MCP tool that allows agents to create Feishu group chats for discussions.

**Features:**
- Create group chats with specified topic
- Optional member invitation during creation
- Returns chatId for subsequent messaging
- Graceful error handling for missing credentials

**Usage:**
```json
{
  "topic": "PR #123 Discussion",
  "members": ["ou_user1", "ou_user2"]
}
```

### Updated PR Scanner Example

Updates `pr-scanner.example.md` to implement Phase 2:
- Creates separate discussion group for each new PR
- Invites PR author to the discussion group
- Sends PR details card to the new group
- Maintains PR-to-chatId mapping in history file

## Changes

| File | Description |
|------|-------------|
| `src/mcp/feishu-context-mcp.ts` | Add `create_group_chat` tool and helper function |
| `src/mcp/feishu-context-mcp.test.ts` | Add 5 unit tests for new tool |
| `examples/schedules/pr-scanner.example.md` | Update to Phase 2 implementation |

## Test Results

- 50 tests passed in feishu-context-mcp.test.ts
- 1560 tests passed overall (2 pre-existing failures unrelated to this change)

Fixes #393

## Test plan

- [x] Unit tests for create_group_chat tool
- [x] All feishu-context-mcp tests pass
- [x] TypeScript compilation passes
- [x] PR Scanner example documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)