### PR TITLE
fix(test): remove unnecessary async keyword in cleanupExpiredContexts test

### DIFF
--- a/src/mcp/tools/interactive-message.test.ts
+++ b/src/mcp/tools/interactive-message.test.ts
@@ -248,7 +248,7 @@ describe('Interactive Message Tool', () => {
   });
 
   describe('cleanupExpiredContexts', () => {
-    it('should clean up expired contexts', async () => {
+    it('should clean up expired contexts', () => {
       // This test would require manipulating time, which is complex
       // For now, just verify the function exists and doesn't throw
       const count = cleanupExpiredContexts();


### PR DESCRIPTION
## Summary
- Remove unnecessary `async` keyword from the `cleanupExpiredContexts` test callback
- The `cleanupExpiredContexts` function is synchronous (returns `number`), so the test does not need to be async

## Test plan
- [x] `npm run lint` - 0 errors (was 1 error before fix)
- [x] `vitest run src/mcp/tools/interactive-message.test.ts` - 16 tests passed

Fixes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)