### PR TITLE
fix(lint): resolve require-await errors in primary-node.ts and test file (Issue #887)

### DIFF
--- a/src/mcp/tools/interactive-message.test.ts
+++ b/src/mcp/tools/interactive-message.test.ts
@@ -248,7 +248,7 @@ describe('Interactive Message Tool', () => {
   });
 
   describe('cleanupExpiredContexts', () => {
-    it('should clean up expired contexts', async () => {
+    it('should clean up expired contexts', () => {
       // This test would require manipulating time, which is complex
       // For now, just verify the function exists and doesn't throw
       const count = cleanupExpiredContexts();

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -163,11 +163,12 @@ export class PrimaryNode extends EventEmitter {
         await triggerNextStepRecommendation(
           chatId,
           threadId,
-          async (id: string, prompt: string, _tid?: string) => {
+          (id: string, prompt: string, _tid?: string) => {
             if (this.agentPool) {
               const agent = this.agentPool.getOrCreateChatAgent(id);
               agent.processMessage(id, prompt, `next-step-${Date.now()}`);
             }
+            return Promise.resolve();
           }
         );
       },


### PR DESCRIPTION
## Summary
- Fixed ESLint `require-await` errors in two files:
  - `src/nodes/primary-node.ts:166` - Removed unnecessary `async` keyword from callback that had no await expressions, added `return Promise.resolve()` to satisfy the `Promise<void>` return type
  - `src/mcp/tools/interactive-message.test.ts:251` - Removed `async` keyword from test since `cleanupExpiredContexts()` returns a number, not a Promise

## Root Cause
The `require-await` ESLint rule was violated because:
1. In `primary-node.ts`, the callback passed to `triggerNextStepRecommendation` was marked as `async` but didn't use `await`
2. In `interactive-message.test.ts`, the test function was marked as `async` but the function being tested is synchronous

## Test plan
- [x] ESLint passes with 0 errors (89 warnings are pre-existing)
- [x] TypeScript compilation succeeds
- [x] Related tests pass (24 tests in primary-node.test.ts and interactive-message.test.ts)

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)