### PR TITLE
refactor: remove CLI and unconfigured credential fallbacks from send_message

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -145,8 +145,12 @@ describe('Feishu Context MCP Tools', () => {
   });
 
   describe('send_user_feedback', () => {
-    describe('CLI Mode', () => {
-      it('should handle CLI mode (chatId starts with "cli-")', async () => {
+    describe('CLI ChatId (now sends to Feishu)', () => {
+      // Note: CLI fallback has been removed (Issue #849)
+      // CLI chatIds now send to Feishu API like any other chatId
+      it('should send message to Feishu even with cli- prefix', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
         const result = await send_user_feedback({
           content: 'Test message',
           format: 'text',
@@ -154,10 +158,13 @@ describe('Feishu Context MCP Tools', () => {
         });
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('CLI mode');
+        expect(result.message).toContain('Feedback sent');
+        expect(mockClient.im.message.create).toHaveBeenCalled();
       });
 
-      it('should display content in CLI mode', async () => {
+      it('should send content with cli- prefix chatId', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
         const result = await send_user_feedback({
           content: 'Test content',
           format: 'text',
@@ -602,7 +609,9 @@ describe('Feishu Context MCP Tools', () => {
       expect(result.error).toContain('Invalid card structure');
     });
 
-    it('should update card in CLI mode', async () => {
+    it('should update card with cli- prefix via Feishu API', async () => {
+      mockClient.im.message.patch.mockResolvedValueOnce({});
+
       const result = await update_card({
         messageId: 'msg-123',
         card: {
@@ -616,8 +625,9 @@ describe('Feishu Context MCP Tools', () => {
         chatId: 'cli-test',
       });
 
+      // CLI fallback removed (Issue #849) - now sends to Feishu API
       expect(result.success).toBe(true);
-      expect(result.message).toContain('CLI mode');
+      expect(mockClient.im.message.patch).toHaveBeenCalled();
     });
 
     it('should call Feishu API patch endpoint', async () => {
@@ -691,15 +701,23 @@ describe('Feishu Context MCP Tools', () => {
       expect(result.error).toContain('chatId is required');
     });
 
-    it('should simulate interaction in CLI mode', async () => {
-      const result = await wait_for_interaction({
-        messageId: 'msg-123',
+    it('should wait for interaction with cli- prefix chatId (no CLI fallback)', async () => {
+      // CLI fallback removed (Issue #849) - now waits for real interaction
+      const waitPromise = wait_for_interaction({
+        messageId: 'msg-cli-test',
         chatId: 'cli-test',
+        timeoutSeconds: 1,
       });
 
+      // Simulate interaction being received
+      setTimeout(() => {
+        resolvePendingInteraction('msg-cli-test', 'test-action', 'button', 'user-123');
+      }, 50);
+
+      const result = await waitPromise;
+
       expect(result.success).toBe(true);
-      expect(result.actionValue).toBe('simulated');
-      expect(result.actionType).toBe('button');
+      expect(result.actionValue).toBe('test-action');
     });
 
     it('should resolve when interaction is received', async () => {

--- a/src/mcp/tools/card-interaction.ts
+++ b/src/mcp/tools/card-interaction.ts
@@ -54,18 +54,15 @@ export async function update_card(params: {
       };
     }
 
-    if (chatId.startsWith('cli-')) {
-      return { success: true, message: '✅ Card updated (CLI mode)' };
-    }
-
     const appId = Config.FEISHU_APP_ID;
     const appSecret = Config.FEISHU_APP_SECRET;
 
     if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
       return {
         success: false,
-        error: 'Feishu credentials not configured',
-        message: '⚠️ Card cannot be updated: Feishu is not configured.',
+        error: errorMsg,
+        message: `❌ ${errorMsg}`,
       };
     }
 
@@ -98,16 +95,6 @@ export async function wait_for_interaction(params: {
   try {
     if (!messageId) { throw new Error('messageId is required'); }
     if (!chatId) { throw new Error('chatId is required'); }
-
-    if (chatId.startsWith('cli-')) {
-      return {
-        success: true,
-        message: '✅ Interaction received (CLI mode - simulated)',
-        actionValue: 'simulated',
-        actionType: 'button',
-        userId: 'cli-user',
-      };
-    }
 
     if (pendingInteractions.has(messageId)) {
       return {

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -54,23 +54,13 @@ export async function send_user_feedback(params: {
     if (!format) { throw new Error('format is required (must be "text" or "card")'); }
     if (!chatId) { throw new Error('chatId is required'); }
 
-    if (chatId.startsWith('cli-')) {
-      const displayContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
-      logger.info({ chatId, format }, 'CLI mode: User feedback');
-      console.log(`\n${displayContent}\n`);
-      invokeMessageSentCallback(chatId);
-      return { success: true, message: `✅ Feedback displayed (CLI mode, format: ${format})` };
-    }
-
     const appId = Config.FEISHU_APP_ID;
     const appSecret = Config.FEISHU_APP_SECRET;
 
     if (!appId || !appSecret) {
-      const displayContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2);
-      logger.info({ chatId, format, reason: 'Feishu credentials not configured' }, 'Feedback logged');
-      console.log(`\n[Feedback] ${displayContent}\n`);
-      invokeMessageSentCallback(chatId);
-      return { success: true, message: `✅ Feedback logged (Feishu not configured, format: ${format})` };
+      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+      logger.error({ chatId, format }, errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
     }
 
     const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });

--- a/src/mcp/unified-messaging-mcp.ts
+++ b/src/mcp/unified-messaging-mcp.ts
@@ -84,8 +84,10 @@ export interface SendMessageResult {
  *
  * Routes to the appropriate channel based on chatId:
  * - Feishu (oc_*, ou_*): Uses Feishu API
- * - CLI (cli-*): Logs to console
- * - REST (other): Graceful degradation
+ * - Other chatIds: Uses Feishu API (requires configured credentials)
+ *
+ * Note: CLI and unconfigured credential fallbacks have been removed (Issue #849).
+ * If Feishu credentials are not configured, an error is returned.
  *
  * @param params - Tool parameters
  * @returns Result with success status and channel info
@@ -166,21 +168,20 @@ function toolSuccess(text: string): { content: Array<{ type: 'text'; text: strin
 export const unifiedMessagingToolDefinitions: InlineToolDefinition[] = [
   {
     name: 'send_message',
-    description: `Send a message to a chat. Automatically routes to the correct channel based on chatId.
+    description: `Send a message to a chat via Feishu.
 
-**Channel Detection:**
-- Feishu (oc_*, ou_*): Full support for text and cards
-- CLI (cli-*): Logs to console
-- REST (other): Graceful degradation
+**Requirements:**
+- Feishu credentials must be configured (FEISHU_APP_ID and FEISHU_APP_SECRET)
+- If credentials are not configured, an error will be returned
 
 **Format Options:**
 - "text": Plain text message
-- "card": Interactive card (Feishu only, falls back to text on other channels)
+- "card": Interactive card (Feishu only)
 
 **Thread Support:**
 When parentMessageId is provided, the message is sent as a reply to that message.
 
-**Card Format (Feishu only):**
+**Card Format:**
 A valid card must include:
 - config: Object with optional "wide_screen_mode"
 - header: Object with "title" and "template" color


### PR DESCRIPTION
## Summary

- Remove CLI mode fallback from `send_user_feedback`, `update_card`, and `wait_for_interaction`
- Remove unconfigured credential fallback from `send_user_feedback` and `update_card`
- Return clear error messages when Feishu credentials are not configured
- Update tool descriptions to reflect new behavior

## Changes

| File | Change |
|------|--------|
| `src/mcp/tools/send-message.ts` | Remove CLI and unconfigured credential fallbacks, return error |
| `src/mcp/tools/card-interaction.ts` | Remove CLI fallbacks from `update_card` and `wait_for_interaction` |
| `src/mcp/unified-messaging-mcp.ts` | Update tool description to remove fallback references |
| `src/mcp/feishu-context-mcp.test.ts` | Update tests to match new behavior |

## Behavior Change

**Before**: CLI chatIds and missing credentials would silently fallback to console logging

**After**: Returns clear error message: "Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml"

## Test Plan

- [x] All 1594 existing tests pass
- [x] Updated tests for new behavior
- [x] Verified error messages are clear and actionable

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)