### PR TITLE
feat(pilot): add image analyzer MCP hint for image attachments

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Pilot, type PilotCallbacks } from './pilot.js';
+import { Config } from '../config/index.js';
 
 // Mock the SDK to avoid unhandled errors
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
@@ -24,25 +25,29 @@ vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   createSdkMcpServer: vi.fn(() => ({})),
 }));
 
-// Mock config
-vi.mock('../config/index.js', () => ({
-  Config: {
-    getWorkspaceDir: vi.fn(() => '/test/workspace'),
-    getAgentConfig: vi.fn(() => ({
-      apiKey: 'test-key',
-      model: 'test-model',
-      provider: 'anthropic',
-    })),
-    getGlobalEnv: vi.fn(() => ({})),
-    getMcpServersConfig: vi.fn(() => null),
-    getLoggingConfig: vi.fn(() => ({
-      level: 'info',
-      pretty: true,
-      rotate: false,
-      sdkDebug: true,
-    })),
-  },
-}));
+// Mock config - use importOriginal to allow per-test overrides
+vi.mock('../config/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config/index.js')>();
+  return {
+    Config: {
+      ...actual.Config,
+      getWorkspaceDir: vi.fn(() => '/test/workspace'),
+      getAgentConfig: vi.fn(() => ({
+        apiKey: 'test-key',
+        model: 'test-model',
+        provider: 'anthropic',
+      })),
+      getGlobalEnv: vi.fn(() => ({})),
+      getMcpServersConfig: vi.fn(() => null),
+      getLoggingConfig: vi.fn(() => ({
+        level: 'info',
+        pretty: true,
+        rotate: false,
+        sdkDebug: true,
+      })),
+    },
+  };
+});
 
 // Mock utils
 vi.mock('../utils/sdk.js', () => ({
@@ -163,6 +168,109 @@ describe('Pilot (Issue #644: ChatId-bound)', () => {
       // dispose() calls async shutdown(), need to wait for it
       await pilot.shutdown();
       expect(pilot.hasActiveSession()).toBe(false);
+    });
+  });
+
+  describe('buildAttachmentsInfo (Issue #809)', () => {
+    // Access private method for testing
+    const getAttachmentsInfo = (attachments: any[]) =>
+      (pilot as any).buildAttachmentsInfo(attachments);
+
+    it('should include image analyzer hint for image attachments when MCP is configured', () => {
+      // Mock MCP server configuration
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+        '4_5v_mcp': { type: 'stdio', command: 'test' },
+      });
+
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.png',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(imageAttachment);
+
+      expect(result).toContain('Image attachment(s) detected');
+      expect(result).toContain('analyze_image');
+      expect(result).toContain('image analyzer MCP');
+    });
+
+    it('should not include image analyzer hint when no image analyzer MCP is configured', () => {
+      // Mock no MCP server configuration
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(null);
+
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.png',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(imageAttachment);
+
+      expect(result).not.toContain('Image attachment(s) detected');
+      expect(result).not.toContain('analyze_image');
+    });
+
+    it('should not include image analyzer hint for non-image attachments', () => {
+      // Mock MCP server configuration
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+        '4_5v_mcp': { type: 'stdio', command: 'test' },
+      });
+
+      const textAttachment = [{
+        id: 'test-id',
+        fileName: 'test.txt',
+        mimeType: 'text/plain',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.txt',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(textAttachment);
+
+      expect(result).not.toContain('Image attachment(s) detected');
+    });
+
+    it('should return empty string for no attachments', () => {
+      const result = getAttachmentsInfo([]);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for undefined attachments', () => {
+      const result = getAttachmentsInfo(undefined);
+      expect(result).toBe('');
+    });
+
+    it('should detect various image analyzer MCP names', () => {
+      const mcpNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
+
+      for (const name of mcpNames) {
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+          [name]: { type: 'stdio', command: 'test' },
+        });
+
+        const imageAttachment = [{
+          id: 'test-id',
+          fileName: 'test.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024,
+          source: 'user' as const,
+          localPath: '/tmp/test.jpg',
+          createdAt: Date.now(),
+        }];
+
+        const result = getAttachmentsInfo(imageAttachment);
+        expect(result).toContain('analyze_image');
+      }
     });
   });
 });

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -772,6 +772,8 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 
   /**
    * Build attachments info string for the message content.
+   *
+   * Issue #809: Added image analyzer MCP hint for image attachments.
    */
   private buildAttachmentsInfo(attachments?: FileRef[]): string {
     if (!attachments || attachments.length === 0) {
@@ -788,14 +790,41 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       })
       .join('\n');
 
+    // Issue #809: Check if there are image attachments and image analyzer MCP is configured
+    const hasImageAttachment = attachments.some(att =>
+      att.mimeType?.startsWith('image/')
+    );
+    const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
+      ? `
+
+**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
+      : '';
+
     return `
 
 --- Attachments ---
 The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
 
-${attachmentList}
+${attachmentList}${imageAnalyzerHint}
 
 You can read these files using the Read tool with the local paths above.`;
+  }
+
+  /**
+   * Check if image analyzer MCP is configured.
+   *
+   * Issue #809: Detects image analyzer MCP server configuration.
+   * Common names: '4_5v_mcp', 'glm-vision', 'image-analyzer', etc.
+   */
+  private hasImageAnalyzerMcp(): boolean {
+    const mcpServers = Config.getMcpServersConfig();
+    if (!mcpServers) {
+      return false;
+    }
+
+    // Check for common image analyzer MCP server names
+    const imageAnalyzerNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
+    return imageAnalyzerNames.some(name => name in mcpServers);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #809

When users send image attachments and have an image analyzer MCP configured, automatically add a hint in the prompt to guide the agent to use the `analyze_image` tool for better image understanding.

### Changes

- Added image type detection in `buildAttachmentsInfo` method (checks if `mimeType` starts with `image/`)
- Added `hasImageAnalyzerMcp` helper to detect image analyzer MCP configuration
- Added prompt hint when both conditions are met (image attachment + MCP configured)
- Maintained compatibility with native multimodal models (Read tool still available as fallback)

### Example Output

When a user sends an image and has `4_5v_mcp` configured:

```
--- Attachments ---
The user has attached 1 file(s). These files have been downloaded to local storage:

1. **screenshot.png** (125.5 KB)
   - File ID: `abc-123`
   - Local path: `/tmp/screenshot.png`
   - MIME type: image/png

**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the `analyze_image` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.

You can read these files using the Read tool with the local paths above.
```

### Supported MCP Server Names

The following MCP server names are recognized as image analyzers:
- `4_5v_mcp`
- `glm-vision`
- `image-analyzer`
- `vision`

## Test plan

- [x] Verify image attachment with MCP configured shows hint
- [x] Verify image attachment without MCP configured shows no hint
- [x] Verify non-image attachments show no hint
- [x] Verify empty/undefined attachments return empty string
- [x] Verify various MCP server name patterns are detected
- [x] All existing pilot tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)