### PR TITLE
fix(next-step): prevent infinite loop in next-step recommendation

### DIFF
--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -159,15 +159,13 @@ export class PrimaryNode extends EventEmitter {
     this.messageRouter = new UnifiedMessageRouter({
       sendFileToUser: this.sendFileToUser.bind(this),
       onTaskDone: async (chatId: string, threadId?: string) => {
-        // Issue #834: Send next-step prompt to ChatAgent as regular message
+        // Issue #884: Send next-step recommendations directly via sendMessage
+        // to avoid infinite loop caused by agent.processMessage triggering onDone again
         await triggerNextStepRecommendation(
           chatId,
           threadId,
           async (id: string, prompt: string, _tid?: string) => {
-            if (this.agentPool) {
-              const agent = this.agentPool.getOrCreateChatAgent(id);
-              agent.processMessage(id, prompt, `next-step-${Date.now()}`);
-            }
+            await this.sendMessage(id, prompt, _tid);
           }
         );
       },


### PR DESCRIPTION
## Summary
- Fix infinite loop caused by next-step recommendation feature
- Use `sendMessage` directly instead of `agent.processMessage` to send next-step recommendations
- This bypasses the agent's processing pipeline, preventing the loop

## Root Cause
When a task completes, the next-step feature triggers an infinite loop:
1. `onTaskDone` callback is triggered
2. `triggerNextStepRecommendation` is called
3. The prompt is sent via `agent.processMessage`
4. `agent.processMessage` treats this as a new user message
5. If the agent processes this and completes, it triggers `onDone` again
6. This creates an infinite loop

## Solution
Use `sendMessage` directly instead of `agent.processMessage` to send the next-step recommendations. This bypasses the agent's processing pipeline entirely, preventing the loop.

## Test plan
- [ ] Verify next-step recommendations are sent to user after task completion
- [ ] Verify no infinite loop occurs
- [ ] Verify agent session remains stable after multiple task completions

Fixes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)