### PR TITLE
refactor(next-step): use simple LLM prompt instead of SkillAgent (Issue #834)

### DIFF
--- a/src/nodes/next-step-recommendation.ts
+++ b/src/nodes/next-step-recommendation.ts
@@ -1,14 +1,17 @@
 /**
  * Next Step Recommendation Module for PrimaryNode.
  *
- * Extracted from primary-node.ts (Issue #695) to improve maintainability.
- * Handles post-task completion recommendations using SkillAgent.
+ * Issue #834: Refactored to use simple LLM prompt instead of SkillAgent.
  *
- * Issue #657: 任务完成后推荐下一步
- * Issue #716: SkillAgent 应该在执行后销毁，不要存储
+ * Design principles:
+ * - Uses simple LLM prompt to generate recommendations
+ * - Returns a string prompt containing candidates
+ * - The prompt is sent to ChatAgent as a regular message via callback
+ *
+ * @module nodes/next-step-recommendation
  */
 
-import { AgentFactory } from '../agents/index.js';
+import { generateNextStepPrompt } from './next-step-service.js';
 import { messageLogger } from '../feishu/message-logger.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -20,88 +23,82 @@ const logger = createLogger('NextStepRecommendation');
 export interface NextStepRecommendationDeps {
   /** Get chat history for a chat ID */
   getChatHistory: (chatId: string) => Promise<string | undefined>;
+  /** Send prompt to ChatAgent */
+  sendToAgent: (chatId: string, prompt: string, threadId?: string) => Promise<void>;
 }
 
 /**
  * Default dependencies using messageLogger.
  */
-const defaultDeps: NextStepRecommendationDeps = {
+const createDefaultDeps = (
+  sendToAgent: (chatId: string, prompt: string, threadId?: string) => Promise<void>
+): NextStepRecommendationDeps => ({
   getChatHistory: async (chatId: string) => {
     const history = await messageLogger.getChatHistory(chatId);
     return history && history.trim().length > 0 ? history : undefined;
   },
-};
+  sendToAgent,
+});
 
 /**
  * Trigger next-step recommendations after task completion.
- * Uses SkillAgent to analyze chat history and suggest follow-up actions.
  *
- * Issue #716: SkillAgent should be disposed after execution, not stored.
- * Context is limited to recent messages to avoid context overflow.
+ * Issue #834: Uses simple LLM prompt instead of SkillAgent.
+ * Generates recommendations and sends them to ChatAgent as a regular message.
  *
  * @param chatId - Chat ID to get history from
  * @param threadId - Optional thread ID for reply
+ * @param sendToAgent - Callback to send prompt to ChatAgent
  * @param deps - Optional dependencies for testing
  */
 export async function triggerNextStepRecommendation(
   chatId: string,
   threadId?: string,
-  deps: NextStepRecommendationDeps = defaultDeps
+  sendToAgent?: (chatId: string, prompt: string, threadId?: string) => Promise<void>,
+  deps?: NextStepRecommendationDeps
 ): Promise<void> {
-  let nextStepAgent: Awaited<ReturnType<typeof AgentFactory.createSkillAgent>> | undefined;
+  // Use provided deps or create default deps with sendToAgent callback
+  const dependencies = deps ?? (sendToAgent ? createDefaultDeps(sendToAgent) : undefined);
+
+  if (!dependencies) {
+    logger.warn({ chatId }, 'No sendToAgent callback provided, skipping next-step recommendations');
+    return;
+  }
 
   try {
     logger.info({ chatId }, 'Triggering next-step recommendations');
 
     // Get chat history for context
-    const chatHistory = await deps.getChatHistory(chatId);
+    const chatHistory = await dependencies.getChatHistory(chatId);
 
     if (!chatHistory) {
       logger.debug({ chatId }, 'No chat history available for recommendations');
       return;
     }
 
-    // Create SkillAgent for next-step recommendations using AgentFactory
-    nextStepAgent = await AgentFactory.createSkillAgent('next-step');
+    // Limit context to recent messages
+    const recentHistory = extractRecentMessages(chatHistory, 20);
 
-    // Limit context to recent messages (Issue #716)
-    // Only use the last 10 messages to avoid context overflow
-    const recentHistory = extractRecentMessages(chatHistory, 10);
+    // Generate next-step prompt using LLM
+    const nextStepPrompt = await generateNextStepPrompt(recentHistory);
 
-    // Build prompt with chat history
-    const prompt = `## Context
-
-**Chat ID for Feishu tools**: \`${chatId}\`
-${threadId ? `**Thread ID**: \`${threadId}\`` : ''}
-
-## Chat History (last 10 messages)
-
-${recentHistory}`;
-
-    // Execute skill and handle responses
-    for await (const message of nextStepAgent.execute(prompt)) {
-      if (message.type === 'tool_use' || message.metadata?.toolName) {
-        logger.debug({ toolName: message.metadata?.toolName }, 'Next-step skill using tool');
-      } else if ((message.type === 'text' || message.messageType === 'text') && message.content) {
-        logger.debug({ contentLength: typeof message.content === 'string' ? message.content.length : 0 }, 'Next-step skill output');
-      }
+    if (!nextStepPrompt || nextStepPrompt.trim().length === 0) {
+      logger.debug({ chatId }, 'No next-step recommendations generated');
+      return;
     }
 
-    logger.info({ chatId }, 'Next-step recommendations completed');
+    // Send the prompt to ChatAgent as a regular message
+    await dependencies.sendToAgent(chatId, nextStepPrompt, threadId);
+
+    logger.info({ chatId }, 'Next-step recommendations sent to ChatAgent');
   } catch (error) {
     logger.error({ err: error, chatId }, 'Failed to trigger next-step recommendations');
-  } finally {
-    // Issue #716: Dispose SkillAgent after execution (do not store)
-    if (nextStepAgent) {
-      nextStepAgent.dispose();
-      logger.debug({ chatId }, 'Next-step SkillAgent disposed');
-    }
   }
 }
 
 /**
  * Extract recent messages from chat history.
- * Limits context size for SkillAgent execution.
+ * Limits context size for LLM execution.
  *
  * @param chatHistory - Full chat history
  * @param count - Number of recent messages to extract (lines)

--- a/src/nodes/next-step-service.ts
+++ b/src/nodes/next-step-service.ts
@@ -1,0 +1,131 @@
+/**
+ * Next Step Service - Generates next-step recommendations using simple LLM prompt.
+ *
+ * Issue #834: Replaces SkillAgent-based approach with simple LLM prompt.
+ *
+ * Design principles:
+ * - Uses simple LLM prompt (not SkillAgent) to generate recommendations
+ * - Returns a string prompt containing candidates
+ * - The prompt is sent to ChatAgent as a regular message
+ *
+ * @module nodes/next-step-service
+ */
+
+import { getProvider } from '../sdk/index.js';
+import type { AgentQueryOptions } from '../sdk/types.js';
+import { Config } from '../config/index.js';
+import { buildSdkEnv } from '../utils/sdk.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('NextStepService');
+
+/**
+ * System prompt for next-step generation.
+ */
+const NEXT_STEP_SYSTEM_PROMPT = `你是一个智能助手，负责分析用户的对话历史并推荐下一步可能的操作。
+
+## 任务
+
+根据最近的对话历史，分析用户可能需要的下一步操作。
+
+## 输出格式
+
+请直接输出推荐的下一步操作，格式如下：
+
+---
+**建议的下一步操作：**
+
+1. [第一个建议] - [简要说明为什么这个建议相关]
+2. [第二个建议] - [简要说明为什么这个建议相关]
+3. [第三个建议] - [简要说明为什么这个建议相关]
+
+**注意事项：**
+- [任何需要用户注意的事项]
+---
+
+## 要求
+
+1. 建议 2-4 个相关的下一步操作
+2. 每个建议应该基于对话历史中的具体内容
+3. 如果对话中有未完成的任务，优先推荐完成这些任务
+4. 如果对话中有提到的问题，推荐解决方案
+5. 保持建议简洁、实用
+6. 如果对话历史太短或没有明确的上下文，可以输出"暂无明确建议"`;
+
+/**
+ * Generate next-step recommendations prompt using LLM.
+ *
+ * This function:
+ * 1. Takes chat history as input
+ * 2. Uses LLM to analyze the history and generate recommendations
+ * 3. Returns a string prompt containing the recommendations
+ *
+ * The returned string should be sent to ChatAgent as a regular message.
+ *
+ * @param chatHistory - Recent chat history
+ * @returns Promise<string> - A string containing next-step recommendations
+ */
+export async function generateNextStepPrompt(chatHistory: string): Promise<string> {
+  logger.debug({ historyLength: chatHistory.length }, 'Generating next-step prompt');
+
+  // Get SDK provider
+  const provider = getProvider();
+
+  // Build SDK options
+  const loggingConfig = Config.getLoggingConfig();
+  const agentConfig = Config.getAgentConfig();
+
+  const options: AgentQueryOptions = {
+    cwd: Config.getWorkspaceDir(),
+    permissionMode: 'bypassPermissions',
+    settingSources: ['project'],
+    env: buildSdkEnv(
+      agentConfig.apiKey,
+      agentConfig.apiBaseUrl,
+      Config.getGlobalEnv(),
+      loggingConfig.sdkDebug
+    ),
+    model: agentConfig.model,
+  };
+
+  // Build the combined prompt (system + user context)
+  const combinedPrompt = `${NEXT_STEP_SYSTEM_PROMPT}
+
+---
+
+## 最近对话历史
+
+${chatHistory}
+
+---
+
+请根据以上对话历史，分析并推荐用户可能需要的下一步操作。`;
+
+  // Execute LLM query
+  let result = '';
+
+  try {
+    const iterator = provider.queryOnce(combinedPrompt, options);
+
+    for await (const message of iterator) {
+      if (message.type === 'text') {
+        result += message.content || '';
+      }
+      // Stop at result type (query complete)
+      if (message.type === 'result') {
+        break;
+      }
+    }
+
+    logger.debug({ resultLength: result.length }, 'Next-step prompt generated');
+
+    // Return the recommendations as a string
+    return `## 💡 下一步建议
+
+${result}`;
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to generate next-step prompt');
+    // Return empty string on error (no recommendations)
+    return '';
+  }
+}

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -159,7 +159,17 @@ export class PrimaryNode extends EventEmitter {
     this.messageRouter = new UnifiedMessageRouter({
       sendFileToUser: this.sendFileToUser.bind(this),
       onTaskDone: async (chatId: string, threadId?: string) => {
-        await triggerNextStepRecommendation(chatId, threadId);
+        // Issue #834: Send next-step prompt to ChatAgent as regular message
+        await triggerNextStepRecommendation(
+          chatId,
+          threadId,
+          async (id: string, prompt: string, _tid?: string) => {
+            if (this.agentPool) {
+              const agent = this.agentPool.getOrCreateChatAgent(id);
+              agent.processMessage(id, prompt, `next-step-${Date.now()}`);
+            }
+          }
+        );
       },
       // Admin chat can be configured via environment or config
       adminChatId: process.env.ADMIN_CHAT_ID || config.adminChatId,


### PR DESCRIPTION
## Summary

- Replace SkillAgent-based next-step recommendations with simple LLM prompt
- Add `next-step-service.ts` for generating recommendations using direct LLM call
- Update `triggerNextStepRecommendation` to send generated prompt to ChatAgent as regular message
- Remove dependency on SkillAgent for next-step functionality

## Changes

### New Files
- `src/nodes/next-step-service.ts`: Service that generates next-step recommendations using simple LLM prompt

### Modified Files
- `src/nodes/next-step-recommendation.ts`: Refactored to use new service, added `sendToAgent` callback
- `src/nodes/primary-node.ts`: Updated to pass `sendToAgent` callback to `triggerNextStepRecommendation`

## Design Principles (based on PR feedback)

Based on feedback from previous PRs (#862, #863, #850, #848):

1. ✅ **Uses simple LLM prompt** - Not SkillAgent, not rule-based approach
2. ✅ **Returns string prompt** - The service returns a string containing recommendations
3. ✅ **Sends to ChatAgent as regular message** - No `promptNextSteps` method needed
4. ✅ **No backward compatibility** - Clean implementation without fallbacks

## Architecture

```
Task Complete
    │
    ▼
triggerNextStepRecommendation()
    │
    ├── Get chat history
    │
    ▼
generateNextStepPrompt() [next-step-service.ts]
    │
    ├── Build combined prompt (system + history)
    │
    ├── Call LLM via SDK Provider
    │
    ▼
Return string prompt
    │
    ▼
Send to ChatAgent via processMessage()
```

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] No new lint errors
- [x] All existing tests pass (1610 tests)

## Related

- Issue: #834
- Previous rejected PRs: #862, #863, #850, #848, #838, #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)