### PR TITLE
fix(interactive): use cross-process shared storage for interaction contexts (Issue #894)

### DIFF
--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -4,7 +4,11 @@
  * This tool sends interactive cards with pre-defined prompt templates
  * that are automatically converted to user messages when interactions occur.
  *
+ * Uses cross-process shared storage for interaction contexts to support
+ * scenarios where MCP and bot processes are separate.
+ *
  * @module mcp/tools/interactive-message
+ * @see Issue #894 - 飞书卡片按钮点击无响应
  */
 
 import * as lark from '@larksuiteoapi/node-sdk';
@@ -14,52 +18,44 @@ import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import { getMessageSentCallback } from './send-message.js';
-import type { SendInteractiveResult, ActionPromptMap, InteractiveMessageContext } from './types.js';
+import {
+  registerInteractionContext,
+  getActionPrompts as getSharedActionPrompts,
+  unregisterInteractionContext,
+  cleanupExpiredContexts as cleanupSharedExpiredContexts,
+} from '../../utils/interaction-state.js';
+import type { SendInteractiveResult, ActionPromptMap } from './types.js';
 
 const logger = createLogger('InteractiveMessage');
 
 /**
- * Store for interactive message contexts.
- * Maps message ID to its action prompts.
- */
-const interactiveContexts = new Map<string, InteractiveMessageContext>();
-
-/**
  * Register action prompts for a message.
  * Called after successfully sending an interactive message.
+ * Uses cross-process shared storage.
  */
 export function registerActionPrompts(
   messageId: string,
   chatId: string,
   actionPrompts: ActionPromptMap
 ): void {
-  interactiveContexts.set(messageId, {
-    messageId,
-    chatId,
-    actionPrompts,
-    createdAt: Date.now(),
-  });
-  logger.debug({ messageId, chatId, actions: Object.keys(actionPrompts) }, 'Action prompts registered');
+  registerInteractionContext(messageId, chatId, actionPrompts);
 }
 
 /**
  * Get action prompts for a message.
  * Returns undefined if no prompts are registered.
+ * Uses cross-process shared storage.
  */
 export function getActionPrompts(messageId: string): ActionPromptMap | undefined {
-  const context = interactiveContexts.get(messageId);
-  return context?.actionPrompts;
+  return getSharedActionPrompts(messageId);
 }
 
 /**
  * Remove action prompts for a message.
+ * Uses cross-process shared storage.
  */
 export function unregisterActionPrompts(messageId: string): boolean {
-  const removed = interactiveContexts.delete(messageId);
-  if (removed) {
-    logger.debug({ messageId }, 'Action prompts unregistered');
-  }
-  return removed;
+  return unregisterInteractionContext(messageId);
 }
 
 /**
@@ -122,24 +118,10 @@ export function generateInteractionPrompt(
 
 /**
  * Cleanup expired interactive contexts (older than 24 hours).
+ * Uses cross-process shared storage.
  */
 export function cleanupExpiredContexts(): number {
-  const maxAge = 24 * 60 * 60 * 1000; // 24 hours
-  const now = Date.now();
-  let cleaned = 0;
-
-  for (const [messageId, context] of interactiveContexts) {
-    if (now - context.createdAt > maxAge) {
-      interactiveContexts.delete(messageId);
-      cleaned++;
-    }
-  }
-
-  if (cleaned > 0) {
-    logger.debug({ count: cleaned }, 'Cleaned up expired interactive contexts');
-  }
-
-  return cleaned;
+  return cleanupSharedExpiredContexts();
 }
 
 /**

--- a/src/utils/interaction-state.test.ts
+++ b/src/utils/interaction-state.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for Interaction State Storage.
+ *
+ * @module utils/interaction-state.test
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  initInteractionState,
+  registerInteractionContext,
+  getInteractionContext,
+  getActionPrompts,
+  unregisterInteractionContext,
+  cleanupExpiredContexts,
+  getContextCount,
+  clearAllContexts,
+} from './interaction-state.js';
+import type { ActionPromptMap } from '../mcp/tools/types.js';
+
+describe('Interaction State Storage', () => {
+  let tempDir: string;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    // Create a temp file for each test
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'interaction-state-test-'));
+    testFilePath = path.join(tempDir, 'interactions.json');
+
+    // Initialize with test file path
+    initInteractionState({ filePath: testFilePath });
+    clearAllContexts();
+  });
+
+  afterEach(() => {
+    // Cleanup temp directory
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('registerInteractionContext', () => {
+    it('should register a new context', () => {
+      const actionPrompts: ActionPromptMap = {
+        confirm: 'User confirmed',
+        cancel: 'User cancelled',
+      };
+
+      registerInteractionContext('msg-1', 'chat-1', actionPrompts);
+
+      expect(getContextCount()).toBe(1);
+      const context = getInteractionContext('msg-1');
+      expect(context).toBeDefined();
+      expect(context?.chatId).toBe('chat-1');
+      expect(context?.actionPrompts).toEqual(actionPrompts);
+    });
+
+    it('should persist context to file', () => {
+      const actionPrompts: ActionPromptMap = {
+        action1: 'Prompt 1',
+      };
+
+      registerInteractionContext('msg-2', 'chat-2', actionPrompts);
+
+      // Verify file was created
+      expect(fs.existsSync(testFilePath)).toBe(true);
+
+      // Read file and verify content
+      const content = fs.readFileSync(testFilePath, 'utf-8');
+      const data = JSON.parse(content);
+      expect(data.contexts['msg-2']).toBeDefined();
+      expect(data.contexts['msg-2'].actionPrompts).toEqual(actionPrompts);
+    });
+
+    it('should update existing context', () => {
+      const prompts1: ActionPromptMap = { action1: 'Prompt 1' };
+      const prompts2: ActionPromptMap = { action1: 'Updated Prompt 1', action2: 'Prompt 2' };
+
+      registerInteractionContext('msg-3', 'chat-3', prompts1);
+      registerInteractionContext('msg-3', 'chat-3', prompts2);
+
+      const context = getInteractionContext('msg-3');
+      expect(context?.actionPrompts).toEqual(prompts2);
+    });
+  });
+
+  describe('getInteractionContext', () => {
+    it('should return undefined for non-existent context', () => {
+      const context = getInteractionContext('non-existent');
+      expect(context).toBeUndefined();
+    });
+
+    it('should return registered context', () => {
+      const actionPrompts: ActionPromptMap = { test: 'Test prompt' };
+      registerInteractionContext('msg-4', 'chat-4', actionPrompts);
+
+      const context = getInteractionContext('msg-4');
+      expect(context).toBeDefined();
+      expect(context?.messageId).toBe('msg-4');
+      expect(context?.chatId).toBe('chat-4');
+    });
+
+    it('should load context from file if not in memory', () => {
+      const actionPrompts: ActionPromptMap = { file: 'File prompt' };
+      registerInteractionContext('msg-5', 'chat-5', actionPrompts);
+
+      // Re-initialize to clear memory cache but keep file
+      initInteractionState({ filePath: testFilePath });
+
+      // Context should still be available from file
+      const context = getInteractionContext('msg-5');
+      expect(context).toBeDefined();
+      expect(context?.actionPrompts).toEqual(actionPrompts);
+    });
+  });
+
+  describe('getActionPrompts', () => {
+    it('should return action prompts for a message', () => {
+      const actionPrompts: ActionPromptMap = {
+        yes: 'User said yes',
+        no: 'User said no',
+      };
+      registerInteractionContext('msg-6', 'chat-6', actionPrompts);
+
+      const prompts = getActionPrompts('msg-6');
+      expect(prompts).toEqual(actionPrompts);
+    });
+
+    it('should return undefined for non-existent message', () => {
+      const prompts = getActionPrompts('non-existent');
+      expect(prompts).toBeUndefined();
+    });
+  });
+
+  describe('unregisterInteractionContext', () => {
+    it('should remove registered context', () => {
+      registerInteractionContext('msg-7', 'chat-7', { action: 'Prompt' });
+
+      const result = unregisterInteractionContext('msg-7');
+
+      expect(result).toBe(true);
+      expect(getInteractionContext('msg-7')).toBeUndefined();
+    });
+
+    it('should return false for non-existent context', () => {
+      const result = unregisterInteractionContext('non-existent');
+      expect(result).toBe(false);
+    });
+
+    it('should update file after removal', () => {
+      registerInteractionContext('msg-8', 'chat-8', { action: 'Prompt' });
+      unregisterInteractionContext('msg-8');
+
+      const content = fs.readFileSync(testFilePath, 'utf-8');
+      const data = JSON.parse(content);
+      expect(data.contexts['msg-8']).toBeUndefined();
+    });
+  });
+
+  describe('cleanupExpiredContexts', () => {
+    it('should remove expired contexts', () => {
+      // Create an expired context manually
+      const expiredContext = {
+        messageId: 'msg-expired',
+        chatId: 'chat-expired',
+        actionPrompts: { action: 'Expired' },
+        createdAt: Date.now() - 25 * 60 * 60 * 1000, // 25 hours ago
+      };
+
+      // Write directly to file and reload
+      const storage = {
+        version: 1,
+        contexts: {
+          'msg-expired': expiredContext,
+          'msg-valid': {
+            messageId: 'msg-valid',
+            chatId: 'chat-valid',
+            actionPrompts: { action: 'Valid' },
+            createdAt: Date.now(),
+          },
+        },
+      };
+      fs.writeFileSync(testFilePath, JSON.stringify(storage));
+      initInteractionState({ filePath: testFilePath });
+
+      const cleaned = cleanupExpiredContexts();
+
+      expect(cleaned).toBe(1);
+      expect(getInteractionContext('msg-expired')).toBeUndefined();
+      expect(getInteractionContext('msg-valid')).toBeDefined();
+    });
+
+    it('should return 0 when nothing to clean', () => {
+      registerInteractionContext('msg-recent', 'chat-recent', { action: 'Recent' });
+
+      const cleaned = cleanupExpiredContexts();
+      expect(cleaned).toBe(0);
+    });
+  });
+
+  describe('getContextCount', () => {
+    it('should return correct count', () => {
+      expect(getContextCount()).toBe(0);
+
+      registerInteractionContext('msg-a', 'chat-a', { action: 'A' });
+      expect(getContextCount()).toBe(1);
+
+      registerInteractionContext('msg-b', 'chat-b', { action: 'B' });
+      expect(getContextCount()).toBe(2);
+    });
+  });
+
+  describe('clearAllContexts', () => {
+    it('should remove all contexts', () => {
+      registerInteractionContext('msg-1', 'chat-1', { action: '1' });
+      registerInteractionContext('msg-2', 'chat-2', { action: '2' });
+
+      clearAllContexts();
+
+      expect(getContextCount()).toBe(0);
+      expect(getInteractionContext('msg-1')).toBeUndefined();
+      expect(getInteractionContext('msg-2')).toBeUndefined();
+    });
+  });
+
+  describe('cross-process simulation', () => {
+    it('should support reading context written by another "process"', () => {
+      // Simulate process A writing
+      const actionPrompts: ActionPromptMap = { cross: 'Cross-process prompt' };
+
+      // Write directly to file (simulating another process)
+      const storage = {
+        version: 1,
+        contexts: {
+          'msg-cross': {
+            messageId: 'msg-cross',
+            chatId: 'chat-cross',
+            actionPrompts,
+            createdAt: Date.now(),
+          },
+        },
+      };
+      fs.writeFileSync(testFilePath, JSON.stringify(storage));
+
+      // Simulate process B reading (clear memory first)
+      initInteractionState({ filePath: testFilePath });
+
+      // Should be able to read the context
+      const context = getInteractionContext('msg-cross');
+      expect(context).toBeDefined();
+      expect(context?.actionPrompts).toEqual(actionPrompts);
+    });
+  });
+});

--- a/src/utils/interaction-state.ts
+++ b/src/utils/interaction-state.ts
@@ -1,0 +1,246 @@
+/**
+ * Interaction State Storage - Cross-process shared storage for interactive message contexts.
+ *
+ * Solves the cross-process state isolation problem where:
+ * - MCP process registers action prompts when sending interactive messages
+ * - Bot main process needs to access these prompts when handling card actions
+ *
+ * Uses file-based storage to share state between processes.
+ *
+ * @see Issue #894 - 飞书卡片按钮点击无响应
+ * @module utils/interaction-state
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { createLogger } from './logger.js';
+import type { ActionPromptMap, InteractiveMessageContext } from '../mcp/tools/types.js';
+
+const logger = createLogger('InteractionState');
+
+/**
+ * Storage format for interaction contexts.
+ */
+interface InteractionStorage {
+  /** Version for future migrations */
+  version: number;
+  /** Contexts indexed by messageId */
+  contexts: Record<string, InteractiveMessageContext>;
+}
+
+/**
+ * Interaction state configuration.
+ */
+export interface InteractionStateConfig {
+  /** Storage file path (default: workspace/.state/interactions.json) */
+  filePath?: string;
+}
+
+/**
+ * Default storage file path.
+ */
+const DEFAULT_FILE_PATH = path.join(process.cwd(), 'workspace', '.state', 'interactions.json');
+
+/**
+ * In-memory cache for performance.
+ * Falls back to file storage on cache miss.
+ */
+let memoryCache: Map<string, InteractiveMessageContext> | null = null;
+let storageFilePath: string = DEFAULT_FILE_PATH;
+
+/**
+ * Get or initialize the memory cache.
+ */
+function getCache(): Map<string, InteractiveMessageContext> {
+  if (!memoryCache) {
+    initInteractionState();
+  }
+  return memoryCache as Map<string, InteractiveMessageContext>;
+}
+
+/**
+ * Initialize the interaction state storage.
+ * Should be called once at application startup.
+ */
+export function initInteractionState(config: InteractionStateConfig = {}): void {
+  storageFilePath = config.filePath || DEFAULT_FILE_PATH;
+  const cache = new Map<string, InteractiveMessageContext>();
+  memoryCache = cache;
+
+  // Pre-load existing contexts into memory cache
+  const storage = loadFromFile();
+  for (const [messageId, context] of Object.entries(storage.contexts)) {
+    cache.set(messageId, context);
+  }
+
+  logger.info(
+    { filePath: storageFilePath, contextCount: cache.size },
+    'Interaction state initialized'
+  );
+}
+
+/**
+ * Load storage from file.
+ */
+function loadFromFile(): InteractionStorage {
+  try {
+    if (fs.existsSync(storageFilePath)) {
+      const content = fs.readFileSync(storageFilePath, 'utf-8');
+      const data = JSON.parse(content) as InteractionStorage;
+      logger.debug({ contextCount: Object.keys(data.contexts || {}).length }, 'Interaction storage loaded from file');
+      return data;
+    }
+  } catch (error) {
+    logger.warn({ err: error }, 'Failed to load interaction storage, starting fresh');
+  }
+  return { version: 1, contexts: {} };
+}
+
+/**
+ * Save storage to file.
+ */
+function saveToFile(): void {
+  try {
+    const dir = path.dirname(storageFilePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const cache = getCache();
+    const storage: InteractionStorage = {
+      version: 1,
+      contexts: Object.fromEntries(cache),
+    };
+
+    fs.writeFileSync(storageFilePath, JSON.stringify(storage, null, 2));
+    logger.debug({ contextCount: Object.keys(storage.contexts).length }, 'Interaction storage saved to file');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to save interaction storage');
+  }
+}
+
+/**
+ * Register action prompts for a message.
+ * Stores in both memory cache and file for cross-process access.
+ *
+ * @param messageId - The message ID
+ * @param chatId - The chat ID
+ * @param actionPrompts - Map of action values to prompt templates
+ */
+export function registerInteractionContext(
+  messageId: string,
+  chatId: string,
+  actionPrompts: ActionPromptMap
+): void {
+  const cache = getCache();
+
+  const context: InteractiveMessageContext = {
+    messageId,
+    chatId,
+    actionPrompts,
+    createdAt: Date.now(),
+  };
+
+  cache.set(messageId, context);
+  saveToFile();
+
+  logger.debug({ messageId, chatId, actions: Object.keys(actionPrompts) }, 'Interaction context registered');
+}
+
+/**
+ * Get action prompts for a message.
+ * Checks memory cache first, then falls back to file storage.
+ *
+ * @param messageId - The message ID
+ * @returns The action prompts or undefined if not found
+ */
+export function getInteractionContext(messageId: string): InteractiveMessageContext | undefined {
+  const cache = getCache();
+
+  // Check memory cache first
+  let context = cache.get(messageId);
+
+  if (!context) {
+    // Fall back to file storage (in case another process wrote it)
+    const storage = loadFromFile();
+    context = storage.contexts[messageId];
+
+    if (context) {
+      // Update memory cache
+      cache.set(messageId, context);
+      logger.debug({ messageId }, 'Interaction context loaded from file');
+    }
+  }
+
+  return context;
+}
+
+/**
+ * Get action prompts for a message.
+ * Convenience function that returns just the prompts.
+ *
+ * @param messageId - The message ID
+ * @returns The action prompts or undefined if not found
+ */
+export function getActionPrompts(messageId: string): ActionPromptMap | undefined {
+  const context = getInteractionContext(messageId);
+  return context?.actionPrompts;
+}
+
+/**
+ * Remove interaction context for a message.
+ *
+ * @param messageId - The message ID
+ * @returns Whether the context was removed
+ */
+export function unregisterInteractionContext(messageId: string): boolean {
+  const cache = getCache();
+  const removed = cache.delete(messageId);
+  if (removed) {
+    saveToFile();
+    logger.debug({ messageId }, 'Interaction context unregistered');
+  }
+  return removed;
+}
+
+/**
+ * Cleanup expired interaction contexts (older than 24 hours).
+ *
+ * @returns Number of contexts cleaned up
+ */
+export function cleanupExpiredContexts(): number {
+  const cache = getCache();
+  const maxAge = 24 * 60 * 60 * 1000; // 24 hours
+  const now = Date.now();
+  let cleaned = 0;
+
+  for (const [messageId, context] of cache) {
+    if (now - context.createdAt > maxAge) {
+      cache.delete(messageId);
+      cleaned++;
+    }
+  }
+
+  if (cleaned > 0) {
+    saveToFile();
+    logger.debug({ count: cleaned }, 'Cleaned up expired interaction contexts');
+  }
+
+  return cleaned;
+}
+
+/**
+ * Get the number of registered contexts (for testing/debugging).
+ */
+export function getContextCount(): number {
+  return getCache().size;
+}
+
+/**
+ * Clear all contexts (for testing).
+ */
+export function clearAllContexts(): void {
+  const cache = getCache();
+  cache.clear();
+  saveToFile();
+}


### PR DESCRIPTION
## Summary

This PR solves the cross-process state isolation problem identified in Issue #894, where interactive card button clicks were not responding due to memory isolation between the MCP process and the bot main process.

### Problem

```
┌─────────────────┐         ┌─────────────────┐
│   MCP 进程       │         │   Bot 主进程     │
│                 │         │                 │
│ send_interactive│         │ handleCardAction│
│ _message()      │         │                 │
│       ↓         │         │       ↓         │
│ registerAction  │         │ generatePrompt  │
│ Prompts() ──────┼── X ───→│ ()              │
│                 │  内存隔离  │                 │
│ interactiveContexts        │ (找不到数据!)    │
│ Map (有数据)    │         │                 │
└─────────────────┘         └─────────────────┘
```

When `send_interactive_message` was called in the MCP process, it registered action prompts in memory. But when the user clicked a button, the bot main process couldn't find those prompts because each process has its own memory space.

### Solution

Created `src/utils/interaction-state.ts` - a file-based shared storage module that persists interaction contexts to `workspace/.state/interactions.json`. Both processes can now read/write to the same file.

## Changes

| File | Change |
|------|--------|
| `src/utils/interaction-state.ts` | New file - file-based shared storage for interaction contexts |
| `src/utils/interaction-state.test.ts` | New file - 16 unit tests for the storage module |
| `src/mcp/tools/interactive-message.ts` | Updated to use shared storage instead of in-memory Map |

## Features

- **File-based persistence**: Contexts are stored in `workspace/.state/interactions.json`
- **Memory cache**: In-memory cache for performance, with file fallback
- **Cross-process access**: Both MCP and bot processes can read/write
- **Auto cleanup**: Expired contexts (older than 24 hours) are automatically cleaned up
- **Backward compatible**: Existing API unchanged

## Test Results

- ✅ 16 new tests for interaction-state module
- ✅ All existing interactive-message tests pass (16 tests)
- ✅ Lint check passes (only pre-existing warning in test file)

## Related

- Closes #894
- Supersedes PR #896 (which only added `click` field but didn't solve the root cause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)