### PR TITLE
feat(pilot): add native multimodal guidance for image attachments (Issue #808)

### DIFF
--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -2,6 +2,7 @@
  * Tests for MessageBuilder class.
  *
  * Issue #809: Tests for image analyzer MCP hint in buildAttachmentsInfo.
+ * Issue #808: Tests for native multimodal guidance when no MCP is configured.
  * Issue #955: Tests for persisted history context in session restoration.
  */
 
@@ -74,100 +75,174 @@ describe('MessageBuilder', () => {
     });
   });
 
-  describe('buildAttachmentsInfo (Issue #809)', () => {
+  describe('buildAttachmentsInfo (Issue #809, #808)', () => {
     // Access private method for testing
     const getAttachmentsInfo = (mb: MessageBuilder, attachments?: any[]) =>
       (mb as any).buildAttachmentsInfo(attachments);
 
-    it('should include image analyzer hint for image attachments when MCP is configured', async () => {
-      // Import Config to get access to the mocked version
-      const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
-        '4_5v_mcp': { command: 'test-command' },
-      } as any);
-
-      const imageAttachment = [{
-        id: 'test-id',
-        fileName: 'test.png',
-        mimeType: 'image/png',
-        size: 1024,
-        localPath: '/tmp/test.png',
-      }];
-
-      const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
-
-      expect(result).toContain('Image attachment(s) detected');
-      expect(result).toContain('analyze_image');
-      expect(result).toContain('image analyzer MCP');
-    });
-
-    it('should not include image analyzer hint when no image analyzer MCP is configured', async () => {
-      const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined as any);
-
-      const imageAttachment = [{
-        id: 'test-id',
-        fileName: 'test.png',
-        mimeType: 'image/png',
-        size: 1024,
-        localPath: '/tmp/test.png',
-      }];
-
-      const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
-
-      expect(result).not.toContain('Image attachment(s) detected');
-      expect(result).not.toContain('analyze_image');
-    });
-
-    it('should not include image analyzer hint for non-image attachments', async () => {
-      const { Config } = await import('../../config/index.js');
-      vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
-        '4_5v_mcp': { command: 'test-command' },
-      } as any);
-
-      const textAttachment = [{
-        id: 'test-id',
-        fileName: 'test.txt',
-        mimeType: 'text/plain',
-        size: 1024,
-        localPath: '/tmp/test.txt',
-      }];
-
-      const result = getAttachmentsInfo(new MessageBuilder(), textAttachment);
-
-      expect(result).not.toContain('Image attachment(s) detected');
-    });
-
-    it('should return empty string for no attachments', () => {
-      const result = getAttachmentsInfo(messageBuilder, []);
-      expect(result).toBe('');
-    });
-
-    it('should return empty string for undefined attachments', () => {
-      const result = getAttachmentsInfo(messageBuilder, undefined);
-      expect(result).toBe('');
-    });
-
-    it('should detect various image analyzer MCP names', async () => {
-      const { Config } = await import('../../config/index.js');
-      const mcpNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
-
-      for (const name of mcpNames) {
+    describe('with image analyzer MCP configured (Issue #809)', () => {
+      it('should include image analyzer hint for image attachments when MCP is configured', async () => {
+        // Import Config to get access to the mocked version
+        const { Config } = await import('../../config/index.js');
         vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
-          [name]: { command: 'test-command' },
+          '4_5v_mcp': { command: 'test-command' },
         } as any);
 
         const imageAttachment = [{
           id: 'test-id',
-          fileName: 'test.jpg',
-          mimeType: 'image/jpeg',
+          fileName: 'test.png',
+          mimeType: 'image/png',
           size: 1024,
-          localPath: '/tmp/test.jpg',
+          localPath: '/tmp/test.png',
         }];
 
         const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
+
+        expect(result).toContain('Image attachment(s) detected');
         expect(result).toContain('analyze_image');
-      }
+        expect(result).toContain('image analyzer MCP');
+      });
+
+      it('should detect various image analyzer MCP names', async () => {
+        const { Config } = await import('../../config/index.js');
+        const mcpNames = ['4_5v_mcp', 'glm-vision', 'image-analyzer', 'vision'];
+
+        for (const name of mcpNames) {
+          vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+            [name]: { command: 'test-command' },
+          } as any);
+
+          const imageAttachment = [{
+            id: 'test-id',
+            fileName: 'test.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            localPath: '/tmp/test.jpg',
+          }];
+
+          const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
+          expect(result).toContain('analyze_image');
+        }
+      });
+
+      it('should show correct image count', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+          '4_5v_mcp': { command: 'test-command' },
+        } as any);
+
+        const multipleImages = [
+          { id: '1', fileName: 'a.png', mimeType: 'image/png', size: 100, localPath: '/tmp/a.png' },
+          { id: '2', fileName: 'b.png', mimeType: 'image/png', size: 200, localPath: '/tmp/b.png' },
+        ];
+
+        const result = getAttachmentsInfo(new MessageBuilder(), multipleImages);
+        expect(result).toContain('(2)');
+      });
+    });
+
+    describe('without image analyzer MCP (Issue #808 - native multimodal)', () => {
+      it('should provide native multimodal guidance when no MCP is configured', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined as any);
+
+        const imageAttachment = [{
+          id: 'test-id',
+          fileName: 'test.png',
+          mimeType: 'image/png',
+          size: 1024,
+          localPath: '/tmp/test.png',
+        }];
+
+        const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
+
+        expect(result).toContain('Image attachment(s) detected');
+        expect(result).toContain('Read tool');
+        expect(result).toContain('Native multimodal');
+        expect(result).not.toContain('analyze_image');
+      });
+
+      it('should show correct image count for native multimodal', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined);
+
+        const multipleImages = [
+          { id: '1', fileName: 'a.png', mimeType: 'image/png', size: 100, localPath: '/tmp/a.png' },
+          { id: '2', fileName: 'b.png', mimeType: 'image/png', size: 200, localPath: '/tmp/b.png' },
+          { id: '3', fileName: 'c.png', mimeType: 'image/png', size: 300, localPath: '/tmp/c.png' },
+        ];
+
+        const result = getAttachmentsInfo(new MessageBuilder(), multipleImages);
+        expect(result).toContain('(3)');
+      });
+
+      it('should support various image MIME types', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined);
+
+        const imageTypes = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+
+        for (const mimeType of imageTypes) {
+          const imageAttachment = [{
+            id: 'test-id',
+            fileName: `test.${mimeType.split('/')[1]}`,
+            mimeType,
+            size: 1024,
+            localPath: '/tmp/test',
+          }];
+
+          const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
+          expect(result).toContain('Image attachment(s) detected');
+          expect(result).toContain('Native multimodal');
+        }
+      });
+    });
+
+    describe('non-image attachments', () => {
+      it('should not include image hint for non-image attachments', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce({
+          '4_5v_mcp': { command: 'test-command' },
+        } as any);
+
+        const textAttachment = [{
+          id: 'test-id',
+          fileName: 'test.txt',
+          mimeType: 'text/plain',
+          size: 1024,
+          localPath: '/tmp/test.txt',
+        }];
+
+        const result = getAttachmentsInfo(new MessageBuilder(), textAttachment);
+
+        expect(result).not.toContain('Image attachment(s) detected');
+      });
+
+      it('should handle mixed attachments (images + files)', async () => {
+        const { Config } = await import('../../config/index.js');
+        vi.mocked(Config.getMcpServersConfig).mockReturnValueOnce(undefined);
+
+        const mixedAttachments = [
+          { id: '1', fileName: 'doc.txt', mimeType: 'text/plain', size: 100, localPath: '/tmp/doc.txt' },
+          { id: '2', fileName: 'img.png', mimeType: 'image/png', size: 200, localPath: '/tmp/img.png' },
+        ];
+
+        const result = getAttachmentsInfo(new MessageBuilder(), mixedAttachments);
+        expect(result).toContain('Image attachment(s) detected');
+        expect(result).toContain('(1)'); // Only 1 image
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should return empty string for no attachments', () => {
+        const result = getAttachmentsInfo(messageBuilder, []);
+        expect(result).toBe('');
+      });
+
+      it('should return empty string for undefined attachments', () => {
+        const result = getAttachmentsInfo(messageBuilder, undefined);
+        expect(result).toBe('');
+      });
     });
   });
 });

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -218,6 +218,7 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
    * Build attachments info string for the message content.
    *
    * Issue #809: Added image analyzer MCP hint for image attachments.
