### PR TITLE
test: 建立测试隔离基础设施 - nock 网络封锁 + ESLint 禁止 SDK Mock (Issue #920)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,44 @@ npm run test               # Run tests
 npm run test -- --coverage # With coverage
 ```
 
+## Testing Rules (Mandatory)
+
+These rules are enforced to maintain test quality and prevent AI Agent from bypassing test failures by modifying mock implementations.
+
+### 1. 严禁对外部 SDK 使用 vi.mock()
+
+`@anthropic-ai/sdk`、`@larksuiteoapi/node-sdk` 等外部网络库**不得使用 vi.mock()**。违反此规则将导致 ESLint 报错并阻断 CI。
+
+**Why?** AI Agent 在重构代码时会同步修改 mock 返回值以维持测试绿灯。外部 API 协议变更、路由接错、参数结构破损均无法被检测到。
+
+### 2. 网络交互测试必须使用 nock
+
+需要模拟 HTTP 交互时，应在 `tests/fixtures/recordings/` 提供录制的请求/响应 JSON，通过 nock 加载后测试。
+
+```typescript
+// ✅ Good: Use nock for HTTP mocking
+import nock from 'nock';
+
+nock('https://api.anthropic.com')
+  .post('/v1/messages')
+  .reply(200, { content: '...' });
+
+// ❌ Bad: Do NOT use vi.mock for external SDKs
+vi.mock('@anthropic-ai/sdk', () => ({ ... })); // ESLint error!
+vi.mock('@larksuiteoapi/node-sdk', () => ({ ... })); // ESLint error!
+```
+
+### 3. 先建后删原则
+
+重构测试时，必须**先新增替代测试并确保覆盖率不下降**，再删除旧的 vi.mock 代码。严禁先删后补，否则覆盖率暴跌将阻塞所有其他 PR 的合入。
+
+**Rationale**: 当前 CI 存在 70% 覆盖率硬门禁，先删后补会导致覆盖率暴跌阻塞 PR。
+
+### Related Issues
+
+- #918 - 四层防御架构总览
+- #920 - 测试隔离基础设施
+
 ## Development Workflow
 
 ### PM2 Restart Policy

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -90,4 +90,26 @@ export default [
       'no-unused-labels': 'error',
     },
   },
+  {
+    // Test file specific rules
+    // @see Issue #920 - Test isolation infrastructure
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name='mock'][arguments.0.value=/@anthropic-ai/]",
+          message:
+            '禁止对 @anthropic-ai/sdk 使用 vi.mock()。请使用 nock VCR 录制回放模式。参见 Issue #918。',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name='mock'][arguments.0.value=/@larksuiteoapi/]",
+          message:
+            '禁止对 @larksuiteoapi/node-sdk 使用 vi.mock()。请使用 nock VCR 录制回放模式。参见 Issue #918。',
+        },
+      ],
+    },
+  },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@types/cron": "2.0.1",
         "@types/js-yaml": "^4.0.9",
+        "@types/nock": "10.0.3",
         "@types/node": "^22.10.5",
         "@types/pino": "^7.0.4",
         "@types/pino-pretty": "^4.7.5",
@@ -35,6 +36,7 @@
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^3.0.0",
         "eslint": "^9.17.0",
+        "nock": "14.0.11",
         "pm2": "^6.0.14",
         "prettier": "^3.4.2",
         "tsup": "^8.5.1",
@@ -1206,6 +1208,49 @@
         "ws": "^8.19.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2014,6 +2059,16 @@
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
       "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
       "license": "MIT"
+    },
+    "node_modules/@types/nock": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-10.0.3.tgz",
+      "integrity": "sha512-OthuN+2FuzfZO3yONJ/QVjKmLEuRagS9TV9lEId+WHL9KhftYG+/2z+pxlr0UgVVXSpVD8woie/3fzQn8ft/Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.19.13",
@@ -4209,6 +4264,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4376,8 +4438,7 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "1.0.2",
@@ -4742,6 +4803,21 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.11.tgz",
+      "integrity": "sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4809,6 +4885,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -5415,6 +5498,16 @@
         "read": "^1.0.4"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -5987,6 +6080,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@types/cron": "2.0.1",
     "@types/js-yaml": "^4.0.9",
+    "@types/nock": "10.0.3",
     "@types/node": "^22.10.5",
     "@types/pino": "^7.0.4",
     "@types/pino-pretty": "^4.7.5",
@@ -66,6 +67,7 @@
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.17.0",
+    "nock": "14.0.11",
     "pm2": "^6.0.14",
     "prettier": "^3.4.2",
     "tsup": "^8.5.1",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,31 @@
+/**
+ * Global test setup for network isolation.
+ *
+ * This file establishes test isolation by blocking all external network requests
+ * using nock, ensuring tests are hermetic and deterministic.
+ *
+ * @see Issue #918 - Four-layer defense architecture overview
+ * @see Issue #920 - Test isolation infrastructure
+ */
+
+import nock from 'nock';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+
+beforeAll(() => {
+  // Block all external network requests by default
+  nock.disableNetConnect();
+
+  // Allow localhost connections for local test servers if needed
+  nock.enableNetConnect('127.0.0.1');
+  nock.enableNetConnect('localhost');
+});
+
+afterEach(() => {
+  // Clean up all nock interceptors after each test
+  nock.cleanAll();
+});
+
+afterAll(() => {
+  // Restore network connections after all tests
+  nock.restore();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -77,6 +77,8 @@ export default defineConfig({
       },
       include: ['src/**/*.ts'],
     },
-    setupFiles: [],
+    // Global setup file for network isolation via nock
+    // @see Issue #920 - Test isolation infrastructure
+    setupFiles: ['./tests/setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary

建立测试隔离基础设施，防止 AI Agent 通过修改 mock 绕过测试失败：

- 安装 nock 和 @types/nock 依赖
- 创建 tests/setup.ts 配置全局网络封锁
- 在 vitest.config.ts 中挂载 setup 文件
- 添加 ESLint 规则禁止对 @anthropic-ai/sdk 和 @larksuiteoapi/node-sdk 使用 vi.mock()
- 更新 CLAUDE.md 追加测试铁律章节

## 背景

本 PR 是 #918（四层防御架构总览）的第一个子任务，也是最高优先级的基础设施改造。

当前项目测试文件中存在大量对外部核心 SDK 的局部 mock（如 `vi.mock('@anthropic-ai/sdk')`），这类 mock 的危害在于：**AI Agent 在重构代码时会同步修改 mock 返回值以维持测试绿灯**，外部 API 协议变更、路由接错、参数结构破损均无法被检测到。

## 改动详情

### Phase 1: 安装依赖
- 添加 `nock` 和 `@types/nock` 作为开发依赖

### Phase 2: 配置全局网络封锁
- 创建 `tests/setup.ts`，在所有测试开始前封死外部网络
- 在 `vitest.config.ts` 中配置 `setupFiles: ['./tests/setup.ts']`

### Phase 3: ESLint 拦截对核心 SDK 的 vi.mock
- 在 `eslint.config.js` 中新增 `no-restricted-syntax` 规则
- 禁止对 `@anthropic-ai/sdk` 和 `@larksuiteoapi/node-sdk` 使用 `vi.mock()`

### Phase 4: 更新 CLAUDE.md
- 追加 "Testing Rules (Mandatory)" 章节
- 明确测试行为边界，供 AI Agent 参考

## Test plan

- [x] `npm run lint` 确认 ESLint 规则生效（检测到 10 个使用 vi.mock 的测试文件）
- [x] `npm test` 确认全部通过（1615 passed, 1 failed - 预存环境问题，与本次改动无关）

## 注意事项

Phase 2 配置 `nock.disableNetConnect()` 后，ESLint 规则检测到的 10 个使用 vi.mock 的测试文件需要后续迁移到 nock VCR 录制回放模式。这些是后续 Issue #918 子任务的工作内容。

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)