### PR TITLE
feat(group): add topic group infrastructure for BBS mode (Issue #721)

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -34,6 +34,9 @@ import {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  TopicGroupCommand,
+  UntopicGroupCommand,
+  ListTopicGroupsCommand,
   PassiveCommand,
   SetDebugCommand,
   ShowDebugCommand,
@@ -56,6 +59,9 @@ export {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  TopicGroupCommand,
+  UntopicGroupCommand,
+  ListTopicGroupsCommand,
   PassiveCommand,
   SetDebugCommand,
   ShowDebugCommand,
@@ -83,6 +89,10 @@ export function registerDefaultCommands(
   registry.register(new ListGroupMembersCommand());
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());
+  // Issue #721: Topic group commands
+  registry.register(new TopicGroupCommand());
+  registry.register(new UntopicGroupCommand());
+  registry.register(new ListTopicGroupsCommand());
   registry.register(new PassiveCommand());
   registry.register(new SetDebugCommand());
   registry.register(new ShowDebugCommand());

--- a/src/nodes/commands/commands/group-commands.ts
+++ b/src/nodes/commands/commands/group-commands.ts
@@ -6,6 +6,7 @@
  * Issue #696: 拆分 builtin-commands.ts
  * Issue #463: 帮助消息系统 - 入群/私聊引导 + 指令注册
  * Issue #537: 完成所有指令的 DI 重构
+ * Issue #721: 话题群基础设施 - BBS 模式支持
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -254,5 +255,156 @@ export class DissolveGroupCommand implements Command {
     } catch (error) {
       return { success: false, error: `解散群失败: ${(error as Error).message}` };
     }
+  }
+}
+
+/**
+ * Topic Group Command - Mark a group as a topic group (BBS mode).
+ *
+ * Issue #721: 话题群基础设施 - BBS 模式支持
+ */
+export class TopicGroupCommand implements Command {
+  readonly name = 'topic-group';
+  readonly category = 'group' as const;
+  readonly description = '标记群为话题群';
+  readonly usage = 'topic-group <groupId> [tag1,tag2,...]';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const { services, args, chatId } = context;
+
+    // Support both explicit chatId and current chat
+    let groupId: string;
+    let tags: string[] | undefined;
+
+    if (args.length === 0) {
+      // Mark current chat as topic group
+      groupId = chatId;
+    } else {
+      [groupId] = args;
+      // Parse tags if provided
+      if (args.length > 1) {
+        tags = args.slice(1).join(' ').split(',').map(t => t.trim()).filter(t => t);
+      }
+    }
+
+    // Check if group is managed
+    const group = services.getGroup(groupId);
+    if (!group) {
+      // For invited groups, we can still mark them as topic groups
+      // by registering them first
+      try {
+        const client = services.getFeishuClient();
+        const chats = await services.getBotChats(client);
+        const chatInfo = chats.find(c => c.chatId === groupId);
+
+        if (!chatInfo) {
+          return {
+            success: false,
+            error: `群 \`${groupId}\` 不存在或机器人不在该群中`,
+          };
+        }
+
+        // Register as topic group
+        services.registerAsTopicGroup(groupId, chatInfo.name, tags);
+        return {
+          success: true,
+          message: `✅ **话题群标记成功**\n\n群: ${chatInfo.name}\nID: \`${groupId}\`${tags ? `\n标签: ${tags.map(t => `\`${t}\``).join(', ')}` : ''}`,
+        };
+      } catch (error) {
+        return { success: false, error: `标记话题群失败: ${(error as Error).message}` };
+      }
+    }
+
+    // Group is managed, just mark it
+    const success = services.markAsTopicGroup(groupId, tags);
+    if (!success) {
+      return { success: false, error: '标记话题群失败' };
+    }
+
+    return {
+      success: true,
+      message: `✅ **话题群标记成功**\n\n群: ${group.name}\nID: \`${groupId}\`${tags ? `\n标签: ${tags.map(t => `\`${t}\``).join(', ')}` : ''}`,
+    };
+  }
+}
+
+/**
+ * Untopic Group Command - Remove topic group mark.
+ *
+ * Issue #721: 话题群基础设施 - BBS 模式支持
+ */
+export class UntopicGroupCommand implements Command {
+  readonly name = 'untopic-group';
+  readonly category = 'group' as const;
+  readonly description = '取消话题群标记';
+  readonly usage = 'untopic-group <groupId>';
+
+  execute(context: CommandContext): CommandResult {
+    const { services, args, chatId } = context;
+
+    const groupId = args.length > 0 ? args[0] : chatId;
+
+    const group = services.getGroup(groupId);
+    if (!group) {
+      return {
+        success: false,
+        error: `群 \`${groupId}\` 不在托管列表中`,
+      };
+    }
+
+    if (!group.isTopicGroup) {
+      return {
+        success: true,
+        message: `ℹ️ 群 \`${groupId}\` 本身不是话题群`,
+      };
+    }
+
+    const success = services.unmarkAsTopicGroup(groupId);
+    if (!success) {
+      return { success: false, error: '取消话题群标记失败' };
+    }
+
+    return {
+      success: true,
+      message: `✅ **话题群标记已移除**\n\n群: ${group.name}\nID: \`${groupId}\``,
+    };
+  }
+}
+
+/**
+ * List Topic Groups Command - List all topic groups.
+ *
+ * Issue #721: 话题群基础设施 - BBS 模式支持
+ */
+export class ListTopicGroupsCommand implements Command {
+  readonly name = 'topic-groups';
+  readonly category = 'group' as const;
+  readonly description = '列出所有话题群';
+
+  execute(context: CommandContext): CommandResult {
+    const { services } = context;
+
+    const topicGroups = services.listTopicGroups();
+
+    if (topicGroups.length === 0) {
+      return {
+        success: true,
+        message: '📋 **话题群列表**\n\n暂无话题群\n\n使用 `/topic-group <群ID>` 标记群为话题群',
+      };
+    }
+
+    const lines: string[] = [`📋 **话题群列表** (共 ${topicGroups.length} 个)\n`];
+
+    for (const g of topicGroups) {
+      const tags = g.topicTags && g.topicTags.length > 0
+        ? ` [${g.topicTags.map(t => `\`${t}\``).join(', ')}]`
+        : '';
+      lines.push(`• ${g.name}${tags} - \`${g.chatId}\``);
+    }
+
+    return {
+      success: true,
+      message: lines.join('\n'),
+    };
   }
 }

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -20,6 +20,9 @@ export {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  TopicGroupCommand,
+  UntopicGroupCommand,
+  ListTopicGroupsCommand,
 } from './group-commands.js';
 
 // Passive command

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -57,6 +57,10 @@ export interface ManagedGroupInfo {
   createdAt: number;
   createdBy?: string;
   initialMembers: string[];
+  /** Whether this is a topic group (BBS mode) */
+  isTopicGroup?: boolean;
+  /** Topic tags for categorization */
+  topicTags?: string[];
 }
 
 /**
@@ -137,6 +141,21 @@ export interface CommandServices {
 
   /** List all managed groups */
   listGroups: () => ManagedGroupInfo[];
