### PR TITLE
fix(card): add click field to button for card.action.trigger callback (Issue #894)

### DIFF
--- a/src/platforms/feishu/card-builders/interactive-card-builder.test.ts
+++ b/src/platforms/feishu/card-builders/interactive-card-builder.test.ts
@@ -17,7 +17,7 @@ import {
 
 describe('Interactive Card Builder', () => {
   describe('buildButton', () => {
-    it('should build a default button', () => {
+    it('should build a default button with click configuration', () => {
       const button = buildButton({ text: 'Click Me', value: 'click' });
 
       expect(button).toEqual({
@@ -25,16 +25,24 @@ describe('Interactive Card Builder', () => {
         text: { tag: 'plain_text', content: 'Click Me' },
         type: 'default',
         value: { action: 'click' },
+        click: {
+          tag: 'request',
+          value: { action: 'click' },
+        },
       });
     });
 
-    it('should build a primary button', () => {
+    it('should build a primary button with click configuration', () => {
       const button = buildButton({ text: 'Confirm', value: 'confirm', style: 'primary' });
 
       expect(button.type).toBe('primary');
+      expect(button.click).toEqual({
+        tag: 'request',
+        value: { action: 'confirm' },
+      });
     });
 
-    it('should build a button with URL', () => {
+    it('should build a button with URL and click configuration', () => {
       const button = buildButton({
         text: 'Open Link',
         value: 'link',
@@ -42,6 +50,16 @@ describe('Interactive Card Builder', () => {
       });
 
       expect(button.url).toBe('https://example.com');
+      expect(button.click).toEqual({
+        tag: 'request',
+        value: { action: 'link' },
+      });
+    });
+
+    it('should have matching value and click.value for callback consistency', () => {
+      const button = buildButton({ text: 'Test', value: 'test-action' });
+
+      expect(button.value).toEqual(button.click.value);
     });
   });
 
@@ -132,12 +150,20 @@ describe('Interactive Card Builder', () => {
             text: { tag: 'plain_text', content: 'Yes' },
             type: 'primary',
             value: { action: 'yes' },
+            click: {
+              tag: 'request',
+              value: { action: 'yes' },
+            },
           },
           {
             tag: 'button',
             text: { tag: 'plain_text', content: 'No' },
             type: 'danger',
             value: { action: 'no' },
+            click: {
+              tag: 'request',
+              value: { action: 'no' },
+            },
           },
         ],
       });

--- a/src/platforms/feishu/card-builders/interactive-card-builder.ts
+++ b/src/platforms/feishu/card-builders/interactive-card-builder.ts
@@ -104,6 +104,15 @@ export type CardElement =
 export type ActionElement = ButtonAction | MenuAction;
 
 /**
+ * Button click configuration for triggering callbacks.
+ * Required for button clicks to trigger card.action.trigger events.
+ */
+export interface ButtonClick {
+  tag: 'request';
+  value: Record<string, string>;
+}
+
+/**
  * Button action element.
  */
 export interface ButtonAction {
@@ -111,6 +120,8 @@ export interface ButtonAction {
   text: { tag: 'plain_text'; content: string };
   type: ButtonStyle;
   value: Record<string, string>;
+  /** Click configuration required for triggering card.action.trigger events */
+  click: ButtonClick;
   url?: string;
 }
 
@@ -176,11 +187,18 @@ export interface BuiltCard {
  * const button = buildButton({ text: 'Confirm', value: 'confirm', style: 'primary' });
  */
 export function buildButton(config: ButtonConfig): ButtonAction {
+  const buttonValue = { action: config.value };
+
   const button: ButtonAction = {
     tag: 'button',
     text: { tag: 'plain_text', content: config.text },
     type: config.style || 'default',
-    value: { action: config.value },
+    value: buttonValue,
+    // click field is required for triggering card.action.trigger events
+    click: {
+      tag: 'request',
+      value: buttonValue,
+    },
   };
 
   if (config.url) {


### PR DESCRIPTION
## Summary

- Fixes #894 - 飞书卡片按钮点击无响应
- Added required `click` field to button configuration for triggering `card.action.trigger` events

## Root Cause

Feishu card buttons were missing the required `click` field. According to Feishu official documentation, buttons need a `click` field with `tag: 'request'` to properly trigger the `card.action.trigger` event when clicked.

**Before:**
```typescript
{
  tag: 'button',
  text: { tag: 'plain_text', content: 'Confirm' },
  type: 'primary',
  value: { action: 'confirm' }
  // Missing: click field!
}
```

**After:**
```typescript
{
  tag: 'button',
  text: { tag: 'plain_text', content: 'Confirm' },
  type: 'primary',
  value: { action: 'confirm' },
  click: {
    tag: 'request',
    value: { action: 'confirm' }
  }
}
```

## Changes

| File | Change |
|------|--------|
| `interactive-card-builder.ts` | Added `ButtonClick` interface and updated `ButtonAction` to include required `click` field |
| `interactive-card-builder.ts` | Modified `buildButton()` to automatically add `click` configuration |
| `interactive-card-builder.test.ts` | Updated tests to verify `click` field presence and consistency |

## Test Results

- ✅ 1617 tests pass (including 5 new/updated button tests)
- ✅ TypeScript compilation passes
- ✅ Lint check passes

## Test Plan

- [x] Unit tests pass (interactive-card-builder: 5 tests)
- [x] Full test suite passes (1617 tests)
- [x] TypeScript compilation passes
- [x] Lint check passes
- [ ] Manual testing with actual Feishu card button clicks

Fixes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)