### PR TITLE
feat(pilot): add native multimodal guidance for image attachments (Issue #656)

### DIFF
--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -2,6 +2,7 @@
  * Tests for MessageBuilder class.
  *
  * Issue #809: Tests for image analyzer MCP hint in buildAttachmentsInfo.
+ * Issue #808: Tests for native multimodal guidance when no MCP is configured.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -22,10 +23,10 @@ describe('MessageBuilder', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
-  describe('buildAttachmentsInfo (Issue #809)', () => {
+  describe('buildAttachmentsInfo (Issue #809, #808)', () => {
     // Access private method for testing
     const getAttachmentsInfo = (mb: MessageBuilder, attachments?: any[]) =>
       (mb as any).buildAttachmentsInfo(attachments);
@@ -33,7 +34,7 @@ describe('MessageBuilder', () => {
     it('should include image analyzer hint for image attachments when MCP is configured', async () => {
       // Import Config to get access to the mocked version
       const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue({
         '4_5v_mcp': { command: 'test-command' },
       } as any);
 
@@ -52,27 +53,31 @@ describe('MessageBuilder', () => {
       expect(result).toContain('image analyzer MCP');
     });
 
-    it('should not include image analyzer hint when no image analyzer MCP is configured', async () => {
+    it('should include native multimodal guidance when no image analyzer MCP is configured (Issue #808)', async () => {
       const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined as any);
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue(undefined as any);
 
       const imageAttachment = [{
         id: 'test-id',
-        fileName: 'test.png',
+        fileName: 'screenshot.png',
         mimeType: 'image/png',
         size: 1024,
-        localPath: '/tmp/test.png',
+        localPath: '/tmp/screenshot.png',
       }];
 
       const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
 
-      expect(result).not.toContain('Image attachment(s) detected');
+      // Issue #808: Should provide native multimodal guidance
+      expect(result).toContain('Image attachment(s) detected');
+      expect(result).toContain('Read tool');
+      expect(result).toContain('Native multimodal models');
       expect(result).not.toContain('analyze_image');
+      expect(result).not.toContain('image analyzer MCP');
     });
 
-    it('should not include image analyzer hint for non-image attachments', async () => {
+    it('should not include image guidance for non-image attachments', async () => {
       const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue({
         '4_5v_mcp': { command: 'test-command' },
       } as any);
 
@@ -89,12 +94,68 @@ describe('MessageBuilder', () => {
       expect(result).not.toContain('Image attachment(s) detected');
     });
 
-    it('should return empty string for no attachments', () => {
+    it('should include image count in guidance for multiple images (Issue #808)', async () => {
+      const { Config } = await import('../../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue(undefined as any);
+
+      const imageAttachments = [
+        {
+          id: 'test-id-1',
+          fileName: 'photo1.jpg',
+          mimeType: 'image/jpeg',
+          size: 2048,
+          localPath: '/tmp/photo1.jpg',
+        },
+        {
+          id: 'test-id-2',
+          fileName: 'photo2.png',
+          mimeType: 'image/png',
+          size: 3072,
+          localPath: '/tmp/photo2.png',
+        },
+      ];
+
+      const result = getAttachmentsInfo(new MessageBuilder(), imageAttachments);
+
+      expect(result).toContain('Image attachment(s) detected (2)');
+      expect(result).toContain('Native multimodal models');
+    });
+
+    it('should prefer analyze_image when MCP is available over native multimodal guidance', async () => {
+      const { Config } = await import('../../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue({
+        '4_5v_mcp': { command: 'test-command' },
+      } as any);
+
+      const imageAttachment = [{
+        id: 'test-id',
+        fileName: 'test.png',
+        mimeType: 'image/png',
+        size: 1024,
+        localPath: '/tmp/test.png',
+      }];
+
+      const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
+
+      // Should mention analyze_image first
+      expect(result).toContain('analyze_image');
+      expect(result).toContain('image analyzer MCP');
+      // Should also mention Read tool as fallback
+      expect(result).toContain('Read tool');
+    });
+
+    it('should return empty string for no attachments', async () => {
+      const { Config } = await import('../../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue(undefined as any);
+
       const result = getAttachmentsInfo(messageBuilder, []);
       expect(result).toBe('');
     });
 
-    it('should return empty string for undefined attachments', () => {
+    it('should return empty string for undefined attachments', async () => {
+      const { Config } = await import('../../config/index.js');
+      vi.mocked(Config.getMcpServersConfig).mockReturnValue(undefined as any);
+
       const result = getAttachmentsInfo(messageBuilder, undefined);
       expect(result).toBe('');
     });
@@ -104,7 +165,7 @@ describe('MessageBuilder', () => {
       const mcpNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
 
       for (const name of mcpNames) {
-        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+        vi.mocked(Config.getMcpServersConfig).mockReturnValue({
           [name]: { command: 'test-command' },
         } as any);
 

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -210,22 +210,34 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       })
       .join('\n');
 
-    // Issue #809: Check if there are image attachments and image analyzer MCP is configured
+    // Issue #809: Check if there are image attachments
     const hasImageAttachment = attachments.some(att =>
       att.mimeType?.startsWith('image/')
     );
-    const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
-      ? `
 
-**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
-      : '';
+    // Issue #808: Provide guidance based on available tools
+    let imageGuidance = '';
+    if (hasImageAttachment) {
+      const imageCount = attachments.filter(att => att.mimeType?.startsWith('image/')).length;
+      if (this.hasImageAnalyzerMcp()) {
+        // Image analyzer MCP available - prefer analyze_image
+        imageGuidance = `
+
+**Image attachment(s) detected (${imageCount}):** If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`;
+      } else {
+        // No image analyzer MCP - provide native multimodal guidance
+        imageGuidance = `
+
+**Image attachment(s) detected (${imageCount}):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.`;
+      }
+    }
 
     return `
 
 --- Attachments ---
 The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
 
-${attachmentList}${imageAnalyzerHint}
+${attachmentList}${imageGuidance}
 
 You can read these files using the Read tool with the local paths above.`;
   }


### PR DESCRIPTION
## Summary

- Fixes #656 (partially - addresses native multimodal guidance)
- Provides native multimodal guidance when no image analyzer MCP is configured
- Updates tests to cover both scenarios (MCP configured vs not configured)

## Changes

When a user sends an image attachment:
- **With image analyzer MCP**: Suggests using `analyze_image` tool (existing behavior from #809)
- **Without image analyzer MCP**: Provides native multimodal guidance to use the Read tool (new behavior)

### Code Changes
- Modified `buildAttachmentsInfo` in `message-builder.ts` to provide native multimodal guidance
- Updated tests to cover both scenarios with proper mock isolation

## Background

Issue #656 identified that the current implementation only provides image guidance when an image analyzer MCP is configured. For native multimodal models (like Claude with vision), no guidance was provided.

This PR fills that gap by providing clear guidance for native multimodal models to use the Read tool for image analysis.

## Example Output

### With MCP configured:
```markdown
**Image attachment(s) detected (1):** If you need to analyze the image content, prefer using the `analyze_image` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.
```

### Without MCP (native multimodal):
```markdown
**Image attachment(s) detected (1):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.
```

## Test Results

- ✅ All 8 tests pass
- ✅ Type check passes
- ✅ Lint passes (no new errors)

## Related

- Issue #808: Testing native multimodal models (has open PR #817 with issues)
- Issue #809: Image analyzer MCP hint (merged in #852)

🤖 Generated with [Claude Code](https://claude.com/claude-code)