### PR TITLE
refactor(agent-pool): rename getOrCreate to getOrCreateChatAgent

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -56,18 +56,23 @@ export class AgentPool {
   }
 
   /**
-   * Get or create a Pilot instance for the given chatId.
+   * Get or create a ChatAgent (Pilot) instance for the given chatId.
    *
-   * If a Pilot already exists for this chatId, returns it.
-   * Otherwise, creates a new Pilot using the factory.
+   * ChatAgents are long-lived and bound to a specific chatId for conversation context.
+   * If a ChatAgent already exists for this chatId, returns it.
+   * Otherwise, creates a new ChatAgent using the factory.
+   *
+   * Note: This method is specifically for ChatAgent (Pilot) lifecycle management.
+   * Other agent types (ScheduleAgent, TaskAgent, SkillAgent) should be created
+   * directly via their factories and have short lifecycles (max 24 hours).
    *
    * @param chatId - The chat identifier
-   * @returns The Pilot instance for this chatId
+   * @returns The ChatAgent instance for this chatId
    */
-  getOrCreate(chatId: string): ChatAgent {
+  getOrCreateChatAgent(chatId: string): ChatAgent {
     let pilot = this.pilots.get(chatId);
     if (!pilot) {
-      this.log.info({ chatId }, 'Creating new Pilot instance for chatId');
+      this.log.info({ chatId }, 'Creating new ChatAgent instance for chatId');
       pilot = this.pilotFactory(chatId);
       this.pilots.set(chatId, pilot);
     }

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -528,8 +528,8 @@ export class PrimaryNode extends EventEmitter {
     this.activeFeedbackChannels.set(chatId, { sendFeedback, threadId });
 
     try {
-      // Issue #644: Get Pilot for this chatId from AgentPool
-      const pilot = this.agentPool.getOrCreate(chatId);
+      // Issue #644: Get ChatAgent for this chatId from AgentPool
+      const pilot = this.agentPool.getOrCreateChatAgent(chatId);
       pilot.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
     } catch (error) {
       const err = error as Error;
@@ -992,8 +992,8 @@ export class PrimaryNode extends EventEmitter {
 
       // Execute task using Pilot
       if (this.agentPool) {
-        // Issue #644: Get Pilot for this chatId from AgentPool
-        const pilot = this.agentPool.getOrCreate(fullTask.chatId);
+        // Issue #644: Get ChatAgent for this chatId from AgentPool
+        const pilot = this.agentPool.getOrCreateChatAgent(fullTask.chatId);
         await pilot.executeOnce(
           fullTask.chatId,
           fullTask.prompt,

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -412,8 +412,8 @@ export class WorkerNode {
           this.activeFeedbackChannels.set(chatId, { sendFeedback, threadId });
 
           try {
-            // Issue #644: Get Pilot for this chatId from AgentPool
-            const pilot = this.agentPool?.getOrCreate(chatId);
+            // Issue #644: Get ChatAgent for this chatId from AgentPool
+            const pilot = this.agentPool?.getOrCreateChatAgent(chatId);
             pilot?.processMessage(chatId, prompt, messageId, senderOpenId, attachments, chatHistoryContext);
           } catch (error) {
             const err = error as Error;

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -37,7 +37,7 @@ const createMockPilot = (): ChatAgent => {
 const createMockAgentPool = (): AgentPool => {
   const pilots = new Map<string, ChatAgent>();
   return {
-    getOrCreate: vi.fn((chatId: string) => {
+    getOrCreateChatAgent: vi.fn((chatId: string) => {
       if (!pilots.has(chatId)) {
         pilots.set(chatId, createMockPilot());
       }
@@ -424,7 +424,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-blocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -470,7 +470,7 @@ describe('Scheduler', () => {
         resolveExecute = resolve;
       });
       const taskChatId = 'test-chat-nonblocking';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockReturnValue(executePromise);
 
       const task: ScheduledTask = {
@@ -521,7 +521,7 @@ describe('Scheduler', () => {
 
     it('should default blocking to true when not specified', async () => {
       const taskChatId = 'test-chat-default';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {
@@ -546,7 +546,7 @@ describe('Scheduler', () => {
 
     it('should allow task to run after previous execution completes', async () => {
       const taskChatId = 'test-chat-sequential';
-      const mockPilot = mockAgentPool.getOrCreate(taskChatId);
+      const mockPilot = mockAgentPool.getOrCreateChatAgent(taskChatId);
       (mockPilot.executeOnce as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
 
       const task: ScheduledTask = {

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -219,9 +219,9 @@ ${task.prompt}`;
       // Build wrapped prompt with anti-recursion instructions
       const wrappedPrompt = this.buildScheduledTaskPrompt(task);
 
-      // Issue #644: Get Pilot for this chatId from AgentPool
-      // Each chatId gets its own Pilot instance for complete isolation
-      const pilot = this.agentPool.getOrCreate(task.chatId);
+      // Issue #644: Get ChatAgent for this chatId from AgentPool
+      // Each chatId gets its own ChatAgent instance for complete isolation
+      const pilot = this.agentPool.getOrCreateChatAgent(task.chatId);
 
       // Execute task using Pilot's executeOnce method
       // messageId is undefined - scheduled tasks send new messages, not replies


### PR DESCRIPTION
## Summary

- Rename `AgentPool.getOrCreate()` to `getOrCreateChatAgent()` to explicitly distinguish ChatAgent lifecycle management from other agent types
- Update all callers to use the new method name

## Changes

- **src/agents/agent-pool.ts**: Rename method and update documentation with clearer semantics
- **src/nodes/primary-node.ts**: Update callers
- **src/nodes/worker-node.ts**: Update callers  
- **src/schedule/scheduler.ts**: Update callers
- **src/schedule/scheduler.test.ts**: Update mock and test code

## Rationale

This change aligns with Issue #711's requirement to distinguish ChatAgent from other Agent types:

| Agent Type | chatId Binding | Max Lifetime | Storage |
|-----------|----------------|--------------|---------|
| ChatAgent | ✅ Yes | Unlimited | AgentPool (Map<chatId, Pilot>) |
| ScheduleAgent | ❌ No | 24 hours | Not stored |
| TaskAgent | ❌ No | Task completion | Not stored |
| SkillAgent | ❌ No | Task completion | Not stored |

The new method name `getOrCreateChatAgent()` makes it clear that this is specifically for ChatAgent lifecycle management, and other agent types should use their respective factories.

## Test Results

- ✅ Build successful
- ✅ TypeScript type check passed
- ✅ All scheduler tests passed (16 tests)

Fixes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)