### PR TITLE
feat(pilot): add image analyzer MCP hint for image attachments (Issue #809)

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -165,4 +165,109 @@ describe('Pilot (Issue #644: ChatId-bound)', () => {
       expect(pilot.hasActiveSession()).toBe(false);
     });
   });
+
+  describe('buildAttachmentsInfo (Issue #809)', () => {
+    // Access private method for testing
+    const getAttachmentsInfo = (attachments?: any[]) =>
+      (pilot as any).buildAttachmentsInfo(attachments);
+
+    it('should include image analyzer hint for image attachments when MCP is configured', async () => {
+      // Import Config to get access to the mocked version
+      const { Config } = await import('../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+        '4_5v_mcp': { command: 'test-command' },
+      });
+
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.png',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(imageAttachment);
+
+      expect(result).toContain('Image attachment(s) detected');
+      expect(result).toContain('analyze_image');
+      expect(result).toContain('image analyzer MCP');
+    });
+
+    it('should not include image analyzer hint when no image analyzer MCP is configured', async () => {
+      const { Config } = await import('../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined as any);
+
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.png',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(imageAttachment);
+
+      expect(result).not.toContain('Image attachment(s) detected');
+      expect(result).not.toContain('analyze_image');
+    });
+
+    it('should not include image analyzer hint for non-image attachments', async () => {
+      const { Config } = await import('../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+        '4_5v_mcp': { command: 'test-command' },
+      });
+
+      const textAttachment = [{
+        id: 'test-id',
+        fileName: 'test.txt',
+        mimeType: 'text/plain',
+        size: 1024,
+        source: 'user' as const,
+        localPath: '/tmp/test.txt',
+        createdAt: Date.now(),
+      }];
+
+      const result = getAttachmentsInfo(textAttachment);
+
+      expect(result).not.toContain('Image attachment(s) detected');
+    });
+
+    it('should return empty string for no attachments', () => {
+      const result = getAttachmentsInfo([]);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for undefined attachments', () => {
+      const result = getAttachmentsInfo(undefined);
+      expect(result).toBe('');
+    });
+
+    it('should detect various image analyzer MCP names', async () => {
+      const { Config } = await import('../config/index.js');
+      const mcpNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
+
+      for (const name of mcpNames) {
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+          [name]: { command: 'test-command' },
+        });
+
+        const imageAttachment = [{
+          id: 'test-id',
+          fileName: 'test.jpg',
+          mimeType: 'image/jpeg',
+          size: 1024,
+          source: 'user' as const,
+          localPath: '/tmp/test.jpg',
+          createdAt: Date.now(),
+        }];
+
+        const result = getAttachmentsInfo(imageAttachment);
+        expect(result).toContain('analyze_image');
+      }
+    });
+  });
 });

--- a/src/agents/pilot.ts
+++ b/src/agents/pilot.ts
@@ -772,6 +772,8 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 
   /**
    * Build attachments info string for the message content.
+   *
+   * Issue #809: Added image analyzer MCP hint for image attachments.
    */
   private buildAttachmentsInfo(attachments?: FileRef[]): string {
     if (!attachments || attachments.length === 0) {
@@ -788,14 +790,41 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       })
       .join('\n');
 
+    // Issue #809: Check if there are image attachments and image analyzer MCP is configured
+    const hasImageAttachment = attachments.some(att =>
+      att.mimeType?.startsWith('image/')
+    );
+    const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
+      ? `
+
+**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
+      : '';
+
     return `
 
 --- Attachments ---
 The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
 
-${attachmentList}
+${attachmentList}${imageAnalyzerHint}
 
 You can read these files using the Read tool with the local paths above.`;
+  }
+
+  /**
+   * Check if image analyzer MCP is configured.
+   *
+   * Issue #809: Detects image analyzer MCP server configuration.
+   * Common names: '4_5v_mcp', 'glm-vision', 'image-analyzer', etc.
+   */
+  private hasImageAnalyzerMcp(): boolean {
+    const mcpServers = Config.getMcpServersConfig();
+    if (!mcpServers) {
+      return false;
+    }
+
+    // Check for common image analyzer MCP server names
+    const imageAnalyzerNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
+    return imageAnalyzerNames.some(name => name in mcpServers);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add image analyzer MCP hint for image attachments when MCP is configured
- When a user sends an image and an image analyzer MCP is configured, automatically prompt the agent to use the `analyze_image` tool for better image analysis results

## Changes

- Modified `buildAttachmentsInfo` in `src/agents/pilot.ts` to detect image attachments
- Added `hasImageAnalyzerMcp` helper method to check MCP configuration
- Added comprehensive tests for the new functionality

## Implementation Details

The feature detects image attachments by checking if the MIME type starts with `image/`. If image attachments are found and an image analyzer MCP server is configured (common names: `4_5v_mcp`, `glm-vision`, `image-analyzer`, `vision`), a hint is added to the prompt suggesting the agent to use the `analyze_image` tool.

## Test Results

- Type check: ✅ Passed
- Unit tests: ✅ 18 tests passed
- Lint: ✅ No errors (only pre-existing warnings)

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)