### PR TITLE
feat(topic-group): add post API and batch management for topic groups (Issue #873)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -13,6 +13,10 @@ import {
   wait_for_interaction,
   send_interactive_message,
   setMessageSentCallback,
+  create_post,
+  reply_post,
+  get_posts,
+  get_post,
 } from './tools/index.js';
 
 // Re-export for backward compatibility
@@ -327,6 +331,177 @@ In actionPrompts, you can use these placeholders:
       required: ['card', 'actionPrompts', 'chatId'],
     },
     handler: send_interactive_message,
+  },
+  create_post: {
+    description: `Create a post in a topic group (BBS mode).
+
+In topic groups, a "post" is a root message that starts a new topic/thread.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "content": "Today's discussion topic: ..."}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **content**: Post content as text (required)
+
+---
+
+## Returns
+
+- **success**: Whether the post was created
+- **messageId**: The created post's message ID
+- **threadId**: The thread ID for replies
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/im-v1/message/create
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: {
+      type: 'object',
+      properties: {
+        chatId: { type: 'string' },
+        content: { type: 'string' },
+      },
+      required: ['chatId', 'content'],
+    },
+    handler: create_post,
+  },
+  reply_post: {
+    description: `Reply to a post in a topic group (BBS mode).
+
+Replies are added to the post's thread. Use the postId (root message ID) to reply.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "postId": "om_xxx", "content": "Great point! I think..."}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **postId**: The post (root message) ID to reply to (required)
+- **content**: Reply content as text (required)
+
+---
+
+## Returns
+
+- **success**: Whether the reply was posted
+- **messageId**: The reply's message ID
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/im-v1/message/reply
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: {
+      type: 'object',
+      properties: {
+        chatId: { type: 'string' },
+        postId: { type: 'string' },
+        content: { type: 'string' },
+      },
+      required: ['chatId', 'postId', 'content'],
+    },
+    handler: reply_post,
+  },
+  get_posts: {
+    description: `Get posts from a topic group (BBS mode).
+
+Retrieves root messages (posts) from the topic group.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "pageSize": 20}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **pageSize**: Maximum posts to return (default: 20, max: 50)
+- **pageToken**: Pagination token from previous response
+
+---
+
+## Returns
+
+- **posts**: Array of post info
+- **hasMore**: Whether more posts exist
+- **pageToken**: Token for next page
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/im-v1/message/list
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: {
+      type: 'object',
+      properties: {
+        chatId: { type: 'string' },
+        pageSize: { type: 'number' },
+        pageToken: { type: 'string' },
+      },
+      required: ['chatId'],
+    },
+    handler: get_posts,
+  },
+  get_post: {
+    description: `Get a specific post by message ID.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "postId": "om_xxx"}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **postId**: The post (message) ID (required)
+
+---
+
+## Returns
+
+- **post**: Post details including content, createTime, senderId
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/im-v1/message/get
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: {
+      type: 'object',
+      properties: {
+        chatId: { type: 'string' },
+        postId: { type: 'string' },
+      },
+      required: ['chatId', 'postId'],
+    },
+    handler: get_post,
   },
 };
 
