### PR TITLE
fix(test): correct MockInstance type for createScheduleAgentSpy (Issue #818)

### DIFF
--- a/src/schedule/scheduler.test.ts
+++ b/src/schedule/scheduler.test.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { Scheduler } from './scheduler.js';
 import { ScheduleManager } from './schedule-manager.js';
-import { AgentFactory } from '../agents/index.js';
+import { AgentFactory, type AgentCreateOptions } from '../agents/index.js';
 import type { ScheduledTask } from './index.js';
 import type { PilotCallbacks } from '../agents/pilot.js';
 import type { ChatAgent } from '../agents/types.js';
@@ -89,7 +89,7 @@ describe('Scheduler', () => {
   let mockCallbacks: PilotCallbacks;
   let testDir: string;
   let mockAgent: ChatAgent;
-  let createScheduleAgentSpy: MockInstance<(...args: unknown[]) => ChatAgent>;
+  let createScheduleAgentSpy: MockInstance<(chatId: string, callbacks: PilotCallbacks, options?: AgentCreateOptions) => ChatAgent>;
 
   beforeEach(async () => {
     testDir = path.join(os.tmpdir(), `scheduler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);


### PR DESCRIPTION
## Summary

Fixes #818

The `createScheduleAgentSpy` variable in `scheduler.test.ts` was declared with a generic type that is incompatible with the actual `AgentFactory.createScheduleAgent` function signature, causing TypeScript compilation errors.

### Changes

- Import `AgentCreateOptions` type from `agents/index.js`
- Update `createScheduleAgentSpy` type declaration to match the actual function signature:
  ```typescript
  // Before
  let createScheduleAgentSpy: MockInstance<(...args: unknown[]) => ChatAgent>;
  
  // After
  let createScheduleAgentSpy: MockInstance<(chatId: string, callbacks: PilotCallbacks, options?: AgentCreateOptions) => ChatAgent>;
  ```

### Root Cause

The generic type `MockInstance<(...args: unknown[]) => ChatAgent>` is not assignable from the more specific type returned by `vi.spyOn(AgentFactory, 'createScheduleAgent')`.

### Test Results

- ✅ TypeScript type-check passes
- ✅ All 17 scheduler tests pass

## Test plan

- [x] Run `npm run type-check` - no errors
- [x] Run `npx vitest run src/schedule/scheduler.test.ts` - 17/17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)