### PR TITLE
feat(mcp): add create_group tool and PR scanner schedule (Issue #393)

### DIFF
--- a/schedules/pr-scanner.md
+++ b/schedules/pr-scanner.md
@@ -1,0 +1,143 @@
+---
+name: "PR 扫描与讨论"
+cron: "0 */30 * * * *"
+enabled: true
+blocking: true
+cooldownPeriod: 300000
+chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+createdAt: "2026-03-06T00:00:00.000Z"
+---
+
+# PR 扫描任务
+
+每30分钟扫描仓库的 open PR，发现新 PR 时创建群聊通知。
+
+## 执行步骤
+
+### 1. 获取当前 open PR 列表
+
+```bash
+gh pr list --repo hs3180/disclaude --state open --json number,title,author,createdAt,headRefName,additions,deletions,changedFiles
+```
+
+### 2. 读取已处理的 PR 记录
+
+```bash
+cat workspace/data/processed-prs.json 2>/dev/null || echo "{}"
+```
+
+如果文件不存在，初始化为空对象 `{}`。
+
+### 3. 识别新 PR
+
+对比当前 open PR 列表与已处理记录，识别新 PR：
+- 在当前列表中但不在已处理记录中的 PR
+- 记录格式: `{ "pr_number": { "processedAt": "timestamp", "chatId": "oc_xxx" } }`
+
+### 4. 处理每个新 PR
+
+对于每个新 PR：
+
+#### 4.1 获取 PR 详细信息
+
+```bash
+gh pr view {number} --repo hs3180/disclaude --json title,body,author,state,createdAt,headRefName,baseRefName,additions,deletions,changedFiles,mergeable,mergeStateStatus,commits,files
+```
+
+#### 4.2 获取 CI 状态
+
+```bash
+gh pr checks {number} --repo hs3180/disclaude --json name,status,conclusion 2>/dev/null || echo "CI status unavailable"
+```
+
+#### 4.3 创建讨论群聊
+
+使用 `create_group` 工具创建群聊：
+
+```json
+{
+  "topic": "PR #{number}: {title}"
+}
+```
+
+记录返回的 chatId。
+
+#### 4.4 发送 PR 信息卡片
+
+使用 `send_user_feedback` 发送包含 PR 详情的卡片消息：
+
+```json
+{
+  "content": {
+    "config": { "wide_screen_mode": true },
+    "header": {
+      "title": { "tag": "plain_text", "content": "PR #{number}: {title}" },
+      "template": "blue"
+    },
+    "elements": [
+      {
+        "tag": "markdown",
+        "content": "**作者**: @{author}\n**分支**: {headRefName} → {baseRefName}\n**变更**: +{additions} -{deletions} ({changedFiles} files)"
+      },
+      {
+        "tag": "markdown",
+        "content": "**CI 状态**: {ciStatus}\n**合并状态**: {mergeStateStatus}"
+      },
+      {
+        "tag": "markdown",
+        "content": "**描述**:\n{body}"
+      },
+      {
+        "tag": "action",
+        "actions": [
+          {
+            "tag": "button",
+            "text": { "tag": "plain_text", "content": "查看 PR" },
+            "url": "https://github.com/hs3180/disclaude/pull/{number}",
+            "type": "primary"
+          }
+        ]
+      }
+    ]
+  },
+  "format": "card",
+  "chatId": "{new_chat_id}"
+}
+```
+
+#### 4.5 更新已处理记录
+
+将新处理的 PR 添加到 `workspace/data/processed-prs.json`：
+
+```json
+{
+  "{pr_number}": {
+    "processedAt": "2026-03-06T12:00:00.000Z",
+    "chatId": "oc_xxx",
+    "title": "PR title"
+  }
+}
+```
+
+### 5. 清理过期记录（可选）
+
+如果已处理记录超过 100 条，清理 30 天前的旧记录。
+
+## 错误处理
+
+1. 如果 GitHub API 调用失败，记录错误并跳过本次执行
+2. 如果创建群聊失败，记录错误并继续处理下一个 PR
+3. 如果发送消息失败，记录错误但仍然标记 PR 为已处理
+
+## 注意事项
+
+- 冷静期设置为 5 分钟，避免短时间内重复执行
+- 使用 blocking 模式，确保上一次执行完成后再开始下一次
+- 已处理的 PR 记录存储在 `workspace/data/processed-prs.json`
+
+## 配置
+
+- **扫描间隔**: 每 30 分钟
+- **仓库**: hs3180/disclaude
+- **通知 chatId**: oc_71e5f41a029f3a120988b7ecb76df314
+- **冷静期**: 5 分钟 (300000ms)

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -12,6 +12,7 @@ import {
   update_card,
   wait_for_interaction,
   send_interactive_message,
+  create_group,
   setMessageSentCallback,
 } from './tools/index.js';
 
@@ -327,6 +328,48 @@ In actionPrompts, you can use these placeholders:
       required: ['card', 'actionPrompts', 'chatId'],
     },
     handler: send_interactive_message,
