### PR TITLE
refactor(agent-pool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -56,15 +56,18 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
+   *
+   * ChatAgents are long-lived and bound to a specific chatId for
+   * conversation context persistence.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
       this.log.info({ chatId }, 'Creating new Pilot instance for chatId');

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -529,7 +529,7 @@ export class PrimaryNode extends EventEmitter {
 
     try {
       // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -993,7 +993,7 @@ export class PrimaryNode extends EventEmitter {
       // Execute task using Pilot
       if (this.agentPool) {
         // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -413,7 +413,7 @@ export class WorkerNode {
 
           try {
             // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -221,7 +221,7 @@ ${task.prompt}`;
 
       // Issue #644: Get Pilot for this chatId from AgentPool
       // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary

Per Issue #711, this PR renames `AgentPool.getOrCreate()` to `getOrCreateChatAgent()` to distinguish ChatAgent lifecycle management from other agent types.

### Changes

- Rename `AgentPool.getOrCreate()` to `getOrCreateChatAgent()`
- Update all callers:
  - `src/schedule/scheduler.ts`
  - `src/nodes/primary-node.ts`
  - `src/nodes/worker-node.ts`
- Update test mocks in `src/schedule/scheduler.test.ts`

### Rationale

As noted in the issue, this is an internal API where all call sites are within the project. Per the feedback on the previous PR #723, no backward compatibility layer is needed - we can directly rename the method and update all callers.

### Design Principle

ChatAgents are long-lived and bound to a specific chatId for conversation context persistence. This naming makes the intent explicit and paves the way for future agent types with different lifecycle management (ScheduleAgent, TaskAgent, SkillAgent).

## Test plan

- [x] All 16 scheduler tests pass
- [x] TypeScript type check passes

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)