### PR TITLE
feat(schedule): add cooldown period for scheduled tasks (Issue #869)

### DIFF
--- a/src/nodes/command-services.ts
+++ b/src/nodes/command-services.ts
@@ -118,6 +118,8 @@ export function buildCommandServices(deps: CommandServicesDeps): CommandServices
     disableSchedule: (nameOrId: string) => scheduleManagement.disableSchedule(nameOrId),
     runSchedule: (nameOrId: string) => scheduleManagement.runSchedule(nameOrId),
     isScheduleRunning: (taskId: string) => scheduleManagement.isScheduleRunning(taskId),
+    getScheduleCooldownStatus: (taskId: string, cooldownPeriod?: number) => scheduleManagement.getScheduleCooldownStatus(taskId, cooldownPeriod),
+    clearScheduleCooldown: (taskId: string) => scheduleManagement.clearScheduleCooldown(taskId),
 
     // Task management
     startTask: (prompt: string, chatId: string, userId?: string) => taskStateManager.startTask(prompt, chatId, userId),

--- a/src/nodes/commands/commands/schedule-command.ts
+++ b/src/nodes/commands/commands/schedule-command.ts
@@ -3,6 +3,7 @@
  *
  * Issue #696: 拆分 builtin-commands.ts
  * Issue #469: 定时任务控制指令
+ * Issue #869: 冷静期支持
  *
  * Subcommands:
  * - list: List all scheduled tasks
@@ -10,6 +11,7 @@
  * - enable <name>: Enable a task
  * - disable <name>: Disable a task
  * - run <name>: Manually trigger a task
+ * - cooldown <name>: View/clear cooldown status
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -17,6 +19,7 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 /**
  * Schedule Command - Manage scheduled tasks.
  * Issue #469: 定时任务控制指令
+ * Issue #869: 冷静期支持
  *
  * Subcommands:
  * - list: List all scheduled tasks
@@ -24,12 +27,13 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
  * - enable <name>: Enable a task
  * - disable <name>: Disable a task
  * - run <name>: Manually trigger a task
+ * - cooldown <name> [clear]: View or clear cooldown status
  */
 export class ScheduleCommand implements Command {
   readonly name = 'schedule';
   readonly category = 'schedule' as const;
   readonly description = '定时任务管理';
-  readonly usage = 'schedule <list|status|enable|disable|run>';
+  readonly usage = 'schedule <list|status|enable|disable|run|cooldown>';
 
   async execute(context: CommandContext): Promise<CommandResult> {
     const subCommand = context.args[0]?.toLowerCase();
@@ -49,6 +53,7 @@ export class ScheduleCommand implements Command {
 - \`enable <名称>\` - 启用定时任务
 - \`disable <名称>\` - 禁用定时任务
 - \`run <名称>\` - 手动触发定时任务
+- \`cooldown <名称> [clear]\` - 查看/清除冷静期状态
 
 示例:
 \`\`\`
@@ -57,12 +62,14 @@ export class ScheduleCommand implements Command {
 /schedule enable daily-report
 /schedule disable daily-report
 /schedule run daily-report
+/schedule cooldown daily-report
+/schedule cooldown daily-report clear
 \`\`\``,
       };
     }
 
     // Validate subcommand
-    const validSubcommands = ['list', 'status', 'enable', 'disable', 'run'];
+    const validSubcommands = ['list', 'status', 'enable', 'disable', 'run', 'cooldown'];
     if (!validSubcommands.includes(subCommand)) {
       return {
         success: false,
@@ -96,6 +103,8 @@ export class ScheduleCommand implements Command {
         return await this.handleDisable(services, taskName);
       case 'run':
         return await this.handleRun(services, taskName);
+      case 'cooldown':
+        return await this.handleCooldown(services, taskName, context.args[2]?.toLowerCase() === 'clear');
       default:
         return { success: false, error: `未知子命令: ${subCommand}` };
     }
@@ -142,6 +151,21 @@ export class ScheduleCommand implements Command {
       ? `\n创建时间: ${new Date(task.createdAt).toLocaleString('zh-CN')}`
       : '';
 
+    // Issue #869: Add cooldown info
+    const cooldownText = task.cooldownPeriod
+      ? `\n冷静期: ${task.cooldownPeriod / 1000} 秒`
+      : '';
+
+    // Get cooldown status if configured
+    let cooldownStatusText = '';
+    if (task.cooldownPeriod) {
+      const cooldownStatus = await services.getScheduleCooldownStatus(task.id, task.cooldownPeriod);
+      if (cooldownStatus?.isInCooldown) {
+        const remainingMinutes = Math.ceil(cooldownStatus.remainingMs / 60000);
+        cooldownStatusText = `\n冷静期状态: 🔒 冷却中 (剩余 ${remainingMinutes} 分钟)`;
+      }
+    }
+
     return {
       success: true,
       message: `⏰ **任务详情**
@@ -149,7 +173,7 @@ export class ScheduleCommand implements Command {
 名称: **${task.name}**
 ID: \`${task.id}\`
 Cron: \`${task.cron}\`
-状态: ${statusText}${runningText}${createdText}
+状态: ${statusText}${runningText}${createdText}${cooldownText}${cooldownStatusText}
 目标聊天: \`${task.chatId}\``,
     };
   }
@@ -217,5 +241,64 @@ Cron: \`${task.cron}\`
       success: true,
       message: `🚀 **任务已触发**\n\n任务 \`${nameOrId}\` 已手动触发执行。`,
     };
+  }
+
+  private async handleCooldown(services: CommandContext['services'], nameOrId: string, clear: boolean): Promise<CommandResult> {
+    // First get the task to check if it exists
+    const task = await services.getSchedule(nameOrId);
+
+    if (!task) {
+      return {
+        success: false,
+        error: `未找到任务: \`${nameOrId}\``,
+      };
+    }
+
+    // Handle clear cooldown
+    if (clear) {
+      const success = await services.clearScheduleCooldown(task.id);
+      if (success) {
+        return {
+          success: true,
+          message: `✅ **冷静期已清除**\n\n任务 \`${task.name}\` 的冷静期已清除，可以立即执行。`,
+        };
+      } else {
+        return {
+          success: false,
+          error: `清除冷静期失败: \`${nameOrId}\`\n\n可能原因: 任务没有冷静期配置或冷静期管理器未初始化`,
+        };
+      }
+    }
+
+    // Get cooldown status
+    const status = await services.getScheduleCooldownStatus(task.id, task.cooldownPeriod);
+
+    if (!status) {
+      // Cooldown manager not available
+      if (task.cooldownPeriod) {
+        return {
+          success: true,
+          message: `⏰ **任务冷静期状态**\n\n任务: \`${task.name}\`\n冷静期配置: ${task.cooldownPeriod / 1000} 秒\n\n⚠️ 冷静期管理器未初始化`,
+        };
+      } else {
+        return {
+          success: true,
+          message: `⏰ **任务冷静期状态**\n\n任务: \`${task.name}\`\n冷静期: 未配置`,
+        };
+      }
+    }
+
+    if (status.isInCooldown) {
+      const remainingMinutes = Math.ceil(status.remainingMs / 60000);
+      return {
+        success: true,
+        message: `⏰ **任务冷静期状态**\n\n任务: \`${task.name}\`\n状态: 🔒 冷静期中\n上次执行: ${status.lastExecutionTime?.toLocaleString('zh-CN')}\n冷静期结束: ${status.cooldownEndsAt?.toLocaleString('zh-CN')}\n剩余时间: ${remainingMinutes} 分钟\n\n使用 \`/schedule cooldown ${nameOrId} clear\` 可清除冷静期`,
+      };
+    } else {
+      return {
+        success: true,
+        message: `⏰ **任务冷静期状态**\n\n任务: \`${task.name}\`\n状态: ✅ 可执行${status.lastExecutionTime ? `\n上次执行: ${status.lastExecutionTime.toLocaleString('zh-CN')}` : ''}${task.cooldownPeriod ? `\n冷静期配置: ${task.cooldownPeriod / 1000} 秒` : ''}`,
+      };
+    }
   }
 }

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -69,6 +69,14 @@ describe('ScheduleCommand', () => {
     disableSchedule: () => Promise.resolve(true),
     runSchedule: () => Promise.resolve(true),
     isScheduleRunning: () => false,
+    // Cooldown management (Issue #869)
+    getScheduleCooldownStatus: () => Promise.resolve({
+      isInCooldown: false,
+      lastExecutionTime: null,
+      cooldownEndsAt: null,
+      remainingMs: 0,
+    }),
+    clearScheduleCooldown: () => Promise.resolve(true),
     // Task management methods (Issue #468)
     startTask: () => Promise.resolve({ id: 'task_test', prompt: 'test', status: 'running', progress: 0, chatId: 'oc_test', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }),
     getCurrentTask: () => Promise.resolve(null),
@@ -110,7 +118,7 @@ describe('ScheduleCommand', () => {
     });
 
     it('should have usage', () => {
-      expect(command.usage).toBe('schedule <list|status|enable|disable|run>');
+      expect(command.usage).toBe('schedule <list|status|enable|disable|run|cooldown>');
     });
   });
 
@@ -125,6 +133,7 @@ describe('ScheduleCommand', () => {
       expect(result.message).toContain('enable');
       expect(result.message).toContain('disable');
       expect(result.message).toContain('run');
+      expect(result.message).toContain('cooldown');
     });
 
     it('should show error for invalid subcommand', async () => {

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -17,6 +17,7 @@ export type CommandCategory = 'session' | 'group' | 'debug' | 'node' | 'task' | 
 /**
  * Schedule task info for display.
  * Issue #469: 定时任务控制指令
+ * Issue #869: 冷静期支持
  */
 export interface ScheduleTaskInfo {
   /** Task ID */
@@ -35,6 +36,8 @@ export interface ScheduleTaskInfo {
   chatId: string;
   /** Creation timestamp */
   createdAt?: string;
+  /** Cooldown period in milliseconds (Issue #869) */
+  cooldownPeriod?: number;
 }
 
 /**
@@ -176,6 +179,17 @@ export interface CommandServices {
 
   /** Check if a schedule is currently running */
   isScheduleRunning: (taskId: string) => boolean;
+
+  /** Get cooldown status for a schedule (Issue #869) */
+  getScheduleCooldownStatus: (taskId: string, cooldownPeriod?: number) => Promise<{
+    isInCooldown: boolean;
+    lastExecutionTime: Date | null;
+    cooldownEndsAt: Date | null;
+    remainingMs: number;
+  } | null>;
+
+  /** Clear cooldown for a schedule (Issue #869) */
+  clearScheduleCooldown: (taskId: string) => Promise<boolean>;
 
   // Task management methods (Issue #468)
 

--- a/src/nodes/schedule-management.ts
+++ b/src/nodes/schedule-management.ts
@@ -64,6 +64,7 @@ export class ScheduleManagement {
         isRunning: scheduler?.isTaskRunning(task.id) ?? false,
         chatId: task.chatId,
         createdAt: task.createdAt,
+        cooldownPeriod: task.cooldownPeriod,
       };
     });
   }
@@ -173,5 +174,30 @@ export class ScheduleManagement {
    */
   isScheduleRunning(taskId: string): boolean {
     return this.deps.schedulerService?.getScheduler()?.isTaskRunning(taskId) ?? false;
+  }
+
+  /**
+   * Get cooldown status for a schedule.
+   * Issue #869: 冷静期支持
+   */
+  async getScheduleCooldownStatus(taskId: string, cooldownPeriod?: number): Promise<{
+    isInCooldown: boolean;
+    lastExecutionTime: Date | null;
+    cooldownEndsAt: Date | null;
+    remainingMs: number;
+  } | null> {
+    const scheduler = this.deps.schedulerService?.getScheduler();
+    if (!scheduler) { return null; }
+    return scheduler.getCooldownStatus(taskId, cooldownPeriod);
+  }
+
+  /**
+   * Clear cooldown for a schedule.
+   * Issue #869: 冷静期支持
+   */
+  async clearScheduleCooldown(taskId: string): Promise<boolean> {
+    const scheduler = this.deps.schedulerService?.getScheduler();
+    if (!scheduler) { return false; }
+    return scheduler.clearCooldown(taskId);
   }
 }

--- a/src/nodes/scheduler-service.ts
+++ b/src/nodes/scheduler-service.ts
@@ -24,6 +24,7 @@ import {
   ScheduleManager,
   Scheduler,
   ScheduleFileWatcher,
+  CooldownManager,
 } from '../schedule/index.js';
 import type { FeedbackMessage } from '../types/websocket-messages.js';
 
@@ -65,13 +66,16 @@ export class SchedulerService {
   private readonly callbacks: SchedulerCallbacks;
   private scheduler?: Scheduler;
   private scheduleFileWatcher?: ScheduleFileWatcher;
+  private cooldownManager?: CooldownManager;
   private schedulesDir: string;
+  private cooldownDir: string;
 
   constructor(config: SchedulerServiceConfig) {
     this.callbacks = config.callbacks;
 
     const workspaceDir = Config.getWorkspaceDir();
     this.schedulesDir = path.join(workspaceDir, 'schedules');
+    this.cooldownDir = path.join(this.schedulesDir, '.cooldown');
   }
 
   /**
@@ -80,10 +84,14 @@ export class SchedulerService {
   async start(): Promise<void> {
     const scheduleManager = new ScheduleManager({ schedulesDir: this.schedulesDir });
 
+    // Issue #869: Create CooldownManager for cooldown period support
+    this.cooldownManager = new CooldownManager({ cooldownDir: this.cooldownDir });
+
     // Issue #711: Scheduler now uses AgentFactory.createScheduleAgent
     // instead of AgentPool for short-lived agents
     this.scheduler = new Scheduler({
       scheduleManager,
+      cooldownManager: this.cooldownManager,
       callbacks: {
         // Directly route messages through PrimaryNode's handleFeedback
         // This ensures scheduled task messages are delivered even though

--- a/src/schedule/cooldown-manager.test.ts
+++ b/src/schedule/cooldown-manager.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for CooldownManager.
+ *
+ * Issue #869: Cooldown period for scheduled tasks.
+ */
+
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { CooldownManager } from './cooldown-manager.js';
+
+describe('CooldownManager', () => {
+  let tempDir: string;
+  let cooldownDir: string;
+  let manager: CooldownManager;
+
+  beforeEach(async () => {
+    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cooldown-test-'));
+    cooldownDir = path.join(tempDir, '.cooldown');
+    manager = new CooldownManager({ cooldownDir });
+  });
+
+  afterEach(async () => {
+    await fsPromises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('isInCooldown', () => {
+    it('should return false when no record exists', async () => {
+      const result = await manager.isInCooldown('task-1', 60000);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when cooldown has expired', async () => {
+      // Record execution with 1ms cooldown
+      await manager.recordExecution('task-1', 1);
+
+      // Wait for cooldown to expire
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const result = await manager.isInCooldown('task-1', 1);
+      expect(result).toBe(false);
+    });
+
+    it('should return true when in cooldown period', async () => {
+      // Record execution with 10 second cooldown
+      await manager.recordExecution('task-1', 10000);
+
+      const result = await manager.isInCooldown('task-1', 10000);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getCooldownStatus', () => {
+    it('should return null status when no record exists', async () => {
+      const status = await manager.getCooldownStatus('task-1');
+
+      expect(status.isInCooldown).toBe(false);
+      expect(status.lastExecutionTime).toBeNull();
+      expect(status.cooldownEndsAt).toBeNull();
+      expect(status.remainingMs).toBe(0);
+    });
+
+    it('should return status when record exists', async () => {
+      await manager.recordExecution('task-1', 60000);
+
+      const status = await manager.getCooldownStatus('task-1', 60000);
+
+      expect(status.isInCooldown).toBe(true);
+      expect(status.lastExecutionTime).not.toBeNull();
+      expect(status.cooldownEndsAt).not.toBeNull();
+      expect(status.remainingMs).toBeGreaterThan(0);
+      expect(status.remainingMs).toBeLessThanOrEqual(60000);
+    });
+
+    it('should show remaining time correctly', async () => {
+      const cooldownPeriod = 60000; // 1 minute
+      await manager.recordExecution('task-1', cooldownPeriod);
+
+      const status = await manager.getCooldownStatus('task-1', cooldownPeriod);
+
+      // Remaining time should be close to cooldown period
+      expect(status.remainingMs).toBeGreaterThan(50000);
+      expect(status.remainingMs).toBeLessThanOrEqual(60000);
+    });
+  });
+
+  describe('recordExecution', () => {
+    it('should record execution and create file', async () => {
+      await manager.recordExecution('task-1', 60000);
+
+      // Check file was created
+      const files = await fsPromises.readdir(cooldownDir);
+      expect(files.length).toBe(1);
+      expect(files[0]).toBe('task-1.json');
+    });
+
+    it('should update existing record', async () => {
+      await manager.recordExecution('task-1', 60000);
+      await new Promise(resolve => setTimeout(resolve, 100));
+      await manager.recordExecution('task-1', 30000);
+
+      const status = await manager.getCooldownStatus('task-1', 30000);
+
+      // Should use the new cooldown period
+      expect(status.remainingMs).toBeLessThanOrEqual(30000);
+    });
+  });
+
+  describe('clearCooldown', () => {
+    it('should return false when no record exists', async () => {
+      const result = await manager.clearCooldown('task-1');
+      expect(result).toBe(false);
+    });
+
+    it('should clear existing cooldown', async () => {
+      await manager.recordExecution('task-1', 60000);
+
+      const result = await manager.clearCooldown('task-1');
+      expect(result).toBe(true);
+
+      // Check file was deleted
+      const files = await fsPromises.readdir(cooldownDir);
+      expect(files.length).toBe(0);
+
+      // Check memory was cleared
+      const isInCooldown = await manager.isInCooldown('task-1', 60000);
+      expect(isInCooldown).toBe(false);
+    });
+  });
+
+  describe('getAllInCooldown', () => {
+    it('should return empty array when no tasks in cooldown', async () => {
+      const result = await manager.getAllInCooldown();
+      expect(result).toEqual([]);
+    });
+
+    it('should return all tasks in cooldown', async () => {
+      await manager.recordExecution('task-1', 60000);
+      await manager.recordExecution('task-2', 120000);
+
+      const result = await manager.getAllInCooldown();
+
+      expect(result.length).toBe(2);
+      expect(result.map(r => r.taskId).sort()).toEqual(['task-1', 'task-2']);
+    });
+
+    it('should not include expired cooldowns', async () => {
+      await manager.recordExecution('task-1', 1); // Expires immediately
+      await manager.recordExecution('task-2', 60000);
+
+      // Wait for task-1 to expire
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const result = await manager.getAllInCooldown();
+
+      expect(result.length).toBe(1);
+      expect(result[0].taskId).toBe('task-2');
+    });
+  });
+
+  describe('persistence', () => {
+    it('should load records from disk on initialization', async () => {
+      // Record with first manager
+      await manager.recordExecution('task-1', 60000);
+
+      // Create new manager (simulates restart)
+      const newManager = new CooldownManager({ cooldownDir });
+
+      // Should load the existing record
+      const isInCooldown = await newManager.isInCooldown('task-1', 60000);
+      expect(isInCooldown).toBe(true);
+    });
+
+    it('should not load expired records', async () => {
+      // Record with 1ms cooldown
+      await manager.recordExecution('task-1', 1);
+
+      // Wait for expiration
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Create new manager (simulates restart)
+      const newManager = new CooldownManager({ cooldownDir });
+
+      // Should not load expired record
+      const isInCooldown = await newManager.isInCooldown('task-1', 1);
+      expect(isInCooldown).toBe(false);
+    });
+  });
+});

--- a/src/schedule/cooldown-manager.ts
+++ b/src/schedule/cooldown-manager.ts
@@ -1,0 +1,296 @@
+/**
+ * CooldownManager - Manages cooldown periods for scheduled tasks.
+ *
+ * Issue #869: Prevents rapid re-execution of scheduled tasks.
+ *
+ * Features:
+ * - File-based persistence (survives restarts)
+ * - Memory + file dual storage for performance
+ * - Automatic cleanup of expired entries
+ *
+ * Storage location: workspace/schedules/.cooldown/{task-id}.json
+ */
+
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('CooldownManager');
+
+/**
+ * Cooldown record stored per task.
+ */
+interface CooldownRecord {
+  /** Task ID */
+  taskId: string;
+  /** Last execution timestamp (ISO string) */
+  lastExecutionTime: string;
+  /** Cooldown period in milliseconds */
+  cooldownPeriod: number;
+}
+
+/**
+ * CooldownManager options.
+ */
+export interface CooldownManagerOptions {
+  /** Directory for cooldown state files */
+  cooldownDir: string;
+}
+
+/**
+ * CooldownManager - Manages cooldown periods for scheduled tasks.
+ *
+ * Usage:
+ * ```typescript
+ * const manager = new CooldownManager({ cooldownDir: './workspace/schedules/.cooldown' });
+ *
+ * // Check if task is in cooldown
+ * if (manager.isInCooldown('task-id', 300000)) {
+ *   console.log('Task is cooling down');
+ * }
+ *
+ * // Record execution
+ * manager.recordExecution('task-id', 300000);
+ *
+ * // Clear cooldown
+ * manager.clearCooldown('task-id');
+ * ```
+ */
+export class CooldownManager {
+  private cooldownDir: string;
+  /** In-memory cache for fast lookups */
+  private cache: Map<string, CooldownRecord> = new Map();
+  /** Whether the manager has been initialized */
+  private initialized = false;
+
+  constructor(options: CooldownManagerOptions) {
+    this.cooldownDir = options.cooldownDir;
+    logger.info({ cooldownDir: this.cooldownDir }, 'CooldownManager initialized');
+  }
+
+  /**
+   * Ensure the cooldown directory exists and load existing records.
+   */
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) { return; }
+
+    try {
+      await fsPromises.mkdir(this.cooldownDir, { recursive: true });
+      await this.loadAllRecords();
+      this.initialized = true;
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to initialize CooldownManager');
+      // Continue without persistence on error
+      this.initialized = true;
+    }
+  }
+
+  /**
+   * Load all cooldown records from disk into memory.
+   */
+  private async loadAllRecords(): Promise<void> {
+    try {
+      const files = await fsPromises.readdir(this.cooldownDir);
+      const jsonFiles = files.filter(f => f.endsWith('.json'));
+
+      for (const file of jsonFiles) {
+        try {
+          const filePath = path.join(this.cooldownDir, file);
+          const content = await fsPromises.readFile(filePath, 'utf-8');
+          const record = JSON.parse(content) as CooldownRecord;
+
+          // Only load if not expired
+          if (!this.isRecordExpired(record)) {
+            this.cache.set(record.taskId, record);
+          } else {
+            // Clean up expired file
+            await fsPromises.unlink(filePath).catch(() => {});
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      }
+
+      logger.debug({ count: this.cache.size }, 'Loaded cooldown records');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.error({ err: error }, 'Error loading cooldown records');
+      }
+    }
+  }
+
+  /**
+   * Check if a cooldown record has expired.
+   */
+  private isRecordExpired(record: CooldownRecord): boolean {
+    const lastExecution = new Date(record.lastExecutionTime).getTime();
+    const cooldownEnd = lastExecution + record.cooldownPeriod;
+    return Date.now() > cooldownEnd;
+  }
+
+  /**
+   * Get the file path for a task's cooldown record.
+   */
+  private getFilePath(taskId: string): string {
+    // Sanitize task ID for filename
+    const safeId = taskId.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return path.join(this.cooldownDir, `${safeId}.json`);
+  }
+
+  /**
+   * Check if a task is currently in its cooldown period.
+   *
+   * @param taskId - Task ID to check
+   * @param cooldownPeriod - Cooldown period in milliseconds (optional, uses stored value if not provided)
+   * @returns true if the task is in cooldown, false otherwise
+   */
+  async isInCooldown(taskId: string, cooldownPeriod?: number): Promise<boolean> {
+    await this.ensureInitialized();
+
+    const record = this.cache.get(taskId);
+    if (!record) { return false; }
+
+    // Use provided cooldown period or stored one
+    const effectiveCooldown = cooldownPeriod ?? record.cooldownPeriod;
+    if (!effectiveCooldown) { return false; }
+
+    const lastExecution = new Date(record.lastExecutionTime).getTime();
+    const cooldownEnd = lastExecution + effectiveCooldown;
+    const now = Date.now();
+
+    return now < cooldownEnd;
+  }
+
+  /**
+   * Get cooldown status for a task.
+   *
+   * @param taskId - Task ID to check
+   * @param cooldownPeriod - Cooldown period in milliseconds
+   * @returns Cooldown status info or null if not in cooldown
+   */
+  async getCooldownStatus(taskId: string, cooldownPeriod?: number): Promise<{
+    isInCooldown: boolean;
+    lastExecutionTime: Date | null;
+    cooldownEndsAt: Date | null;
+    remainingMs: number;
+  }> {
+    await this.ensureInitialized();
+
+    const record = this.cache.get(taskId);
+
+    if (!record) {
+      return {
+        isInCooldown: false,
+        lastExecutionTime: null,
+        cooldownEndsAt: null,
+        remainingMs: 0,
+      };
+    }
+
+    const effectiveCooldown = cooldownPeriod ?? record.cooldownPeriod;
+    const lastExecution = new Date(record.lastExecutionTime);
+    const cooldownEndsAt = effectiveCooldown
+      ? new Date(lastExecution.getTime() + effectiveCooldown)
+      : null;
+
+    const remainingMs = cooldownEndsAt
+      ? Math.max(0, cooldownEndsAt.getTime() - Date.now())
+      : 0;
+
+    return {
+      isInCooldown: remainingMs > 0,
+      lastExecutionTime: lastExecution,
+      cooldownEndsAt,
+      remainingMs,
+    };
+  }
+
+  /**
+   * Record a task execution, starting its cooldown period.
+   *
+   * @param taskId - Task ID
+   * @param cooldownPeriod - Cooldown period in milliseconds
+   */
+  async recordExecution(taskId: string, cooldownPeriod: number): Promise<void> {
+    await this.ensureInitialized();
+
+    const record: CooldownRecord = {
+      taskId,
+      lastExecutionTime: new Date().toISOString(),
+      cooldownPeriod,
+    };
+
+    // Update memory cache
+    this.cache.set(taskId, record);
+
+    // Persist to file
+    try {
+      const filePath = this.getFilePath(taskId);
+      await fsPromises.writeFile(filePath, JSON.stringify(record, null, 2), 'utf-8');
+      logger.debug({ taskId, cooldownPeriod }, 'Recorded task execution');
+    } catch (error) {
+      logger.error({ err: error, taskId }, 'Failed to persist cooldown record');
+    }
+  }
+
+  /**
+   * Clear the cooldown for a task.
+   *
+   * @param taskId - Task ID to clear
+   */
+  async clearCooldown(taskId: string): Promise<boolean> {
+    await this.ensureInitialized();
+
+    // Remove from memory
+    const existed = this.cache.delete(taskId);
+
+    // Remove file
+    try {
+      const filePath = this.getFilePath(taskId);
+      await fsPromises.unlink(filePath);
+      logger.debug({ taskId }, 'Cleared cooldown');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        logger.error({ err: error, taskId }, 'Failed to clear cooldown file');
+      }
+    }
+
+    return existed;
+  }
+
+  /**
+   * Get all tasks currently in cooldown.
+   */
+  async getAllInCooldown(): Promise<Array<{
+    taskId: string;
+    lastExecutionTime: Date;
+    cooldownEndsAt: Date;
+    remainingMs: number;
+  }>> {
+    await this.ensureInitialized();
+
+    const result: Array<{
+      taskId: string;
+      lastExecutionTime: Date;
+      cooldownEndsAt: Date;
+      remainingMs: number;
+    }> = [];
+
+    for (const [taskId, record] of this.cache) {
+      const lastExecution = new Date(record.lastExecutionTime);
+      const cooldownEndsAt = new Date(lastExecution.getTime() + record.cooldownPeriod);
+      const remainingMs = Math.max(0, cooldownEndsAt.getTime() - Date.now());
+
+      if (remainingMs > 0) {
+        result.push({
+          taskId,
+          lastExecutionTime: lastExecution,
+          cooldownEndsAt,
+          remainingMs,
+        });
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/schedule/index.ts
+++ b/src/schedule/index.ts
@@ -6,6 +6,7 @@
  * - Scheduler: Cron-based task execution
  * - ScheduleFileScanner: Scans and parses schedule markdown files
  * - ScheduleFileWatcher: Hot reload for schedule files
+ * - CooldownManager: Manages cooldown periods for tasks
  *
  * Note: CRUD operations (create/update/delete) are handled via file system directly.
  * Users create schedule files manually, and ScheduleFileWatcher auto-loads them.
@@ -16,6 +17,7 @@
  * @see Issue #123 - Remove MCP dependency, use basic tools directly
  * @see Issue #354 - Remove unused lastExecutedAt maintenance
  * @see Issue #355 - Remove unused CRUD methods
+ * @see Issue #869 - Cooldown period for scheduled tasks
  */
 
 export { ScheduleManager, type ScheduledTask, type ScheduleManagerOptions } from './schedule-manager.js';
@@ -30,3 +32,4 @@ export {
   type OnFileRemoved,
   type ScheduleFileWatcherOptions,
 } from './schedule-watcher.js';
+export { CooldownManager, type CooldownManagerOptions } from './cooldown-manager.js';

--- a/src/schedule/schedule-manager.ts
+++ b/src/schedule/schedule-manager.ts
@@ -39,6 +39,8 @@ export interface ScheduledTask {
   enabled: boolean;
   /** Whether to block concurrent executions (skip if previous still running) */
   blocking?: boolean;
+  /** Cooldown period in milliseconds (prevents re-execution for this duration after execution) */
+  cooldownPeriod?: number;
   /** Creation timestamp */
   createdAt: string;
   /** Last execution timestamp (read from file, for display purposes only) */

--- a/src/schedule/schedule-watcher.ts
+++ b/src/schedule/schedule-watcher.ts
@@ -55,6 +55,7 @@ export interface ScheduleFileTask extends ScheduledTask {
  * - cron (required)
  * - enabled (optional, default: true)
  * - blocking (optional, default: true)
+ * - cooldownPeriod (optional, cooldown in milliseconds)
  * - chatId (required)
  * - createdBy (optional)
  * - createdAt (optional)
@@ -99,6 +100,10 @@ function parseScheduleFrontmatter(content: string): {
       case 'enabled':
       case 'blocking':
         frontmatter[key] = value === 'true';
+        break;
+      case 'cooldownPeriod':
+        // Parse as integer (milliseconds)
+        frontmatter[key] = parseInt(value, 10);
         break;
     }
   }
@@ -208,6 +213,7 @@ export class ScheduleFileScanner {
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
         blocking: (frontmatter['blocking'] as boolean) ?? true,
+        cooldownPeriod: frontmatter['cooldownPeriod'] as number | undefined,
         createdBy: frontmatter['createdBy'] as string | undefined,
         createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
         lastExecutedAt: frontmatter['lastExecutedAt'] as string | undefined,
@@ -249,6 +255,9 @@ export class ScheduleFileScanner {
       `chatId: ${task.chatId}`,
     ];
 
+    if (task.cooldownPeriod) {
+      frontmatter.push(`cooldownPeriod: ${task.cooldownPeriod}`);
+    }
     if (task.createdBy) {
       frontmatter.push(`createdBy: ${task.createdBy}`);
     }
@@ -520,6 +529,7 @@ export class ScheduleFileWatcher {
         prompt,
         enabled: (frontmatter['enabled'] as boolean) ?? true,
         blocking: (frontmatter['blocking'] as boolean) ?? true,
+        cooldownPeriod: frontmatter['cooldownPeriod'] as number | undefined,
         createdBy: frontmatter['createdBy'] as string | undefined,
         createdAt: (frontmatter['createdAt'] as string) || stats.birthtime.toISOString(),
         sourceFile: filePath,

--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -18,6 +18,7 @@
 import { CronJob } from 'cron';
 import { createLogger } from '../utils/logger.js';
 import { AgentFactory } from '../agents/index.js';
+import { CooldownManager } from './cooldown-manager.js';
 import type { ScheduleManager, ScheduledTask } from './schedule-manager.js';
 import type { PilotCallbacks } from '../agents/pilot/index.js';
 import type { ChatAgent } from '../agents/types.js';
@@ -38,12 +39,15 @@ interface ActiveJob {
  *
  * Issue #711: No longer requires AgentPool.
  * Uses AgentFactory.createScheduleAgent for short-lived agents.
+ * Issue #869: Added cooldownManager for cooldown period support.
  */
 export interface SchedulerOptions {
   /** ScheduleManager instance for task CRUD */
   scheduleManager: ScheduleManager;
   /** Callbacks for sending messages */
   callbacks: PilotCallbacks;
+  /** CooldownManager for cooldown period management */
+  cooldownManager?: CooldownManager;
 }
 
 /**
@@ -72,6 +76,7 @@ export interface SchedulerOptions {
 export class Scheduler {
   private scheduleManager: ScheduleManager;
   private callbacks: PilotCallbacks;
+  private cooldownManager?: CooldownManager;
   private activeJobs: Map<string, ActiveJob> = new Map();
   private running = false;
   /** Tracks tasks currently being executed (for blocking mechanism) */
@@ -80,6 +85,7 @@ export class Scheduler {
   constructor(options: SchedulerOptions) {
     this.scheduleManager = options.scheduleManager;
     this.callbacks = options.callbacks;
+    this.cooldownManager = options.cooldownManager;
     logger.info('Scheduler created');
   }
 
@@ -197,10 +203,35 @@ ${task.prompt}`;
    *
    * Issue #711: Creates a short-lived ScheduleAgent for each execution.
    * Agent is disposed after execution to free resources.
+   * Issue #869: Added cooldown period check before execution.
    *
    * @param task - Task to execute
    */
   private async executeTask(task: ScheduledTask): Promise<void> {
+    // Issue #869: Check cooldown period first
+    if (task.cooldownPeriod && this.cooldownManager) {
+      const isInCooldown = await this.cooldownManager.isInCooldown(task.id, task.cooldownPeriod);
+      if (isInCooldown) {
+        const status = await this.cooldownManager.getCooldownStatus(task.id, task.cooldownPeriod);
+        const remainingMinutes = Math.ceil(status.remainingMs / 60000);
+
+        logger.info(
+          { taskId: task.id, name: task.name, remainingMinutes },
+          'Task skipped - in cooldown period'
+        );
+
+        // Send cooldown notification
+        await this.callbacks.sendMessage(
+          task.chatId,
+          `⏰ 定时任务「${task.name}」冷静期中，跳过执行\n` +
+          `   上次执行: ${status.lastExecutionTime?.toLocaleString('zh-CN')}\n` +
+          `   冷静期结束: ${status.cooldownEndsAt?.toLocaleString('zh-CN')}\n` +
+          `   剩余时间: ${remainingMinutes} 分钟`
+        );
+        return;
+      }
+    }
+
     // Check blocking mechanism
     if (task.blocking && this.runningTasks.has(task.id)) {
       logger.info(
@@ -255,6 +286,12 @@ ${task.prompt}`;
     } finally {
       // Always remove from running tasks
       this.runningTasks.delete(task.id);
+
+      // Issue #869: Record execution for cooldown period
+      if (task.cooldownPeriod && this.cooldownManager) {
+        await this.cooldownManager.recordExecution(task.id, task.cooldownPeriod);
+        logger.debug({ taskId: task.id, cooldownPeriod: task.cooldownPeriod }, 'Recorded task execution for cooldown');
+      }
 
       // Issue #711: Always dispose the agent after execution
       if (agent) {
@@ -319,5 +356,33 @@ ${task.prompt}`;
    */
   getRunningTaskIds(): string[] {
     return Array.from(this.runningTasks);
+  }
+
+  /**
+   * Get cooldown status for a task.
+   *
+   * @param taskId - Task ID to check
+   * @param cooldownPeriod - Cooldown period in milliseconds
+   * @returns Cooldown status or null if not applicable
+   */
+  async getCooldownStatus(taskId: string, cooldownPeriod?: number): Promise<{
+    isInCooldown: boolean;
+    lastExecutionTime: Date | null;
+    cooldownEndsAt: Date | null;
+    remainingMs: number;
+  } | null> {
+    if (!this.cooldownManager) { return null; }
+    return this.cooldownManager.getCooldownStatus(taskId, cooldownPeriod);
+  }
+
+  /**
+   * Clear cooldown for a task (for debugging).
+   *
+   * @param taskId - Task ID to clear cooldown for
+   * @returns true if cooldown was cleared, false otherwise
+   */
+  async clearCooldown(taskId: string): Promise<boolean> {
+    if (!this.cooldownManager) { return false; }
+    return this.cooldownManager.clearCooldown(taskId);
   }
 }


### PR DESCRIPTION
## Summary

Implements a cooldown period mechanism to prevent rapid re-execution of scheduled tasks.

### Background
In the 2026-03-06 scheduled task execution, PR #859 and #860 were created within 36 seconds for the same Issue #855:
- 05:40:24: PR #859 created
- 05:41:00: Second scheduled task started (only 36 seconds later)
- 05:50:30: PR #860 created (duplicate)

**Root Cause**: Short execution intervals + GitHub API caching delays meant the second task couldn't detect the just-created PR.

### Solution
A cooldown period mechanism that prevents re-execution for a configurable duration after each task execution.

## Changes

### New Module: CooldownManager
- File path: `src/schedule/cooldown-manager.ts`
- Track last execution time per task
- File-based persistence (survives restarts)
- Memory + file dual storage for performance
- Automatic cleanup of expired entries

### Modified Files

| File | Change |
|------|--------|
| `schedule-manager.ts` | Add `cooldownPeriod` to `ScheduledTask` interface |
| `schedule-watcher.ts` | Parse and write `cooldownPeriod` in frontmatter |
| `scheduler.ts` | Check cooldown before execution, record after completion |
| `scheduler-service.ts` | Initialize `CooldownManager` |
| `schedule-command.ts` | Add `cooldown` subcommand |
| `types.ts` | Add cooldown service methods to `CommandServices` |
| `schedule-management.ts` | Implement cooldown management methods |
| `command-services.ts` | Wire up cooldown methods |

## Usage

### Configuration
Add `cooldownPeriod` (milliseconds) to schedule file frontmatter:

```yaml
---
name: "Daily Task"
cron: "0 9 * * *"
cooldownPeriod: 300000  # 5 minutes
chatId: oc_xxx
---

Task prompt here...
```

### Commands
```bash
/schedule cooldown <name>       # View cooldown status
/schedule cooldown <name> clear # Clear cooldown (for debugging)
```

### Example Output
```
⏰ 定时任务「XXX」冷静期中，跳过执行
   上次执行: 2026-03-06T05:40:24Z
   冷静期结束: 2026-03-06T05:45:24Z
   剩余时间: 3分钟
```

## Test Results
- ✅ 15 new unit tests for CooldownManager
- ✅ 24 tests pass for ScheduleCommand
- ✅ Build successful
- ✅ Type check passes

## Acceptance Criteria

- [x] Support configurable cooldown period (in milliseconds)
- [x] Skip task execution during cooldown and log the skip
- [x] Support viewing cooldown status
- [x] Cooldown state persists across service restarts
- [x] Provide command to clear cooldown (for debugging)

Fixes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)