### PR TITLE
fix(logger): correct log split structure - date folder + chatId filename

### DIFF
--- a/src/feishu/message-logger.ts
+++ b/src/feishu/message-logger.ts
@@ -2,7 +2,7 @@
  * Message logger for persistent message history.
  *
  * Logs all user and bot messages to chat-specific MD files.
- * Uses date-based directory structure: {chatId}/{YYYY-MM-DD}.md
+ * Uses date-based directory structure: {YYYY-MM-DD}/{chatId}.md
  * Provides message ID-based deduplication via in-memory cache only.
  */
 
@@ -71,39 +71,93 @@ export class MessageLogger {
   }
 
   /**
-   * Migrate legacy flat files ({chatId}.md) to date-based structure.
-   * Moves old files to today's directory.
+   * Migrate legacy files to date-based structure.
+   * Handles two legacy formats:
+   * 1. Flat files: {chatId}.md -> {date}/{chatId}.md
+   * 2. Old structure: {chatId}/{date}.md -> {date}/{chatId}.md
    */
   private async migrateLegacyFiles(): Promise<void> {
     try {
       const entries = await fs.readdir(this.chatDir, { withFileTypes: true });
 
       // Find legacy flat .md files (not in subdirectories)
-      const legacyFiles = entries.filter(
+      const legacyFlatFiles = entries.filter(
         entry => entry.isFile() && entry.name.endsWith('.md')
       );
 
-      if (legacyFiles.length === 0) {
+      // Find legacy chatId directories with date files inside
+      const legacyChatDirs = entries.filter(
+        entry => entry.isDirectory() && !/^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+      );
+
+      if (legacyFlatFiles.length === 0 && legacyChatDirs.length === 0) {
         return;
       }
 
-      console.log(`[MessageLogger] Migrating ${legacyFiles.length} legacy chat files...`);
-
       const today = getDateString();
+      let migratedCount = 0;
 
-      for (const file of legacyFiles) {
+      // Migrate flat files
+      for (const file of legacyFlatFiles) {
         const legacyPath = path.join(this.chatDir, file.name);
         const chatId = file.name.replace('.md', '');
 
-        // Create chat directory
-        const chatDir = path.join(this.chatDir, chatId);
-        await fs.mkdir(chatDir, { recursive: true });
+        // Create date directory
+        const dateDir = path.join(this.chatDir, today);
+        await fs.mkdir(dateDir, { recursive: true });
 
         // Move to new location
-        const newPath = path.join(chatDir, `${today}.md`);
+        const newPath = path.join(dateDir, `${chatId}.md`);
         await fs.rename(legacyPath, newPath);
 
-        console.log(`[MessageLogger] Migrated ${file.name} -> ${chatId}/${today}.md`);
+        console.log(`[MessageLogger] Migrated ${file.name} -> ${today}/${chatId}.md`);
+        migratedCount++;
+      }
+
+      // Migrate old structure {chatId}/{date}.md -> {date}/{chatId}.md
+      for (const dir of legacyChatDirs) {
+        const chatDir = path.join(this.chatDir, dir.name);
+        const dateFiles = await fs.readdir(chatDir, { withFileTypes: true });
+
+        for (const dateFile of dateFiles) {
+          if (!dateFile.isFile() || !dateFile.name.endsWith('.md')) {
+            continue;
+          }
+
+          const dateStr = dateFile.name.replace('.md', '');
+          // Validate date format
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+            continue;
+          }
+
+          const oldPath = path.join(chatDir, dateFile.name);
+
+          // Create date directory
+          const newDateDir = path.join(this.chatDir, dateStr);
+          await fs.mkdir(newDateDir, { recursive: true });
+
+          // Move to new location
+          const newPath = path.join(newDateDir, `${dir.name}.md`);
+          await fs.rename(oldPath, newPath);
+
+          console.log(`[MessageLogger] Migrated ${dir.name}/${dateStr}.md -> ${dateStr}/${dir.name}.md`);
+          migratedCount++;
+        }
+
+        // Remove empty chatId directory
+        try {
+          const remaining = await fs.readdir(chatDir);
+          if (remaining.length === 0) {
+            await fs.rmdir(chatDir);
+            console.log(`[MessageLogger] Removed empty directory: ${dir.name}`);
+          }
+        } catch {
+          // Ignore errors when cleaning up
+        }
+      }
+
+      if (migratedCount > 0) {
+        console.log(`[MessageLogger] Migrated ${migratedCount} files to new structure`);
       }
     } catch (_error) {
       // Directory doesn't exist or migration failed, that's fine
@@ -173,12 +227,12 @@ export class MessageLogger {
 
   /**
    * Get chat log file path for a specific date.
-   * Structure: {chatDir}/{chatId}/{YYYY-MM-DD}.md
+   * Structure: {chatDir}/{YYYY-MM-DD}/{chatId}.md
    */
   private getChatLogPath(chatId: string, date: Date = new Date()): string {
     const sanitizedId = this.sanitizeId(chatId);
     const dateStr = getDateString(date);
-    return path.join(this.chatDir, sanitizedId, `${dateStr}.md`);
+    return path.join(this.chatDir, dateStr, `${sanitizedId}.md`);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #763

将日志分割结构从 `{chatId}/{date}.md` 修正为 `{date}/{chatId}.md`。

### Before (错误)
```
workspace/logs/
├── oc_abc123/           ← chatId 作为文件夹
│   ├── 2026-03-05.md    ← 日期作为文件名
```

### After (正确)
```
workspace/logs/
├── 2026-03-05/              ← 日期作为文件夹
│   ├── oc_abc123.md         ← chatId 作为文件名
```

## Changes

| 文件 | 变更 |
|------|------|
| `src/feishu/message-logger.ts` | 修改 `getChatLogPath()` 逻辑，更新迁移逻辑 |

### 关键改动

1. **`getChatLogPath()` 方法** - 将日期作为文件夹，chatId 作为文件名
2. **`migrateLegacyFiles()` 方法** - 支持两种旧格式迁移：
   - 扁平文件: `{chatId}.md` -> `{date}/{chatId}.md`
   - 旧结构: `{chatId}/{date}.md` -> `{date}/{chatId}.md`

## Benefits

| 方面 | 日期文件夹 | chatId 文件夹 |
|------|-----------|---------------|
| 清理旧日志 | ✅ 删除日期文件夹即可 | ❌ 需遍历每个 chatId |
| 查看某天活动 | ✅ 打开一个文件夹 | ❌ 需遍历所有 chatId |
| 日志归档 | ✅ 按日期打包 | ❌ 分散在多个文件夹 |
| 磁盘监控 | ✅ du -sh 2026-03-* | ❌ 需汇总所有 chatId |

## Test Plan

- [x] 运行 `npx tsc --noEmit` 无错误
- [x] 运行 `npx vitest run src/feishu/message-logger.test.ts` 23 个测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)