### PR TITLE
feat(mcp): add send_interactive_message tool and improve interaction prompts (Issue #853)

### DIFF
--- a/src/channels/feishu/interaction-prompt-builder.ts
+++ b/src/channels/feishu/interaction-prompt-builder.ts
@@ -1,0 +1,236 @@
+/**
+ * Interaction event to prompt converter.
+ *
+ * Converts Feishu card interaction events into human-readable prompts
+ * that the agent can process naturally.
+ *
+ * @module channels/feishu/interaction-prompt-builder
+ */
+
+import type { FeishuCardAction } from '../../types/platform.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('InteractionPromptBuilder');
+
+/**
+ * Action types supported by Feishu interactive cards.
+ */
+export type FeishuActionType =
+  | 'button'           // Button click
+  | 'select_static'    // Static dropdown selection
+  | 'select_person'    // Person picker selection
+  | 'input'            // Input field submission
+  | 'date_picker'      // Date picker selection
+  | 'time_picker'      // Time picker selection
+  | 'datetime_picker'  // DateTime picker selection
+  | 'overflow'         // Overflow menu selection
+  | 'collapsible'      // Collapsible section toggle
+  | 'form';            // Form submission
+
+/**
+ * Context for building interaction prompts.
+ */
+export interface InteractionContext {
+  /** The action that was performed */
+  action: FeishuCardAction;
+  /** The message ID of the card */
+  messageId: string;
+  /** The chat ID */
+  chatId: string;
+  /** The user who performed the action */
+  userId?: string;
+  /** Whether this was a pending interaction that was resolved */
+  wasPendingInteraction?: boolean;
+}
+
+/**
+ * Build a prompt message from a card interaction event.
+ *
+ * @param context - The interaction context
+ * @returns A human-readable prompt string
+ */
+export function buildInteractionPrompt(context: InteractionContext): string {
+  const { action, wasPendingInteraction } = context;
+  const actionType = action.type as FeishuActionType;
+  const actionValue = action.value;
+  const actionText = action.text || action.value;
+
+  logger.debug({ actionType, actionValue, actionText }, 'Building interaction prompt');
+
+  // Build prompt based on action type
+  switch (actionType) {
+    case 'button':
+      return buildButtonPrompt(actionText, actionValue, wasPendingInteraction);
+
+    case 'select_static':
+    case 'overflow':
+      return buildSelectionPrompt(actionText, actionValue);
+
+    case 'select_person':
+      return buildPersonSelectionPrompt(actionText, actionValue);
+
+    case 'input':
+    case 'form':
+      return buildInputPrompt(actionText, actionValue);
+
+    case 'date_picker':
+      return buildDatePrompt(actionText, actionValue);
+
+    case 'time_picker':
+      return buildTimePrompt(actionText, actionValue);
+
+    case 'datetime_picker':
+      return buildDateTimePrompt(actionText, actionValue);
+
+    case 'collapsible':
+      return buildCollapsiblePrompt(actionText, actionValue);
+
+    default:
+      // Fallback for unknown action types
+      return buildGenericPrompt(actionText, actionValue, actionType);
+  }
+}
+
+/**
+ * Build prompt for button click.
+ */
+function buildButtonPrompt(
+  buttonText: string,
+  buttonValue: string,
+  wasPending?: boolean
+): string {
+  // Use Chinese for better user experience
+  const prefix = wasPending
+    ? '[用户操作]'
+    : '[用户操作]';
+
+  // Check for common action patterns
+  const lowerValue = buttonValue.toLowerCase();
+
+  if (lowerValue === 'confirm' || lowerValue === '确认' || lowerValue === 'yes') {
+    return `${prefix} 用户点击了「${buttonText}」按钮，确认执行操作。请继续执行任务。`;
+  }
+
+  if (lowerValue === 'cancel' || lowerValue === '取消' || lowerValue === 'no') {
+    return `${prefix} 用户点击了「${buttonText}」按钮，取消操作。请根据此决定继续。`;
+  }
+
+  if (lowerValue === 'dismiss' || lowerValue === '关闭' || lowerValue === 'ignore') {
+    return `${prefix} 用户点击了「${buttonText}」按钮，关闭了提示。`;
+  }
+
+  // Generic button prompt
+  return `${prefix} 用户点击了「${buttonText}」按钮。请根据此操作继续执行任务。`;
+}
+
+/**
+ * Build prompt for selection action.
+ */
+function buildSelectionPrompt(selectedText: string, selectedValue: string): string {
+  return `[用户操作] 用户选择了「${selectedText}」选项（值：${selectedValue}）。请根据此选择继续执行任务。`;
+}
+
+/**
+ * Build prompt for person selection.
+ */
+function buildPersonSelectionPrompt(personName: string, personId: string): string {
+  return `[用户操作] 用户选择了人员「${personName}」。请根据此选择继续执行任务。`;
+}
+
+/**
+ * Build prompt for input/form submission.
+ */
+function buildInputPrompt(inputText: string, inputValue: string): string {
+  if (inputValue && inputValue.trim()) {
+    return `[用户操作] 用户提交了输入：「${inputValue}」。请根据此输入继续执行任务。`;
+  }
+  return `[用户操作] 用户提交了表单。请根据提交内容继续执行任务。`;
+}
+
+/**
+ * Build prompt for date selection.
+ */
+function buildDatePrompt(dateText: string, dateValue: string): string {
+  return `[用户操作] 用户选择了日期「${dateValue}」。请根据此日期继续执行任务。`;
+}
+
+/**
+ * Build prompt for time selection.
+ */
+function buildTimePrompt(timeText: string, timeValue: string): string {
+  return `[用户操作] 用户选择了时间「${timeValue}」。请根据此时间继续执行任务。`;
+}
+
+/**
+ * Build prompt for datetime selection.
+ */
+function buildDateTimePrompt(datetimeText: string, datetimeValue: string): string {
+  return `[用户操作] 用户选择了日期时间「${datetimeValue}」。请根据此日期时间继续执行任务。`;
+}
+
+/**
+ * Build prompt for collapsible toggle.
+ */
+function buildCollapsiblePrompt(sectionText: string, isExpanded: string): string {
+  const state = isExpanded === 'true' || isExpanded === '1' ? '展开' : '收起';
+  return `[用户操作] 用户${state}了「${sectionText}」部分。`;
+}
+
+/**
+ * Build generic prompt for unknown action types.
+ */
+function buildGenericPrompt(text: string, value: string, actionType: string): string {
+  return `[用户操作] 用户执行了 ${actionType} 操作：${text || value}。请根据此操作继续执行任务。`;
+}
+
+/**
+ * Interaction prompt templates for different scenarios.
+ */
+export const INTERACTION_PROMPT_TEMPLATES = {
+  /**
+   * Template for confirmation dialogs.
+   */
+  confirm: {
+    confirm: '[用户操作] 用户确认了操作。请继续执行。',
+    cancel: '[用户操作] 用户取消了操作。',
+  },
+
+  /**
+   * Template for selection dialogs.
+   */
+  selection: {
+    selected: '[用户操作] 用户选择了「{option}」。请根据此选择继续执行。',
+  },
+
+  /**
+   * Template for input collection.
+   */
+  input: {
+    submitted: '[用户操作] 用户提交了：「{input}」。请根据此输入继续执行。',
+    empty: '[用户操作] 用户提交了空输入。',
+  },
+
+  /**
+   * Template for multi-step workflows.
+   */
+  workflow: {
+    next: '[用户操作] 用户点击了「下一步」。请继续工作流。',
+    back: '[用户操作] 用户点击了「上一步」。请返回上一步骤。',
+    skip: '[用户操作] 用户跳过了当前步骤。',
+    done: '[用户操作] 用户完成了操作。',
+  },
+} as const;
+
+/**
+ * Format a template with values.
+ */
+export function formatTemplate(
+  template: string,
+  values: Record<string, string>
+): string {
+  let result = template;
+  for (const [key, value] of Object.entries(values)) {
+    result = result.replace(`{${key}}`, value);
+  }
+  return result;
+}

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -27,6 +27,7 @@ import type {
 } from '../../types/platform.js';
 import type { PassiveModeManager } from './passive-mode.js';
 import type { MentionDetector } from './mention-detector.js';
+import { buildInteractionPrompt } from './interaction-prompt-builder.js';
 
 const logger = createLogger('MessageHandler');
 
@@ -566,8 +567,14 @@ export class MessageHandler {
 
     // Always emit card action as a message to the agent
     try {
-      const buttonText = action.text || action.value;
-      const messageContent = `User clicked '${buttonText}' button`;
+      // Use the new interaction prompt builder for better messages
+      const messageContent = buildInteractionPrompt({
+        action,
+        messageId: message_id,
+        chatId: chat_id,
+        userId: user?.sender_id?.open_id,
+        wasPendingInteraction: resolved,
+      });
 
       await this.callbacks.emitMessage({
         messageId: `${message_id}-${action.value}`,
@@ -599,8 +606,13 @@ export class MessageHandler {
     try {
       // Try to handle via InteractionManager
       const handled = await this.interactionManager.handleAction(event, async (defaultEvent) => {
-        const buttonText = defaultEvent.action.text || defaultEvent.action.value;
-        const messageContent = `The user clicked '${buttonText}' button`;
+        // Use the new interaction prompt builder for better messages
+        const messageContent = buildInteractionPrompt({
+          action: defaultEvent.action,
+          messageId: defaultEvent.message_id,
+          chatId: defaultEvent.chat_id,
+          userId: defaultEvent.user?.sender_id?.open_id,
+        });
 
         await this.callbacks.emitMessage({
           messageId: `${defaultEvent.message_id}-${defaultEvent.action.value}`,

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -12,6 +12,8 @@ import {
   update_card,
   wait_for_interaction,
   setMessageSentCallback,
+  send_interactive_message,
+  SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
 } from './tools/index.js';
 
 // Re-export for backward compatibility
@@ -21,6 +23,10 @@ export { resolvePendingInteraction } from './tools/card-interaction.js';
 export { send_user_feedback } from './tools/send-message.js';
 export { send_file_to_feishu } from './tools/send-file.js';
 export { update_card, wait_for_interaction } from './tools/card-interaction.js';
+export {
+  send_interactive_message,
+  SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+} from './tools/interactive-message.js';
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };
@@ -83,7 +89,7 @@ export const feishuContextTools = {
     handler: send_file_to_feishu,
   },
   update_card: {
-    description: 'Update an existing interactive card message.',
+    description: '[DEPRECATED] Update an existing interactive card message. Use send_interactive_message instead.',
     parameters: {
       type: 'object',
       properties: { messageId: { type: 'string' }, card: { type: 'object' }, chatId: { type: 'string' } },
@@ -92,13 +98,27 @@ export const feishuContextTools = {
     handler: update_card,
   },
   wait_for_interaction: {
-    description: 'Wait for the user to interact with a card.',
+    description: '[DEPRECATED] Wait for the user to interact with a card. Interactions are now automatically converted to messages - no need to wait.',
     parameters: {
       type: 'object',
       properties: { messageId: { type: 'string' }, chatId: { type: 'string' }, timeoutSeconds: { type: 'number' } },
       required: ['messageId', 'chatId'],
     },
     handler: wait_for_interaction,
+  },
+  send_interactive_message: {
+    description: SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+    parameters: {
+      type: 'object',
+      properties: {
+        card: { type: 'object' },
+        chatId: { type: 'string' },
+        parentMessageId: { type: 'string' },
+        description: { type: 'string' },
+      },
+      required: ['card', 'chatId'],
+    },
+    handler: send_interactive_message,
   },
 };
 
@@ -179,7 +199,7 @@ When \`format: "card"\`, content MUST include:
   },
   {
     name: 'update_card',
-    description: 'Update an existing interactive card message.',
+    description: '[DEPRECATED] Update an existing interactive card message. Use send_interactive_message instead.',
     parameters: z.object({ messageId: z.string(), card: z.object({}).passthrough(), chatId: z.string() }),
     handler: async ({ messageId, card, chatId }) => {
       try {
@@ -192,7 +212,7 @@ When \`format: "card"\`, content MUST include:
   },
   {
     name: 'wait_for_interaction',
-    description: 'Wait for the user to interact with a card.',
+    description: '[DEPRECATED] Wait for the user to interact with a card. Interactions are now automatically converted to messages - no need to wait.',
     parameters: z.object({ messageId: z.string(), chatId: z.string(), timeoutSeconds: z.number().optional() }),
     handler: async ({ messageId, chatId, timeoutSeconds }) => {
       try {
@@ -202,6 +222,26 @@ When \`format: "card"\`, content MUST include:
           : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Wait failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'send_interactive_message',
+    description: SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+    parameters: z.object({
+      card: z.object({}).passthrough(),
+      chatId: z.string(),
+      parentMessageId: z.string().optional(),
+      description: z.string().optional(),
+    }),
+    handler: async ({ card, chatId, parentMessageId, description }) => {
+      try {
+        const result = await send_interactive_message({ card, chatId, parentMessageId, description });
+        return toolSuccess(result.success
+          ? `${result.message}${result.messageId ? `\nMessage ID: ${result.messageId}` : ''}`
+          : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Interactive message failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -8,8 +8,9 @@
  * Tools provided:
  * - send_user_feedback: Send a message to a Feishu chat
  * - send_file_to_feishu: Send a file to a Feishu chat
- * - update_card: Update an existing interactive card
- * - wait_for_interaction: Wait for user to interact with a card
+ * - update_card: Update an existing interactive card (deprecated, use send_interactive_message instead)
+ * - wait_for_interaction: Wait for user to interact with a card (deprecated)
+ * - send_interactive_message: Send an interactive card with buttons/menus (recommended)
  *
  * Environment Variables Required:
  * - FEISHU_APP_ID: Feishu app ID
@@ -21,7 +22,14 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction } from './feishu-context-mcp.js';
+import {
+  send_user_feedback,
+  send_file_to_feishu,
+  update_card,
+  wait_for_interaction,
+  send_interactive_message,
+  SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+} from './feishu-context-mcp.js';
 
 const logger = createLogger('FeishuMCPServer');
 
@@ -84,6 +92,32 @@ async function handleMessage(message: unknown) {
                     },
                   },
                   required: ['filePath', 'chatId'],
+                },
+              },
+              {
+                name: 'send_interactive_message',
+                description: SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    card: {
+                      type: 'object',
+                      description: 'The interactive card JSON structure (Feishu card format). Use this for cards with buttons, menus, or other interactive components.',
+                    },
+                    chatId: {
+                      type: 'string',
+                      description: 'Feishu chat ID to send the message to',
+                    },
+                    parentMessageId: {
+                      type: 'string',
+                      description: 'Optional parent message ID for thread replies',
+                    },
+                    description: {
+                      type: 'string',
+                      description: 'Optional description of what this card is for (for logging)',
+                    },
+                  },
+                  required: ['card', 'chatId'],
                 },
               },
               {
@@ -205,6 +239,29 @@ async function handleMessage(message: unknown) {
                 type: 'text',
                 text: result.success
                   ? `${result.message}\nAction: ${result.actionValue}\nType: ${result.actionType}\nUser: ${result.userId}`
+                  : `⚠️ ${result.message}`,
+              }],
+            },
+          };
+        }
+
+        if (name === 'send_interactive_message') {
+          const args = toolArgs as {
+            card: Record<string, unknown>;
+            chatId: string;
+            parentMessageId?: string;
+            description?: string;
+          };
+          const result = await send_interactive_message(args);
+
+          return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              content: [{
+                type: 'text',
+                text: result.success
+                  ? `${result.message}${result.messageId ? `\nMessage ID: ${result.messageId}` : ''}`
                   : `⚠️ ${result.message}`,
               }],
             },

--- a/src/mcp/tools/card-interaction.ts
+++ b/src/mcp/tools/card-interaction.ts
@@ -2,6 +2,17 @@
  * Card interaction tools: update_card and wait_for_interaction.
  *
  * @module mcp/tools/card-interaction
+ *
+ * @deprecated These tools are deprecated. Use send_interactive_message instead.
+ *
+ * Migration Guide:
+ * - update_card: Instead of updating cards, send new messages to reflect state changes
+ * - wait_for_interaction: No replacement needed - interactions are automatically converted to messages
+ *
+ * The new approach:
+ * 1. Use send_interactive_message to send interactive cards
+ * 2. User interactions are automatically converted to prompts
+ * 3. Process the prompts like regular messages
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -11,8 +11,14 @@ export type {
   WaitForInteractionResult,
   MessageSentCallback,
   PendingInteraction,
+  SendInteractiveResult,
 } from './types.js';
 
 export { send_user_feedback, setMessageSentCallback, getMessageSentCallback } from './send-message.js';
 export { send_file_to_feishu } from './send-file.js';
 export { update_card, wait_for_interaction, resolvePendingInteraction } from './card-interaction.js';
+export {
+  send_interactive_message,
+  setInteractiveMessageSentCallback,
+  SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION,
+} from './interactive-message.js';

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -1,0 +1,181 @@
+/**
+ * Interactive message tool: send_interactive_message.
+ *
+ * This tool is designed specifically for interactive cards with buttons, menus, etc.
+ * Unlike send_user_feedback (which handles both text and static cards),
+ * this tool focuses on interactive components and provides better guidance.
+ *
+ * @module mcp/tools/interactive-message
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { sendMessageToFeishu } from '../utils/feishu-api.js';
+import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
+import type { SendInteractiveResult, MessageSentCallback } from './types.js';
+
+const logger = createLogger('InteractiveMessage');
+
+let messageSentCallback: MessageSentCallback | null = null;
+
+export function setInteractiveMessageSentCallback(callback: MessageSentCallback | null): void {
+  messageSentCallback = callback;
+}
+
+function invokeMessageSentCallback(chatId: string): void {
+  if (messageSentCallback) {
+    try {
+      messageSentCallback(chatId);
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to invoke message sent callback');
+    }
+  }
+}
+
+/**
+ * Send an interactive card message to a Feishu chat.
+ *
+ * This tool is specifically designed for interactive cards with buttons, menus,
+ * input fields, and other interactive components. All user interactions will be
+ * automatically converted to messages that the agent can process.
+ *
+ * ## Interactive Component Events
+ *
+ * When users interact with the card, the system will automatically generate
+ * a message like:
+ * - Button click: "[用户操作] 用户点击了「按钮文本」按钮。请根据此操作继续执行任务。"
+ * - Menu selection: "[用户操作] 用户选择了「选项文本」。请根据此选择继续执行任务。"
+ * - Input submission: "[用户操作] 用户提交了输入：「输入内容」。请根据此输入继续执行任务。"
+ *
+ * ## Best Practices
+ *
+ * 1. Use clear, action-oriented button text (e.g., "确认删除" instead of "确认")
+ * 2. Include cancel/dismiss options for destructive actions
+ * 3. Limit interactive cards to 4-5 buttons for better UX
+ * 4. Use appropriate action values that your agent can understand
+ *
+ * @param params - The parameters for sending the interactive message
+ * @returns Result with messageId for potential future operations
+ */
+export async function send_interactive_message(params: {
+  /** The interactive card JSON structure (Feishu card format) */
+  card: Record<string, unknown>;
+  /** The Feishu chat ID to send the message to */
+  chatId: string;
+  /** Optional parent message ID for thread replies */
+  parentMessageId?: string;
+  /** Optional description of what this card is for (for logging) */
+  description?: string;
+}): Promise<SendInteractiveResult> {
+  const { card, chatId, parentMessageId, description } = params;
+
+  logger.info({
+    chatId,
+    parentMessageId,
+    description,
+    cardPreview: JSON.stringify(card).substring(0, 200),
+  }, 'send_interactive_message called');
+
+  try {
+    if (!card) {
+      throw new Error('card is required');
+    }
+    if (!chatId) {
+      throw new Error('chatId is required');
+    }
+
+    // Validate card structure
+    if (!isValidFeishuCard(card)) {
+      return {
+        success: false,
+        error: `Invalid Feishu card structure: ${getCardValidationError(card)}`,
+        message: `❌ Card validation failed. ${getCardValidationError(card)}`,
+      };
+    }
+
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+      return {
+        success: false,
+        error: errorMsg,
+        message: `❌ ${errorMsg}`,
+      };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    // Send the interactive card
+    const response = await sendMessageToFeishu(
+      client,
+      chatId,
+      'interactive',
+      JSON.stringify(card),
+      parentMessageId
+    );
+
+    // Extract messageId from response if available
+    const messageId = (response as { data?: { message_id?: string } })?.data?.message_id;
+
+    logger.debug({ chatId, parentMessageId, messageId }, 'Interactive message sent');
+
+    invokeMessageSentCallback(chatId);
+
+    return {
+      success: true,
+      message: '✅ Interactive message sent successfully',
+      messageId,
+    };
+
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'send_interactive_message FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ Failed to send interactive message: ${errorMessage}`,
+    };
+  }
+}
+
+/**
+ * Tool description for send_interactive_message.
+ * This is used when registering the tool with the MCP server.
+ */
+export const SEND_INTERACTIVE_MESSAGE_TOOL_DESCRIPTION = `Send an interactive card message with buttons, menus, or other interactive components.
+
+## When to Use This Tool
+
+Use this tool when you need to:
+- Present choices to the user (confirmation dialogs, selections)
+- Collect user input through form fields
+- Create actionable notifications
+
+## How Interactive Events Work
+
+**IMPORTANT**: You do NOT need to wait for or handle callbacks. When users interact with the card:
+1. The system captures the interaction event
+2. It automatically generates a descriptive message
+3. The message appears in the chat as if the user sent it
+4. You process it like any other message
+
+Example: If a user clicks a "确认" button, you'll receive:
+"[用户操作] 用户点击了「确认」按钮。请根据此操作继续执行任务。"
+
+## Card Structure
+
+The card parameter must follow Feishu's interactive card JSON format:
+- Use "config" for card-level settings
+- Use "elements" array for card content
+- Use "actions" in elements for interactive components
+
+## Best Practices
+
+1. Use clear, descriptive button text (e.g., "确认删除" not just "确认")
+2. Always include a cancel/dismiss option for important actions
+3. Keep button count reasonable (3-5 max for better UX)
+4. Use meaningful action values that describe the intent`;

--- a/src/mcp/tools/types.ts
+++ b/src/mcp/tools/types.ts
@@ -66,3 +66,14 @@ export interface PendingInteraction {
   reject: (error: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
 }
+
+/**
+ * Result type for send_interactive_message tool.
+ */
+export interface SendInteractiveResult {
+  success: boolean;
+  message: string;
+  /** The message ID of the sent card (for potential future operations) */
+  messageId?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

- 创建新的 `send_interactive_message` 工具，专门用于交互式卡片消息
- 实现交互事件到 prompt 的自动转换模块
- 标记 `wait_for_interaction` 和 `update_card` 为 deprecated

## Changes

### New Tool: send_interactive_message
- 专门用于发送交互式卡片（带按钮、菜单等）
- 提供详细的交互组件使用指南
- 返回 messageId 以便后续操作
- 无需处理回调 - 交互自动转换为 prompt

### Interaction Prompt Builder
- 创建 `interaction-prompt-builder.ts` 将卡片操作转换为 prompt
- 支持多种操作类型：按钮、选择、输入、日期/时间选择等
- 生成用户友好的中文提示
- 提供常见场景的模板（确认、选择、工作流）

### Deprecation
- `wait_for_interaction`: 不再需要等待，交互自动转换为消息
- `update_card`: 通过发送新消息来反映状态变化

## Technical Details
- 添加 `SendInteractiveResult` 类型
- 更新 `message-handler.ts` 使用新的 prompt builder
- 在 `feishu-mcp-server.ts` 和 `feishu-context-mcp.ts` 注册新工具

## Test Results
- ✅ 所有 1594 个测试通过
- ✅ 编译成功

## Benefits
1. **简化 Agent 逻辑**: 无需处理回调
2. **统一消息流**: 所有用户输入通过消息传递
3. **更好的 prompt 设计**: 精心设计的交互 prompt 格式
4. **降低出错率**: 消除异步等待带来的竞态条件

Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)