### PR TITLE
feat(metrics): add TTFR (Time to First Response) tracking (Issue #855)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -16,6 +16,7 @@ import type { WelcomeService } from '../platforms/feishu/welcome-service.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
 import { attachmentManager } from '../file-transfer/inbound/index.js';
+import { initTTFRTracker } from '../metrics/index.js';
 import { BaseChannel } from './base-channel.js';
 import {
   PassiveModeManager,
@@ -119,6 +120,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
   protected async doStart(): Promise<void> {
     // Initialize message logger
     await messageLogger.init();
+
+    // Initialize TTFR tracker (Issue #855)
+    initTTFRTracker();
 
     // Get bot info for mention detection
     await this.mentionDetector.fetchBotInfo(this.appId, this.appSecret);

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -19,6 +19,7 @@ import { resolvePendingInteraction } from '../../mcp/feishu-context-mcp.js';
 import { filteredMessageForwarder } from '../../feishu/filtered-message-forwarder.js';
 import type { FilterReason } from '../../config/types.js';
 import { stripLeadingMentions } from '../../utils/mention-parser.js';
+import { getTTFRTracker } from '../../metrics/index.js';
 import type {
   FeishuEventData,
   FeishuMessageEvent,
@@ -522,6 +523,10 @@ export class MessageHandler {
       threadId,
       metadata: chatHistoryContext ? { chatHistoryContext } : undefined,
     });
+
+    // Record user message for TTFR tracking (Issue #855)
+    const ttfrTracker = getTTFRTracker();
+    ttfrTracker.recordUserMessage(chat_id, message_id, create_time || Date.now());
   }
 
   /**

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -8,6 +8,7 @@ import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
 import { Config } from '../../config/index.js';
 import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getTTFRTracker } from '../../metrics/index.js';
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import type { SendFeedbackResult, MessageSentCallback } from './types.js';
@@ -103,6 +104,17 @@ export async function send_user_feedback(params: {
     }
 
     invokeMessageSentCallback(chatId);
+
+    // Record TTFR (Issue #855)
+    const ttfrTracker = getTTFRTracker();
+    const ttfrResult = ttfrTracker.recordFirstResponse(chatId);
+    if (ttfrResult) {
+      logger.debug(
+        { chatId, userMessageId: ttfrResult.userMessageId, ttfrMs: ttfrResult.ttfrMs },
+        'TTFR recorded'
+      );
+    }
+
     return { success: true, message: `✅ Feedback sent (format: ${format})` };
 
   } catch (error) {

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Metrics module.
+ *
+ * @module metrics
+ */
+
+export {
+  TTFRTracker,
+  getTTFRTracker,
+  initTTFRTracker,
+  getTTFRRating,
+  TTFR_RATINGS,
+  type TTFRRecord,
+  type TTFRStats,
+} from './ttfr-tracker.js';

--- a/src/metrics/ttfr-tracker.test.ts
+++ b/src/metrics/ttfr-tracker.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for TTFR Tracker.
+ *
+ * @module metrics/ttfr-tracker.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  TTFRTracker,
+  getTTFRTracker,
+  getTTFRRating,
+  TTFR_RATINGS,
+} from './ttfr-tracker.js';
+
+// Mock fs module
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(() => '[]'),
+  writeFileSync: vi.fn(),
+}));
+
+describe('TTFRTracker', () => {
+  let tracker: TTFRTracker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = new TTFRTracker('/tmp/test-ttfr');
+  });
+
+  afterEach(() => {
+    tracker.clear();
+  });
+
+  describe('recordUserMessage', () => {
+    it('should record a user message', () => {
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      expect(tracker.getPendingCount()).toBe(1);
+    });
+
+    it('should record multiple user messages', () => {
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      tracker.recordUserMessage('chat1', 'msg2', 2000);
+      tracker.recordUserMessage('chat2', 'msg3', 3000);
+      expect(tracker.getPendingCount()).toBe(3);
+    });
+  });
+
+  describe('recordFirstResponse', () => {
+    it('should calculate TTFR when response is recorded', async () => {
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+
+      // Mock Date.now to return a fixed time
+      const originalDateNow = Date.now;
+      Date.now = () => 3000;
+
+      const result = await tracker.recordFirstResponse('chat1');
+
+      Date.now = originalDateNow;
+
+      expect(result).toBeDefined();
+      expect(result?.ttfrMs).toBe(2000);
+      expect(result?.userMessageId).toBe('msg1');
+    });
+
+    it('should remove pending message after response', async () => {
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      await tracker.recordFirstResponse('chat1');
+      expect(tracker.getPendingCount()).toBe(0);
+    });
+
+    it('should return undefined when no pending message', async () => {
+      const result = await tracker.recordFirstResponse('unknown-chat');
+      expect(result).toBeUndefined();
+    });
+
+    it('should use the most recent pending message', async () => {
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      tracker.recordUserMessage('chat1', 'msg2', 2000);
+
+      const originalDateNow = Date.now;
+      Date.now = () => 5000;
+
+      const result = await tracker.recordFirstResponse('chat1');
+
+      Date.now = originalDateNow;
+
+      expect(result?.userMessageId).toBe('msg2');
+      expect(result?.ttfrMs).toBe(3000);
+    });
+  });
+
+  describe('getRecords', () => {
+    it('should return empty array initially', async () => {
+      await tracker.init();
+      expect(tracker.getRecords()).toHaveLength(0);
+    });
+
+    it('should return recorded TTFR records', async () => {
+      await tracker.init();
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+
+      const originalDateNow = Date.now;
+      Date.now = () => 3000;
+      await tracker.recordFirstResponse('chat1');
+      Date.now = originalDateNow;
+
+      const records = tracker.getRecords();
+      expect(records).toHaveLength(1);
+      expect(records[0].chatId).toBe('chat1');
+      expect(records[0].ttfrMs).toBe(2000);
+    });
+  });
+
+  describe('getRecordsFiltered', () => {
+    beforeEach(async () => {
+      await tracker.init();
+      tracker.clear();
+
+      // Add some test records
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      const originalDateNow = Date.now;
+      Date.now = () => 3000;
+      await tracker.recordFirstResponse('chat1');
+      Date.now = originalDateNow;
+
+      tracker.recordUserMessage('chat2', 'msg2', 5000);
+      Date.now = () => 7000;
+      await tracker.recordFirstResponse('chat2');
+      Date.now = originalDateNow;
+    });
+
+    it('should filter by chatId', () => {
+      const records = tracker.getRecordsFiltered({ chatId: 'chat1' });
+      expect(records).toHaveLength(1);
+      expect(records[0].chatId).toBe('chat1');
+    });
+
+    it('should filter by startTime', () => {
+      const records = tracker.getRecordsFiltered({ startTime: 4000 });
+      expect(records).toHaveLength(1);
+      expect(records[0].chatId).toBe('chat2');
+    });
+
+    it('should filter by endTime', () => {
+      const records = tracker.getRecordsFiltered({ endTime: 2000 });
+      expect(records).toHaveLength(1);
+      expect(records[0].chatId).toBe('chat1');
+    });
+
+    it('should limit results', () => {
+      const records = tracker.getRecordsFiltered({ limit: 1 });
+      expect(records).toHaveLength(1);
+    });
+  });
+
+  describe('calculateStats', () => {
+    it('should return null for empty records', () => {
+      const stats = tracker.calculateStats([]);
+      expect(stats).toBeNull();
+    });
+
+    it('should calculate correct statistics', async () => {
+      await tracker.init();
+      tracker.clear();
+
+      // Create records with known TTFR values
+      const baseTime = 10000;
+      const ttfrs = [1000, 2000, 3000, 4000, 5000];
+
+      for (let i = 0; i < ttfrs.length; i++) {
+        tracker.recordUserMessage('chat1', `msg${i}`, baseTime + i * 10000);
+        const originalDateNow = Date.now;
+        Date.now = () => baseTime + i * 10000 + ttfrs[i];
+        await tracker.recordFirstResponse('chat1');
+        Date.now = originalDateNow;
+      }
+
+      const records = tracker.getRecords();
+      const stats = tracker.calculateStats(records);
+
+      expect(stats).not.toBeNull();
+      expect(stats!.count).toBe(5);
+      expect(stats!.minMs).toBe(1000);
+      expect(stats!.maxMs).toBe(5000);
+      expect(stats!.avgMs).toBe(3000);
+      expect(stats!.p50Ms).toBe(3000);
+    });
+  });
+
+  describe('getStatsForChat', () => {
+    it('should return stats for specific chat', async () => {
+      await tracker.init();
+      tracker.clear();
+
+      tracker.recordUserMessage('chat1', 'msg1', 1000);
+      const originalDateNow = Date.now;
+      Date.now = () => 3000;
+      await tracker.recordFirstResponse('chat1');
+      Date.now = originalDateNow;
+
+      const stats = tracker.getStatsForChat('chat1');
+      expect(stats).not.toBeNull();
+      expect(stats!.count).toBe(1);
+    });
+
+    it('should return null for unknown chat', () => {
+      const stats = tracker.getStatsForChat('unknown-chat');
+      expect(stats).toBeNull();
+    });
+  });
+});
+
+describe('getTTFRRating', () => {
+  it('should return EXCELLENT for < 3s', () => {
+    const rating = getTTFRRating(2000);
+    expect(rating.level).toBe('EXCELLENT');
+    expect(rating.emoji).toBe('🟢');
+  });
+
+  it('should return GOOD for 3-5s', () => {
+    const rating = getTTFRRating(4000);
+    expect(rating.level).toBe('GOOD');
+    expect(rating.emoji).toBe('🟡');
+  });
+
+  it('should return PASS for 5-10s', () => {
+    const rating = getTTFRRating(7000);
+    expect(rating.level).toBe('PASS');
+    expect(rating.emoji).toBe('🟠');
+  });
+
+  it('should return NEEDS_IMPROVEMENT for > 10s', () => {
+    const rating = getTTFRRating(15000);
+    expect(rating.level).toBe('NEEDS_IMPROVEMENT');
+    expect(rating.emoji).toBe('🔴');
+  });
+});
+
+describe('TTFR_RATINGS', () => {
+  it('should have correct thresholds', () => {
+    expect(TTFR_RATINGS.EXCELLENT.maxMs).toBe(3000);
+    expect(TTFR_RATINGS.GOOD.maxMs).toBe(5000);
+    expect(TTFR_RATINGS.PASS.maxMs).toBe(10000);
+    expect(TTFR_RATINGS.NEEDS_IMPROVEMENT.maxMs).toBe(Infinity);
+  });
+});
+
+describe('getTTFRTracker singleton', () => {
+  it('should return the same instance', () => {
+    const instance1 = getTTFRTracker();
+    const instance2 = getTTFRTracker();
+    expect(instance1).toBe(instance2);
+  });
+});

