### PR TITLE
feat(command): add /feedback command for quick issue submission (Issue #930)

### DIFF
--- a/src/nodes/command-services.ts
+++ b/src/nodes/command-services.ts
@@ -23,6 +23,7 @@ import type { ExecNodeRegistry } from './exec-node-registry.js';
 import type { DebugGroupService } from './debug-group-service.js';
 import type { ScheduleManagement } from './schedule-management.js';
 import type { CommandServices, ManagedGroupInfo } from './commands/types.js';
+import { messageHistoryManager } from '../core/message-history.js';
 
 /**
  * Dependencies needed for building command services.
@@ -149,5 +150,8 @@ export function buildCommandServices(deps: CommandServicesDeps): CommandServices
     markAsTopicGroup: (chatId: string, isTopic: boolean) => groupService.markAsTopicGroup(chatId, isTopic),
     isTopicGroup: (chatId: string) => groupService.isTopicGroup(chatId),
     listTopicGroups: () => groupService.listTopicGroups(),
+
+    // Feedback and history (Issue #930)
+    getFormattedHistory: (chatId: string, maxMessages?: number) => messageHistoryManager.getFormattedHistory(chatId, maxMessages),
   };
 }

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -44,6 +44,7 @@ import {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  FeedbackCommand,
 } from './commands/index.js';
 
 // Re-export all command classes for backward compatibility
@@ -68,6 +69,7 @@ export {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  FeedbackCommand,
 };
 
 /**
@@ -101,4 +103,6 @@ export function registerDefaultCommands(
   registry.register(new TopicGroupCommand());
   // Issue #535: Expert registration and skill management
   registry.register(new ExpertCommand());
+  // Issue #930: Feedback command for user feedback submission
+  registry.register(new FeedbackCommand());
 }

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -62,6 +62,8 @@ function createMockServices(): CommandServices {
     markAsTopicGroup: () => false,
     isTopicGroup: () => false,
     listTopicGroups: () => [],
+    // Feedback and history (Issue #930)
+    getFormattedHistory: () => '(No previous conversation history)',
   };
 }
 

--- a/src/nodes/commands/commands/feedback-command.ts
+++ b/src/nodes/commands/commands/feedback-command.ts
@@ -1,0 +1,180 @@
+/**
+ * Feedback Command - Submit user feedback as GitHub Issue.
+ *
+ * Analyzes user complaints/feedback, sanitizes sensitive data,
+ * and creates a GitHub issue in the official repository.
+ *
+ * Usage:
+ *   /feedback 这个功能太难用了，每次都要点好几次
+ *   /feedback  (analyzes recent conversation for potential issues)
+ *
+ * Issue #930: /feedback command for quick issue submission
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import type { Command, CommandContext, CommandResult } from '../types.js';
+
+const execAsync = promisify(exec);
+
+/**
+ * Sanitization rules for removing sensitive data.
+ */
+const SANITIZATION_RULES = [
+  { pattern: /ou_[a-f0-9]+/gi, replacement: '[USER_ID]' },
+  { pattern: /oc_[a-f0-9]+/gi, replacement: '[CHAT_ID]' },
+  { pattern: /cli-[a-f0-9]+/gi, replacement: '[MESSAGE_ID]' },
+  { pattern: /[\w.-]+@[\w.-]+\.\w+/gi, replacement: '[EMAIL]' },
+  { pattern: /\/[^\s"'`]+\.(ts|js|json|md)/gi, replacement: '[FILE]' },
+  { pattern: /https?:\/\/[^\s<>"{}|\\^`\[\]]+/gi, replacement: '[URL]' },
+  { pattern: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, replacement: '[IP]' },
+  { pattern: /token[=:]\s*\S+/gi, replacement: 'token=[TOKEN]' },
+  { pattern: /api[_-]?key[=:]\s*\S+/gi, replacement: 'api_key=[API_KEY]' },
+  { pattern: /password[=:]\s*\S+/gi, replacement: 'password=[PASSWORD]' },
+  { pattern: /secret[=:]\s*\S+/gi, replacement: 'secret=[SECRET]' },
+];
+
+/**
+ * Sanitize text by replacing sensitive patterns.
+ */
+function sanitize(text: string): string {
+  let result = text;
+  for (const rule of SANITIZATION_RULES) {
+    result = result.replace(rule.pattern, rule.replacement);
+  }
+  return result;
+}
+
+/**
+ * Extract key issues from conversation history.
+ */
+function analyzeConversation(history: string): string {
+  // Look for error messages, complaints, or problem indicators
+  const errorPatterns = [
+    /error[:：]\s*.+/gi,
+    /失败[:：]\s*.+/gi,
+    /不行[:：]\s*.+/gi,
+    /问题[:：]\s*.+/gi,
+    /bug[:：]\s*.+/gi,
+    /无法\s*.+/gi,
+    /不能\s*.+/gi,
+    /不对[:：]\s*.+/gi,
+    /不满意.*/gi,
+    /太.+(了|难)/gi,
+  ];
+
+  const issues: string[] = [];
+  for (const pattern of errorPatterns) {
+    const matches = history.match(pattern);
+    if (matches) {
+      issues.push(...matches);
+    }
+  }
+
+  if (issues.length > 0) {
+    return issues.slice(0, 5).join('\n');
+  }
+
+  return '(未检测到明确问题，请手动描述)';
+}
+
+/**
+ * Create a GitHub issue using gh CLI.
+ */
+async function createGitHubIssue(title: string, body: string): Promise<{ success: boolean; url?: string; error?: string }> {
+  const repo = 'hs3180/disclaude';
+
+  // Escape title and body for shell
+  const escapedTitle = title.replace(/"/g, '\\"');
+  const escapedBody = body.replace(/"/g, '\\"');
+
+  try {
+    const { stdout } = await execAsync(
+      `gh issue create --repo ${repo} --title "${escapedTitle}" --body "${escapedBody}" --label "user-feedback"`,
+      { timeout: 30000 }
+    );
+
+    const url = stdout.trim();
+    return { success: true, url };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return { success: false, error: errorMessage };
+  }
+}
+
+/**
+ * Feedback Command - Submit user feedback as GitHub Issue.
+ */
+export class FeedbackCommand implements Command {
+  readonly name = 'feedback';
+  readonly category = 'feedback' as const;
+  readonly description = '提交反馈给开发者';
+  readonly usage = 'feedback [反馈内容]';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const { args, chatId, services } = context;
+
+    // Get user feedback from args or analyze conversation history
+    let feedbackContent: string;
+    let isAutoAnalysis = false;
+
+    if (args.length > 0) {
+      // User provided explicit feedback
+      feedbackContent = args.join(' ');
+    } else {
+      // Auto-analyze recent conversation
+      isAutoAnalysis = true;
+      const history = services.getFormattedHistory(chatId, 20);
+      feedbackContent = analyzeConversation(history);
+
+      if (feedbackContent === '(未检测到明确问题，请手动描述)') {
+        return {
+          success: false,
+          error: '未能自动检测到问题。请使用 `/feedback <问题描述>` 直接描述您的反馈。',
+        };
+      }
+    }
+
+    // Sanitize feedback content
+    const sanitizedFeedback = sanitize(feedbackContent);
+
+    // Get recent conversation history for context
+    const history = services.getFormattedHistory(chatId, 10);
+    const sanitizedHistory = sanitize(history);
+
+    // Build issue body
+    const issueTitle = `[User Feedback] ${sanitizedFeedback.slice(0, 50)}${sanitizedFeedback.length > 50 ? '...' : ''}`;
+
+    const issueBody = `## User Feedback
+
+${isAutoAnalysis ? '_自动分析检测到的问题_' : '_用户直接反馈_'}
+
+### Description
+${sanitizedFeedback}
+
+### Interaction Summary
+\`\`\`
+${sanitizedHistory}
+\`\`\`
+
+---
+_Issue created via /feedback command_
+_Chat ID: ${chatId.slice(0, 8)}..._
+_Time: ${new Date().toISOString()}_`;
+
+    // Create GitHub issue
+    const result = await createGitHubIssue(issueTitle, issueBody);
+
+    if (result.success) {
+      return {
+        success: true,
+        message: `✅ **反馈已提交**\n\n感谢您的反馈！我们已收到并会尽快处理。\n\n🔗 Issue: ${result.url}`,
+      };
+    } else {
+      return {
+        success: false,
+        error: `提交反馈失败: ${result.error}\n\n您也可以直接访问 https://github.com/hs3180/disclaude/issues 提交反馈。`,
+      };
+    }
+  }
+}

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -39,3 +39,6 @@ export { TopicGroupCommand } from './topic-group-command.js';
 
 // Expert commands (Issue #535)
 export { ExpertCommand } from './expert-commands.js';
+
+// Feedback command (Issue #930)
+export { FeedbackCommand } from './feedback-command.js';

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -86,6 +86,8 @@ describe('ScheduleCommand', () => {
     markAsTopicGroup: () => false,
     isTopicGroup: () => false,
     listTopicGroups: () => [],
+    // Feedback and history (Issue #930)
+    getFormattedHistory: () => '(No previous conversation history)',
   });
 
   const createContext = (args: string[], services: CommandServices = createMockServices()): CommandContext => ({

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -12,7 +12,7 @@ import type * as lark from '@larksuiteoapi/node-sdk';
 /**
  * Command category for grouping related commands.
  */
-export type CommandCategory = 'session' | 'group' | 'debug' | 'node' | 'task' | 'schedule' | 'skill';
+export type CommandCategory = 'session' | 'group' | 'debug' | 'node' | 'task' | 'schedule' | 'skill' | 'feedback';
 
 /**
  * Schedule task info for display.
@@ -222,6 +222,10 @@ export interface CommandServices {
 
   /** List all topic groups */
   listTopicGroups: () => ManagedGroupInfo[];
+
+  // Feedback and history (Issue #930)
+  /** Get formatted conversation history for a chat */
+  getFormattedHistory: (chatId: string, maxMessages?: number) => string;
 }
 
 /**
@@ -320,4 +324,5 @@ export const CATEGORY_CONFIG: Record<CommandCategory, CategoryInfo> = {
   task: { label: '任务', emoji: '📋', order: 5 },
   schedule: { label: '定时', emoji: '⏰', order: 6 },
   skill: { label: '技能', emoji: '🎯', order: 7 },
+  feedback: { label: '反馈', emoji: '📢', order: 8 },
 };


### PR DESCRIPTION
## Summary

Add a new `/feedback` command that allows users to submit feedback directly to the GitHub repository (`hs3180/disclaude`).

### Features

- **Explicit feedback**: `/feedback 这个功能太难用了` - Submit specific feedback
- **Auto-analysis**: `/feedback` (no args) - Analyzes recent conversation for potential issues

### Implementation

1. **FeedbackCommand class** (`feedback-command.ts`)
   - Parses optional feedback text from command arguments
   - Auto-analyzes conversation history when no text provided
   - Detects common problem patterns (errors, complaints, bugs)

2. **Sanitization**
   - Removes sensitive data: user IDs, chat IDs, emails, IPs, tokens, etc.
   - Uses regex patterns to identify and replace sensitive information

3. **GitHub Integration**
   - Uses `gh` CLI to create issues
   - Adds `user-feedback` label automatically
   - Includes sanitized conversation context

4. **Service Integration**
   - Added `getFormattedHistory` to `CommandServices`
   - Integrated with `messageHistoryManager` for history access

### Usage

```bash
# 带参数：直接描述抱怨
/feedback 这个功能太难用了，每次都要点好几次

# 不带参数：自动分析最近交互
/feedback
```

### Test Results

- ✅ TypeScript compilation passes
- ✅ All 41 command-related tests pass
- ✅ Lint check passes (no new errors)

Fixes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)