+  },
+  create_group: {
+    description: `Create a new Feishu group chat.
+
+This tool creates a group chat that can be used for discussions. The bot will automatically be added as a member.
+
+## Parameters
+
+- **topic** (optional): Group name/topic. If not provided, an auto-generated name will be used.
+- **members** (optional): Array of open_ids to add as initial members.
+
+## Example
+
+\`\`\`json
+{
+  "topic": "PR #123 Discussion",
+  "members": ["ou_xxx", "ou_yyy"]
+}
+\`\`\`
+
+## Return Value
+
+Returns the created group's chatId and name.
+
+## Use Cases
+
+- Creating discussion groups for PRs (Issue #393)
+- Creating topic groups for specific discussions
+- Setting up temporary discussion channels
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/group/chat/chat/create`,
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: { type: 'string', description: 'Group name/topic (optional, auto-generated if not provided)' },
+        members: { type: 'array', items: { type: 'string' }, description: 'Initial member open_ids (optional)' },
+      },
+      required: [],
+    },
+    handler: create_group,
   },
 };
 
@@ -656,6 +699,54 @@ In actionPrompts, you can use these placeholders:
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Interactive message failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'create_group',
+    description: `Create a new Feishu group chat.
+
+This tool creates a group chat that can be used for discussions. The bot will automatically be added as a member.
+
+## Parameters
+
+- **topic** (optional): Group name/topic. If not provided, an auto-generated name will be used.
+- **members** (optional): Array of open_ids to add as initial members.
+
+## Example
+
+\`\`\`json
+{
+  "topic": "PR #123 Discussion",
+  "members": ["ou_xxx", "ou_yyy"]
+}
+\`\`\`
+
+## Return Value
+
+Returns the created group's chatId and name.
+
+## Use Cases
+
+- Creating discussion groups for PRs (Issue #393)
+- Creating topic groups for specific discussions
+- Setting up temporary discussion channels
+
+---
+
+**Reference:** https://open.feishu.cn/document/server-docs/group/chat/chat/create`,
+    parameters: z.object({
+      topic: z.string().optional(),
+      members: z.array(z.string()).optional(),
+    }),
+    handler: async ({ topic, members }) => {
+      try {
+        const result = await create_group({ topic, members });
+        return toolSuccess(result.success
+          ? `${result.message}\nchatId: ${result.chatId}\nname: ${result.name}`
+          : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Group creation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/create-group.test.ts
+++ b/src/mcp/tools/create-group.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for create_group MCP tool.
+ *
+ * @module mcp/tools/create-group.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../config/index.js', () => ({
+  Config: {
+    FEISHU_APP_ID: 'test_app_id',
+    FEISHU_APP_SECRET: 'test_app_secret',
+  },
+}));
+
+vi.mock('../../platforms/feishu/create-feishu-client.js', () => ({
+  createFeishuClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../../platforms/feishu/group-service.js', () => ({
+  getGroupService: vi.fn(() => ({
+    createGroup: vi.fn().mockResolvedValue({
+      chatId: 'oc_test_chat_id',
+      name: 'Test Group',
+      createdAt: Date.now(),
+      initialMembers: [],
+    }),
+  })),
+}));
+
+import { create_group } from './create-group.js';
+
+describe('create_group', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a group with topic', async () => {
+    const result = await create_group({
+      topic: 'Test Group',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.chatId).toBe('oc_test_chat_id');
+    expect(result.name).toBe('Test Group');
+    expect(result.message).toContain('Group created');
+  });
+
+  it('should create a group with topic and members', async () => {
+    const result = await create_group({
+      topic: 'Test Group',
+      members: ['ou_user1', 'ou_user2'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.chatId).toBe('oc_test_chat_id');
+  });
+
+  it('should create a group without topic (auto-generated name)', async () => {
+    const result = await create_group({});
+
+    expect(result.success).toBe(true);
+    expect(result.chatId).toBe('oc_test_chat_id');
+  });
+});

