### PR TITLE
refactor(agent-pool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -4,18 +4,31 @@
  * This class solves the concurrency issue (Issue #644) where messages
  * were being routed to the wrong agent instance.
  *
+ * Issue #711: Distinguishes ChatAgent from other Agent types:
+ * - ChatAgent (Pilot): Long-lived, bound to chatId, stored in AgentPool
+ * - SkillAgent/ScheduleAgent/TaskAgent: Short-lived, not stored
+ *
  * Key Design:
  * - Each chatId gets its own Pilot instance
  * - Pilot instances are created with chatId bound at construction time
  * - No session management needed inside Pilot (each Pilot = one chatId)
+ * - Other agent types are created on-demand and NOT stored
  *
  * Architecture:
  * ```
  * PrimaryNode
  *     └── AgentPool
- *             └── Map<chatId, Pilot>
+ *             └── Map<chatId, Pilot>  (ChatAgent only)
  *                     └── Each Pilot handles ONE chatId only
  * ```
+ *
+ * Lifecycle Management (Issue #711):
+ * | Agent Type     | chatId Binding | Max Lifetime | Storage Location          |
+ * |----------------|----------------|--------------|---------------------------|
+ * | ChatAgent      | ✅ Yes         | Unlimited    | AgentPool (Map<chatId, Pilot>) |
+ * | SkillAgent     | ❌ No          | Task done    | Not stored (caller manages) |
+ * | ScheduleAgent  | ❌ No          | 24 hours     | Not stored                |
+ * | TaskAgent      | ❌ No          | Task done    | Not stored                |
  */
 
 import type pino from 'pino';
@@ -44,6 +57,10 @@ export interface AgentPoolConfig {
  *
  * Ensures complete isolation between different chat sessions by
  * giving each chatId its own Pilot instance.
+ *
+ * Issue #711: Distinguishes ChatAgent from other Agent types.
+ * - ChatAgent: Long-lived, stored in pool
+ * - SkillAgent/ScheduleAgent/TaskAgent: Short-lived, not stored
  */
 export class AgentPool {
   private readonly pilotFactory: PilotFactory;
@@ -56,18 +73,21 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent (Pilot) instance for the given chatId.
+   *
+   * Issue #711: This is the primary method for ChatAgent management.
+   * ChatAgents are long-lived and stored in the pool.
    *
    * If a Pilot already exists for this chatId, returns it.
    * Otherwise, creates a new Pilot using the factory.
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
-      this.log.info({ chatId }, 'Creating new Pilot instance for chatId');
+      this.log.info({ chatId }, 'Creating new ChatAgent instance for chatId');
       pilot = this.pilotFactory(chatId);
       this.pilots.set(chatId, pilot);
     }

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -529,7 +529,8 @@ export class PrimaryNode extends EventEmitter {
 
     try {
       // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      // Issue #711: Use getOrCreateChatAgent() for ChatAgent management
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -993,7 +994,8 @@ export class PrimaryNode extends EventEmitter {
       // Execute task using Pilot
       if (this.agentPool) {
         // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        // Issue #711: Use getOrCreateChatAgent() for ChatAgent management
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -413,7 +413,8 @@ export class WorkerNode {
 
           try {
             // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            // Issue #711: Use getOrCreateChatAgent() for ChatAgent management
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -220,8 +220,9 @@ ${task.prompt}`;
       const wrappedPrompt = this.buildScheduledTaskPrompt(task);
 
       // Issue #644: Get Pilot for this chatId from AgentPool
+      // Issue #711: Use getOrCreateChatAgent() for ChatAgent management
       // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary

- 将 `AgentPool.getOrCreate()` 重命名为 `getOrCreateChatAgent()`
- 区分 ChatAgent 与其他 Agent 类型的生命周期管理
- 更新所有调用处直接使用新方法名，不保留向后兼容

Fixes #711

## Changes

### src/agents/agent-pool.ts
- 重命名 `getOrCreate()` 为 `getOrCreateChatAgent()`
- 添加 Issue #711 相关的文档注释
- 说明 ChatAgent 与其他 Agent 类型的生命周期管理差异

### src/nodes/primary-node.ts
- 更新 2 处 `getOrCreate()` 调用为 `getOrCreateChatAgent()`

### src/nodes/worker-node.ts
- 更新 `getOrCreate()` 调用为 `getOrCreateChatAgent()`

### src/schedule/scheduler.ts
- 更新 `getOrCreate()` 调用为 `getOrCreateChatAgent()`

### src/schedule/scheduler.test.ts
- 更新 mock 中的 `getOrCreate` 为 `getOrCreateChatAgent`

## Test Results

✅ 所有 scheduler 测试通过 (16 tests)
✅ 总体测试通过 (1555/1557 tests, 2 个失败与本次修改无关)

## Notes

根据 #711 的要求，不保留向后兼容的 `getOrCreate()` 方法，因为这是内部 API，所有调用点都在项目内部。

🤖 Generated with [Claude Code](https://claude.com/claude-code)