### PR TITLE
fix(agent-pool): remove backward compatibility per Issue #711 feedback

### DIFF
--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -46,10 +46,6 @@ const logger = createLogger('AgentPool');
  */
 export type ChatAgentFactory = (chatId: string) => ChatAgent;
 
-/**
- * @deprecated Use ChatAgentFactory instead. Kept for backward compatibility.
- */
-export type PilotFactory = ChatAgentFactory;
 
 /**
  * Configuration for AgentPool.
@@ -57,10 +53,6 @@ export type PilotFactory = ChatAgentFactory;
 export interface AgentPoolConfig {
   /** Factory function to create ChatAgent instances */
   chatAgentFactory: ChatAgentFactory;
-  /**
-   * @deprecated Use chatAgentFactory instead. Kept for backward compatibility.
-   */
-  pilotFactory?: ChatAgentFactory;
   /** Optional logger */
   logger?: pino.Logger;
 }
@@ -81,8 +73,7 @@ export class AgentPool {
   private readonly log: pino.Logger;
 
   constructor(config: AgentPoolConfig) {
-    // Support both new and legacy config property names
-    this.chatAgentFactory = config.chatAgentFactory ?? config.pilotFactory!;
+    this.chatAgentFactory = config.chatAgentFactory;
     this.log = config.logger ?? logger;
   }
 
@@ -106,18 +97,6 @@ export class AgentPool {
       this.chatAgents.set(chatId, agent);
     }
     return agent;
-  }
-
-  /**
-   * Get or create a ChatAgent instance for the given chatId.
-   *
-   * @deprecated Use getOrCreateChatAgent instead. Kept for backward compatibility.
-   *
-   * @param chatId - The chat identifier
-   * @returns The ChatAgent instance for this chatId
-   */
-  getOrCreate(chatId: string): ChatAgent {
-    return this.getOrCreateChatAgent(chatId);
   }
 
   /**

--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -9,7 +9,7 @@
  * - Issue #711: Short-lived ScheduleAgent creation and disposal
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type MockInstance } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -89,7 +89,7 @@ describe('Scheduler', () => {
   let mockCallbacks: PilotCallbacks;
   let testDir: string;
   let mockAgent: ChatAgent;
-  let createScheduleAgentSpy: ReturnType<typeof vi.spyOn>;
+  let createScheduleAgentSpy: MockInstance<(...args: unknown[]) => ChatAgent>;
 
   beforeEach(async () => {
     testDir = path.join(os.tmpdir(), `scheduler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);


### PR DESCRIPTION
## Summary

Remove deprecated backward compatibility code from PR #724 (2663630) based on review feedback that backward compatibility is not needed.

## Changes

| File | Change |
|------|--------|
| `src/agents/agent-pool.ts` | Remove deprecated `PilotFactory` type alias |
| `src/agents/agent-pool.ts` | Remove deprecated `pilotFactory` config option |
| `src/agents/agent-pool.ts` | Remove deprecated `getOrCreate()` method |
| `src/agents/agent-pool.ts` | Simplify constructor |
| `src/schedule/scheduler.test.ts` | Fix TypeScript error with `MockInstance` type |

## Related

- Fixes CI issues from #724
- Based on review feedback: "不需要向后兼容"

## Test Results

- TypeScript: ✅ No errors
- Lint: ✅ 0 errors, 78 warnings
- Scheduler tests: ✅ 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)