--- a/src/metrics/ttfr-tracker.ts
+++ b/src/metrics/ttfr-tracker.ts
@@ -1,0 +1,374 @@
+/**
+ * TTFR (Time to First Response) Tracker.
+ *
+ * Tracks the time from user message receipt to agent's first response.
+ * Implements Issue #855.
+ *
+ * @module metrics/ttfr-tracker
+ */
+
+import { createLogger } from '../utils/logger.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const logger = createLogger('TTFRTracker');
+
+/**
+ * Single TTFR record.
+ */
+export interface TTFRRecord {
+  /** Chat ID */
+  chatId: string;
+  /** User message ID */
+  userMessageId: string;
+  /** User message timestamp (ms) */
+  userMessageTime: number;
+  /** First response timestamp (ms) */
+  firstResponseTime: number;
+  /** TTFR in milliseconds */
+  ttfrMs: number;
+  /** Model used for response (optional) */
+  model?: string;
+  /** Record creation time */
+  createdAt: string;
+}
+
+/**
+ * TTFR statistics for a period.
+ */
+export interface TTFRStats {
+  /** Total records count */
+  count: number;
+  /** Average TTFR in ms */
+  avgMs: number;
+  /** Minimum TTFR in ms */
+  minMs: number;
+  /** Maximum TTFR in ms */
+  maxMs: number;
+  /** P50 (median) TTFR in ms */
+  p50Ms: number;
+  /** P90 TTFR in ms */
+  p90Ms: number;
+  /** P99 TTFR in ms */
+  p99Ms: number;
+  /** Time period */
+  period: {
+    start: string;
+    end: string;
+  };
+}
+
+/**
+ * Pending user message awaiting response.
+ */
+interface PendingMessage {
+  chatId: string;
+  messageId: string;
+  timestamp: number;
+}
+
+/**
+ * TTFR rating levels.
+ */
+export const TTFR_RATINGS = {
+  EXCELLENT: { maxMs: 3000, label: '优秀', emoji: '🟢' },
+  GOOD: { maxMs: 5000, label: '良好', emoji: '🟡' },
+  PASS: { maxMs: 10000, label: '及格', emoji: '🟠' },
+  NEEDS_IMPROVEMENT: { maxMs: Infinity, label: '需改进', emoji: '🔴' },
+} as const;
+
+/**
+ * Get TTFR rating for a given value.
+ */
+export function getTTFRRating(ttfrMs: number): { label: string; emoji: string; level: string } {
+  if (ttfrMs < TTFR_RATINGS.EXCELLENT.maxMs) {
+    return { ...TTFR_RATINGS.EXCELLENT, level: 'EXCELLENT' };
+  }
+  if (ttfrMs < TTFR_RATINGS.GOOD.maxMs) {
+    return { ...TTFR_RATINGS.GOOD, level: 'GOOD' };
+  }
+  if (ttfrMs < TTFR_RATINGS.PASS.maxMs) {
+    return { ...TTFR_RATINGS.PASS, level: 'PASS' };
+  }
+  return { ...TTFR_RATINGS.NEEDS_IMPROVEMENT, level: 'NEEDS_IMPROVEMENT' };
+}
+
+/**
+ * TTFR Tracker class.
+ *
+ * Tracks time-to-first-response metrics for user messages.
+ */
+export class TTFRTracker {
+  private dataDir: string;
+  private recordsFile: string;
+  private pendingMessages: Map<string, PendingMessage> = new Map();
+  private records: TTFRRecord[] = [];
+  private initialized = false;
+  private maxRecords = 10000; // Keep last 10k records in memory
+
+  constructor(dataDir?: string) {
+    this.dataDir = dataDir || path.join(process.cwd(), 'workspace', 'metrics');
+    this.recordsFile = path.join(this.dataDir, 'ttfr-records.json');
+  }
+
+  /**
+   * Initialize the tracker (load existing records).
+   */
+  init(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    try {
+      // Ensure directory exists
+      if (!fs.existsSync(this.dataDir)) {
+        fs.mkdirSync(this.dataDir, { recursive: true });
+      }
+
+      // Load existing records
+      if (fs.existsSync(this.recordsFile)) {
+        const data = fs.readFileSync(this.recordsFile, 'utf-8');
+        this.records = JSON.parse(data);
+        logger.info({ count: this.records.length }, 'Loaded TTFR records');
+      }
+
+      this.initialized = true;
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to initialize TTFR tracker');
+      this.records = [];
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Record a user message (start of TTFR measurement).
+   */
+  recordUserMessage(chatId: string, messageId: string, timestamp?: number): void {
+    const ts = timestamp || Date.now();
+    const key = `${chatId}:${messageId}`;
+
+    this.pendingMessages.set(key, {
+      chatId,
+      messageId,
+      timestamp: ts,
+    });
+
+    logger.debug({ chatId, messageId, timestamp: ts }, 'Recorded user message for TTFR tracking');
+  }
+
+  /**
+   * Record agent's first response (end of TTFR measurement).
+   * Returns the TTFR value if a pending message was found, undefined otherwise.
+   */
+  recordFirstResponse(
+    chatId: string,
+    model?: string
+  ): { ttfrMs: number; userMessageId: string } | undefined {
+    // Find the most recent pending message for this chat
+    let latestPending: PendingMessage | undefined;
+    let latestKey: string | undefined;
+
+    for (const [key, pending] of this.pendingMessages) {
+      if (pending.chatId === chatId) {
+        if (!latestPending || pending.timestamp > latestPending.timestamp) {
+          latestPending = pending;
+          latestKey = key;
+        }
+      }
+    }
+
+    if (!latestPending || !latestKey) {
+      logger.debug({ chatId }, 'No pending user message found for TTFR calculation');
+      return undefined;
+    }
+
+    const responseTime = Date.now();
+    const ttfrMs = responseTime - latestPending.timestamp;
+
+    // Create record
+    const record: TTFRRecord = {
+      chatId,
+      userMessageId: latestPending.messageId,
+      userMessageTime: latestPending.timestamp,
+      firstResponseTime: responseTime,
+      ttfrMs,
+      model,
+      createdAt: new Date().toISOString(),
+    };
+
+    // Remove from pending
+    this.pendingMessages.delete(latestKey);
+
+    // Add to records
+    this.addRecord(record);
+
+    const rating = getTTFRRating(ttfrMs);
+    logger.info(
+      {
+        chatId,
+        userMessageId: latestPending.messageId,
+        ttfrMs,
+        rating: rating.label,
+      },
+      'TTFR recorded'
+    );
+
+    return { ttfrMs, userMessageId: latestPending.messageId };
+  }
+
+  /**
+   * Add a record to storage.
+   */
+  private addRecord(record: TTFRRecord): void {
+    this.records.push(record);
+
+    // Trim to max records
+    if (this.records.length > this.maxRecords) {
+      this.records = this.records.slice(-this.maxRecords);
+    }
+
+    // Persist to file
+    this.persist();
+  }
+
+  /**
+   * Persist records to file.
+   */
+  private persist(): void {
+    try {
+      const data = JSON.stringify(this.records, null, 2);
+      fs.writeFileSync(this.recordsFile, data, 'utf-8');
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to persist TTFR records');
+    }
+  }
+
+  /**
+   * Get all records.
+   */
+  getRecords(): TTFRRecord[] {
+    return [...this.records];
+  }
+
+  /**
+   * Get records filtered by options.
+   */
+  getRecordsFiltered(options?: {
+    chatId?: string;
+    startTime?: number;
+    endTime?: number;
+    limit?: number;
+  }): TTFRRecord[] {
+    let filtered = [...this.records];
+
+    if (options?.chatId) {
+      filtered = filtered.filter((r) => r.chatId === options.chatId);
+    }
+
+    if (options?.startTime) {
+      filtered = filtered.filter((r) => r.userMessageTime >= options.startTime!);
+    }
+
+    if (options?.endTime) {
+      filtered = filtered.filter((r) => r.userMessageTime <= options.endTime!);
+    }
+
+    // Sort by time descending
+    filtered.sort((a, b) => b.userMessageTime - a.userMessageTime);
+
+    if (options?.limit) {
+      filtered = filtered.slice(0, options.limit);
+    }
+
+    return filtered;
+  }
+
+  /**
+   * Calculate statistics for a set of records.
+   */
+  calculateStats(records: TTFRRecord[]): TTFRStats | null {
+    if (records.length === 0) {
+      return null;
+    }
+
+    const ttfrValues = records.map((r) => r.ttfrMs).sort((a, b) => a - b);
+
+    const sum = ttfrValues.reduce((acc, val) => acc + val, 0);
+    const avgMs = sum / ttfrValues.length;
+    const [minMs] = ttfrValues;
+    const maxMs = ttfrValues.at(-1) as number;
+
+    // Percentiles
+    const p50Index = Math.floor(ttfrValues.length * 0.5);
+    const p90Index = Math.floor(ttfrValues.length * 0.9);
+    const p99Index = Math.floor(ttfrValues.length * 0.99);
+
+    const timestamps = records.map((r) => r.userMessageTime).sort((a, b) => a - b);
+
+    return {
+      count: records.length,
+      avgMs: Math.round(avgMs),
+      minMs,
+      maxMs,
+      p50Ms: ttfrValues[p50Index],
+      p90Ms: ttfrValues[p90Index],
+      p99Ms: ttfrValues[p99Index],
+      period: {
+        start: new Date(timestamps[0]).toISOString(),
+        end: new Date(timestamps[timestamps.length - 1]).toISOString(),
+      },
+    };
+  }
+
+  /**
+   * Get statistics for a chat.
+   */
+  getStatsForChat(chatId: string, startTime?: number, endTime?: number): TTFRStats | null {
+    const records = this.getRecordsFiltered({ chatId, startTime, endTime });
+    return this.calculateStats(records);
+  }
+
+  /**
+   * Get global statistics.
+   */
+  getGlobalStats(startTime?: number, endTime?: number): TTFRStats | null {
+    const records = this.getRecordsFiltered({ startTime, endTime });
+    return this.calculateStats(records);
+  }
+
+  /**
+   * Clear all records (for testing).
+   */
+  clear(): void {
+    this.records = [];
+    this.pendingMessages.clear();
+  }
+
+  /**
+   * Get count of pending messages (for testing/debugging).
+   */
+  getPendingCount(): number {
+    return this.pendingMessages.size;
+  }
+}
+
+// Singleton instance
+let trackerInstance: TTFRTracker | null = null;
+
+/**
+ * Get the singleton TTFR tracker instance.
+ */
+export function getTTFRTracker(): TTFRTracker {
+  if (!trackerInstance) {
+    trackerInstance = new TTFRTracker();
+  }
+  return trackerInstance;
+}
+
+/**
+ * Initialize the TTFR tracker.
+ */
+export function initTTFRTracker(): void {
+  const tracker = getTTFRTracker();
+  tracker.init();
+}

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -44,6 +44,8 @@ import {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  TtfrStatsCommand,
+  TtfrClearCommand,
 } from './commands/index.js';
 
 // Re-export all command classes for backward compatibility
@@ -68,6 +70,8 @@ export {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  TtfrStatsCommand,
+  TtfrClearCommand,
 };
 
 /**
@@ -101,4 +105,7 @@ export function registerDefaultCommands(
   registry.register(new TopicGroupCommand());
   // Issue #535: Expert registration and skill management
   registry.register(new ExpertCommand());
+  // Issue #855: TTFR statistics command
+  registry.register(new TtfrStatsCommand());
+  registry.register(new TtfrClearCommand());
 }

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -39,3 +39,6 @@ export { TopicGroupCommand } from './topic-group-command.js';
 
 // Expert commands (Issue #535)
 export { ExpertCommand } from './expert-commands.js';
+
+// Metrics commands (Issue #855)
+export { TtfrStatsCommand, TtfrClearCommand } from './metrics-commands.js';

--- a/src/nodes/commands/commands/metrics-commands.ts
+++ b/src/nodes/commands/commands/metrics-commands.ts
@@ -1,0 +1,112 @@
+/**
+ * Metrics Commands - TTFR and performance metrics.
+ *
+ * Provides commands for viewing TTFR (Time to First Response) statistics.
+ *
+ * Issue #855: 添加用户消息第一响应时间考核指标
+ */
+
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { getTTFRTracker, getTTFRRating } from '../../../metrics/index.js';
+
+/**
+ * TTFR Stats Command - View TTFR statistics.
+ */
+export class TtfrStatsCommand implements Command {
+  readonly name = 'ttfr';
+  readonly category = 'debug' as const;
+  readonly description = '查看响应时间统计';
+
+  execute(context: CommandContext): CommandResult {
+    const { args } = context;
+    const tracker = getTTFRTracker();
+
+    // Parse time range (default: last 24 hours)
+    const now = Date.now();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const startTime = now - dayMs;
+
+    // Get stats
+    const stats = tracker.getGlobalStats(startTime, now);
+
+    if (!stats || stats.count === 0) {
+      return {
+        success: true,
+        message: `📊 **TTFR 统计** (最近 24 小时)
+
+暂无数据
+
+使用提示：
+- 数据会在用户发送消息并收到 Agent 回复后自动记录
+- 支持查看不同时间段的统计`,
+      };
+    }
+
+    const avgRating = getTTFRRating(stats.avgMs);
+    const p50Rating = getTTFRRating(stats.p50Ms);
+    const p90Rating = getTTFRRating(stats.p90Ms);
+
+    const formatMs = (ms: number) => {
+      if (ms < 1000) {
+        return `${ms}ms`;
+      }
+      return `${(ms / 1000).toFixed(2)}s`;
+    };
+
+    // Check if user wants detailed view
+    const showDetails = args.length > 0 && args[0] === 'detail';
+
+    let message = `📊 **TTFR 统计** (最近 24 小时)
+
+| 指标 | 值 | 评级 |
+|------|-----|------|
+| 记录数 | ${stats.count} | - |
+| 平均响应 | ${formatMs(stats.avgMs)} | ${avgRating.emoji} ${avgRating.label} |
+| P50 (中位数) | ${formatMs(stats.p50Ms)} | ${p50Rating.emoji} ${p50Rating.label} |
+| P90 | ${formatMs(stats.p90Ms)} | ${p90Rating.emoji} ${p90Rating.label} |
+| 最快 | ${formatMs(stats.minMs)} | - |
+| 最慢 | ${formatMs(stats.maxMs)} | - |
+
+**评级标准**:
+🟢 优秀 < 3s | 🟡 良好 < 5s | 🟠 及格 < 10s | 🔴 需改进`;
+
+    if (showDetails) {
+      const recentRecords = tracker.getRecordsFiltered({ limit: 10 });
+      if (recentRecords.length > 0) {
+        message += `\n\n**最近 ${recentRecords.length} 条记录**:\n`;
+        for (const record of recentRecords) {
+          const rating = getTTFRRating(record.ttfrMs);
+          const time = new Date(record.userMessageTime).toLocaleString('zh-CN');
+          message += `\n- ${rating.emoji} ${formatMs(record.ttfrMs)} - ${time}`;
+        }
+      }
+      message += '\n\n💡 使用 `/ttfr` 查看简略统计';
+    } else {
+      message += '\n\n💡 使用 `/ttfr detail` 查看详细记录';
+    }
+
+    return {
+      success: true,
+      message,
+    };
+  }
+}
+
+/**
+ * TTFR Clear Command - Clear TTFR records.
+ */
+export class TtfrClearCommand implements Command {
+  readonly name = 'ttfr-clear';
+  readonly category = 'debug' as const;
+  readonly description = '清除 TTFR 统计数据';
+
+  execute(_context: CommandContext): CommandResult {
+    const tracker = getTTFRTracker();
+    tracker.clear();
+
+    return {
+      success: true,
+      message: '✅ **TTFR 数据已清除**\n\n所有统计数据已被重置',
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Implements Issue #855 - Adding user message first response time (TTFR) metrics.

- Add TTFR tracking module (`src/metrics/ttfr-tracker.ts`)
- Record user message timestamps on message receive
- Calculate TTFR when agent sends first response
- Store TTFR records in JSON file for persistence
- Add `/ttfr` command to view statistics
- Add `/ttfr-clear` command to reset data

## Changes

### New Files
| File | Description |
|------|-------------|
| `src/metrics/ttfr-tracker.ts` | TTFR tracking implementation |
| `src/metrics/ttfr-tracker.test.ts` | 22 test cases |
| `src/metrics/index.ts` | Module exports |
| `src/nodes/commands/commands/metrics-commands.ts` | `/ttfr` and `/ttfr-clear` commands |

### Modified Files
| File | Change |
|------|--------|
| `src/channels/feishu-channel.ts` | Initialize TTFR tracker |
| `src/channels/feishu/message-handler.ts` | Record user message timestamps |
| `src/mcp/tools/send-message.ts` | Calculate TTFR on first response |
| `src/nodes/commands/builtin-commands.ts` | Register TTFR commands |
| `src/nodes/commands/commands/index.ts` | Export TTFR commands |

## Features

### TTFR Rating Levels

| Level | TTFR | Label |
|-------|------|-------|
| 🟢 EXCELLENT | < 3s | 优秀 |
| 🟡 GOOD | < 5s | 良好 |
| 🟠 PASS | < 10s | 及格 |
| 🔴 NEEDS_IMPROVEMENT | >= 10s | 需改进 |

### Statistics Provided
- Record count
- Average, min, max TTFR
- P50, P90, P99 percentiles

## Usage

```
/ttfr         # View TTFR statistics for last 24 hours
/ttfr detail  # View detailed records
/ttfr-clear   # Clear all TTFR data
```

## Test Results

| Metric | Result |
|--------|--------|
| Tests | ✅ 22 passed |
| Lint | ✅ Passed |
| Build | ✅ Passed |

## Data Storage

TTFR records are stored in `workspace/metrics/ttfr-records.json` with a maximum of 10,000 records in memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)