### PR TITLE
fix(logger): skip pino-pretty in test environment (Issue #825)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -90,10 +90,29 @@ function getDefaultLogLevel(): LogLevel {
 
 /**
  * Get development environment configuration
+ *
+ * Note: In test environment, we skip pino-pretty transport to avoid
+ * conflicts with vitest's worker mechanism (Issue #825).
+ * The transport uses worker_threads internally which can cause module
+ * loading timeouts in CI environments.
  */
 function getDevelopmentConfig(): LoggerOptions {
-  return {
+  const baseConfig: LoggerOptions = {
     level: getDefaultLogLevel(),
+    formatters: {
+      level: (label) => {
+        return { level: label };
+      }
+    }
+  };
+
+  // Skip pino-pretty in test environment to avoid worker_threads conflicts
+  if (process.env.NODE_ENV === 'test') {
+    return baseConfig;
+  }
+
+  return {
+    ...baseConfig,
     transport: {
       target: 'pino-pretty',
       options: {
@@ -102,11 +121,6 @@ function getDevelopmentConfig(): LoggerOptions {
         ignore: 'pid,hostname',
         singleLine: false,
         messageFormat: '[{context}] {msg}' // Add context prefix if present
-      }
-    },
-    formatters: {
-      level: (label) => {
-        return { level: label };
       }
     }
   };


### PR DESCRIPTION
## Summary

Fixes #825

The `logger.test.ts` tests were timing out in CI environments due to a conflict between `pino-pretty` transport's internal worker_threads and vitest's worker mechanism.

### Root Cause

The `getDevelopmentConfig()` function in `logger.ts` always configures `pino-pretty` transport for development mode. However:
1. `pino-pretty` uses worker_threads internally
2. vitest's forks pool mode also uses worker processes
3. In CI environments (Node.js 20), this combination causes module loading timeouts

### Changes

- Modified `getDevelopmentConfig()` to skip `pino-pretty` transport when `NODE_ENV === 'test'`
- Added documentation explaining the issue and reference to Issue #825

### Test Results

| Metric | Result |
|--------|--------|
| Unit Tests | ✅ 1572 passed |
| Lint | ✅ 0 errors (78 warnings - pre-existing) |
| Type Check | ✅ No errors |

## Test plan

- [x] Run `npm test` - all 1572 tests pass
- [x] Run `npm run lint` - 0 errors
- [x] Run `npm run type-check` - no errors
- [x] Run `npx vitest run src/utils/logger.test.ts` - 26 tests pass in 213ms (previously could timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)