### PR TITLE
fix(vitest): increase timeouts for CI to prevent worker timeout (Issue #825)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,14 @@ import { defineConfig } from 'vitest/config';
  *
  * @see https://vitest.dev/guide/cli.html#options
  * @see Issue #80 - OOM issue with child processes
+ * @see Issue #825 - vitest-worker timeout fix with increased timeouts
  */
+
+// CI environments need longer timeouts due to slower I/O and module loading
+const isCI = process.env.CI === 'true';
+const testTimeout = isCI ? 30000 : 10000;
+const hookTimeout = isCI ? 30000 : 10000;
+
 export default defineConfig({
   test: {
     globals: true,
@@ -38,6 +45,10 @@ export default defineConfig({
         singleFork: true,
       },
     },
+    // Increased timeouts for CI to prevent "Timeout calling fetch" errors
+    // during module loading (Issue #825)
+    testTimeout,
+    hookTimeout,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
@@ -67,6 +78,5 @@ export default defineConfig({
       include: ['src/**/*.ts'],
     },
     setupFiles: [],
-    testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Summary

Fixes #825 - The vitest-worker "Timeout calling fetch" error occurs during module loading in CI environments where I/O operations are slower.

### Changes

- Detects CI environment via `process.env.CI`
- Increases `testTimeout` from 10s to 30s for CI environments
- Adds `hookTimeout` configuration (30s for CI, 10s for local)

### Root Cause

The error `[vitest-worker]: Timeout calling "fetch"` is a birpc timeout that occurs during module initialization. In CI environments, file I/O operations (especially module loading) can be slower, causing the RPC communication to timeout.

### Solution

By increasing the timeout values specifically for CI environments (detected via `process.env.CI === 'true'`), we give the RPC communication more time to complete during module initialization, preventing the timeout errors.

Local development is unaffected and continues to use the faster 10s timeout.

## Test plan

- [x] Verify logger.test.ts passes locally (26 tests)
- [x] Type check passes
- [x] Lint check passes (0 errors)
- [ ] CI tests should pass without timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)