### PR TITLE
fix(interactive): use globalThis singleton for interactive contexts (Issue #894)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -26,6 +26,8 @@ export {
   send_interactive_message,
   generateInteractionPrompt,
   getActionPrompts,
+  getInteractiveContextsSize,
+  getInteractiveContextsDebugInfo,
 } from './tools/interactive-message.js';
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -26,4 +26,6 @@ export {
   unregisterActionPrompts,
   generateInteractionPrompt,
   cleanupExpiredContexts,
+  getInteractiveContextsSize,
+  getInteractiveContextsDebugInfo,
 } from './interactive-message.js';

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -19,10 +19,32 @@ import type { SendInteractiveResult, ActionPromptMap, InteractiveMessageContext 
 const logger = createLogger('InteractiveMessage');
 
 /**
+ * Global symbol key for interactive contexts storage.
+ * Using globalThis ensures the Map is shared across all module instances
+ * within the same Node.js process, solving the cross-module state isolation issue.
+ *
+ * Issue #894: 飞书卡片按钮点击无响应
+ */
+const INTERACTIVE_CONTEXTS_SYMBOL = Symbol.for('disclaude.interactiveContexts');
+
+/**
+ * Get or create the global interactive contexts Map.
+ * This ensures a single shared instance across all module imports.
+ */
+function getInteractiveContexts(): Map<string, InteractiveMessageContext> {
+  if (!(globalThis as Record<symbol, Map<string, InteractiveMessageContext>>)[INTERACTIVE_CONTEXTS_SYMBOL]) {
+    (globalThis as Record<symbol, Map<string, InteractiveMessageContext>>)[INTERACTIVE_CONTEXTS_SYMBOL] = new Map();
+    logger.debug('Created new global interactive contexts Map');
+  }
+  return (globalThis as Record<symbol, Map<string, InteractiveMessageContext>>)[INTERACTIVE_CONTEXTS_SYMBOL];
+}
+
+/**
  * Store for interactive message contexts.
  * Maps message ID to its action prompts.
+ * Uses globalThis for cross-module state sharing (Issue #894).
  */
-const interactiveContexts = new Map<string, InteractiveMessageContext>();
+const interactiveContexts = getInteractiveContexts();
 
 /**
  * Register action prompts for a message.
@@ -48,7 +70,37 @@ export function registerActionPrompts(
  */
 export function getActionPrompts(messageId: string): ActionPromptMap | undefined {
   const context = interactiveContexts.get(messageId);
+  if (!context) {
+    logger.debug(
+      { messageId, totalContexts: interactiveContexts.size },
+      'No context found for message ID'
+    );
+  }
   return context?.actionPrompts;
+}
+
+/**
+ * Get the current number of stored interactive contexts.
+ * Useful for debugging cross-process state sharing issues.
+ */
+export function getInteractiveContextsSize(): number {
+  return interactiveContexts.size;
+}
+
+/**
+ * Check if the global interactive contexts Map is properly initialized.
+ * Returns debug information for troubleshooting Issue #894.
+ */
+export function getInteractiveContextsDebugInfo(): {
+  size: number;
+  hasGlobalInstance: boolean;
+  messageIds: string[];
+} {
+  return {
+    size: interactiveContexts.size,
+    hasGlobalInstance: (globalThis as Record<symbol, unknown>)[INTERACTIVE_CONTEXTS_SYMBOL] !== undefined,
+    messageIds: Array.from(interactiveContexts.keys()),
+  };
 }
 
 /**
@@ -81,6 +133,16 @@ export function generateInteractionPrompt(
 ): string | undefined {
   const prompts = getActionPrompts(messageId);
   if (!prompts) {
+    // Log detailed debug info for Issue #894 troubleshooting
+    logger.debug(
+      {
+        messageId,
+        actionValue,
+        contextsSize: interactiveContexts.size,
+        availableMessageIds: Array.from(interactiveContexts.keys()).slice(0, 5),
+      },
+      'No action prompts found for message - context not registered or cross-process issue'
+    );
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- Fixes #894 - 飞书卡片按钮点击无响应
- Uses `globalThis` with `Symbol.for()` to ensure a single shared `interactiveContexts` Map instance across all module imports within the same Node.js process

## Problem

Issue #894 identified a cross-process memory isolation problem where:
1. `send_interactive_message` (MCP tool) registers action prompts in a Map
2. `handleCardAction` (main process) tries to retrieve prompts from a different Map instance
3. The prompts are not found because each module has its own Map

## Solution

Use `globalThis` with `Symbol.for()` to create a truly global Map instance:

```typescript
const INTERACTIVE_CONTEXTS_SYMBOL = Symbol.for('disclaude.interactiveContexts');

function getInteractiveContexts(): Map<string, InteractiveMessageContext> {
  if (!globalThis[INTERACTIVE_CONTEXTS_SYMBOL]) {
    globalThis[INTERACTIVE_CONTEXTS_SYMBOL] = new Map();
  }
  return globalThis[INTERACTIVE_CONTEXTS_SYMBOL];
}

const interactiveContexts = getInteractiveContexts();
```

This ensures that:
- All module imports share the same Map instance
- The Map persists across module reloads
- No file I/O or external dependencies required

## Changes

| File | Change |
|------|--------|
| `src/mcp/tools/interactive-message.ts` | Use globalThis singleton pattern for interactiveContexts Map |
| `src/mcp/tools/interactive-message.ts` | Add `getInteractiveContextsSize()` debug function |
| `src/mcp/tools/interactive-message.ts` | Add `getInteractiveContextsDebugInfo()` for troubleshooting |
| `src/mcp/tools/interactive-message.ts` | Enhanced logging in `generateInteractionPrompt()` |
| `src/mcp/tools/index.ts` | Export new debug functions |
| `src/mcp/feishu-context-mcp.ts` | Export new debug functions |

## Test Results

- ✅ All 1616 tests pass
- ✅ TypeScript compilation successful
- ✅ Lint check passes (no new errors)

## Related

- Issue #894: 飞书卡片按钮点击无响应
- Alternative to rejected PR #929 (file-based storage was rejected due to stability concerns)
- Complements PR #936 (Worker Node card action routing for Issue #935)

## Note

This solution addresses the cross-module state sharing within a single Node.js process. For Worker Node scenarios where processes are truly separate, PR #936 provides the WebSocket-based routing solution.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)