### PR TITLE
feat(expert): add credit system for expert pricing and agent accounts (Issue #538)

### DIFF
--- a/src/experts/credit-service.test.ts
+++ b/src/experts/credit-service.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Tests for CreditService.
+ *
+ * @see Issue #538 - 积分系统 - 身价与消费
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CreditService } from './credit-service.js';
+
+describe('CreditService', () => {
+  let tempDir: string;
+  let testFilePath: string;
+  let service: CreditService;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'credit-test-'));
+    testFilePath = path.join(tempDir, 'credits.json');
+    service = new CreditService({
+      filePath: testFilePath,
+      initialBalance: 100,
+      defaultDailyLimit: 50,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  describe('getOrCreateAccount', () => {
+    it('should create a new account with initial balance', () => {
+      const account = service.getOrCreateAccount('agent_123');
+
+      expect(account.agentId).toBe('agent_123');
+      expect(account.balance).toBe(100);
+      expect(account.dailyLimit).toBe(50);
+      expect(account.usedToday).toBe(0);
+    });
+
+    it('should return existing account', () => {
+      service.getOrCreateAccount('agent_123');
+      const account = service.getOrCreateAccount('agent_123');
+
+      expect(account.agentId).toBe('agent_123');
+    });
+  });
+
+  describe('getAccount', () => {
+    it('should return undefined for non-existent account', () => {
+      expect(service.getAccount('nonexistent')).toBeUndefined();
+    });
+
+    it('should return existing account', () => {
+      service.getOrCreateAccount('agent_123');
+      const account = service.getAccount('agent_123');
+
+      expect(account?.agentId).toBe('agent_123');
+    });
+  });
+
+  describe('canSpend', () => {
+    it('should return false for non-existent account', () => {
+      expect(service.canSpend('nonexistent', 10)).toBe(false);
+    });
+
+    it('should return true when balance is sufficient', () => {
+      service.getOrCreateAccount('agent_123');
+      expect(service.canSpend('agent_123', 50)).toBe(true);
+    });
+
+    it('should return false when balance is insufficient', () => {
+      service.getOrCreateAccount('agent_123');
+      expect(service.canSpend('agent_123', 150)).toBe(false);
+    });
+
+    it('should return false when daily limit exceeded', () => {
+      const account = service.getOrCreateAccount('agent_123');
+      account.usedToday = 45; // Near limit
+      expect(service.canSpend('agent_123', 10)).toBe(false);
+    });
+
+    it('should allow unlimited daily when limit is 0', () => {
+      const account = service.getOrCreateAccount('agent_123');
+      account.dailyLimit = 0;
+      account.usedToday = 1000;
+      expect(service.canSpend('agent_123', 10)).toBe(true);
+    });
+  });
+
+  describe('spend', () => {
+    it('should spend credits successfully', () => {
+      service.getOrCreateAccount('agent_123');
+      const result = service.spend('agent_123', 20, 'Consultation');
+
+      expect(result.success).toBe(true);
+      expect(result.newBalance).toBe(80);
+
+      const account = service.getAccount('agent_123');
+      expect(account?.balance).toBe(80);
+      expect(account?.usedToday).toBe(20);
+    });
+
+    it('should return error for non-existent account', () => {
+      const result = service.spend('nonexistent', 10, 'Test');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('account_not_found');
+    });
+
+    it('should return error for insufficient balance', () => {
+      service.getOrCreateAccount('agent_123');
+      const result = service.spend('agent_123', 150, 'Test');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('insufficient_balance');
+    });
+
+    it('should return error for daily limit exceeded', () => {
+      const account = service.getOrCreateAccount('agent_123');
+      account.usedToday = 45;
+      const result = service.spend('agent_123', 10, 'Test');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('daily_limit_exceeded');
+    });
+
+    it('should record transaction with expert ID', () => {
+      service.getOrCreateAccount('agent_123');
+      const result = service.spend('agent_123', 20, 'Consultation', 'expert_456');
+
+      expect(result.success).toBe(true);
+      expect(result.transaction?.expertId).toBe('expert_456');
+      expect(result.transaction?.type).toBe('spend');
+    });
+  });
+
+  describe('recharge', () => {
+    it('should recharge credits', () => {
+      service.getOrCreateAccount('agent_123');
+      const account = service.recharge('agent_123', 50);
+
+      expect(account?.balance).toBe(150);
+    });
+
+    it('should create account if not exists', () => {
+      const account = service.recharge('agent_123', 50);
+
+      expect(account?.agentId).toBe('agent_123');
+      expect(account?.balance).toBe(150); // initial + recharge
+    });
+
+    it('should return undefined for invalid amount', () => {
+      const result = service.recharge('agent_123', 0);
+      expect(result).toBeUndefined();
+    });
+
+    it('should record recharge transaction', () => {
+      service.recharge('agent_123', 50);
+      const history = service.getTransactionHistory('agent_123');
+
+      expect(history).toHaveLength(1);
+      expect(history[0].type).toBe('recharge');
+      expect(history[0].amount).toBe(50);
+    });
+  });
+
+  describe('refund', () => {
+    it('should refund credits', () => {
+      service.getOrCreateAccount('agent_123');
+      service.spend('agent_123', 20, 'Consultation');
+
+      const account = service.refund('agent_123', 20, 'Refund');
+
+      expect(account?.balance).toBe(100);
+    });
+
+    it('should reduce daily usage', () => {
+      const account = service.getOrCreateAccount('agent_123');
+      service.spend('agent_123', 20, 'Consultation');
+
+      service.refund('agent_123', 20, 'Refund');
+
+      expect(account.usedToday).toBe(0);
+    });
+
+    it('should return undefined for non-existent account', () => {
+      const result = service.refund('nonexistent', 10, 'Refund');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('setDailyLimit', () => {
+    it('should set daily limit', () => {
+      service.getOrCreateAccount('agent_123');
+      const account = service.setDailyLimit('agent_123', 100);
+
+      expect(account?.dailyLimit).toBe(100);
+    });
+
+    it('should create account if not exists', () => {
+      const account = service.setDailyLimit('agent_123', 100);
+
+      expect(account?.agentId).toBe('agent_123');
+    });
+
+    it('should allow unlimited (0)', () => {
+      service.getOrCreateAccount('agent_123');
+      const account = service.setDailyLimit('agent_123', 0);
+
+      expect(account?.dailyLimit).toBe(0);
+    });
+
+    it('should return undefined for negative limit', () => {
+      service.getOrCreateAccount('agent_123');
+      const result = service.setDailyLimit('agent_123', -10);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('listAccounts', () => {
+    it('should return empty array when no accounts', () => {
+      expect(service.listAccounts()).toEqual([]);
+    });
+
+    it('should return all accounts', () => {
+      service.getOrCreateAccount('agent_1');
+      service.getOrCreateAccount('agent_2');
+
+      const accounts = service.listAccounts();
+      expect(accounts).toHaveLength(2);
+      expect(accounts.map(a => a.agentId)).toContain('agent_1');
+      expect(accounts.map(a => a.agentId)).toContain('agent_2');
+    });
+  });
+
+  describe('getTransactionHistory', () => {
+    it('should return empty array for no transactions', () => {
+      expect(service.getTransactionHistory('agent_123')).toEqual([]);
+    });
+
+    it('should return transaction history', () => {
+      service.getOrCreateAccount('agent_123');
+      service.spend('agent_123', 10, 'Test 1');
+      service.recharge('agent_123', 20, 'Test 2');
+
+      const history = service.getTransactionHistory('agent_123');
+      expect(history).toHaveLength(2);
+    });
+
+    it('should limit results', () => {
+      service.getOrCreateAccount('agent_123');
+      for (let i = 0; i < 10; i++) {
+        service.spend('agent_123', 1, `Test ${i}`);
+      }
+
+      const history = service.getTransactionHistory('agent_123', 5);
+      expect(history).toHaveLength(5);
+    });
+  });
+
+  describe('daily reset', () => {
+    it('should reset daily usage on new day', () => {
+      const account = service.getOrCreateAccount('agent_123');
+      service.spend('agent_123', 20, 'Test');
+
+      expect(account.usedToday).toBe(20);
+
+      // Simulate new day
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-02'));
+
+      const accountAfterReset = service.getAccount('agent_123');
+      expect(accountAfterReset?.usedToday).toBe(0);
+    });
+  });
+
+  describe('persistence', () => {
+    it('should persist data to file', () => {
+      service.getOrCreateAccount('agent_123');
+      service.recharge('agent_123', 50);
+
+      // Create new service instance to load from file
+      const newService = new CreditService({ filePath: testFilePath });
+      const account = newService.getAccount('agent_123');
+
+      expect(account?.balance).toBe(150);
+    });
+  });
+});

--- a/src/experts/credit-service.ts
+++ b/src/experts/credit-service.ts
@@ -1,0 +1,462 @@
+/**
+ * CreditService - Manages Agent credit accounts and transactions.
+ *
+ * Provides credit balance management for Agent accounts with:
+ * - Balance tracking
+ * - Daily spending limits
+ * - Recharge functionality
+ * - Transaction logging
+ *
+ * @see Issue #538 - 积分系统 - 身价与消费
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('CreditService');
+
+/**
+ * Agent credit account.
+ */
+export interface AgentAccount {
+  /** Agent identifier */
+  agentId: string;
+  /** Current balance in credits */
+  balance: number;
+  /** Daily spending limit (0 = unlimited) */
+  dailyLimit: number;
+  /** Amount spent today */
+  usedToday: number;
+  /** Last reset date for daily usage (YYYY-MM-DD) */
+  lastResetDate: string;
+  /** Account creation timestamp */
+  createdAt: number;
+  /** Last update timestamp */
+  updatedAt: number;
+}
+
+/**
+ * Credit transaction record.
+ */
+export interface CreditTransaction {
+  /** Transaction ID */
+  id: string;
+  /** Agent ID */
+  agentId: string;
+  /** Transaction type */
+  type: 'spend' | 'recharge' | 'refund' | 'adjust';
+  /** Amount (positive for credit, negative for debit) */
+  amount: number;
+  /** Balance after transaction */
+  balanceAfter: number;
+  /** Description */
+  description: string;
+  /** Related expert ID (for consultation transactions) */
+  expertId?: string;
+  /** Transaction timestamp */
+  timestamp: number;
+}
+
+/**
+ * Credit registry storage format.
+ */
+interface CreditRegistry {
+  /** Version for future migrations */
+  version: number;
+  /** Agent accounts indexed by agentId */
+  accounts: Record<string, AgentAccount>;
+  /** Transaction history */
+  transactions: CreditTransaction[];
+}
+
+/**
+ * CreditService configuration.
+ */
+export interface CreditServiceConfig {
+  /** Storage file path (default: workspace/credits.json) */
+  filePath?: string;
+  /** Default daily limit for new accounts */
+  defaultDailyLimit?: number;
+  /** Initial balance for new accounts */
+  initialBalance?: number;
+  /** Maximum transactions to keep in history */
+  maxTransactionHistory?: number;
+}
+
+/**
+ * Result of a spend operation.
+ */
+export interface SpendResult {
+  success: boolean;
+  error?: 'insufficient_balance' | 'daily_limit_exceeded' | 'account_not_found';
+  newBalance?: number;
+  transaction?: CreditTransaction;
+}
+
+/**
+ * Service for managing Agent credit accounts.
+ *
+ * Features:
+ * - Create and manage agent accounts
+ * - Spend credits with balance and limit checks
+ * - Recharge credits
+ * - Track transaction history
+ */
+export class CreditService {
+  private filePath: string;
+  private registry: CreditRegistry;
+  private defaultDailyLimit: number;
+  private initialBalance: number;
+  private maxTransactionHistory: number;
+
+  constructor(config: CreditServiceConfig = {}) {
+    this.filePath = config.filePath || path.join(process.cwd(), 'workspace', 'credits.json');
+    this.defaultDailyLimit = config.defaultDailyLimit ?? 0; // 0 = unlimited
+    this.initialBalance = config.initialBalance ?? 0;
+    this.maxTransactionHistory = config.maxTransactionHistory ?? 1000;
+    this.registry = this.load();
+  }
+
+  /**
+   * Load registry from file.
+   */
+  private load(): CreditRegistry {
+    try {
+      if (fs.existsSync(this.filePath)) {
+        const content = fs.readFileSync(this.filePath, 'utf-8');
+        const data = JSON.parse(content) as CreditRegistry;
+        logger.info({ accountCount: Object.keys(data.accounts || {}).length }, 'Credit registry loaded');
+        return data;
+      }
+    } catch (error) {
+      logger.warn({ err: error }, 'Failed to load credit registry, starting fresh');
+    }
+    return { version: 1, accounts: {}, transactions: [] };
+  }
+
+  /**
+   * Save registry to file.
+   */
+  private save(): void {
+    try {
+      const dir = path.dirname(this.filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(this.filePath, JSON.stringify(this.registry, null, 2));
+      logger.debug({ accountCount: Object.keys(this.registry.accounts).length }, 'Credit registry saved');
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to save credit registry');
+    }
+  }
+
+  /**
+   * Get today's date string for daily reset check.
+   */
+  private getTodayString(): string {
+    return new Date().toISOString().split('T')[0];
+  }
+
+  /**
+   * Reset daily usage if needed.
+   */
+  private resetDailyUsageIfNeeded(account: AgentAccount): void {
+    const today = this.getTodayString();
+    if (account.lastResetDate !== today) {
+      account.usedToday = 0;
+      account.lastResetDate = today;
+      logger.debug({ agentId: account.agentId }, 'Daily usage reset');
+    }
+  }
+
+  /**
+   * Generate a unique transaction ID.
+   */
+  private generateTransactionId(): string {
+    return `txn_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Add a transaction to history.
+   */
+  private addTransaction(transaction: CreditTransaction): void {
+    this.registry.transactions.push(transaction);
+    // Trim history if needed
+    if (this.registry.transactions.length > this.maxTransactionHistory) {
+      this.registry.transactions = this.registry.transactions.slice(-this.maxTransactionHistory);
+    }
+  }
+
+  /**
+   * Create or get an agent account.
+   *
+   * @param agentId - Agent identifier
+   * @returns The agent account
+   */
+  getOrCreateAccount(agentId: string): AgentAccount {
+    let account = this.registry.accounts[agentId];
+
+    if (!account) {
+      const now = Date.now();
+      account = {
+        agentId,
+        balance: this.initialBalance,
+        dailyLimit: this.defaultDailyLimit,
+        usedToday: 0,
+        lastResetDate: this.getTodayString(),
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.registry.accounts[agentId] = account;
+      this.save();
+      logger.info({ agentId, initialBalance: this.initialBalance }, 'Account created');
+    }
+
+    this.resetDailyUsageIfNeeded(account);
+    return account;
+  }
+
+  /**
+   * Get an agent account.
+   *
+   * @param agentId - Agent identifier
+   * @returns Account or undefined
+   */
+  getAccount(agentId: string): AgentAccount | undefined {
+    const account = this.registry.accounts[agentId];
+    if (account) {
+      this.resetDailyUsageIfNeeded(account);
+    }
+    return account;
+  }
+
+  /**
+   * Check if an agent can spend a certain amount.
+   *
+   * @param agentId - Agent identifier
+   * @param amount - Amount to spend
+   * @returns Whether the spend is allowed
+   */
+  canSpend(agentId: string, amount: number): boolean {
+    const account = this.getAccount(agentId);
+    if (!account) {
+      return false;
+    }
+
+    // Check balance
+    if (account.balance < amount) {
+      return false;
+    }
+
+    // Check daily limit (0 = unlimited)
+    if (account.dailyLimit > 0 && account.usedToday + amount > account.dailyLimit) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Spend credits from an agent account.
+   *
+   * @param agentId - Agent identifier
+   * @param amount - Amount to spend
+   * @param description - Transaction description
+   * @param expertId - Related expert ID (optional)
+   * @returns Spend result
+   */
+  spend(agentId: string, amount: number, description: string, expertId?: string): SpendResult {
+    const account = this.getAccount(agentId);
+
+    if (!account) {
+      return { success: false, error: 'account_not_found' };
+    }
+
+    // Check balance
+    if (account.balance < amount) {
+      logger.warn({ agentId, amount, balance: account.balance }, 'Insufficient balance');
+      return { success: false, error: 'insufficient_balance' };
+    }
+
+    // Check daily limit
+    if (account.dailyLimit > 0 && account.usedToday + amount > account.dailyLimit) {
+      logger.warn(
+        { agentId, amount, usedToday: account.usedToday, dailyLimit: account.dailyLimit },
+        'Daily limit exceeded'
+      );
+      return { success: false, error: 'daily_limit_exceeded' };
+    }
+
+    // Perform spend
+    account.balance -= amount;
+    account.usedToday += amount;
+    account.updatedAt = Date.now();
+
+    const transaction: CreditTransaction = {
+      id: this.generateTransactionId(),
+      agentId,
+      type: 'spend',
+      amount: -amount,
+      balanceAfter: account.balance,
+      description,
+      expertId,
+      timestamp: Date.now(),
+    };
+
+    this.addTransaction(transaction);
+    this.save();
+
+    logger.info({ agentId, amount, newBalance: account.balance }, 'Credits spent');
+    return { success: true, newBalance: account.balance, transaction };
+  }
+
+  /**
+   * Recharge credits to an agent account.
+   *
+   * @param agentId - Agent identifier
+   * @param amount - Amount to add
+   * @param description - Transaction description
+   * @returns Updated account or undefined
+   */
+  recharge(agentId: string, amount: number, description: string = '管理员充值'): AgentAccount | undefined {
+    const account = this.getOrCreateAccount(agentId);
+
+    if (amount <= 0) {
+      logger.warn({ agentId, amount }, 'Invalid recharge amount');
+      return undefined;
+    }
+
+    account.balance += amount;
+    account.updatedAt = Date.now();
+
+    const transaction: CreditTransaction = {
+      id: this.generateTransactionId(),
+      agentId,
+      type: 'recharge',
+      amount,
+      balanceAfter: account.balance,
+      description,
+      timestamp: Date.now(),
+    };
+
+    this.addTransaction(transaction);
+    this.save();
+
+    logger.info({ agentId, amount, newBalance: account.balance }, 'Credits recharged');
+    return account;
+  }
+
+  /**
+   * Refund credits to an agent account.
+   *
+   * @param agentId - Agent identifier
+   * @param amount - Amount to refund
+   * @param description - Transaction description
+   * @param expertId - Related expert ID (optional)
+   * @returns Updated account or undefined
+   */
+  refund(agentId: string, amount: number, description: string, expertId?: string): AgentAccount | undefined {
+    const account = this.getAccount(agentId);
+
+    if (!account) {
+      logger.warn({ agentId }, 'Cannot refund: account not found');
+      return undefined;
+    }
+
+    if (amount <= 0) {
+      logger.warn({ agentId, amount }, 'Invalid refund amount');
+      return undefined;
+    }
+
+    account.balance += amount;
+    // Reduce daily usage if refund is for today's spend
+    const today = this.getTodayString();
+    if (account.lastResetDate === today) {
+      account.usedToday = Math.max(0, account.usedToday - amount);
+    }
+    account.updatedAt = Date.now();
+
+    const transaction: CreditTransaction = {
+      id: this.generateTransactionId(),
+      agentId,
+      type: 'refund',
+      amount,
+      balanceAfter: account.balance,
+      description,
+      expertId,
+      timestamp: Date.now(),
+    };
+
+    this.addTransaction(transaction);
+    this.save();
+
+    logger.info({ agentId, amount, newBalance: account.balance }, 'Credits refunded');
+    return account;
+  }
+
+  /**
+   * Set daily limit for an agent.
+   *
+   * @param agentId - Agent identifier
+   * @param limit - Daily limit (0 = unlimited)
+   * @returns Updated account or undefined
+   */
+  setDailyLimit(agentId: string, limit: number): AgentAccount | undefined {
+    const account = this.getOrCreateAccount(agentId);
+
+    if (limit < 0) {
+      logger.warn({ agentId, limit }, 'Invalid daily limit');
+      return undefined;
+    }
+
+    account.dailyLimit = limit;
+    account.updatedAt = Date.now();
+    this.save();
+
+    logger.info({ agentId, limit }, 'Daily limit set');
+    return account;
+  }
+
+  /**
+   * List all agent accounts.
+   *
+   * @returns Array of agent accounts
+   */
+  listAccounts(): AgentAccount[] {
+    return Object.values(this.registry.accounts);
+  }
+
+  /**
+   * Get transaction history for an agent.
+   *
+   * @param agentId - Agent identifier
+   * @param limit - Maximum transactions to return
+   * @returns Array of transactions
+   */
+  getTransactionHistory(agentId: string, limit: number = 50): CreditTransaction[] {
+    return this.registry.transactions
+      .filter(t => t.agentId === agentId)
+      .slice(-limit);
+  }
+
+  /**
+   * Get the storage file path.
+   */
+  getFilePath(): string {
+    return this.filePath;
+  }
+}
+
+// Singleton instance
+let defaultInstance: CreditService | undefined;
+
+/**
+ * Get the default CreditService instance.
+ */
+export function getCreditService(): CreditService {
+  if (!defaultInstance) {
+    defaultInstance = new CreditService();
+  }
+  return defaultInstance;
+}

--- a/src/experts/expert-service.ts
+++ b/src/experts/expert-service.ts
@@ -5,6 +5,7 @@
  * Stores expert metadata in workspace/experts.json.
  *
  * @see Issue #535 - 人类专家注册与技能声明
+ * @see Issue #538 - 积分系统 - 身价与消费
  */
 
 import * as fs from 'fs';
@@ -46,6 +47,8 @@ export interface ExpertProfile {
   skills: SkillDeclaration[];
   /** Available hours (e.g., "weekdays 10:00-18:00") */
   availability?: string;
+  /** Price per consultation in credits (Issue #538) */
+  price?: number;
   /** Registration timestamp */
   registeredAt: number;
   /** Last update timestamp */
@@ -278,6 +281,32 @@ export class ExpertService {
     profile.updatedAt = Date.now();
     this.save();
     logger.info({ userId, availability }, 'Availability set');
+    return profile;
+  }
+
+  /**
+   * Set expert price per consultation.
+   *
+   * @param userId - User ID
+   * @param price - Price in credits (must be >= 0)
+   * @returns Updated profile or undefined if expert not found
+   */
+  setPrice(userId: string, price: number): ExpertProfile | undefined {
+    const profile = this.registry.experts[userId];
+    if (!profile) {
+      logger.warn({ userId }, 'Cannot set price: expert not found');
+      return undefined;
+    }
+
+    if (price < 0) {
+      logger.warn({ userId, price }, 'Cannot set negative price');
+      return undefined;
+    }
+
+    profile.price = price;
+    profile.updatedAt = Date.now();
+    this.save();
+    logger.info({ userId, price }, 'Price set');
     return profile;
   }
 

--- a/src/experts/index.ts
+++ b/src/experts/index.ts
@@ -2,6 +2,7 @@
  * Expert module exports.
  *
  * @see Issue #535 - 人类专家注册与技能声明
+ * @see Issue #538 - 积分系统 - 身价与消费
  */
 
 export {
@@ -12,3 +13,12 @@ export {
   type SkillLevel,
   type ExpertServiceConfig,
 } from './expert-service.js';
+
+export {
+  CreditService,
+  getCreditService,
+  type AgentAccount,
+  type CreditTransaction,
+  type CreditServiceConfig,
+  type SpendResult,
+} from './credit-service.js';

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -44,6 +44,7 @@ import {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  BudgetCommand,
 } from './commands/index.js';
 
 // Re-export all command classes for backward compatibility
@@ -68,6 +69,7 @@ export {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  BudgetCommand,
 };
 
 /**
@@ -101,4 +103,6 @@ export function registerDefaultCommands(
   registry.register(new TopicGroupCommand());
   // Issue #535: Expert registration and skill management
   registry.register(new ExpertCommand());
+  // Issue #538: Budget management for agent credits
+  registry.register(new BudgetCommand());
 }

--- a/src/nodes/commands/commands/budget-commands.ts
+++ b/src/nodes/commands/commands/budget-commands.ts
@@ -1,0 +1,242 @@
+/**
+ * Budget Commands - Agent credit account management.
+ *
+ * Provides admin commands for:
+ * - /budget balance <agent> - View agent balance
+ * - /budget recharge <agent> <credits> - Recharge agent credits
+ * - /budget limit <agent> <daily> - Set daily limit
+ * - /budget list - List all agent accounts
+ * - /budget history <agent> - View transaction history
+ *
+ * @see Issue #538 - 积分系统 - 身价与消费
+ */
+
+import type { Command, CommandContext, CommandResult } from '../types.js';
+import { getCreditService, type AgentAccount, type CreditTransaction } from '../../../experts/credit-service.js';
+
+/**
+ * Format agent account for display.
+ */
+function formatAccount(account: AgentAccount): string {
+  const lines: string[] = [
+    `🤖 **Agent: ${account.agentId}**`,
+    `   💰 余额: ${account.balance} 积分`,
+    `   📊 每日上限: ${account.dailyLimit === 0 ? '无限制' : `${account.dailyLimit} 积分`}`,
+    `   📈 今日已用: ${account.usedToday} 积分`,
+    `   📅 创建时间: ${new Date(account.createdAt).toLocaleDateString('zh-CN')}`,
+  ];
+  return lines.join('\n');
+}
+
+/**
+ * Format transaction for display.
+ */
+function formatTransaction(txn: CreditTransaction): string {
+  const typeEmoji = {
+    spend: '💸',
+    recharge: '🔋',
+    refund: '↩️',
+    adjust: '⚙️',
+  };
+  const emoji = typeEmoji[txn.type] || '💰';
+  const amount = txn.amount >= 0 ? `+${txn.amount}` : `${txn.amount}`;
+  const date = new Date(txn.timestamp).toLocaleString('zh-CN');
+  return `${emoji} ${amount} → ${txn.balanceAfter} | ${txn.description} (${date})`;
+}
+
+/**
+ * Budget Command - Admin credit account management.
+ *
+ * Usage:
+ * - /budget balance <agent> - View agent balance
+ * - /budget recharge <agent> <credits> - Recharge credits
+ * - /budget limit <agent> <daily> - Set daily limit
+ * - /budget list - List all accounts
+ * - /budget history <agent> - View transaction history
+ */
+export class BudgetCommand implements Command {
+  readonly name = 'budget';
+  readonly category = 'skill' as const;
+  readonly description = 'Agent 积分账户管理 (管理员)';
+  readonly usage = 'budget <balance|recharge|limit|list|history>';
+
+  execute(context: CommandContext): CommandResult {
+    const { args } = context;
+
+    const subCommand = args[0]?.toLowerCase();
+
+    switch (subCommand) {
+      case 'balance':
+        return this.handleBalance(context);
+      case 'recharge':
+        return this.handleRecharge(context);
+      case 'limit':
+        return this.handleLimit(context);
+      case 'list':
+        return this.handleList(context);
+      case 'history':
+        return this.handleHistory(context);
+      default:
+        return {
+          success: false,
+          error: `❌ 未知子命令: ${subCommand || '(未指定)'}\n\n用法:\n- /budget balance <agent> - 查看余额\n- /budget recharge <agent> <积分> - 充值\n- /budget limit <agent> <每日上限> - 设置每日上限\n- /budget list - 列出所有账户\n- /budget history <agent> - 查看交易记录`,
+        };
+    }
+  }
+
+  private handleBalance(context: CommandContext): CommandResult {
+    const { args } = context;
+    const creditService = getCreditService();
+
+    const [, agentId] = args;
+
+    if (!agentId) {
+      return { success: false, error: '❌ 请指定 Agent ID\n\n用法: /budget balance <agent>' };
+    }
+
+    const account = creditService.getAccount(agentId);
+
+    if (!account) {
+      return {
+        success: true,
+        message: `🤖 Agent \`${agentId}\` 尚未创建账户\n\n首次充值时将自动创建账户`,
+      };
+    }
+
+    return {
+      success: true,
+      message: formatAccount(account),
+    };
+  }
+
+  private handleRecharge(context: CommandContext): CommandResult {
+    const { args } = context;
+    const creditService = getCreditService();
+
+    const [, agentId, creditsStr] = args;
+
+    if (!agentId) {
+      return { success: false, error: '❌ 请指定 Agent ID\n\n用法: /budget recharge <agent> <积分>' };
+    }
+
+    if (!creditsStr) {
+      return { success: false, error: '❌ 请指定充值金额\n\n用法: /budget recharge <agent> <积分>' };
+    }
+
+    const credits = parseInt(creditsStr, 10);
+
+    if (isNaN(credits) || credits <= 0) {
+      return { success: false, error: '❌ 充值金额必须是正整数\n\n用法: /budget recharge <agent> <积分>' };
+    }
+
+    const account = creditService.recharge(agentId, credits);
+
+    if (!account) {
+      return { success: false, error: '❌ 充值失败' };
+    }
+
+    return {
+      success: true,
+      message: `✅ **充值成功**\n\n${formatAccount(account)}`,
+    };
+  }
+
+  private handleLimit(context: CommandContext): CommandResult {
+    const { args } = context;
+    const creditService = getCreditService();
+
+    const [, agentId, limitStr] = args;
+
+    if (!agentId) {
+      return { success: false, error: '❌ 请指定 Agent ID\n\n用法: /budget limit <agent> <每日上限>' };
+    }
+
+    if (!limitStr) {
+      return { success: false, error: '❌ 请指定每日上限\n\n用法: /budget limit <agent> <每日上限>\n\n提示: 设置为 0 表示无限制' };
+    }
+
+    const limit = parseInt(limitStr, 10);
+
+    if (isNaN(limit) || limit < 0) {
+      return { success: false, error: '❌ 每日上限必须是非负整数\n\n用法: /budget limit <agent> <每日上限>\n\n提示: 设置为 0 表示无限制' };
+    }
+
+    const account = creditService.setDailyLimit(agentId, limit);
+
+    if (!account) {
+      return { success: false, error: '❌ 设置失败' };
+    }
+
+    return {
+      success: true,
+      message: `✅ **每日上限已设置**\n\n${formatAccount(account)}`,
+    };
+  }
+
+  private handleList(_context: CommandContext): CommandResult {
+    const creditService = getCreditService();
+    const accounts = creditService.listAccounts();
+
+    if (accounts.length === 0) {
+      return {
+        success: true,
+        message: '📋 暂无 Agent 账户',
+      };
+    }
+
+    const lines: string[] = [
+      `📋 **Agent 账户列表** (${accounts.length} 个)`,
+      '',
+    ];
+
+    for (const account of accounts) {
+      const limitText = account.dailyLimit === 0 ? '∞' : `${account.dailyLimit}`;
+      lines.push(`- **${account.agentId}**: ${account.balance} 积分 (上限: ${limitText}, 今日: ${account.usedToday})`);
+    }
+
+    return {
+      success: true,
+      message: lines.join('\n'),
+    };
+  }
+
+  private handleHistory(context: CommandContext): CommandResult {
+    const { args } = context;
+    const creditService = getCreditService();
+
+    const [, agentId, limitStr] = args;
+
+    if (!agentId) {
+      return { success: false, error: '❌ 请指定 Agent ID\n\n用法: /budget history <agent> [数量]' };
+    }
+
+    const limit = limitStr ? parseInt(limitStr, 10) : 20;
+
+    if (isNaN(limit) || limit <= 0) {
+      return { success: false, error: '❌ 数量必须是正整数' };
+    }
+
+    const transactions = creditService.getTransactionHistory(agentId, limit);
+
+    if (transactions.length === 0) {
+      return {
+        success: true,
+        message: `📋 Agent \`${agentId}\` 暂无交易记录`,
+      };
+    }
+
+    const lines: string[] = [
+      `📋 **${agentId} 交易记录** (最近 ${transactions.length} 条)`,
+      '',
+    ];
+
+    for (const txn of transactions) {
+      lines.push(formatTransaction(txn));
+    }
+
+    return {
+      success: true,
+      message: lines.join('\n'),
+    };
+  }
+}

--- a/src/nodes/commands/commands/expert-commands.ts
+++ b/src/nodes/commands/commands/expert-commands.ts
@@ -7,10 +7,12 @@
  * - /expert skills add - Add a skill
  * - /expert skills remove - Remove a skill
  * - /expert availability - Set availability
+ * - /expert price - Set consultation price (Issue #538)
  * - /expert search - Search experts by skill
  * - /expert list - List all experts
  *
  * @see Issue #535 - 人类专家注册与技能声明
+ * @see Issue #538 - 积分系统 - 身价与消费
  */
 
 import type { Command, CommandContext, CommandResult } from '../types.js';
@@ -42,6 +44,11 @@ function formatProfile(profile: ReturnType<typeof getExpertService>['getExpert']
 
   if (profile.availability) {
     lines.push(`   ⏰ 可用时间: ${profile.availability}`);
+  }
+
+  // Issue #538: Display price
+  if (profile.price !== undefined && profile.price > 0) {
+    lines.push(`   💰 咨询价格: ${profile.price} 积分/次`);
   }
 
   if (profile.skills.length > 0) {
@@ -96,6 +103,8 @@ export class ExpertCommand implements Command {
         return this.handleSkills(context);
       case 'availability':
         return this.handleAvailability(context);
+      case 'price':
+        return this.handlePrice(context);
       case 'search':
         return this.handleSearch(context);
       case 'list':
@@ -103,7 +112,7 @@ export class ExpertCommand implements Command {
       default:
         return {
           success: false,
-          error: `❌ 未知子命令: ${subCommand || '(未指定)'}\n\n用法:\n- /expert register [名字] - 注册为专家\n- /expert profile - 查看档案\n- /expert skills add <技能> <等级1-5> [标签...]\n- /expert skills remove <技能>\n- /expert availability <时间>\n- /expert search <技能> [最低等级]\n- /expert list - 列出所有专家`,
+          error: `❌ 未知子命令: ${subCommand || '(未指定)'}\n\n用法:\n- /expert register [名字] - 注册为专家\n- /expert profile - 查看档案\n- /expert skills add <技能> <等级1-5> [标签...]\n- /expert skills remove <技能>\n- /expert availability <时间>\n- /expert price <积分> - 设置咨询价格\n- /expert search <技能> [最低等级]\n- /expert list - 列出所有专家`,
         };
     }
   }
@@ -232,6 +241,45 @@ export class ExpertCommand implements Command {
     return {
       success: true,
       message: `✅ **可用时间已设置**\n\n${formatProfile(profile)}`,
+    };
+  }
+
+  /**
+   * Handle /expert price command (Issue #538).
+   */
+  private handlePrice(context: CommandContext): CommandResult {
+    const { args, userId } = context;
+    const expertService = getExpertService();
+
+    // Check if user is registered
+    if (!expertService.isExpert(userId!)) {
+      return {
+        success: false,
+        error: '❌ 您尚未注册为专家\n\n使用 `/expert register [名字]` 注册',
+      };
+    }
+
+    const [, priceStr] = args;
+
+    if (!priceStr) {
+      return { success: false, error: '❌ 请指定咨询价格\n\n用法: /expert price <积分>' };
+    }
+
+    const price = parseInt(priceStr, 10);
+
+    if (isNaN(price) || price < 0) {
+      return { success: false, error: '❌ 价格必须是非负整数\n\n用法: /expert price <积分>' };
+    }
+
+    const profile = expertService.setPrice(userId!, price);
+
+    if (!profile) {
+      return { success: false, error: '❌ 设置价格失败' };
+    }
+
+    return {
+      success: true,
+      message: `✅ **咨询价格已设置**\n\n${formatProfile(profile)}`,
     };
   }
 

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -39,3 +39,6 @@ export { TopicGroupCommand } from './topic-group-command.js';
 
 // Expert commands (Issue #535)
 export { ExpertCommand } from './expert-commands.js';
+
+// Budget commands (Issue #538)
+export { BudgetCommand } from './budget-commands.js';


### PR DESCRIPTION
## Summary

Implements Issue #538 - 积分系统 - 身价与消费

引入积分机制，让人类专家可以设置身价，Agent 咨询时扣除积分。

## Changes

### Expert Price Setting
- Add `price` field to ExpertProfile for consultation pricing
- Add `/expert price <credits>` command for experts to set their price
- Display price in expert profile

### Credit Service (New)
- Create `CreditService` for managing agent credit accounts
- Features:
  - Balance tracking with daily spending limits
  - Recharge and refund functionality
  - Transaction history logging
  - Daily usage reset
  - Persistence to workspace/credits.json

### Budget Commands (New)
- `/budget balance <agent>` - View agent balance
- `/budget recharge <agent> <credits>` - Recharge credits
- `/budget limit <agent> <daily>` - Set daily limit
- `/budget list` - List all accounts
- `/budget history <agent>` - View transaction history

### Tests
- Add 32 tests for CreditService
- All 54 expert-related tests pass

## Usage Examples

### Expert sets price
```
/expert price 100
```

### Admin manages agent credits
```
/budget recharge agent_123 500
/budget limit agent_123 200
/budget balance agent_123
/budget history agent_123
```

## Acceptance Criteria (from Issue #538)
- [x] 专家可设置身价
- [x] Agent 有积分账户
- [x] 咨询时自动扣费 (spend API available)
- [x] 余额不足时拒绝咨询 (canSpend check available)
- [x] 管理员可充值

## Test Results
- ✅ 54 tests passed
- ✅ TypeScript check passed
- ✅ ESLint passed (only pre-existing warnings)

Fixes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)