### PR TITLE
fix(nodes): prevent infinite loop in next-step recommendation (Issue #884)

### DIFF
--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -159,15 +159,14 @@ export class PrimaryNode extends EventEmitter {
     this.messageRouter = new UnifiedMessageRouter({
       sendFileToUser: this.sendFileToUser.bind(this),
       onTaskDone: async (chatId: string, threadId?: string) => {
-        // Issue #834: Send next-step prompt to ChatAgent as regular message
+        // Issue #884: Use sendMessage instead of agent.processMessage to prevent infinite loop
+        // Previously, agent.processMessage would trigger onDone again after processing,
+        // creating an infinite loop. Now we send the recommendation directly to the user.
         await triggerNextStepRecommendation(
           chatId,
           threadId,
-          async (id: string, prompt: string, _tid?: string) => {
-            if (this.agentPool) {
-              const agent = this.agentPool.getOrCreateChatAgent(id);
-              agent.processMessage(id, prompt, `next-step-${Date.now()}`);
-            }
+          async (id: string, prompt: string, tid?: string) => {
+            await this.sendMessage(id, prompt, tid);
           }
         );
       },


### PR DESCRIPTION
## Summary
- Fixed infinite loop in next-step recommendation by using `sendMessage` instead of `agent.processMessage`
- Previously, `agent.processMessage` would trigger `onDone` again after processing, creating an infinite loop when next-step recommendations were generated
- Now recommendations are sent directly to the user without triggering agent processing

## Root Cause
When a task completes:
1. `onTaskDone` callback is triggered
2. `triggerNextStepRecommendation` is called
3. Recommendations are sent via `agent.processMessage`
4. If the agent processes this and completes, it triggers `onDone` again
5. This creates an infinite loop

## Solution
Changed the callback in `primary-node.ts` to use `sendMessage` directly instead of `agent.processMessage`. This bypasses the agent's processing pipeline entirely, preventing the loop while still delivering recommendations to the user.

## Test plan
- [x] All 1616 existing tests pass
- [x] TypeScript compilation succeeds
- [x] Manual verification of the fix logic

Fixes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)