### PR TITLE
fix(test): remove unnecessary async from cleanupExpiredContexts test (Issue #903)

### DIFF
--- a/src/mcp/tools/interactive-message.test.ts
+++ b/src/mcp/tools/interactive-message.test.ts
@@ -248,7 +248,7 @@ describe('Interactive Message Tool', () => {
   });
 
   describe('cleanupExpiredContexts', () => {
-    it('should clean up expired contexts', async () => {
+    it('should clean up expired contexts', () => {
       // This test would require manipulating time, which is complex
       // For now, just verify the function exists and doesn't throw
       const count = cleanupExpiredContexts();


### PR DESCRIPTION
## Summary
- Removed unnecessary `async` keyword from the `cleanupExpiredContexts` test case
- The `cleanupExpiredContexts()` function returns a number synchronously, not a Promise
- This fixes the ESLint `require-await` rule violation

## Test plan
- [x] ESLint check passes (0 errors, 89 warnings - same as before)
- [x] All 16 tests in `interactive-message.test.ts` pass

Fixes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)