### PR TITLE
fix(pilot): improve next step prompt for better suggestions (Issue #900)

### DIFF
--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -275,9 +275,9 @@ You can read these files using the Read tool with the local paths above.`;
 
 ---
 
-## Next Steps After Task Completion
+## Next Steps After Response
 
-After completing the user's task, proactively suggest 2-3 relevant next steps the user might want to take. Present these suggestions as an **interactive card** with clickable options.
+At the end of your response, proactively suggest 2-3 relevant next steps the user might want to take. Present these suggestions as an **interactive card** with clickable options.
 
 ### Card Template for Next Steps
 
@@ -302,7 +302,7 @@ After completing the user's task, proactively suggest 2-3 relevant next steps th
 - Suggest 2-3 relevant next steps based on the conversation context
 - Make suggestions specific and actionable
 - Use primary button style for the most recommended option
-- If no clear next steps exist, skip this section`;
+- Always include a suggestions card, even for simple questions (e.g., "Want to know more about X?", "Try this related feature")`;
     }
 
     // Fallback for channels without card support
@@ -310,15 +310,15 @@ After completing the user's task, proactively suggest 2-3 relevant next steps th
 
 ---
 
-## Next Steps After Task Completion
+## Next Steps After Response
 
-After completing the user's task, proactively suggest 2-3 relevant next steps the user might want to take.
+At the end of your response, proactively suggest 2-3 relevant next steps the user might want to take.
 
 ### Guidelines
 
 - Suggest 2-3 relevant next steps based on the conversation context
 - Make suggestions specific and actionable
 - Format as a simple list
-- If no clear next steps exist, skip this section`;
+- Always include suggestions, even for simple questions (e.g., "Want to know more about X?", "Try this related feature")`;
   }
 }


### PR DESCRIPTION
## Summary

改进 `buildNextStepGuidance()` 方法中的 prompt，确保所有回答都能收到建议卡片：

- 将标题从 "After Task Completion" 改为 "After Response"
- 将 "completing the user's task" 改为 "At the end of your response"
- 移除 skip 指令，防止 Agent 过于轻易地跳过发送建议
- 添加 "Always include suggestions" 指导，即使对于简单问答也提供建议

## Changes

| File | Description |
|------|-------------|
| `src/agents/pilot/message-builder.ts` | 更新 `buildNextStepGuidance()` 方法的 prompt 文本 |

## 预期效果

- ✅ 简单问答也会收到建议卡片
- ✅ Agent 不会轻易跳过发送建议
- ✅ 更积极的用户引导体验

## Test plan

- [x] TypeScript compilation passes
- [x] All 6 message-builder tests pass

Fixes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)