### PR TITLE
fix(ruliu): resolve type check error in ruliu-crypto.ts

### DIFF
--- a/src/platforms/ruliu/ruliu-crypto.ts
+++ b/src/platforms/ruliu/ruliu-crypto.ts
@@ -71,12 +71,12 @@ export function decryptMessage(
     const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
     decipher.setAutoPadding(false);
 
-    let decrypted = Buffer.concat([
+    const decryptedRaw = Buffer.concat([
       decipher.update(encrypted),
       decipher.final(),
     ]);
 
-    decrypted = pkcs7Unpad(decrypted) as Buffer;
+    const decrypted = pkcs7Unpad(decryptedRaw);
 
     // Remove random bytes (first 16 bytes) and length prefix
     // Format: random(16) + msgLen(4) + msg + appId


### PR DESCRIPTION
## Summary

- Fix TypeScript error TS2322 in `ruliu-crypto.ts`
- Avoid type assertion issue with `Buffer<ArrayBufferLike>` vs `Buffer<ArrayBuffer>`
- Use separate const declarations instead of reassignment

## Changes

| File | Change |
|------|--------|
| `src/platforms/ruliu/ruliu-crypto.ts` | Fixed type error on line 79 |

## Details

### Error Fixed
```typescript
// Before - causes TS2322 error
let decrypted = Buffer.concat([...]);
decrypted = pkcs7Unpad(decrypted) as Buffer;  // type assertion not working

// After - clean type inference
const decryptedRaw = Buffer.concat([...]);
const decrypted = pkcs7Unpad(decryptedRaw);  // correct Buffer type
```

## Test Results

| Check | Status |
|--------|-------|
| Type Check | ✅ Passed |
| Lint | ✅ Passed (0 errors) |
| Ruliu Tests | ✅ 4 passed |

## Related

- Targets PR #766 (Issue #725 - 如流平台适配器)
- Follows PR #772 (lint fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)