@@ -656,6 +831,166 @@ In actionPrompts, you can use these placeholders:
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Interactive message failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'create_post',
+    description: `Create a post in a topic group (BBS mode).
+
+In topic groups, a "post" is a root message that starts a new topic/thread.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "content": "Today's discussion topic: ..."}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **content**: Post content as text (required)
+
+---
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: z.object({
+      chatId: z.string(),
+      content: z.string(),
+    }),
+    handler: async ({ chatId, content }) => {
+      try {
+        const result = await create_post({ chatId, content });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Create post failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'reply_post',
+    description: `Reply to a post in a topic group (BBS mode).
+
+Replies are added to the post's thread. Use the postId (root message ID) to reply.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "postId": "om_xxx", "content": "Great point!"}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **postId**: The post (root message) ID to reply to (required)
+- **content**: Reply content as text (required)
+
+---
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: z.object({
+      chatId: z.string(),
+      postId: z.string(),
+      content: z.string(),
+    }),
+    handler: async ({ chatId, postId, content }) => {
+      try {
+        const result = await reply_post({ chatId, postId, content });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Reply post failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'get_posts',
+    description: `Get posts from a topic group (BBS mode).
+
+Retrieves root messages (posts) from the topic group.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "pageSize": 20}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **pageSize**: Maximum posts to return (default: 20, max: 50)
+- **pageToken**: Pagination token from previous response
+
+---
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: z.object({
+      chatId: z.string(),
+      pageSize: z.number().optional(),
+      pageToken: z.string().optional(),
+    }),
+    handler: async ({ chatId, pageSize, pageToken }) => {
+      try {
+        const result = await get_posts({ chatId, pageSize, pageToken });
+        if (result.success && result.posts) {
+          const postList = result.posts.map(p =>
+            `- ID: ${p.messageId}\n  时间: ${new Date(p.createTime * 1000).toLocaleString('zh-CN')}\n  内容: ${p.content.substring(0, 100)}...`
+          ).join('\n\n');
+          return toolSuccess(`✅ 获取到 ${result.posts.length} 个帖子\n\n${postList}${result.hasMore ? `\n\n还有更多帖子，使用 pageToken: ${result.pageToken}` : ''}`);
+        }
+        return toolSuccess(`⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Get posts failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'get_post',
+    description: `Get a specific post by message ID.
+
+---
+
+## Usage
+
+\`\`\`json
+{"chatId": "oc_xxx", "postId": "om_xxx"}
+\`\`\`
+
+---
+
+## Parameters
+
+- **chatId**: Topic group chat ID (required)
+- **postId**: The post (message) ID (required)
+
+---
+
+**See also:** Issue #873 - 话题群扩展`,
+    parameters: z.object({
+      chatId: z.string(),
+      postId: z.string(),
+    }),
+    handler: async ({ chatId, postId }) => {
+      try {
+        const result = await get_post({ chatId, postId });
+        if (result.success && result.post) {
+          const post = result.post;
+          return toolSuccess(`✅ 帖子详情\n\nID: ${post.messageId}\n时间: ${new Date(post.createTime * 1000).toLocaleString('zh-CN')}\n类型: ${post.contentType}\n内容:\n${post.content}`);
+        }
+        return toolSuccess(`⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Get post failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -27,3 +27,6 @@ export {
   generateInteractionPrompt,
   cleanupExpiredContexts,
 } from './interactive-message.js';
+
+export type { PostResult, PostInfo, ListPostsOptions, ListPostsResult } from './topic-post.js';
+export { create_post, reply_post, get_posts, get_post } from './topic-post.js';

--- a/src/mcp/tools/topic-post.ts
+++ b/src/mcp/tools/topic-post.ts
@@ -1,0 +1,383 @@
+/**
+ * Topic Post tools for topic groups (BBS mode).
+ *
+ * These tools allow agents to create posts and reply to posts in topic groups.
+ * In Feishu, topic groups use a thread-based message structure where:
+ * - A "post" is a root message (thread starter)
+ * - A "reply" is a message in a thread
+ *
+ * @module mcp/tools/topic-post
+ * @see Issue #873 - 话题群扩展 - 群管理操作与发帖跟帖接口
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+
+const logger = createLogger('TopicPost');
+
+/**
+ * Result of post operations.
+ */
+export interface PostResult {
+  success: boolean;
+  messageId?: string;
+  threadId?: string;
+  error?: string;
+  message: string;
+}
+
+/**
+ * Post information from Feishu API.
+ */
+export interface PostInfo {
+  messageId: string;
+  threadId?: string;
+  rootId?: string;
+  content: string;
+  contentType: string;
+  createTime: number;
+  senderId?: string;
+}
+
+/**
+ * Options for listing posts.
+ */
+export interface ListPostsOptions {
+  /** Maximum number of posts to return (default: 20, max: 50) */
+  pageSize?: number;
+  /** Page token for pagination */
+  pageToken?: string;
+  /** Start time (Unix timestamp in seconds) */
+  startTime?: number;
+  /** End time (Unix timestamp in seconds) */
+  endTime?: number;
+}
+
+/**
+ * Result of listing posts.
+ */
+export interface ListPostsResult {
+  success: boolean;
+  posts?: PostInfo[];
+  hasMore?: boolean;
+  pageToken?: string;
+  error?: string;
+  message: string;
+}
+
+/**
+ * Create a post in a topic group.
+ *
+ * In topic groups, a "post" is simply a root message (message without parent).
+ * This is the equivalent of creating a new topic/thread.
+ *
+ * @param chatId - Topic group chat ID
+ * @param content - Post content (text)
+ * @returns Post creation result with message ID
+ */
+export async function create_post(params: {
+  chatId: string;
+  content: string;
+}): Promise<PostResult> {
+  const { chatId, content } = params;
+
+  logger.info({ chatId, contentLength: content.length }, 'create_post called');
+
+  try {
+    if (!chatId) {
+      return { success: false, error: 'chatId is required', message: '❌ chatId 参数必填' };
+    }
+    if (!content) {
+      return { success: false, error: 'content is required', message: '❌ content 参数必填' };
+    }
+
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured';
+      logger.error({ chatId }, errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    // Send message to create a post (root message without parent)
+    const response = await client.im.message.create({
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        msg_type: 'text',
+        content: JSON.stringify({ text: content }),
+      },
+    });
+
+    const messageId = response?.data?.message_id;
+    const threadId = response?.data?.thread_id;
+
+    if (!messageId) {
+      throw new Error('Failed to get message_id from response');
+    }
+
+    logger.info({ chatId, messageId, threadId }, 'Post created successfully');
+
+    return {
+      success: true,
+      messageId,
+      threadId,
+      message: `✅ 帖子创建成功\n消息ID: ${messageId}`,
+    };
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'create_post FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ 创建帖子失败: ${errorMessage}` };
+  }
+}
+
+/**
+ * Reply to a post in a topic group.
+ *
+ * In topic groups, replies are messages with a parent_id (thread reply).
+ * Use the root message ID (postId) to reply to a post.
+ *
+ * @param chatId - Topic group chat ID
+ * @param postId - The post (root message) ID to reply to
+ * @param content - Reply content (text)
+ * @returns Reply creation result with message ID
+ */
+export async function reply_post(params: {
+  chatId: string;
+  postId: string;
+  content: string;
+}): Promise<PostResult> {
+  const { chatId, postId, content } = params;
+
+  logger.info({ chatId, postId, contentLength: content.length }, 'reply_post called');
+
+  try {
+    if (!chatId) {
+      return { success: false, error: 'chatId is required', message: '❌ chatId 参数必填' };
+    }
+    if (!postId) {
+      return { success: false, error: 'postId is required', message: '❌ postId 参数必填' };
+    }
+    if (!content) {
+      return { success: false, error: 'content is required', message: '❌ content 参数必填' };
+    }
+
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured';
+      logger.error({ chatId }, errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    // Reply to the post using reply API with reply_in_thread
+    const response = await client.im.message.reply({
+      path: { message_id: postId },
+      data: {
+        msg_type: 'text',
+        content: JSON.stringify({ text: content }),
+        reply_in_thread: true,
+      },
+    });
+
+    const messageId = response?.data?.message_id;
+
+    if (!messageId) {
+      throw new Error('Failed to get message_id from response');
+    }
+
+    logger.info({ chatId, postId, messageId }, 'Reply posted successfully');
+
+    return {
+      success: true,
+      messageId,
+      threadId: postId, // In topic groups, thread_id is the root message ID
+      message: `✅ 回复成功\n消息ID: ${messageId}\n帖子ID: ${postId}`,
+    };
+  } catch (error) {
+    logger.error({ err: error, chatId, postId }, 'reply_post FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ 回复失败: ${errorMessage}` };
+  }
+}
+
+/**
+ * Get posts (root messages) from a topic group.
+ *
+ * This retrieves messages from the chat. In topic groups, root messages
+ * (messages without root_id) represent posts.
+ *
+ * Note: Feishu API pagination and filtering may be limited.
+ *
+ * @param chatId - Topic group chat ID
+ * @param options - List options (pagination, time range)
+ * @returns List of posts
+ */
+export async function get_posts(params: {
+  chatId: string;
+  pageSize?: number;
+  pageToken?: string;
+}): Promise<ListPostsResult> {
+  const { chatId, pageSize = 20, pageToken } = params;
+
+  logger.info({ chatId, pageSize, pageToken }, 'get_posts called');
+
+  try {
+    if (!chatId) {
+      return { success: false, error: 'chatId is required', message: '❌ chatId 参数必填' };
+    }
+
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured';
+      logger.error({ chatId }, errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    // Get chat messages
+    const response = await client.im.message.list({
+      params: {
+        container_id_type: 'chat_id',
+        container_id: chatId,
+        page_size: Math.min(pageSize, 50),
+        page_token: pageToken,
+      },
+    });
+
+    const items = response?.data?.items || [];
+    const posts: PostInfo[] = [];
+
+    for (const item of items) {
+      // In topic groups, root messages (posts) have no root_id
+      // or have root_id equal to message_id
+      const isRootMessage = !item.root_id || item.root_id === item.message_id;
+
+      if (isRootMessage && item.message_id) {
+        const createTimeStr = item.create_time || '0';
+        const createTimeNum = typeof createTimeStr === 'string' ? parseInt(createTimeStr, 10) : createTimeStr;
+        posts.push({
+          messageId: item.message_id,
+          threadId: item.thread_id || undefined,
+          rootId: item.root_id || undefined,
+          content: item.body?.content || '', // Note: content is in body.content
+          contentType: item.msg_type || 'text',
+          createTime: createTimeNum || 0,
+          senderId: item.sender?.id || undefined,
+        });
+      }
+    }
+
+    const hasMore = response?.data?.has_more || false;
+    const nextPageToken = response?.data?.page_token;
+
+    logger.info({ chatId, postCount: posts.length, hasMore }, 'Posts retrieved');
+
+    return {
+      success: true,
+      posts,
+      hasMore,
+      pageToken: nextPageToken,
+      message: `✅ 获取到 ${posts.length} 个帖子`,
+    };
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'get_posts FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ 获取帖子失败: ${errorMessage}` };
+  }
+}
+
+/**
+ * Get a specific post by message ID.
+ *
+ * @param chatId - Topic group chat ID
+ * @param postId - The post (message) ID
+ * @returns Post details
+ */
+export async function get_post(params: {
+  chatId: string;
+  postId: string;
+}): Promise<{ success: boolean; post?: PostInfo; error?: string; message: string }> {
+  const { chatId, postId } = params;
+
+  logger.info({ chatId, postId }, 'get_post called');
+
+  try {
+    if (!chatId) {
+      return { success: false, error: 'chatId is required', message: '❌ chatId 参数必填' };
+    }
+    if (!postId) {
+      return { success: false, error: 'postId is required', message: '❌ postId 参数必填' };
+    }
+
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured';
+      logger.error({ chatId }, errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    // Get message by ID
+    const response = await client.im.message.get({
+      path: { message_id: postId },
+    });
+
+    // The response data structure may vary - check for both 'items' array and direct object
+    const data = response?.data;
+    const item = data?.items?.[0] || (data as unknown as Record<string, unknown>);
+
+    if (!item || typeof item !== 'object' || !('message_id' in item) || !item.message_id) {
+      return { success: false, error: 'Post not found', message: '❌ 帖子不存在' };
+    }
+
+    const msgItem = item as {
+      message_id?: string;
+      thread_id?: string;
+      root_id?: string;
+      body?: { content?: string };
+      msg_type?: string;
+      create_time?: string | number;
+      sender?: { id?: string };
+    };
+
+    const createTimeStr = msgItem.create_time || '0';
+    const createTimeNum = typeof createTimeStr === 'string' ? parseInt(createTimeStr, 10) : createTimeStr;
+
+    const post: PostInfo = {
+      messageId: msgItem.message_id || '',
+      threadId: msgItem.thread_id || undefined,
+      rootId: msgItem.root_id || undefined,
+      content: msgItem.body?.content || '',
+      contentType: msgItem.msg_type || 'text',
+      createTime: createTimeNum || 0,
+      senderId: msgItem.sender?.id || undefined,
+    };
+
+    logger.info({ chatId, postId }, 'Post retrieved');
+
+    return {
+      success: true,
+      post,
+      message: `✅ 获取帖子成功\n消息ID: ${post.messageId}\n创建时间: ${new Date(post.createTime * 1000).toLocaleString('zh-CN')}`,
+    };
+  } catch (error) {
+    logger.error({ err: error, chatId, postId }, 'get_post FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ 获取帖子失败: ${errorMessage}` };
+  }
+}

--- a/src/nodes/commands/commands/topic-group-command.ts
+++ b/src/nodes/commands/commands/topic-group-command.ts
@@ -3,6 +3,7 @@
  *
  * Issue #721: 话题群基础设施 - BBS 模式支持
  * Issue #696: 拆分 builtin-commands.ts
+ * Issue #873: 话题群扩展 - 群管理操作与发帖跟帖接口
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -16,14 +17,14 @@ export class TopicGroupCommand implements Command {
   readonly name = 'topic-group';
   readonly category = 'group' as const;
   readonly description = '话题群管理';
-  readonly usage = 'topic-group <mark|unmark|list|status> [chatId]';
+  readonly usage = 'topic-group <mark|unmark|list|status|batch-mark|batch-unmark> [chatId...]';
 
   execute(context: CommandContext): CommandResult {
     const { services, chatId } = context;
     const subCommand = context.args[0]?.toLowerCase() || 'status';
 
     // Validate subcommand
-    const validSubcommands = ['mark', 'unmark', 'list', 'status'];
+    const validSubcommands = ['mark', 'unmark', 'list', 'status', 'batch-mark', 'batch-unmark', 'members', 'add-members', 'remove-members'];
     if (!validSubcommands.includes(subCommand)) {
       return {
         success: false,
@@ -39,6 +40,24 @@ export class TopicGroupCommand implements Command {
     // Handle status subcommand - show current group status
     if (subCommand === 'status') {
       return this.handleStatus(services, chatId);
+    }
+
+    // Handle batch-mark subcommand - mark multiple groups as topic groups
+    if (subCommand === 'batch-mark') {
+      const chatIds = context.args.slice(1);
+      return this.handleBatchMark(services, chatIds);
+    }
+
+    // Handle batch-unmark subcommand - unmark multiple groups
+    if (subCommand === 'batch-unmark') {
+      const chatIds = context.args.slice(1);
+      return this.handleBatchUnmark(services, chatIds);
+    }
+
+    // Handle members subcommand - list members of a topic group
+    if (subCommand === 'members') {
+      const targetChatId = context.args[1] || chatId;
+      return this.handleMembers(services, targetChatId);
     }
 
     // mark/unmark require a target chatId
@@ -124,6 +143,105 @@ export class TopicGroupCommand implements Command {
     return {
       success: true,
       message: `✅ **话题群标记已取消**\n\n群 \`${chatId}\` 已不再是话题群`,
+    };
+  }
+
+  /**
+   * Batch mark multiple groups as topic groups.
+   *
+   * Issue #873: 话题群扩展 - 批量管理话题群
+   */
+  private handleBatchMark(services: CommandContext['services'], chatIds: string[]): CommandResult {
+    if (chatIds.length === 0) {
+      return {
+        success: false,
+        error: '请提供要标记的群 ID 列表\n\n用法: `/topic-group batch-mark chatId1 chatId2 ...`',
+      };
+    }
+
+    const results: { chatId: string; success: boolean; error?: string }[] = [];
+    let successCount = 0;
+
+    for (const targetChatId of chatIds) {
+      const success = services.markAsTopicGroup(targetChatId, true);
+      if (success) {
+        successCount++;
+        results.push({ chatId: targetChatId, success: true });
+      } else {
+        results.push({ chatId: targetChatId, success: false, error: '群不在托管列表中' });
+      }
+    }
+
+    const successList = results.filter(r => r.success).map(r => `- ✅ \`${r.chatId}\``).join('\n');
+    const failList = results.filter(r => !r.success).map(r => `- ❌ \`${r.chatId}\`: ${r.error}`).join('\n');
+
+    let message = `📋 **批量标记话题群**\n\n成功: ${successCount}/${chatIds.length}\n\n`;
+    if (successList) message += `**成功**:\n${successList}\n\n`;
+    if (failList) message += `**失败**:\n${failList}`;
+
+    return { success: successCount > 0, message };
+  }
+
+  /**
+   * Batch unmark multiple topic groups.
+   *
+   * Issue #873: 话题群扩展 - 批量管理话题群
+   */
+  private handleBatchUnmark(services: CommandContext['services'], chatIds: string[]): CommandResult {
+    if (chatIds.length === 0) {
+      return {
+        success: false,
+        error: '请提供要取消标记的群 ID 列表\n\n用法: `/topic-group batch-unmark chatId1 chatId2 ...`',
+      };
+    }
+
+    const results: { chatId: string; success: boolean; error?: string }[] = [];
+    let successCount = 0;
+
+    for (const targetChatId of chatIds) {
+      const success = services.markAsTopicGroup(targetChatId, false);
+      if (success) {
+        successCount++;
+        results.push({ chatId: targetChatId, success: true });
+      } else {
+        results.push({ chatId: targetChatId, success: false, error: '群不在托管列表中' });
+      }
+    }
+
+    const successList = results.filter(r => r.success).map(r => `- ✅ \`${r.chatId}\``).join('\n');
+    const failList = results.filter(r => !r.success).map(r => `- ❌ \`${r.chatId}\`: ${r.error}`).join('\n');
+
+    let message = `📋 **批量取消话题群标记**\n\n成功: ${successCount}/${chatIds.length}\n\n`;
+    if (successList) message += `**成功**:\n${successList}\n\n`;
+    if (failList) message += `**失败**:\n${failList}`;
+
+    return { success: successCount > 0, message };
+  }
+
+  /**
+   * List members of a topic group.
+   * Note: This is a placeholder - actual member management requires Feishu API calls.
+   *
+   * Issue #873: 话题群扩展 - 话题群成员管理
+   */
+  private handleMembers(services: CommandContext['services'], chatId: string): CommandResult {
+    const allGroups = services.listGroups();
+    const group = allGroups.find(g => g.chatId === chatId);
+
+    if (!group) {
+      return {
+        success: false,
+        error: `群 \`${chatId}\` 不在托管列表中`,
+      };
+    }
+
+    const memberList = group.initialMembers.length > 0
+      ? group.initialMembers.map(m => `- \`${m}\``).join('\n')
+      : '(无记录)';
+
+    return {
+      success: true,
+      message: `📋 **话题群成员**\n\n群名称: **${group.name}**\n群 ID: \`${chatId}\`\n\n初始成员:\n${memberList}\n\n> 注: 完整成员管理需要通过飞书客户端或 API 操作`,
     };
   }
 }


### PR DESCRIPTION
## Summary

Implements post API and batch management operations for topic groups (BBS mode).

Fixes #873

### New MCP Tools

| Tool | Description |
|------|-------------|
| `create_post` | Create a post (root message) in topic group |
| `reply_post` | Reply to a post in topic group thread |
| `get_posts` | List posts from a topic group |
| `get_post` | Get specific post details |

### Extended Commands

| Command | Description |
|---------|-------------|
| `/topic-group batch-mark <chatId...>` | Mark multiple groups as topic groups |
| `/topic-group batch-unmark <chatId...>` | Unmark multiple topic groups |
| `/topic-group members [chatId]` | List members of a topic group |

## Changes

### New Files

| File | Description |
|------|-------------|
| `src/mcp/tools/topic-post.ts` | Post API implementation |

### Modified Files

| File | Change |
|------|--------|
| `src/mcp/tools/index.ts` | Export new post tools |
| `src/mcp/feishu-context-mcp.ts` | Register new MCP tools |
| `src/nodes/commands/commands/topic-group-command.ts` | Add batch operations and members command |

## Test Plan

- [x] TypeScript compilation passes
- [x] Unit tests pass (1609 passed)
- [ ] Manual testing with topic group

🤖 Generated with [Claude Code](https://claude.com/claude-code)