--- a/src/mcp/tools/create-group.ts
+++ b/src/mcp/tools/create-group.ts
@@ -1,0 +1,74 @@
+/**
+ * create_group tool implementation.
+ *
+ * Allows agents to create Feishu group chats.
+ *
+ * @see Issue #393 - PR Scanner scheduled task
+ * @module mcp/tools/create-group
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getGroupService } from '../../platforms/feishu/group-service.js';
+import type { CreateGroupResult } from './types.js';
+
+const logger = createLogger('CreateGroup');
+
+/**
+ * Create a Feishu group chat.
+ *
+ * @param params - Group creation parameters
+ * @param params.topic - Group name/topic (optional, auto-generated if not provided)
+ * @param params.members - Initial member open_ids (optional)
+ * @returns Result with chatId and name on success
+ */
+export async function create_group(params: {
+  topic?: string;
+  members?: string[];
+}): Promise<CreateGroupResult> {
+  const { topic, members } = params;
+
+  logger.info({
+    topic,
+    memberCount: members?.length || 0,
+  }, 'create_group called');
+
+  try {
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+      logger.error(errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const groupService = getGroupService();
+
+    // Create the group using GroupService
+    const groupInfo = await groupService.createGroup(client, {
+      topic,
+      members,
+    });
+
+    logger.info({
+      chatId: groupInfo.chatId,
+      name: groupInfo.name,
+    }, 'Group created successfully');
+
+    return {
+      success: true,
+      chatId: groupInfo.chatId,
+      name: groupInfo.name,
+      message: `✅ Group created: ${groupInfo.name} (chatId: ${groupInfo.chatId})`,
+    };
+
+  } catch (error) {
+    logger.error({ err: error }, 'create_group FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ Failed to create group: ${errorMessage}` };
+  }
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -14,6 +14,7 @@ export type {
   ActionPromptMap,
   InteractiveMessageContext,
   SendInteractiveResult,
+  CreateGroupResult,
 } from './types.js';
 
 export { send_user_feedback, setMessageSentCallback, getMessageSentCallback } from './send-message.js';
@@ -27,3 +28,4 @@ export {
   generateInteractionPrompt,
   cleanupExpiredContexts,
 } from './interactive-message.js';
+export { create_group } from './create-group.js';

--- a/src/mcp/tools/types.ts
+++ b/src/mcp/tools/types.ts
@@ -97,3 +97,16 @@ export interface SendInteractiveResult {
   messageId?: string;
   error?: string;
 }
+
+/**
+ * Result type for create_group tool.
+ *
+ * @see Issue #393 - PR Scanner scheduled task
+ */
+export interface CreateGroupResult {
+  success: boolean;
+  chatId?: string;
+  name?: string;
+  error?: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- Add `create_group` MCP tool for creating Feishu group chats
- Add PR scanner scheduled task configuration

### create_group Tool

Allows agents to create Feishu group chats programmatically:
- Supports optional topic (auto-generated if not provided)
- Supports optional initial members list
- Returns chatId and name on success

### PR Scanner Schedule

Every 30 minutes:
1. Fetches open PRs from hs3180/disclaude
2. Compares with processed PR records
3. Creates discussion group for new PRs
4. Sends PR info card with details

## Changes

| File | Change |
|------|--------|
| src/mcp/tools/create-group.ts | New file - create_group implementation |
| src/mcp/tools/create-group.test.ts | New file - 3 unit tests |
| src/mcp/tools/types.ts | Add CreateGroupResult type |
| src/mcp/tools/index.ts | Export create_group |
| src/mcp/feishu-context-mcp.ts | Add create_group tool definition |
| schedules/pr-scanner.md | New file - PR scanner schedule config |

## Test Results

- ✅ 3 new tests pass
- ✅ TypeScript compilation passes
- ✅ Lint passes (no new errors)

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)