### PR TITLE
feat(pilot): add native multimodal guidance for image attachments (Issue #808)

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -165,4 +165,137 @@ describe('Pilot (Issue #644: ChatId-bound)', () => {
       expect(pilot.hasActiveSession()).toBe(false);
     });
   });
+
+  describe('buildAttachmentsInfo (Issue #808: Native Multimodal)', () => {
+    // Access private method for testing
+    const getAttachmentsInfo = (attachments: any[]) =>
+      (pilot as any).buildAttachmentsInfo(attachments);
+
+    it('should include image guidance for image attachments (native multimodal)', () => {
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'screenshot.png',
+        mimeType: 'image/png',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/screenshot.png',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(imageAttachment);
+
+      // Issue #808: Should provide native multimodal guidance
+      expect(result).toContain('Image attachments detected');
+      expect(result).toContain('Read tool');
+      expect(result).toContain('Native multimodal models');
+      expect(result).toContain('screenshot.png');
+      expect(result).toContain('image/png');
+    });
+
+    it('should include image guidance for multiple image attachments', () => {
+      const imageAttachments = [
+        {
+          id: 'test-id-1',
+          fileName: 'photo1.jpg',
+          mimeType: 'image/jpeg',
+          size: 2048,
+          source: 'user' as const,
+          localPath: '/tmp/photo1.jpg',
+          createdAt: Date.now(),
+        },
+        {
+          id: 'test-id-2',
+          fileName: 'photo2.png',
+          mimeType: 'image/png',
+          size: 3072,
+          source: 'user' as const,
+          localPath: '/tmp/photo2.png',
+          createdAt: Date.now(),
+        },
+      ];
+
+      const result = getAttachmentsInfo(imageAttachments);
+
+      expect(result).toContain('Image attachments detected (2)');
+      expect(result).toContain('photo1.jpg');
+      expect(result).toContain('photo2.png');
+    });
+
+    it('should not include image guidance for non-image attachments', () => {
+      const textAttachment = [{
+        id: 'test-id',
+        fileName: 'document.pdf',
+        mimeType: 'application/pdf',
+        size: 10240,
+        source: 'user' as const,
+        localPath: '/tmp/document.pdf',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(textAttachment);
+
+      expect(result).not.toContain('Image attachments detected');
+      expect(result).toContain('document.pdf');
+      expect(result).toContain('application/pdf');
+    });
+
+    it('should handle mixed attachments (images and files)', () => {
+      const mixedAttachments = [
+        {
+          id: 'test-id-1',
+          fileName: 'image.png',
+          mimeType: 'image/png',
+          size: 1024,
+          source: 'user' as const,
+          localPath: '/tmp/image.png',
+          createdAt: Date.now(),
+        },
+        {
+          id: 'test-id-2',
+          fileName: 'data.csv',
+          mimeType: 'text/csv',
+          size: 512,
+          source: 'user' as const,
+          localPath: '/tmp/data.csv',
+          createdAt: Date.now(),
+        },
+      ];
+
+      const result = getAttachmentsInfo(mixedAttachments);
+
+      // Should still show image guidance since there's at least one image
+      expect(result).toContain('Image attachments detected (1)');
+      expect(result).toContain('image.png');
+      expect(result).toContain('data.csv');
+    });
+
+    it('should return empty string for no attachments', () => {
+      const result = getAttachmentsInfo([]);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for undefined attachments', () => {
+      const result = getAttachmentsInfo(undefined);
+      expect(result).toBe('');
+    });
+
+    it('should detect various image MIME types', () => {
+      const imageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+
+      for (const mimeType of imageTypes) {
+        const imageAttachment = [{
+          id: 'test-id',
+          fileName: 'test.image',
+          mimeType,
+          size: 1024,
+          source: 'user' as const,
+          localPath: '/tmp/test.image',
+          createdAt: Date.now(),
+        }];
+
+        const result = getAttachmentsInfo(imageAttachment);
+        expect(result).toContain('Image attachments detected');
+      }
+    });
+  });
 });

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -772,6 +772,10 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 
   /**
    * Build attachments info string for the message content.
+   *
+   * Issue #808: Added native multimodal model support for image attachments.
+   * When images are attached, provides clear guidance for native multimodal models
+   * to use the Read tool directly for image understanding.
    */
   private buildAttachmentsInfo(attachments?: FileRef[]): string {
     if (!attachments || attachments.length === 0) {
@@ -788,12 +792,20 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       })
       .join('\n');
 
+    // Issue #808: Check for image attachments and provide native multimodal guidance
+    const imageAttachments = attachments.filter(att => att.mimeType?.startsWith('image/'));
+    const imageGuidance = imageAttachments.length > 0
+      ? `
+
+**Image attachments detected (${imageAttachments.length}):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.`
+      : '';
+
     return `
 
 --- Attachments ---
 The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
 
-${attachmentList}
+${attachmentList}${imageGuidance}
 
 You can read these files using the Read tool with the local paths above.`;
   }


### PR DESCRIPTION
## Summary

Fixes #808

Enhanced the `buildAttachmentsInfo` method to provide clear guidance for native multimodal models when image attachments are detected.

### Changes

- **Detect image attachments**: Filter attachments by MIME type (`image/*`)
- **Native multimodal guidance**: Add clear instructions for native multimodal models to use the Read tool
- **Image count**: Display the number of image attachments in the guidance
- **Comprehensive tests**: Add 7 new test cases covering various scenarios

### Example Output

When a user sends an image attachment, the agent now receives:

```markdown
--- Attachments ---
The user has attached 1 file(s). These files have been downloaded to local storage:

1. **screenshot.png** (45.2 KB)
   - File ID: `abc123`
   - Local path: `/workspace/files/screenshot.png`
   - MIME type: image/png

**Image attachments detected (1):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.

You can read these files using the Read tool with the local paths above.
```

### Test Results

- ✅ All 19 tests pass
- ✅ Build successful
- ✅ Lint passed (only existing warnings)

## Test plan

- [x] Image attachment shows guidance message
- [x] Multiple image attachments show correct count
- [x] Non-image attachments don't show image guidance
- [x] Mixed attachments (images + files) work correctly
- [x] Empty/undefined attachments return empty string
- [x] Various image MIME types are detected (png, jpeg, gif, webp, svg+xml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)