### PR TITLE
feat(agents): add Skill Agent System for background execution (Issue #455)

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -88,3 +88,14 @@ export {
 
 // Factory
 export { AgentFactory, type AgentCreateOptions } from './factory.js';
+
+// Skill Agent Manager (Issue #455)
+export {
+  SkillAgentManager,
+  getSkillAgentManager,
+  resetSkillAgentManager,
+  type RunningAgentInfo,
+  type AgentStatus,
+  type SkillAgentManagerConfig,
+  type StartAgentOptions,
+} from './skill-agent-manager.js';

--- a/src/agents/skill-agent-manager.test.ts
+++ b/src/agents/skill-agent-manager.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for SkillAgentManager.
+ *
+ * Issue #455: Skill Agent System - Background execution of independent Agent processes
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  SkillAgentManager,
+  getSkillAgentManager,
+  resetSkillAgentManager,
+  type SkillAgentManagerConfig,
+} from './skill-agent-manager.js';
+import type { BaseAgentConfig } from './types.js';
+
+// Mock the skills/finder module
+vi.mock('../skills/finder.js', () => ({
+  listSkills: vi.fn(),
+  findSkill: vi.fn(),
+}));
+
+// Mock the skill-agent module
+vi.mock('./skill-agent.js', () => ({
+  SkillAgent: vi.fn().mockImplementation(() => ({
+    execute: vi.fn().mockImplementation(async function* () {
+      yield { content: 'Test result' };
+    }),
+    executeWithContext: vi.fn().mockImplementation(async function* () {
+      yield { content: 'Test result' };
+    }),
+    dispose: vi.fn(),
+  })),
+}));
+
+import { listSkills, findSkill } from '../skills/finder.js';
+
+const mockListSkills = vi.mocked(listSkills);
+const mockFindSkill = vi.mocked(findSkill);
+
+describe('SkillAgentManager', () => {
+  let manager: SkillAgentManager;
+  let sendMessageMock: ReturnType<typeof vi.fn>;
+
+  const baseConfig: BaseAgentConfig = {
+    apiKey: 'test-api-key',
+    model: 'claude-3-5-sonnet-20241022',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSkillAgentManager();
+
+    sendMessageMock = vi.fn().mockResolvedValue(undefined);
+
+    const config: SkillAgentManagerConfig = {
+      baseAgentConfig: baseConfig,
+      sendMessage: sendMessageMock,
+      maxConcurrent: 3,
+    };
+
+    manager = new SkillAgentManager(config);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('discoverSkills', () => {
+    it('should return skills from finder', async () => {
+      const mockSkills = [
+        { name: 'evaluator', path: '/skills/evaluator/SKILL.md', domain: 'package' as const },
+        { name: 'executor', path: '/skills/executor/SKILL.md', domain: 'package' as const },
+      ];
+      mockListSkills.mockResolvedValueOnce(mockSkills);
+
+      const skills = await manager.discoverSkills();
+
+      expect(skills).toEqual(mockSkills);
+      expect(mockListSkills).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cache skills', async () => {
+      const mockSkills = [
+        { name: 'evaluator', path: '/skills/evaluator/SKILL.md', domain: 'package' as const },
+      ];
+      mockListSkills.mockResolvedValueOnce(mockSkills);
+
+      // First call
+      await manager.discoverSkills();
+      // Second call (should use cache)
+      await manager.discoverSkills();
+
+      expect(mockListSkills).toHaveBeenCalledTimes(1);
+    });
+
+    it('should force refresh when requested', async () => {
+      const mockSkills = [
+        { name: 'evaluator', path: '/skills/evaluator/SKILL.md', domain: 'package' as const },
+      ];
+      mockListSkills.mockResolvedValue(mockSkills);
+
+      // First call
+      await manager.discoverSkills();
+      // Force refresh
+      await manager.discoverSkills(true);
+
+      expect(mockListSkills).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getSkill', () => {
+    it('should return skill path if found', async () => {
+      mockFindSkill.mockResolvedValueOnce('/skills/test/SKILL.md');
+
+      const path = await manager.getSkill('test');
+
+      expect(path).toBe('/skills/test/SKILL.md');
+    });
+
+    it('should return null if skill not found', async () => {
+      mockFindSkill.mockResolvedValueOnce(null);
+
+      const path = await manager.getSkill('nonexistent');
+
+      expect(path).toBeNull();
+    });
+  });
+
+  describe('startAgent', () => {
+    it('should start an agent successfully', async () => {
+      mockFindSkill.mockResolvedValueOnce('/skills/test/SKILL.md');
+
+      const agentId = await manager.startAgent({
+        skillName: 'test',
+        chatId: 'oc_test',
+      });
+
+      expect(agentId).toBeDefined();
+      expect(typeof agentId).toBe('string');
+
+      const info = manager.getAgentInfo(agentId);
+      expect(info).toBeDefined();
+      expect(info?.skillName).toBe('test');
+      expect(info?.chatId).toBe('oc_test');
+    });
+
+    it('should throw if skill not found', async () => {
+      mockFindSkill.mockResolvedValueOnce(null);
+
+      await expect(
+        manager.startAgent({
+          skillName: 'nonexistent',
+          chatId: 'oc_test',
+        })
+      ).rejects.toThrow('Skill not found: nonexistent');
+    });
+
+    it('should throw if max concurrent reached', async () => {
+      mockFindSkill.mockResolvedValue('/skills/test/SKILL.md');
+
+      // Start max agents
+      await manager.startAgent({ skillName: 'test1', chatId: 'oc_test' });
+      await manager.startAgent({ skillName: 'test2', chatId: 'oc_test' });
+      await manager.startAgent({ skillName: 'test3', chatId: 'oc_test' });
+
+      // Should throw on 4th
+      await expect(
+        manager.startAgent({ skillName: 'test4', chatId: 'oc_test' })
+      ).rejects.toThrow('Maximum concurrent agents reached');
+    });
+  });
+
+  describe('stopAgent', () => {
+    it('should stop a running agent', async () => {
+      mockFindSkill.mockResolvedValueOnce('/skills/test/SKILL.md');
+
+      const agentId = await manager.startAgent({
+        skillName: 'test',
+        chatId: 'oc_test',
+      });
+
+      const stopped = await manager.stopAgent(agentId);
+      expect(stopped).toBe(true);
+    });
+
+    it('should return false if agent not found', async () => {
+      const stopped = await manager.stopAgent('nonexistent');
+      expect(stopped).toBe(false);
+    });
+  });
+
+  describe('getAgentInfo', () => {
+    it('should return agent info', async () => {
+      mockFindSkill.mockResolvedValueOnce('/skills/test/SKILL.md');
+
+      const agentId = await manager.startAgent({
+        skillName: 'test',
+        chatId: 'oc_test',
+      });
+
+      const info = manager.getAgentInfo(agentId);
+
+      expect(info).toBeDefined();
+      expect(info?.id).toBe(agentId);
+      expect(info?.skillName).toBe('test');
+      expect(info?.status).toBeDefined();
+    });
+
+    it('should return undefined for unknown agent', () => {
+      const info = manager.getAgentInfo('unknown');
+      expect(info).toBeUndefined();
+    });
+  });
+
+  describe('listRunningAgents', () => {
+    it('should list all running agents', async () => {
+      mockFindSkill.mockResolvedValue('/skills/test/SKILL.md');
+
+      await manager.startAgent({ skillName: 'test1', chatId: 'oc_test' });
+      await manager.startAgent({ skillName: 'test2', chatId: 'oc_test' });
+
+      const agents = manager.listRunningAgents();
+
+      expect(agents).toHaveLength(2);
+      expect(agents.map((a) => a.skillName)).toContain('test1');
+      expect(agents.map((a) => a.skillName)).toContain('test2');
+    });
+
+    it('should return empty array if no agents', () => {
+      const agents = manager.listRunningAgents();
+      expect(agents).toHaveLength(0);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return correct stats', async () => {
+      mockFindSkill.mockResolvedValue('/skills/test/SKILL.md');
+
+      await manager.startAgent({ skillName: 'test1', chatId: 'oc_test' });
+      await manager.startAgent({ skillName: 'test2', chatId: 'oc_test' });
+
+      const stats = manager.getStats();
+
+      expect(stats.total).toBe(2);
+      expect(stats.maxConcurrent).toBe(3);
+    });
+  });
+
+  describe('cleanupOldAgents', () => {
+    it('should remove old completed agents', async () => {
+      mockFindSkill.mockResolvedValue('/skills/test/SKILL.md');
+
+      // Start and complete an agent
+      const agentId = await manager.startAgent({
+        skillName: 'test',
+        chatId: 'oc_test',
+      });
+
+      // Manually set agent as completed with old timestamp
+      const info = manager.getAgentInfo(agentId);
+      if (info) {
+        info.status = 'completed';
+        info.completedAt = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+      }
+
+      // Cleanup agents older than 1 hour
+      const cleaned = manager.cleanupOldAgents(60 * 60 * 1000);
+
+      expect(cleaned).toBe(1);
+      expect(manager.listRunningAgents()).toHaveLength(0);
+    });
+  });
+});
+
+describe('Singleton functions', () => {
+  beforeEach(() => {
+    resetSkillAgentManager();
+  });
+
+  afterEach(() => {
+    resetSkillAgentManager();
+  });
+
+  it('should throw if getSkillAgentManager called without config', () => {
+    // Reset the singleton to null state
+    resetSkillAgentManager();
+    // Import fresh module to get uninitialized state
+    expect(() => {
+      getSkillAgentManager(); // Should throw since we just reset
+    }).toThrow('SkillAgentManager not initialized');
+  });
+});

--- a/src/agents/skill-agent-manager.ts
+++ b/src/agents/skill-agent-manager.ts
@@ -1,0 +1,507 @@
+/**
+ * SkillAgentManager - Manages lifecycle of background Skill Agents.
+ *
+ * This module implements the Skill Agent system as described in Issue #455:
+ *
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │                    Skill Agent Architecture                  │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │                                                             │
+ * │   Chat Agent (Pilot)                                        │
+ * │        │                                                    │
+ * │        │ /skill run <name> [options]                        │
+ * │        ▼                                                    │
+ * │   ┌────────────────────────────────────────────┐            │
+ * │   │            SkillAgentManager                │            │
+ * │   │                                            │            │
+ * │   │  ┌─────────┐ ┌─────────┐ ┌─────────┐      │            │
+ * │   │  │ Agent 1 │ │ Agent 2 │ │ Agent N │      │            │
+ * │   │  │ (skill) │ │ (skill) │ │ (skill) │      │            │
+ * │   │  └─────────┘ └─────────┘ └─────────┘      │            │
+ * │   └────────────────────────────────────────────┘            │
+ * │        │                                                    │
+ * │        │ sendMessage (on completion)                        │
+ * │        ▼                                                    │
+ * │   User (via Feishu)                                         │
+ * │                                                             │
+ * └─────────────────────────────────────────────────────────────┘
+ *
+ * Key Features:
+ * - Start/stop Skill Agents on demand
+ * - Track running agents and their status
+ * - Send completion notifications to users
+ * - Maximum concurrent agent limit
+ *
+ * @module agents/skill-agent-manager
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { createLogger } from '../utils/logger.js';
+import { SkillAgent, type SkillAgentExecuteOptions } from './skill-agent.js';
+import { findSkill, listSkills, type DiscoveredSkill } from '../skills/finder.js';
+import type { BaseAgentConfig } from './types.js';
+
+const logger = createLogger('SkillAgentManager');
+
+/**
+ * Status of a running Skill Agent.
+ */
+export type AgentStatus = 'starting' | 'running' | 'completed' | 'failed' | 'stopped';
+
+/**
+ * Information about a running Skill Agent.
+ */
+export interface RunningAgentInfo {
+  /** Unique agent instance ID */
+  id: string;
+  /** Skill name */
+  skillName: string;
+  /** Current status */
+  status: AgentStatus;
+  /** Target chat ID for notifications */
+  chatId: string;
+  /** Start timestamp */
+  startedAt: Date;
+  /** Completion timestamp (if completed/failed/stopped) */
+  completedAt?: Date;
+  /** Error message (if failed) */
+  error?: string;
+  /** Result summary (if completed) */
+  result?: string;
+  /** AbortController for cancellation */
+  abortController: AbortController;
+}
+
+/**
+ * Configuration for SkillAgentManager.
+ */
+export interface SkillAgentManagerConfig {
+  /** Maximum concurrent agents (default: 5) */
+  maxConcurrent?: number;
+  /** Base agent config for creating SkillAgents */
+  baseAgentConfig: BaseAgentConfig;
+  /** Callback to send messages to users */
+  sendMessage: (chatId: string, text: string) => Promise<void>;
+}
+
+/**
+ * Options for starting a Skill Agent.
+ */
+export interface StartAgentOptions {
+  /** Skill name to run */
+  skillName: string;
+  /** Target chat ID for notifications */
+  chatId: string;
+  /** Template variables for skill execution */
+  templateVars?: Record<string, string>;
+  /** Additional input for the skill */
+  input?: string;
+}
+
+/**
+ * Cache entry for skill discovery.
+ */
+interface SkillCacheEntry {
+  skills: DiscoveredSkill[];
+  cachedAt: number;
+}
+
+/**
+ * SkillAgentManager - Manages lifecycle of background Skill Agents.
+ *
+ * Provides:
+ * - Skill discovery and caching
+ * - Agent lifecycle management (start/stop/status)
+ * - Concurrent execution limits
+ * - Completion notifications
+ *
+ * @example
+ * ```typescript
+ * const manager = new SkillAgentManager({
+ *   baseAgentConfig: { apiKey: '...', model: 'claude-3-5-sonnet-20241022' },
+ *   sendMessage: async (chatId, text) => { ... },
+ * });
+ *
+ * // Start a skill agent
+ * const agentId = await manager.startAgent({
+ *   skillName: 'site-miner',
+ *   chatId: 'oc_xxx',
+ *   input: 'Extract product info from https://example.com',
+ * });
+ *
+ * // Check status
+ * const info = manager.getAgentInfo(agentId);
+ * console.log(info?.status);
+ *
+ * // Stop if needed
+ * await manager.stopAgent(agentId);
+ * ```
+ */
+export class SkillAgentManager {
+  /** Running agents indexed by ID */
+  private runningAgents = new Map<string, RunningAgentInfo>();
+
+  /** Skill discovery cache with TTL */
+  private skillCache: SkillCacheEntry | null = null;
+
+  /** Cache TTL in milliseconds (5 minutes) */
+  private readonly cacheTtl = 5 * 60 * 1000;
+
+  /** Maximum concurrent agents */
+  private readonly maxConcurrent: number;
+
+  /** Base agent config for creating SkillAgents */
+  private readonly baseAgentConfig: BaseAgentConfig;
+
+  /** Callback to send messages to users */
+  private readonly sendMessage: (chatId: string, text: string) => Promise<void>;
+
+  constructor(config: SkillAgentManagerConfig) {
+    this.maxConcurrent = config.maxConcurrent ?? 5;
+    this.baseAgentConfig = config.baseAgentConfig;
+    this.sendMessage = config.sendMessage;
+
+    logger.info(
+      { maxConcurrent: this.maxConcurrent },
+      'SkillAgentManager initialized'
+    );
+  }
+
+  /**
+   * Discover all available skills.
+   *
+   * Uses caching to avoid frequent disk scans.
+   *
+   * @param forceRefresh - Force refresh the cache
+   * @returns Array of discovered skills
+   */
+  async discoverSkills(forceRefresh = false): Promise<DiscoveredSkill[]> {
+    // Check cache
+    if (!forceRefresh && this.skillCache) {
+      const age = Date.now() - this.skillCache.cachedAt;
+      if (age < this.cacheTtl) {
+        logger.debug({ count: this.skillCache.skills.length }, 'Using cached skills');
+        return this.skillCache.skills;
+      }
+    }
+
+    // Refresh cache
+    const skills = await listSkills();
+    this.skillCache = {
+      skills,
+      cachedAt: Date.now(),
+    };
+
+    logger.debug({ count: skills.length }, 'Skills discovered');
+    return skills;
+  }
+
+  /**
+   * Get a skill by name.
+   *
+   * @param name - Skill name
+   * @returns Skill path or null if not found
+   */
+  async getSkill(name: string): Promise<string | null> {
+    return findSkill(name);
+  }
+
+  /**
+   * Start a Skill Agent.
+   *
+   * Creates a new SkillAgent instance and runs it in the background.
+   * Sends a completion notification when done.
+   *
+   * @param options - Start options
+   * @returns Agent instance ID
+   * @throws Error if max concurrent limit reached or skill not found
+   */
+  async startAgent(options: StartAgentOptions): Promise<string> {
+    // Check concurrent limit
+    if (this.runningAgents.size >= this.maxConcurrent) {
+      throw new Error(
+        `Maximum concurrent agents reached (${this.maxConcurrent}). ` +
+        `Please wait for existing agents to complete.`
+      );
+    }
+
+    // Find skill
+    const skillPath = await this.getSkill(options.skillName);
+    if (!skillPath) {
+      throw new Error(`Skill not found: ${options.skillName}`);
+    }
+
+    // Create agent ID and abort controller
+    const agentId = uuidv4();
+    const abortController = new AbortController();
+
+    // Create agent info
+    const info: RunningAgentInfo = {
+      id: agentId,
+      skillName: options.skillName,
+      status: 'starting',
+      chatId: options.chatId,
+      startedAt: new Date(),
+      abortController,
+    };
+
+    // Register agent
+    this.runningAgents.set(agentId, info);
+
+    logger.info(
+      { agentId, skillName: options.skillName, chatId: options.chatId },
+      'Starting Skill Agent'
+    );
+
+    // Run agent in background
+    this.runAgentInBackground(agentId, skillPath, options).catch((error) => {
+      logger.error({ agentId, error }, 'Failed to start agent');
+      this.handleAgentError(agentId, error);
+    });
+
+    return agentId;
+  }
+
+  /**
+   * Run a Skill Agent in the background.
+   */
+  private async runAgentInBackground(
+    agentId: string,
+    skillPath: string,
+    options: StartAgentOptions
+  ): Promise<void> {
+    const info = this.runningAgents.get(agentId);
+    if (!info) {
+      return;
+    }
+
+    // Update status
+    info.status = 'running';
+
+    // Create SkillAgent
+    const agent = new SkillAgent(this.baseAgentConfig, skillPath);
+
+    try {
+      // Build execute options
+      const executeOptions: SkillAgentExecuteOptions = {
+        templateVars: options.templateVars,
+      };
+
+      // Collect results
+      const results: string[] = [];
+
+      // Execute with optional input
+      const generator = options.input
+        ? agent.execute(options.input)
+        : agent.executeWithContext(executeOptions);
+
+      for await (const message of generator) {
+        // Check for cancellation
+        if (info.abortController.signal.aborted) {
+          info.status = 'stopped';
+          info.completedAt = new Date();
+          logger.info({ agentId }, 'Agent stopped by user');
+          return;
+        }
+
+        // Collect message content
+        if (message.content) {
+          if (typeof message.content === 'string') {
+            results.push(message.content);
+          } else if (Array.isArray(message.content)) {
+            // Extract text from ContentBlock[]
+            const textContent = message.content
+              .filter((block): block is { type: 'text'; text: string } =>
+                block.type === 'text' && typeof block.text === 'string'
+              )
+              .map((block) => block.text)
+              .join('\n');
+            if (textContent) {
+              results.push(textContent);
+            }
+          }
+        }
+      }
+
+      // Mark as completed
+      info.status = 'completed';
+      info.completedAt = new Date();
+      info.result = results.join('\n').slice(0, 1000); // Limit result size
+
+      logger.info({ agentId, skillName: options.skillName }, 'Agent completed');
+
+      // Send completion notification
+      await this.sendCompletionNotification(info);
+
+    } catch (error) {
+      this.handleAgentError(agentId, error);
+    } finally {
+      agent.dispose();
+    }
+  }
+
+  /**
+   * Handle agent execution error.
+   */
+  private async handleAgentError(agentId: string, error: unknown): Promise<void> {
+    const info = this.runningAgents.get(agentId);
+    if (!info) {
+      return;
+    }
+
+    info.status = 'failed';
+    info.completedAt = new Date();
+    info.error = error instanceof Error ? error.message : String(error);
+
+    logger.error({ agentId, error: info.error }, 'Agent failed');
+
+    // Send error notification
+    try {
+      await this.sendMessage(
+        info.chatId,
+        `❌ **Skill Agent 失败**\n\n` +
+        `技能: ${info.skillName}\n` +
+        `错误: ${info.error}`
+      );
+    } catch (sendError) {
+      logger.error({ agentId, sendError }, 'Failed to send error notification');
+    }
+  }
+
+  /**
+   * Send completion notification to user.
+   */
+  private async sendCompletionNotification(info: RunningAgentInfo): Promise<void> {
+    const duration = info.completedAt!
+      ? Math.round((info.completedAt!.getTime() - info.startedAt.getTime()) / 1000)
+      : 0;
+
+    const message =
+      `✅ **Skill Agent 完成**\n\n` +
+      `技能: ${info.skillName}\n` +
+      `耗时: ${duration}秒\n` +
+      `状态: ${info.status}`;
+
+    try {
+      await this.sendMessage(info.chatId, message);
+    } catch (error) {
+      logger.error({ agentId: info.id, error }, 'Failed to send completion notification');
+    }
+  }
+
+  /**
+   * Stop a running Skill Agent.
+   *
+   * @param agentId - Agent instance ID
+   * @returns True if agent was stopped, false if not found or already stopped
+   */
+  async stopAgent(agentId: string): Promise<boolean> {
+    const info = this.runningAgents.get(agentId);
+    if (!info) {
+      return false;
+    }
+
+    if (info.status !== 'running' && info.status !== 'starting') {
+      return false;
+    }
+
+    // Abort the agent
+    info.abortController.abort();
+
+    logger.info({ agentId }, 'Agent stop requested');
+    return true;
+  }
+
+  /**
+   * Get information about a running agent.
+   *
+   * @param agentId - Agent instance ID
+   * @returns Agent info or undefined if not found
+   */
+  getAgentInfo(agentId: string): RunningAgentInfo | undefined {
+    return this.runningAgents.get(agentId);
+  }
+
+  /**
+   * List all running agents.
+   *
+   * @returns Array of running agent info
+   */
+  listRunningAgents(): RunningAgentInfo[] {
+    return Array.from(this.runningAgents.values());
+  }
+
+  /**
+   * Clean up completed/failed agents older than the specified age.
+   *
+   * @param maxAgeMs - Maximum age in milliseconds (default: 1 hour)
+   * @returns Number of agents cleaned up
+   */
+  cleanupOldAgents(maxAgeMs = 60 * 60 * 1000): number {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [id, info] of this.runningAgents.entries()) {
+      if (
+        (info.status === 'completed' || info.status === 'failed' || info.status === 'stopped') &&
+        info.completedAt &&
+        now - info.completedAt.getTime() > maxAgeMs
+      ) {
+        this.runningAgents.delete(id);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0) {
+      logger.debug({ cleaned }, 'Cleaned up old agents');
+    }
+
+    return cleaned;
+  }
+
+  /**
+   * Get current statistics.
+   */
+  getStats(): {
+    total: number;
+    running: number;
+    completed: number;
+    failed: number;
+    maxConcurrent: number;
+  } {
+    const agents = Array.from(this.runningAgents.values());
+    return {
+      total: agents.length,
+      running: agents.filter((a) => a.status === 'running').length,
+      completed: agents.filter((a) => a.status === 'completed').length,
+      failed: agents.filter((a) => a.status === 'failed').length,
+      maxConcurrent: this.maxConcurrent,
+    };
+  }
+}
+
+// Singleton instance
+let instance: SkillAgentManager | null = null;
+
+/**
+ * Get the singleton SkillAgentManager instance.
+ *
+ * @param config - Configuration (only used on first call)
+ * @returns SkillAgentManager instance
+ */
+export function getSkillAgentManager(config?: SkillAgentManagerConfig): SkillAgentManager {
+  if (!instance) {
+    if (!config) {
+      throw new Error('SkillAgentManager not initialized. Call with config first.');
+    }
+    instance = new SkillAgentManager(config);
+  }
+  return instance;
+}
+
+/**
+ * Reset the singleton instance (for testing).
+ */
+export function resetSkillAgentManager(): void {
+  instance = null;
+}

--- a/src/nodes/command-services.ts
+++ b/src/nodes/command-services.ts
@@ -23,6 +23,7 @@ import type { ExecNodeRegistry } from './exec-node-registry.js';
 import type { DebugGroupService } from './debug-group-service.js';
 import type { ScheduleManagement } from './schedule-management.js';
 import type { CommandServices, ManagedGroupInfo } from './commands/types.js';
+import type { SkillAgentManager } from '../agents/skill-agent-manager.js';
 
 /**
  * Dependencies needed for building command services.
@@ -50,6 +51,8 @@ export interface CommandServicesDeps {
   getChannelStatus: () => string;
   /** Get channels for passive mode operations */
   getChannels: () => Array<{ id: string; name: string; setPassiveModeDisabled?: (chatId: string, disabled: boolean) => void; isPassiveModeDisabled?: (chatId: string) => boolean }>;
+  /** Skill Agent manager (optional, Issue #455) */
+  skillAgentManager?: SkillAgentManager;
 }
 
 /**
@@ -71,6 +74,7 @@ export function buildCommandServices(deps: CommandServicesDeps): CommandServices
     taskStateManager,
     getChannelStatus,
     getChannels,
+    skillAgentManager,
   } = deps;
 
   return {
@@ -149,5 +153,24 @@ export function buildCommandServices(deps: CommandServicesDeps): CommandServices
     markAsTopicGroup: (chatId: string, isTopic: boolean) => groupService.markAsTopicGroup(chatId, isTopic),
     isTopicGroup: (chatId: string) => groupService.isTopicGroup(chatId),
     listTopicGroups: () => groupService.listTopicGroups(),
+
+    // Skill Agent management (Issue #455)
+    listSkills: skillAgentManager ? () => skillAgentManager.discoverSkills() : undefined,
+    startSkillAgent: skillAgentManager
+      ? async (options) => {
+          return skillAgentManager.startAgent(options);
+        }
+      : undefined,
+    stopSkillAgent: skillAgentManager
+      ? async (agentId) => {
+          return skillAgentManager.stopAgent(agentId);
+        }
+      : undefined,
+    getSkillAgentInfo: skillAgentManager
+      ? (agentId) => skillAgentManager.getAgentInfo(agentId)
+      : undefined,
+    listSkillAgents: skillAgentManager
+      ? () => skillAgentManager.listRunningAgents()
+      : undefined,
   };
 }

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -44,6 +44,7 @@ import {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  SkillCommand,
 } from './commands/index.js';
 
 // Re-export all command classes for backward compatibility
@@ -68,6 +69,7 @@ export {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  SkillCommand,
 };
 
 /**
@@ -101,4 +103,6 @@ export function registerDefaultCommands(
   registry.register(new TopicGroupCommand());
   // Issue #535: Expert registration and skill management
   registry.register(new ExpertCommand());
+  // Issue #455: Skill Agent management command
+  registry.register(new SkillCommand());
 }

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -39,3 +39,6 @@ export { TopicGroupCommand } from './topic-group-command.js';
 
 // Expert commands (Issue #535)
 export { ExpertCommand } from './expert-commands.js';
+
+// Skill Agent commands (Issue #455)
+export { SkillCommand } from './skill-command.js';

--- a/src/nodes/commands/commands/skill-command.test.ts
+++ b/src/nodes/commands/commands/skill-command.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for SkillCommand.
+ *
+ * Issue #455: Skill Agent System - Background execution of independent Agent processes
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SkillCommand } from './skill-command.js';
+import type { CommandContext, CommandServices } from '../types.js';
+
+describe('SkillCommand', () => {
+  let command: SkillCommand;
+  let mockServices: CommandServices;
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    command = new SkillCommand();
+
+    mockServices = {
+      isRunning: vi.fn(() => true),
+      getLocalNodeId: vi.fn(() => 'node-1'),
+      getExecNodes: vi.fn(() => []),
+      getChatNodeAssignment: vi.fn(),
+      switchChatNode: vi.fn(),
+      getNode: vi.fn(),
+      sendCommand: vi.fn(),
+      getFeishuClient: vi.fn(),
+      createDiscussionChat: vi.fn(),
+      createGroup: vi.fn(),
+      addMembers: vi.fn(),
+      removeMembers: vi.fn(),
+      getMembers: vi.fn(),
+      dissolveChat: vi.fn(),
+      registerGroup: vi.fn(),
+      unregisterGroup: vi.fn(),
+      listGroups: vi.fn(() => []),
+      getBotChats: vi.fn(),
+      setDebugGroup: vi.fn(),
+      getDebugGroup: vi.fn(),
+      clearDebugGroup: vi.fn(),
+      getChannelStatus: vi.fn(() => 'OK'),
+      listSchedules: vi.fn(),
+      getSchedule: vi.fn(),
+      enableSchedule: vi.fn(),
+      disableSchedule: vi.fn(),
+      runSchedule: vi.fn(),
+      isScheduleRunning: vi.fn(),
+      startTask: vi.fn(),
+      getCurrentTask: vi.fn(),
+      updateTaskProgress: vi.fn(),
+      pauseTask: vi.fn(),
+      resumeTask: vi.fn(),
+      cancelTask: vi.fn(),
+      completeTask: vi.fn(),
+      setTaskError: vi.fn(),
+      listTaskHistory: vi.fn(),
+      setPassiveMode: vi.fn(),
+      getPassiveMode: vi.fn(),
+      markAsTopicGroup: vi.fn(),
+      isTopicGroup: vi.fn(),
+      listTopicGroups: vi.fn(),
+      // Skill Agent methods
+      listSkills: vi.fn(),
+      startSkillAgent: vi.fn(),
+      stopSkillAgent: vi.fn(),
+      getSkillAgentInfo: vi.fn(),
+      listSkillAgents: vi.fn(),
+    };
+
+    mockContext = {
+      chatId: 'oc_test',
+      args: [],
+      rawText: '/skill',
+      services: mockServices,
+    };
+  });
+
+  describe('metadata', () => {
+    it('should have correct name and category', () => {
+      expect(command.name).toBe('skill');
+      expect(command.category).toBe('skill');
+      expect(command.description).toContain('Skill Agents');
+    });
+  });
+
+  describe('execute', () => {
+    it('should return error if no subcommand', async () => {
+      mockContext.args = [];
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('请指定子命令');
+    });
+
+    it('should return error for unknown subcommand', async () => {
+      mockContext.args = ['unknown'];
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('未知子命令');
+    });
+  });
+
+  describe('list', () => {
+    it('should list available skills', async () => {
+      mockContext.args = ['list'];
+      vi.mocked(mockServices.listSkills!).mockResolvedValueOnce([
+        { name: 'evaluator', path: '/skills/evaluator/SKILL.md', domain: 'package' },
+        { name: 'executor', path: '/skills/executor/SKILL.md', domain: 'package' },
+      ]);
+      vi.mocked(mockServices.listSkillAgents!).mockReturnValue([]);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('evaluator');
+      expect(result.message).toContain('executor');
+    });
+
+    it('should show running agents', async () => {
+      mockContext.args = ['list'];
+      vi.mocked(mockServices.listSkills!).mockResolvedValueOnce([]);
+      vi.mocked(mockServices.listSkillAgents!).mockReturnValue([
+        {
+          id: 'test-agent-id',
+          skillName: 'test-skill',
+          status: 'running',
+          chatId: 'oc_test',
+          startedAt: new Date(),
+          abortController: new AbortController(),
+        },
+      ]);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('test-skill');
+      expect(result.message).toContain('running');
+    });
+  });
+
+  describe('run', () => {
+    it('should return error if no skill name', async () => {
+      mockContext.args = ['run'];
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('请指定要运行的技能名称');
+    });
+
+    it('should start skill agent', async () => {
+      mockContext.args = ['run', 'test-skill', 'some', 'input'];
+      vi.mocked(mockServices.startSkillAgent!).mockResolvedValueOnce('new-agent-id');
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Skill Agent 已启动');
+      expect(result.message).toContain('test-skill');
+      expect(mockServices.startSkillAgent).toHaveBeenCalledWith({
+        skillName: 'test-skill',
+        chatId: 'oc_test',
+        input: 'some input',
+      });
+    });
+
+    it('should handle start failure', async () => {
+      mockContext.args = ['run', 'test-skill'];
+      vi.mocked(mockServices.startSkillAgent!).mockRejectedValueOnce(
+        new Error('Skill not found')
+      );
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Skill not found');
+    });
+  });
+
+  describe('stop', () => {
+    it('should return error if no agent id', async () => {
+      mockContext.args = ['stop'];
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('请指定要停止的 Agent ID');
+    });
+
+    it('should stop agent', async () => {
+      mockContext.args = ['stop', 'test-agent-id'];
+      vi.mocked(mockServices.stopSkillAgent!).mockResolvedValueOnce(true);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('已停止');
+    });
+
+    it('should handle stop failure', async () => {
+      mockContext.args = ['stop', 'nonexistent-id'];
+      vi.mocked(mockServices.stopSkillAgent!).mockResolvedValueOnce(false);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('无法停止 Agent');
+    });
+  });
+
+  describe('status', () => {
+    it('should show all running agents if no id', async () => {
+      mockContext.args = ['status'];
+      vi.mocked(mockServices.listSkillAgents!).mockReturnValue([
+        {
+          id: 'agent-1',
+          skillName: 'skill-1',
+          status: 'running',
+          chatId: 'oc_test',
+          startedAt: new Date(),
+          abortController: new AbortController(),
+        },
+      ]);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('skill-1');
+    });
+
+    it('should show specific agent status', async () => {
+      mockContext.args = ['status', 'agent-1'];
+      vi.mocked(mockServices.getSkillAgentInfo!).mockReturnValue({
+        id: 'agent-1',
+        skillName: 'test-skill',
+        status: 'running',
+        chatId: 'oc_test',
+        startedAt: new Date(),
+        abortController: new AbortController(),
+      });
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('test-skill');
+      expect(result.message).toContain('running');
+    });
+
+    it('should handle agent not found', async () => {
+      mockContext.args = ['status', 'nonexistent'];
+      vi.mocked(mockServices.getSkillAgentInfo!).mockReturnValue(undefined);
+
+      const result = await command.execute(mockContext);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('未找到 Agent');
+    });
+  });
+});

--- a/src/nodes/commands/commands/skill-command.ts
+++ b/src/nodes/commands/commands/skill-command.ts
@@ -1,0 +1,372 @@
+/**
+ * Skill Command - Manage Skill Agents via Feishu commands.
+ *
+ * Implements the Feishu control interface for Skill Agents as described in Issue #455:
+ *
+ * Commands:
+ * - /skill list - List all available skills and running agents
+ * - /skill run <name> [input] - Start a skill agent
+ * - /skill stop <agent-id> - Stop a running agent
+ * - /skill status [agent-id] - Show agent status
+ *
+ * @module nodes/commands/commands/skill-command
+ */
+
+import type {
+  Command,
+  CommandContext,
+  CommandResult,
+  CommandServices,
+} from '../types.js';
+import { createLogger } from '../../../utils/logger.js';
+
+const logger = createLogger('SkillCommand');
+
+/**
+ * Skill command for managing Skill Agents.
+ *
+ * @example
+ * ```bash
+ * # List all skills
+ * /skill list
+ *
+ * # Run a skill
+ * /skill run site-miner Extract product info from https://example.com
+ *
+ * # Check status
+ * /skill status abc-123
+ *
+ * # Stop an agent
+ * /skill stop abc-123
+ * ```
+ */
+export class SkillCommand implements Command {
+  readonly name = 'skill';
+  readonly category = 'skill' as const;
+  readonly description = '管理 Skill Agents（后台执行的技能代理）';
+  readonly usage = `/skill <list|run|stop|status> [args...]
+
+子命令:
+  list              列出所有可用技能和运行中的 agents
+  run <name> [input] 启动一个 skill agent
+  stop <agent-id>   停止一个运行中的 agent
+  status [agent-id] 查看 agent 状态`;
+
+  execute(context: CommandContext): CommandResult | Promise<CommandResult> {
+    const { args, services, chatId } = context;
+
+    if (args.length === 0) {
+      return {
+        success: false,
+        error: `请指定子命令。用法:\n${this.usage}`,
+      };
+    }
+
+    const subCommand = args[0].toLowerCase();
+    const subArgs = args.slice(1);
+
+    switch (subCommand) {
+      case 'list':
+      case 'ls':
+        return this.handleList(services, chatId);
+
+      case 'run':
+      case 'start':
+        return this.handleRun(subArgs, services, chatId);
+
+      case 'stop':
+        return this.handleStop(subArgs, services);
+
+      case 'status':
+        return this.handleStatus(subArgs, services);
+
+      default:
+        return {
+          success: false,
+          error: `未知子命令: ${subCommand}\n${this.usage}`,
+        };
+    }
+  }
+
+  /**
+   * Handle /skill list command.
+   */
+  private async handleList(
+    services: CommandServices,
+    _chatId: string
+  ): Promise<CommandResult> {
+    try {
+      // Get available skills
+      const skills = await services.listSkills?.() ?? [];
+
+      // Get running agents
+      const agents = services.listSkillAgents?.() ?? [];
+
+      // Build response
+      const parts: string[] = ['🎯 **Skill Agent 管理**\n'];
+
+      // Available skills
+      if (skills.length > 0) {
+        parts.push('**可用技能:**');
+        for (const skill of skills) {
+          parts.push(`  • ${skill.name} (${skill.domain})`);
+        }
+        parts.push('');
+      } else {
+        parts.push('_没有发现可用技能_\n');
+      }
+
+      // Running agents
+      if (agents.length > 0) {
+        parts.push('**运行中的 Agents:**');
+        for (const agent of agents) {
+          const statusEmoji = this.getStatusEmoji(agent.status);
+          const duration = this.formatDuration(agent.startedAt);
+          parts.push(
+            `  ${statusEmoji} \`${agent.id.slice(0, 8)}\` ${agent.skillName} ` +
+            `(${agent.status}, ${duration})`
+          );
+        }
+      }
+
+      // Usage hint
+      parts.push(
+        '',
+        '💡 **使用方法:**',
+        '  `/skill run <技能名> [输入]` - 启动一个 skill agent',
+        '  `/skill status <agent-id>` - 查看详细状态',
+        '  `/skill stop <agent-id>` - 停止 agent'
+      );
+
+      return {
+        success: true,
+        message: parts.join('\n'),
+      };
+    } catch (error) {
+      logger.error({ error }, 'Failed to list skills');
+      return {
+        success: false,
+        error: `获取技能列表失败: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Handle /skill run command.
+   */
+  private async handleRun(
+    args: string[],
+    services: CommandServices,
+    chatId: string
+  ): Promise<CommandResult> {
+    if (args.length === 0) {
+      return {
+        success: false,
+        error: '请指定要运行的技能名称。\n用法: /skill run <技能名> [输入]',
+      };
+    }
+
+    const skillName = args[0];
+    const input = args.slice(1).join(' ').trim() || undefined;
+
+    try {
+      const agentId = await services.startSkillAgent?.({
+        skillName,
+        chatId,
+        input,
+      });
+
+      if (!agentId) {
+        return {
+          success: false,
+          error: 'Skill Agent 服务未初始化',
+        };
+      }
+
+      return {
+        success: true,
+        message:
+          `🚀 **Skill Agent 已启动**\n\n` +
+          `技能: ${skillName}\n` +
+          `Agent ID: \`${agentId.slice(0, 8)}\`\n\n` +
+          `Agent 将在后台运行，完成后会发送通知。\n` +
+          `使用 \`/skill status ${agentId.slice(0, 8)}\` 查看状态。`,
+      };
+    } catch (error) {
+      logger.error({ error, skillName }, 'Failed to start skill agent');
+      return {
+        success: false,
+        error: `启动 Skill Agent 失败: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Handle /skill stop command.
+   */
+  private async handleStop(
+    args: string[],
+    services: CommandServices
+  ): Promise<CommandResult> {
+    if (args.length === 0) {
+      return {
+        success: false,
+        error: '请指定要停止的 Agent ID。\n用法: /skill stop <agent-id>',
+      };
+    }
+
+    const agentId = args[0];
+
+    try {
+      const stopped = await services.stopSkillAgent?.(agentId);
+
+      if (!stopped) {
+        return {
+          success: false,
+          error: `无法停止 Agent: 未找到或已停止`,
+        };
+      }
+
+      return {
+        success: true,
+        message: `⏹️ Agent \`${agentId.slice(0, 8)}\` 已停止`,
+      };
+    } catch (error) {
+      logger.error({ error, agentId }, 'Failed to stop skill agent');
+      return {
+        success: false,
+        error: `停止 Agent 失败: ${error instanceof Error ? error.message : String(error)}`,
+      };
+    }
+  }
+
+  /**
+   * Handle /skill status command.
+   */
+  private handleStatus(
+    args: string[],
+    services: CommandServices
+  ): CommandResult {
+    if (args.length === 0) {
+      // Show all running agents status
+      const agents = services.listSkillAgents?.() ?? [];
+
+      if (agents.length === 0) {
+        return {
+          success: true,
+          message: '没有运行中的 Skill Agents',
+        };
+      }
+
+      const lines = agents.map((agent) => {
+        const emoji = this.getStatusEmoji(agent.status);
+        const duration = this.formatDuration(agent.startedAt);
+        return (
+          `${emoji} \`${agent.id.slice(0, 8)}\` **${agent.skillName}**\n` +
+          `   状态: ${agent.status} | 耗时: ${duration}`
+        );
+      });
+
+      return {
+        success: true,
+        message: '**运行中的 Skill Agents:**\n\n' + lines.join('\n\n'),
+      };
+    }
+
+    // Show specific agent status
+    const agentId = args[0];
+    const agent = services.getSkillAgentInfo?.(agentId);
+
+    if (!agent) {
+      return {
+        success: false,
+        error: `未找到 Agent: ${agentId}`,
+      };
+    }
+
+    const emoji = this.getStatusEmoji(agent.status);
+    const duration = this.formatDuration(agent.startedAt);
+    const completedDuration = agent.completedAt
+      ? this.formatDuration(agent.completedAt)
+      : '';
+
+    const parts = [
+      `${emoji} **Skill Agent 状态**`,
+      '',
+      `**ID:** \`${agent.id.slice(0, 8)}\``,
+      `**技能:** ${agent.skillName}`,
+      `**状态:** ${agent.status}`,
+      `**启动时间:** ${this.formatDateTime(agent.startedAt)}`,
+      `**耗时:** ${duration}`,
+    ];
+
+    if (agent.completedAt) {
+      parts.push(`**完成时间:** ${this.formatDateTime(agent.completedAt)}`);
+      parts.push(`**运行时长:** ${completedDuration}`);
+    }
+
+    if (agent.error) {
+      parts.push('', `**错误:** ${agent.error}`);
+    }
+
+    if (agent.result) {
+      parts.push('', '**结果:**', agent.result.slice(0, 500));
+    }
+
+    return {
+      success: true,
+      message: parts.join('\n'),
+    };
+  }
+
+  /**
+   * Get emoji for agent status.
+   */
+  private getStatusEmoji(status: string): string {
+    switch (status) {
+      case 'starting':
+        return '🔄';
+      case 'running':
+        return '▶️';
+      case 'completed':
+        return '✅';
+      case 'failed':
+        return '❌';
+      case 'stopped':
+        return '⏹️';
+      default:
+        return '❓';
+    }
+  }
+
+  /**
+   * Format duration since a date.
+   */
+  private formatDuration(date: Date): string {
+    const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+
+    if (seconds < 60) {
+      return `${seconds}秒`;
+    }
+
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}分钟`;
+    }
+
+    const hours = Math.floor(minutes / 60);
+    return `${hours}小时${minutes % 60}分钟`;
+  }
+
+  /**
+   * Format date time for display.
+   */
+  private formatDateTime(date: Date): string {
+    return new Date(date).toLocaleString('zh-CN', {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+}

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -222,6 +222,27 @@ export interface CommandServices {
 
   /** List all topic groups */
   listTopicGroups: () => ManagedGroupInfo[];
+
+  // Skill Agent management (Issue #455)
+  /** List all available skills */
+  listSkills?: () => Promise<import('../../skills/finder.js').DiscoveredSkill[]>;
+
+  /** Start a Skill Agent */
+  startSkillAgent?: (options: {
+    skillName: string;
+    chatId: string;
+    input?: string;
+    templateVars?: Record<string, string>;
+  }) => Promise<string>;
+
+  /** Stop a Skill Agent */
+  stopSkillAgent?: (agentId: string) => Promise<boolean>;
+
+  /** Get Skill Agent info */
+  getSkillAgentInfo?: (agentId: string) => import('../../agents/skill-agent-manager.js').RunningAgentInfo | undefined;
+
+  /** List all running Skill Agents */
+  listSkillAgents?: () => import('../../agents/skill-agent-manager.js').RunningAgentInfo[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Issue #455 - Skill Agent System for background execution of independent Agent processes.

### Key Features

- **SkillAgentManager**: Manages lifecycle of background Skill Agents
  - Start/stop agents on demand
  - Track running agents and their status
  - Send completion notifications to users
  - Maximum concurrent agent limit (configurable)
  - Skill discovery caching (5-minute TTL)

- **SkillCommand**: Feishu control interface for Skill Agents
  - `/skill list` - List all available skills and running agents
  - `/skill run <name> [input]` - Start a skill agent
  - `/skill stop <agent-id>` - Stop a running agent
  - `/skill status [agent-id]` - Show agent status

### Architecture

```
Chat Agent (Pilot)
     │
     │ /skill run <name> [options]
     ▼
┌────────────────────────────────────────────┐
│            SkillAgentManager                │
│                                            │
│  ┌─────────┐ ┌─────────┐ ┌─────────┐      │
│  │ Agent 1 │ │ Agent 2 │ │ Agent N │      │
│  │ (skill) │ │ (skill) │ │ (skill) │      │
│  └─────────┘ └─────────┘ └─────────┘      │
└────────────────────────────────────────────┘
     │
     │ sendMessage (on completion)
     ▼
User (via Feishu)
```

### Changes

| File | Change |
|------|--------|
| `src/agents/skill-agent-manager.ts` | New file - SkillAgentManager implementation |
| `src/agents/skill-agent-manager.test.ts` | New file - 17 unit tests |
| `src/nodes/commands/commands/skill-command.ts` | New file - SkillCommand implementation |
| `src/nodes/commands/commands/skill-command.test.ts` | New file - 14 unit tests |
| `src/agents/index.ts` | Export SkillAgentManager and types |
| `src/nodes/commands/types.ts` | Add Skill Agent service methods |
| `src/nodes/commands/commands/index.ts` | Export SkillCommand |
| `src/nodes/commands/builtin-commands.ts` | Register SkillCommand |
| `src/nodes/command-services.ts` | Add Skill Agent services |

### Test Results

- ✅ 31 tests pass (17 + 14)
- ✅ TypeScript compilation passes
- ✅ Lint check passes

## Usage Examples

### List Skills
```
/skill list
```

### Run a Skill
```
/skill run site-miner Extract product info from https://example.com
```

### Check Status
```
/skill status abc-123
```

### Stop an Agent
```
/skill stop abc-123
```

Fixes #455

## Test plan

- [x] Unit tests pass (SkillAgentManager: 17, SkillCommand: 14)
- [x] TypeScript compilation passes
- [x] Lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)