### PR TITLE
feat(expert): add expert search with availability check (Issue #536)

### DIFF
--- a/src/experts/expert-service.test.ts
+++ b/src/experts/expert-service.test.ts
@@ -221,4 +221,62 @@ describe('ExpertService', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('isAvailable', () => {
+    it('should return true if no availability set', () => {
+      service.registerExpert('user_123', 'John Doe');
+      expect(service.isAvailable('user_123')).toBe(true);
+    });
+
+    it('should return true for "always" availability', () => {
+      service.registerExpert('user_123', 'John Doe');
+      service.setAvailability('user_123', 'always');
+      expect(service.isAvailable('user_123')).toBe(true);
+    });
+
+    it('should return false for non-existent expert', () => {
+      expect(service.isAvailable('nonexistent')).toBe(false);
+    });
+
+    it('should return true if availability cannot be parsed', () => {
+      service.registerExpert('user_123', 'John Doe');
+      service.setAvailability('user_123', 'some random text');
+      expect(service.isAvailable('user_123')).toBe(true);
+    });
+  });
+
+  describe('searchAvailableExperts', () => {
+    beforeEach(() => {
+      service.registerExpert('user_1', 'Expert 1');
+      service.registerExpert('user_2', 'Expert 2');
+
+      service.addSkill('user_1', { name: 'TypeScript', level: 5 });
+      service.addSkill('user_2', { name: 'TypeScript', level: 3 });
+
+      // Set availability to "always" so tests don't depend on current time
+      service.setAvailability('user_1', 'always');
+      service.setAvailability('user_2', 'always');
+    });
+
+    it('should find available experts by skill', () => {
+      const experts = service.searchAvailableExperts('TypeScript');
+      expect(experts).toHaveLength(2);
+    });
+
+    it('should filter by minimum level', () => {
+      const experts = service.searchAvailableExperts('TypeScript', { minLevel: 4 });
+      expect(experts).toHaveLength(1);
+      expect(experts[0].name).toBe('Expert 1');
+    });
+
+    it('should skip availability check when disabled', () => {
+      // Set availability to something that would fail
+      service.setAvailability('user_1', 'weekdays 1:00-2:00');
+
+      const experts = service.searchAvailableExperts('TypeScript', {
+        checkAvailability: false,
+      });
+      expect(experts).toHaveLength(2);
+    });
+  });
 });

--- a/src/experts/expert-service.ts
+++ b/src/experts/expert-service.ts
@@ -306,6 +306,102 @@ export class ExpertService {
   getFilePath(): string {
     return this.filePath;
   }
+
+  /**
+   * Check if an expert is currently available.
+   *
+   * Parses the availability string and checks if the current time falls within
+   * the specified time range.
+   *
+   * Supported formats:
+   * - "weekdays 9:00-18:00" - Available on weekdays (Mon-Fri) during hours
+   * - "weekends 10:00-20:00" - Available on weekends (Sat-Sun) during hours
+   * - "daily 9:00-18:00" - Available every day during hours
+   * - "9:00-18:00" - Available every day during hours (same as daily)
+   * - "always" or empty - Always available
+   *
+   * @param userId - User ID
+   * @returns Whether the expert is currently available
+   */
+  isAvailable(userId: string): boolean {
+    const profile = this.registry.experts[userId];
+    if (!profile) {
+      return false;
+    }
+
+    // If no availability set, consider always available
+    if (!profile.availability) {
+      return true;
+    }
+
+    const availability = profile.availability.toLowerCase().trim();
+
+    // Always available
+    if (availability === 'always' || availability === '') {
+      return true;
+    }
+
+    const now = new Date();
+    const dayOfWeek = now.getDay(); // 0 = Sunday, 6 = Saturday
+    const currentHour = now.getHours();
+    const currentMinute = now.getMinutes();
+    const currentTime = currentHour * 60 + currentMinute; // Minutes since midnight
+
+    // Parse time range (e.g., "9:00-18:00")
+    const timeMatch = availability.match(/(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})/);
+    if (!timeMatch) {
+      // If we can't parse the time, consider available
+      logger.warn({ userId, availability }, 'Could not parse availability, considering available');
+      return true;
+    }
+
+    const [, startHour, startMin, endHour, endMin] = timeMatch.map(Number);
+    const startTime = startHour * 60 + startMin;
+    const endTime = endHour * 60 + endMin;
+
+    const inTimeRange = currentTime >= startTime && currentTime <= endTime;
+
+    // Check day constraints
+    const isWeekday = dayOfWeek >= 1 && dayOfWeek <= 5;
+    const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+
+    if (availability.includes('weekday')) {
+      return isWeekday && inTimeRange;
+    }
+
+    if (availability.includes('weekend')) {
+      return isWeekend && inTimeRange;
+    }
+
+    // "daily" or just time range - available any day
+    return inTimeRange;
+  }
+
+  /**
+   * Search for available experts by skill.
+   *
+   * Combines skill search with availability check.
+   *
+   * @param query - Skill name or tag to search for
+   * @param options - Search options
+   * @returns Array of matching expert profiles that are currently available
+   */
+  searchAvailableExperts(
+    query: string,
+    options?: {
+      minLevel?: SkillLevel;
+      checkAvailability?: boolean;
+    }
+  ): ExpertProfile[] {
+    const { minLevel, checkAvailability = true } = options || {};
+    const experts = this.searchBySkill(query, minLevel);
+
+    if (!checkAvailability) {
+      return experts;
+    }
+
+    return experts.filter(expert => this.isAvailable(expert.userId));
+  }
 }
 
 // Singleton instance

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -20,6 +20,7 @@ import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { Config } from '../config/index.js';
 import { createFeishuClient } from '../platforms/feishu/create-feishu-client.js';