+
+  /** Get a specific group by chatId */
+  getGroup: (chatId: string) => ManagedGroupInfo | undefined;
+
+  /** Mark a group as topic group */
+  markAsTopicGroup: (chatId: string, tags?: string[]) => boolean;
+
+  /** Remove topic group mark */
+  unmarkAsTopicGroup: (chatId: string) => boolean;
+
+  /** List all topic groups */
+  listTopicGroups: () => ManagedGroupInfo[];
+
+  /** Register an existing chat as a topic group */
+  registerAsTopicGroup: (chatId: string, name: string, tags?: string[]) => ManagedGroupInfo;
 
   /** Get all chats the bot is in (from Feishu API) */
   getBotChats: (client: lark.Client) => Promise<BotChatInfo[]>;

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -621,6 +621,12 @@ export class PrimaryNode extends EventEmitter {
         registerGroup: (group: Parameters<typeof this.groupService.registerGroup>[0]) => this.groupService.registerGroup(group),
         unregisterGroup: (chatId: string) => this.groupService.unregisterGroup(chatId),
         listGroups: () => this.groupService.listGroups(),
+        // Topic group management (Issue #721)
+        getGroup: (chatId: string) => this.groupService.getGroup(chatId),
+        markAsTopicGroup: (chatId: string, tags?: string[]) => this.groupService.markAsTopicGroup(chatId, tags),
+        unmarkAsTopicGroup: (chatId: string) => this.groupService.unmarkAsTopicGroup(chatId),
+        listTopicGroups: () => this.groupService.listTopicGroups(),
+        registerAsTopicGroup: (chatId: string, name: string, tags?: string[]) => this.groupService.registerAsTopicGroup(chatId, name, tags),
         // Group creation (Issue #692)
         createGroup: (client: lark.Client, options: { topic?: string; members?: string[]; creatorId?: string }) => this.groupService.createGroup(client, options),
         getBotChats,

--- a/src/platforms/feishu/group-service.ts
+++ b/src/platforms/feishu/group-service.ts
@@ -30,6 +30,10 @@ export interface GroupInfo {
   createdBy?: string;
   /** Initial members */
   initialMembers: string[];
+  /** Whether this is a topic group (BBS mode) */
+  isTopicGroup?: boolean;
+  /** Topic tags for categorization */
+  topicTags?: string[];
 }
 
 /**
@@ -174,6 +178,101 @@ export class GroupService {
    */
   getFilePath(): string {
     return this.filePath;
+  }
+
+  /**
+   * Mark a group as a topic group (BBS mode).
+   *
+   * @param chatId - Group chat ID
+   * @param tags - Optional topic tags
+   * @returns Whether the operation succeeded
+   *
+   * @see Issue #721 - 话题群基础设施
+   */
+  markAsTopicGroup(chatId: string, tags?: string[]): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group) {
+      logger.warn({ chatId }, 'Cannot mark unmanaged group as topic group');
+      return false;
+    }
+
+    group.isTopicGroup = true;
+    if (tags && tags.length > 0) {
+      group.topicTags = tags;
+    }
+    this.save();
+    logger.info({ chatId, tags }, 'Group marked as topic group');
+    return true;
+  }
+
+  /**
+   * Remove topic group mark from a group.
+   *
+   * @param chatId - Group chat ID
+   * @returns Whether the operation succeeded
+   *
+   * @see Issue #721 - 话题群基础设施
+   */
+  unmarkAsTopicGroup(chatId: string): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group) {
+      logger.warn({ chatId }, 'Cannot unmark unmanaged group');
+      return false;
+    }
+
+    delete group.isTopicGroup;
+    delete group.topicTags;
+    this.save();
+    logger.info({ chatId }, 'Group unmarked as topic group');
+    return true;
+  }
+
+  /**
+   * Check if a group is a topic group.
+   *
+   * @param chatId - Group chat ID
+   * @returns Whether the group is a topic group
+   *
+   * @see Issue #721 - 话题群基础设施
+   */
+  isTopicGroup(chatId: string): boolean {
+    const group = this.registry.groups[chatId];
+    return group?.isTopicGroup === true;
+  }
+
+  /**
+   * List all topic groups.
+   *
+   * @returns Array of topic group info
+   *
+   * @see Issue #721 - 话题群基础设施
+   */
+  listTopicGroups(): GroupInfo[] {
+    return Object.values(this.registry.groups).filter(g => g.isTopicGroup === true);
+  }
+
+  /**
+   * Register an existing chat as a topic group.
+   * This is useful for marking invited groups as topic groups.
+   *
+   * @param chatId - Group chat ID
+   * @param name - Group name
+   * @param tags - Optional topic tags
+   * @returns The registered group info
+   *
+   * @see Issue #721 - 话题群基础设施
+   */
+  registerAsTopicGroup(chatId: string, name: string, tags?: string[]): GroupInfo {
+    const groupInfo: GroupInfo = {
+      chatId,
+      name,
+      createdAt: Date.now(),
+      initialMembers: [],
+      isTopicGroup: true,
+      topicTags: tags,
+    };
+    this.registerGroup(groupInfo);
+    return groupInfo;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Extend `GroupInfo` interface with `isTopicGroup` and `topicTags` fields
- Add topic group management methods to `GroupService`:
  - `markAsTopicGroup()` - mark a group as topic group
  - `unmarkAsTopicGroup()` - remove topic group mark
  - `listTopicGroups()` - list all topic groups
  - `registerAsTopicGroup()` - register external chat as topic group
- Add three new commands:
  - `/topic-group [chatId] [tags]` - mark group as topic group
  - `/untopic-group [chatId]` - remove topic group mark
  - `/topic-groups` - list all topic groups
- Update `CommandServices` interface with new methods
- Register commands in `builtin-commands.ts`

## Issue
Fixes #721

## 功能需求

### 1. 话题群管理
- [x] 创建/注册话题群
- [x] 与普通群区分标记
- [x] 话题群列表管理

### 2. 开放式推送机制
- [x] Agent 能主动向话题群发送消息 (通过现有 `send_message` 工具)
- [x] 不需要用户触发
- [x] 支持定时推送 (通过现有定时任务机制)

### 3. 多元化议题支持
- [x] 支持话题标签

## 验收标准
- [x] 能标记群为「话题群」
- [x] Agent 能向话题群推送消息
- [x] 定时任务能触发话题群推送

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] All existing tests pass (1555 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)