### PR TITLE
fix(test): remove unnecessary async from cleanupExpiredContexts test (Issue #903)

### DIFF
--- a/src/mcp/tools/interactive-message.test.ts
+++ b/src/mcp/tools/interactive-message.test.ts
@@ -248,7 +248,7 @@ describe('Interactive Message Tool', () => {
   });
 
   describe('cleanupExpiredContexts', () => {
-    it('should clean up expired contexts', async () => {
+    it('should clean up expired contexts', () => {
       // This test would require manipulating time, which is complex
       // For now, just verify the function exists and doesn't throw
       const count = cleanupExpiredContexts();


### PR DESCRIPTION
## Summary

Fixes ESLint `require-await` error in `interactive-message.test.ts` line 251.

The `cleanupExpiredContexts` function is synchronous and returns a `number`, so the test callback does not need to be `async`.

## Changes

- Removed `async` keyword from the test callback in line 251

## Test Results

- ✅ ESLint check passes (0 errors, 89 pre-existing warnings)
- ✅ All 16 tests in `interactive-message.test.ts` pass

Fixes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)