+   * Issue #808: Added native multimodal guidance when no MCP is configured.
    */
   private buildAttachmentsInfo(attachments?: MessageData['attachments']): string {
     if (!attachments || attachments.length === 0) {
@@ -234,24 +235,46 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       })
       .join('\n');
 
-    // Issue #809: Check if there are image attachments and image analyzer MCP is configured
-    const hasImageAttachment = attachments.some(att =>
+    // Issue #809/#808: Check if there are image attachments
+    const imageAttachments = attachments.filter(att =>
       att.mimeType?.startsWith('image/')
     );
-    const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
-      ? `
-
-**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
-      : '';
+    const imageGuidance = this.buildImageGuidance(imageAttachments);
 
     return `
 
 --- Attachments ---
 The user has attached ${attachments.length} file(s). These files have been downloaded to local storage:
 
-${attachmentList}${imageAnalyzerHint}
+${attachmentList}${imageGuidance}
 
 You can read these files using the Read tool with the local paths above.`;
+  }
+
+  /**
+   * Build image guidance based on MCP configuration.
+   *
+   * Issue #808: Provides appropriate guidance for image analysis.
+   * - With MCP: Suggests using analyze_image tool
+   * - Without MCP: Suggests using Read tool for native multimodal models
+   */
+  private buildImageGuidance(imageAttachments: NonNullable<MessageData['attachments']>): string {
+    if (imageAttachments.length === 0) {
+      return '';
+    }
+
+    const count = imageAttachments.length;
+
+    if (this.hasImageAnalyzerMcp()) {
+      return `
+
+**Image attachment(s) detected (${count}):** If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`;
+    }
+
+    // Issue #808: Native multimodal guidance when no MCP is configured
+    return `
+
+**Image attachment(s) detected (${count}):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.`;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fixes #808 - Testing native multimodal models in disclaude
- Provides native multimodal guidance when no image analyzer MCP is configured
- Updates tests to cover both scenarios (MCP configured vs not configured)

## Changes

When a user sends an image attachment:
- **With image analyzer MCP**: Suggests using `analyze_image` tool (existing behavior from #809)
- **Without image analyzer MCP**: Provides native multimodal guidance to use the Read tool (new behavior)

### Code Changes
- Modified `buildAttachmentsInfo` in message-builder.ts to provide native multimodal guidance
- Added `buildImageGuidance` method to handle both scenarios
- Updated tests to cover both scenarios with proper mock isolation

## Example Output

### With MCP configured:
```markdown
**Image attachment(s) detected (1):** If you need to analyze the image content, prefer using the `analyze_image` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.
```

### Without MCP (native multimodal):
```markdown
**Image attachment(s) detected (1):** Use the Read tool with the local paths above to view and analyze the images. Native multimodal models can directly understand image content through the Read tool.
```

## Test Results

- ✅ 10 tests pass
- ✅ TypeScript compilation passes
- ✅ Lint passes (0 errors, 7 pre-existing warnings)

## Verification

- [x] Native multimodal models (like Claude) receive correct guidance to use Read tool
- [x] Image count is displayed correctly in guidance message
- [x] Both MCP and non-MCP scenarios work as expected

## Related

- Parent Issue: #656
- Related: #809 (MCP hint - merged in #852)
- Supersedes closed PR: #817 (had CI failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)