### PR TITLE
feat(schedules): add workspace/schedules directory for scheduled tasks (Issue #357)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ tasks/
 # Workspace directory (keep directory structure, ignore contents)
 workspace/*
 !workspace/.gitkeep
+!workspace/schedules/
+!workspace/schedules/*
 ecosystem.config.cjs
 
 # Integration test environment (contains secrets)

--- a/workspace/schedules/.gitkeep
+++ b/workspace/schedules/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the schedules directory is tracked by git
+# Place your schedule markdown files here

--- a/workspace/schedules/README.md
+++ b/workspace/schedules/README.md
@@ -1,0 +1,33 @@
+# Scheduled Tasks
+
+This directory contains scheduled task definitions.
+
+## Usage
+
+1. Copy an example from `examples/schedules/` to this directory
+2. Rename the file (e.g., `my-task.md`)
+3. Edit the YAML frontmatter:
+   - Replace `chatId` with your actual Feishu chat ID
+   - Set `enabled: true` to activate the task
+4. The scheduler will automatically load and execute the task
+
+## Example
+
+```bash
+cp examples/schedules/recommend-analysis.example.md workspace/schedules/recommend-analysis.md
+```
+
+Then edit `workspace/schedules/recommend-analysis.md`:
+```yaml
+---
+name: "智能推荐分析"
+cron: "0 3 * * *"
+enabled: true
+chatId: "oc_your_actual_chat_id"
+---
+```
+
+## Available Examples
+
+- `recommend-analysis.example.md` - Daily analysis of interaction patterns
+- `pr-scanner.example.md` - Periodic PR scanning and notifications


### PR DESCRIPTION
## Summary
- Creates `workspace/schedules/` directory structure for scheduled tasks
- Adds README with usage instructions for setting up scheduled tasks
- Updates `.gitignore` to allow tracking the schedules directory

## Background
Issue #357 (智能定时任务推荐系统) requires enabling the schedule recommendation system. The infrastructure already exists:
- ✅ `send_user_feedback` MCP tool
- ✅ Scheduler infrastructure
- ✅ `schedule-recommend` skill
- ✅ Example files in `examples/schedules/`

This PR completes the setup by creating the directory structure where users can place their scheduled task files.

## Usage
Users can now:
1. Copy an example from `examples/schedules/` to `workspace/schedules/`
2. Configure `chatId` and set `enabled: true`
3. The scheduler will automatically load and execute the task

## Test plan
- [x] Directory structure created
- [x] README documentation added
- [x] `.gitignore` updated correctly
- [x] Files are tracked by git

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)