+import { getExpertService } from '../experts/index.js';
 
 const logger = createLogger('FeishuContextMCP');
 
@@ -843,6 +844,71 @@ export async function wait_for_interaction(params: {
 }
 
 /**
+ * Find experts by skill.
+ *
+ * @see Issue #536 - 专家查询与匹配
+ */
+async function find_experts(params: {
+  skill: string;
+  minLevel?: number;
+  availableOnly?: boolean;
+}): Promise<{
+  success: boolean;
+  experts: Array<{
+    userId: string;
+    name: string;
+    skills: Array<{ name: string; level: number; tags?: string[] }>;
+    availability?: string;
+    isAvailable: boolean;
+  }>;
+  message: string;
+}> {
+  const { skill, minLevel, availableOnly = true } = params;
+
+  try {
+    const expertService = getExpertService();
+    const experts = expertService.searchAvailableExperts(skill, {
+      minLevel: minLevel as 1 | 2 | 3 | 4 | 5 | undefined,
+      checkAvailability: availableOnly,
+    });
+
+    const result = experts.map(expert => ({
+      userId: expert.userId,
+      name: expert.name,
+      skills: expert.skills.map(s => ({
+        name: s.name,
+        level: s.level,
+        tags: s.tags,
+      })),
+      availability: expert.availability,
+      isAvailable: expertService.isAvailable(expert.userId),
+    }));
+
+    if (result.length === 0) {
+      return {
+        success: true,
+        experts: [],
+        message: `No experts found for skill "${skill}"${minLevel ? ` with min level ${minLevel}` : ''}${availableOnly ? ' (available only)' : ''}`,
+      };
+    }
+
+    return {
+      success: true,
+      experts: result,
+      message: `Found ${result.length} expert(s) for skill "${skill}"`,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error({ err: error, skill }, 'find_experts failed');
+    return {
+      success: false,
+      experts: [],
+      message: `Failed to find experts: ${errorMessage}`,
+    };
+  }
+}
+
+/**
  * Tool definitions for Agent SDK integration.
  *
  * Export tools in a format compatible with inline MCP servers.
@@ -992,6 +1058,53 @@ export const feishuContextTools = {
       required: ['messageId', 'chatId'],
     },
     handler: wait_for_interaction,
+  },
+  find_experts: {
+    description: `Find human experts by skill. Searches the expert registry for experts with matching skills.
+
+**Usage:**
+\`\`\`json
+{
+  "skill": "TypeScript",
+  "minLevel": 3,
+  "availableOnly": true
+}
+\`\`\`
+
+**Returns:**
+- List of experts with their skills, levels, and availability status
+- Each expert includes userId (for contacting via Feishu), name, and skill details
+
+**Parameters:**
+- skill: Skill name or tag to search for (required)
+- minLevel: Minimum skill level filter (1-5, optional)
+- availableOnly: Only return currently available experts (default: true)
+
+**Use Cases:**
+- Find an expert to review code
+- Find an expert for consultation on a specific topic
+- Match experts to tasks based on skill requirements`,
+    parameters: {
+      type: 'object',
+      properties: {
+        skill: {
+          type: 'string',
+          description: 'Skill name or tag to search for (e.g., "TypeScript", "React", "backend")',
+        },
+        minLevel: {
+          type: 'number',
+          minimum: 1,
+          maximum: 5,
+          description: 'Minimum skill level filter (1-5)',
+        },
+        availableOnly: {
+          type: 'boolean',
+          description: 'Only return currently available experts (default: true)',
+        },
+      },
+      required: ['skill'],
+    },
+    handler: find_experts,
   },
 };
 
@@ -1213,6 +1326,53 @@ When parentMessageId is provided, the message is sent as a reply to that message
         }
       } catch (error) {
         return toolSuccess(`⚠️ Wait failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'find_experts',
+    description: `Find human experts by skill. Searches the expert registry for experts with matching skills.
+
+**Usage:**
+\`\`\`json
+{
+  "skill": "TypeScript",
+  "minLevel": 3,
+  "availableOnly": true
+}
+\`\`\`
+
+**Returns:**
+- List of experts with their skills, levels, and availability status
+- Each expert includes userId (for contacting via Feishu), name, and skill details
+
+**Use Cases:**
+- Find an expert to review code
+- Find an expert for consultation on a specific topic
+- Match experts to tasks based on skill requirements`,
+    parameters: z.object({
+      skill: z.string().describe('Skill name or tag to search for (e.g., "TypeScript", "React", "backend")'),
+      minLevel: z.number().min(1).max(5).optional().describe('Minimum skill level filter (1-5)'),
+      availableOnly: z.boolean().optional().describe('Only return currently available experts (default: true)'),
+    }),
+    handler: async ({ skill, minLevel, availableOnly }) => {
+      try {
+        const result = await find_experts({ skill, minLevel, availableOnly });
+        if (result.success && result.experts.length > 0) {
+          const expertList = result.experts
+            .map(
+              e =>
+                `- **${e.name}** (${e.userId})
+  Skills: ${e.skills.map(s => `${s.name} (L${s.level})`).join(', ')}
+  Available: ${e.isAvailable ? '✅' : '❌'}`
+            )
+            .join('\n');
+          return toolSuccess(`${result.message}\n\n${expertList}`);
+        } else {
+          return toolSuccess(result.message);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Expert search failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },


### PR DESCRIPTION
## Summary

Implements Issue #536 - 专家查询与匹配

让 Agent 能够根据技能需求查询和匹配专家。

## Changes

| File | Description |
|------|-------------|
| `src/experts/expert-service.ts` | Add `isAvailable()` and `searchAvailableExperts()` methods |
| `src/experts/expert-service.test.ts` | Add tests for availability checking |
| `src/mcp/feishu-context-mcp.ts` | Add `find_experts` MCP tool |

## New Features

### 1. 可用性检查 (`isAvailable`)

支持解析以下格式的可用性设置：
- `"weekdays 9:00-18:00"` - 工作日指定时间可用
- `"weekends 10:00-20:00"` - 周末指定时间可用
- `"daily 9:00-18:00"` - 每天指定时间可用
- `"9:00-18:00"` - 同 daily
- `"always"` 或空 - 始终可用

### 2. 搜索可用专家 (`searchAvailableExperts`)

结合技能搜索和可用性检查，返回符合条件的专家列表。

### 3. MCP 工具 (`find_experts`)

让 Agent 可以通过 MCP 工具查询专家：

```json
{
  "skill": "TypeScript",
  "minLevel": 3,
  "availableOnly": true
}
```

返回：
- 专家列表，包含 userId、姓名、技能、等级、可用性状态

## Test Results

| Metric | Value |
|--------|-------|
| ExpertService Tests | 29 passed ✅ |
| MCP Tests | 45 passed ✅ |
| TypeScript | ✅ No errors |

## Issue #536 Verification

| # | Criteria | Status |
|---|----------|--------|
| 1 | `/expert search` 按技能搜索 | ✅ (已在 #535 中实现) |
| 2 | `findExperts()` API 可用 | ✅ `find_experts` MCP 工具 |
| 3 | 支持技能等级过滤 | ✅ `minLevel` 参数 |
| 4 | 支持可用性检查 | ✅ `isAvailable()` 方法 |

## Dependencies

⚠️ **Based on PR #830** (Issue #535 - 专家注册与技能声明)

This PR should be merged after #830.

Fixes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)