### PR TITLE
feat(ruliu): add RuliuChannel with Webhook support (Issue #725)

### DIFF
--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -8,6 +8,7 @@
  * Available Channels:
  * - FeishuChannel: Feishu/Lark messaging via WebSocket
  * - RestChannel: RESTful API for direct agent interaction
+ * - RuliuChannel: Ruliu (如流) messaging via HTTP Webhook
  *
  * Platform Adapters:
  * - IMessageSender: Platform-agnostic message sending
@@ -15,7 +16,7 @@
  *
  * Usage:
  * ```typescript
- * import { IChannel, FeishuChannel, RestChannel } from './channels/index.js';
+ * import { IChannel, FeishuChannel, RestChannel, RuliuChannel } from './channels/index.js';
  *
  * // Create a Feishu channel
  * const feishuChannel = new FeishuChannel({
@@ -26,6 +27,16 @@
  * // Create a REST channel
  * const restChannel = new RestChannel({
  *   port: 3000,
+ * });
+ *
+ * // Create a Ruliu channel
+ * const ruliuChannel = new RuliuChannel({
+ *   apiHost: 'https://apiin.im.baidu.com',
+ *   checkToken: '...',
+ *   encodingAESKey: '...',
+ *   appKey: '...',
+ *   appSecret: '...',
+ *   robotName: 'MyBot',
  * });
  *
  * // Register message handler
@@ -61,6 +72,7 @@ export { BaseChannel } from './base-channel.js';
 // Channel implementations
 export { FeishuChannel, type FeishuChannelConfig } from './feishu-channel.js';
 export { RestChannel, type RestChannelConfig } from './rest-channel.js';
+export { RuliuChannel, type RuliuChannelConfig } from './ruliu-channel.js';
 
 // Platform Adapters
 export type {

--- a/src/channels/ruliu-channel.ts
+++ b/src/channels/ruliu-channel.ts
@@ -1,0 +1,384 @@
+/**
+ * Ruliu Channel Implementation.
+ *
+ * Handles Ruliu (如流) messaging platform integration via HTTP Webhook.
+ * Implements the IChannel interface for unified message handling.
+ *
+ * Issue #725: Ruliu platform adapter integration
+ */
+
+import http from 'node:http';
+import { createLogger } from '../utils/logger.js';
+import { BaseChannel } from './base-channel.js';
+import type {
+  ChannelConfig,
+  OutgoingMessage,
+  ChannelCapabilities,
+  IncomingMessage,
+} from './types.js';
+import {
+  RuliuMessageSender,
+  type RuliuMessageSenderConfig,
+} from '../platforms/ruliu/ruliu-message-sender.js';
+import {
+  RuliuWebhookHandler,
+  type WebhookCallbacks,
+} from '../platforms/ruliu/ruliu-webhook-handler.js';
+import type { RuliuConfig, RuliuMessageEvent } from '../platforms/ruliu/types.js';
+
+const logger = createLogger('RuliuChannel');
+
+/**
+ * Ruliu channel configuration.
+ */
+export interface RuliuChannelConfig extends ChannelConfig, RuliuConfig {
+  /** Server port for webhook (default: 8080) */
+  webhookPort?: number;
+  /** Server host (default: 0.0.0.0) */
+  webhookHost?: string;
+  /** Webhook path (default: /webhook/ruliu) */
+  webhookPath?: string;
+}
+
+/**
+ * Ruliu Channel - Handles Ruliu messaging via HTTP Webhook.
+ *
+ * Features:
+ * - HTTP Webhook-based event receiving
+ * - Message deduplication
+ * - Text and Markdown support
+ * - @mention detection
+ * - Follow-up mode for conversation context
+ */
+export class RuliuChannel extends BaseChannel<RuliuChannelConfig> {
+  private webhookPort: number;
+  private webhookHost: string;
+  private webhookPath: string;
+
+  private server?: http.Server;
+  private messageSender: RuliuMessageSender;
+  private webhookHandler: RuliuWebhookHandler;
+
+  // Message deduplication
+  private processedMessages = new Set<string>();
+  private readonly maxProcessedMessages = 10000;
+
+  // Follow-up mode tracking
+  private followUpChats = new Map<string, number>();
+  private readonly followUpWindow: number;
+
+  constructor(config: RuliuChannelConfig) {
+    super(config, 'ruliu', 'Ruliu (如流)');
+
+    this.webhookPort = config.webhookPort || 8080;
+    this.webhookHost = config.webhookHost || '0.0.0.0';
+    this.webhookPath = config.webhookPath || '/webhook/ruliu';
+    this.followUpWindow = (config.followUpWindow || 300) * 1000; // Convert to ms
+
+    // Create message sender
+    this.messageSender = new RuliuMessageSender({
+      config: {
+        apiHost: config.apiHost,
+        checkToken: config.checkToken,
+        encodingAESKey: config.encodingAESKey,
+        appKey: config.appKey,
+        appSecret: config.appSecret,
+        robotName: config.robotName,
+        replyMode: config.replyMode,
+        followUp: config.followUp,
+        followUpWindow: config.followUpWindow,
+        watchMentions: config.watchMentions,
+      },
+      logger,
+    } as RuliuMessageSenderConfig);
+
+    // Create webhook handler
+    const callbacks: WebhookCallbacks = {
+      onMessage: async (event: RuliuMessageEvent) => {
+        await this.handleMessageEvent(event);
+      },
+    };
+
+    this.webhookHandler = new RuliuWebhookHandler({
+      config: {
+        apiHost: config.apiHost,
+        checkToken: config.checkToken,
+        encodingAESKey: config.encodingAESKey,
+        appKey: config.appKey,
+        appSecret: config.appSecret,
+        robotName: config.robotName,
+        replyMode: config.replyMode,
+      },
+      logger,
+      callbacks,
+    });
+
+    logger.info({ id: this.id, port: this.webhookPort }, 'RuliuChannel created');
+  }
+
+  protected doStart(): Promise<void> {
+    // Create HTTP server for webhook
+    this.server = http.createServer((req, res) => {
+      this.handleWebhookRequest(req, res).catch((error) => {
+        logger.error({ err: error }, 'Failed to handle webhook request');
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Internal server error');
+      });
+    });
+
+    return new Promise((resolve, reject) => {
+      if (!this.server) {
+        reject(new Error('Server not created'));
+        return;
+      }
+      this.server.listen(this.webhookPort, this.webhookHost, () => {
+        logger.info(
+          { port: this.webhookPort, host: this.webhookHost, path: this.webhookPath },
+          'RuliuChannel webhook server started'
+        );
+        resolve();
+      });
+
+      this.server.on('error', (error) => {
+        logger.error({ err: error }, 'Failed to start webhook server');
+        reject(error);
+      });
+    });
+  }
+
+  protected doStop(): Promise<void> {
+    if (this.server) {
+      const serverRef = this.server;
+      return new Promise((resolve) => {
+        serverRef.close(() => {
+          logger.info('RuliuChannel webhook server stopped');
+          resolve();
+        });
+      });
+    }
+    return Promise.resolve();
+  }
+
+  protected async doSendMessage(message: OutgoingMessage): Promise<void> {
+    switch (message.type) {
+      case 'text':
+        await this.messageSender.sendText(
+          message.chatId,
+          message.text || '',
+          message.threadId
+        );
+        break;
+      case 'card':
+        await this.messageSender.sendCard(
+          message.chatId,
+          message.card || {},
+          message.description,
+          message.threadId
+        );
+        break;
+      case 'file':
+        await this.messageSender.sendFile(
+          message.chatId,
+          message.filePath || '',
+          message.threadId
+        );
+        break;
+      case 'done':
+        logger.debug({ chatId: message.chatId }, 'Task completed (done signal)');
+        break;
+      default:
+        throw new Error(`Unsupported message type: ${(message as { type: string }).type}`);
+    }
+  }
+
+  protected checkHealth(): boolean {
+    return this.server !== undefined && this.server.listening;
+  }
+
+  /**
+   * Get the capabilities of Ruliu channel.
+   */
+  getCapabilities(): ChannelCapabilities {
+    return {
+      supportsCard: false, // Ruliu uses Markdown instead of cards
+      supportsThread: true,
+      supportsFile: false, // Not fully implemented
+      supportsMarkdown: true,
+      supportsMention: true,
+      supportsUpdate: false,
+      supportedMcpTools: ['send_user_feedback'],
+    };
+  }
+
+  /**
+   * Handle incoming webhook request.
+   */
+  private async handleWebhookRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    // Check path
+    if (!req.url?.startsWith(this.webhookPath)) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+
+    // Parse query parameters
+    const url = new URL(req.url || '', `http://${req.headers.host}`);
+    const query = {
+      signature: url.searchParams.get('signature') || undefined,
+      timestamp: url.searchParams.get('timestamp') || undefined,
+      nonce: url.searchParams.get('nonce') || undefined,
+      msgSignature: url.searchParams.get('msg_signature') || undefined,
+    };
+
+    // Read request body
+    const body = await this.readRequestBody(req);
+
+    // Handle URL verification (GET request)
+    if (req.method === 'GET') {
+      const result = await this.webhookHandler.handleUrlVerification(body, query);
+      res.writeHead(result.status, { 'Content-Type': 'text/plain' });
+      res.end(result.body);
+      return;
+    }
+
+    // Handle message webhook (POST request)
+    if (req.method === 'POST') {
+      const result = await this.webhookHandler.handleWebhook(body, query);
+      res.writeHead(result.status, { 'Content-Type': 'text/plain' });
+      res.end(result.body);
+      return;
+    }
+
+    res.writeHead(405, { 'Content-Type': 'text/plain' });
+    res.end('Method not allowed');
+  }
+
+  /**
+   * Read request body from incoming message.
+   */
+  private readRequestBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
+      req.on('end', () => resolve(body));
+      req.on('error', reject);
+    });
+  }
+
+  /**
+   * Handle parsed message event from webhook.
+   */
+  private async handleMessageEvent(event: RuliuMessageEvent): Promise<void> {
+    // Message deduplication
+    if (event.messageId && this.processedMessages.has(event.messageId)) {
+      logger.debug({ messageId: event.messageId }, 'Skipping duplicate message');
+      return;
+    }
+
+    // Add to processed set
+    if (event.messageId) {
+      this.processedMessages.add(event.messageId);
+      // Cleanup old messages
+      if (this.processedMessages.size > this.maxProcessedMessages) {
+        const iterator = this.processedMessages.values();
+        for (let i = 0; i < this.maxProcessedMessages / 2; i++) {
+          const val = iterator.next().value;
+          if (val !== undefined) {
+            this.processedMessages.delete(val);
+          }
+        }
+      }
+    }
+
+    // Determine chat ID
+    const chatId = event.chatType === 'group'
+      ? `group_${event.groupId}`
+      : `direct_${event.fromuser}`;
+
+    // Check if should respond based on reply mode
+    if (!this.shouldRespond(event)) {
+      logger.debug(
+        { chatId, replyMode: this.config.replyMode },
+        'Skipping message based on reply mode'
+      );
+      return;
+    }
+
+    // Update follow-up tracking
+    if (this.config.followUp) {
+      this.followUpChats.set(chatId, Date.now());
+    }
+
+    // Build incoming message
+    const incomingMessage: IncomingMessage = {
+      chatId,
+      userId: event.fromuser,
+      content: event.mes,
+      messageType: 'text',
+      messageId: event.messageId || `ruliu_${Date.now()}`,
+      timestamp: event.timestamp ? event.timestamp * 1000 : Date.now(),
+      threadId: undefined, // Ruliu thread support would need additional parsing
+      attachments: [],
+      metadata: {
+        platform: 'ruliu',
+        chatType: event.chatType,
+        wasMentioned: event.wasMentioned,
+        senderName: event.senderName,
+      },
+    };
+
+    // Emit message to handler
+    await this.emitMessage(incomingMessage);
+  }
+
+  /**
+   * Determine if bot should respond based on reply mode.
+   */
+  private shouldRespond(event: RuliuMessageEvent): boolean {
+    const mode = this.config.replyMode || 'mention-and-watch';
+
+    switch (mode) {
+      case 'ignore':
+        return false;
+
+      case 'record':
+        return false; // Only record, don't respond
+
+      case 'mention-only':
+        return event.wasMentioned === true;
+
+      case 'mention-and-watch':
+        // Respond if mentioned, in watch list, or in follow-up window
+        if (event.wasMentioned) {
+          return true;
+        }
+
+        // Check watch list
+        if (this.config.watchMentions?.includes(event.fromuser)) {
+          return true;
+        }
+
+        // Check follow-up window
+        const chatId = event.chatType === 'group'
+          ? `group_${event.groupId}`
+          : `direct_${event.fromuser}`;
+        const lastMessageTime = this.followUpChats.get(chatId);
+        if (lastMessageTime && Date.now() - lastMessageTime < this.followUpWindow) {
+          return true;
+        }
+
+        return false;
+
+      case 'proactive':
+        return true;
+
+      default:
+        return event.wasMentioned === true;
+    }
+  }
+}

--- a/src/platforms/ruliu/index.ts
+++ b/src/platforms/ruliu/index.ts
@@ -25,6 +25,7 @@
 
 export { RuliuPlatformAdapter, type RuliuPlatformAdapterConfig } from './ruliu-adapter.js';
 export { RuliuMessageSender, type RuliuMessageSenderConfig } from './ruliu-message-sender.js';
+export { RuliuWebhookHandler, type WebhookCallbacks, type RuliuWebhookHandlerConfig } from './ruliu-webhook-handler.js';
 export {
   decryptMessage,
   encryptMessage,

--- a/src/platforms/ruliu/ruliu-webhook-handler.ts
+++ b/src/platforms/ruliu/ruliu-webhook-handler.ts
@@ -1,0 +1,206 @@
+/**
+ * Ruliu (如流) Webhook Handler.
+ *
+ * Handles incoming webhook messages from Ruliu platform.
+ * Performs signature verification, decryption, and message parsing.
+ *
+ * Issue #725: Ruliu platform adapter integration
+ */
+
+import type { Logger } from 'pino';
+import { createLogger } from '../../utils/logger.js';
+import {
+  decryptMessage,
+  verifySignature,
+} from './ruliu-crypto.js';
+import type {
+  RuliuConfig,
+  RuliuEncryptedMessage,
+  RuliuDecryptedContent,
+  RuliuMessageEvent,
+} from './types.js';
+
+/**
+ * Webhook message callbacks.
+ */
+export interface WebhookCallbacks {
+  /** Called when a message is received */
+  onMessage: (event: RuliuMessageEvent) => Promise<void>;
+}
+
+/**
+ * Ruliu Webhook Handler Configuration.
+ */
+export interface RuliuWebhookHandlerConfig {
+  /** Ruliu configuration */
+  config: RuliuConfig;
+  /** Logger instance */
+  logger?: Logger;
+  /** Message callbacks */
+  callbacks: WebhookCallbacks;
+}
+
+/**
+ * Ruliu Webhook Handler.
+ *
+ * Processes incoming webhook requests from Ruliu:
+ * 1. Verifies signature
+ * 2. Decrypts message content
+ * 3. Parses message event
+ * 4. Routes to appropriate handler
+ */
+export class RuliuWebhookHandler {
+  private config: RuliuConfig;
+  private logger: Logger;
+  private callbacks: WebhookCallbacks;
+
+  constructor(handlerConfig: RuliuWebhookHandlerConfig) {
+    this.config = handlerConfig.config;
+    this.logger = handlerConfig.logger ?? createLogger('RuliuWebhookHandler');
+    this.callbacks = handlerConfig.callbacks;
+  }
+
+  /**
+   * Handle incoming webhook request.
+   *
+   * @param body - Request body (parsed JSON or raw string)
+   * @param query - Query parameters (signature, timestamp, nonce)
+   * @returns Response to send back to Ruliu
+   */
+  async handleWebhook(
+    body: RuliuEncryptedMessage | string,
+    query: { signature?: string; timestamp?: string; nonce?: string }
+  ): Promise<{ status: number; body: string }> {
+    try {
+      // Parse body if string
+      const encrypted: RuliuEncryptedMessage =
+        typeof body === 'string' ? JSON.parse(body) : body;
+
+      // Verify signature
+      if (query.signature && query.timestamp && query.nonce) {
+        const isValid = verifySignature(
+          query.signature,
+          this.config.checkToken,
+          query.timestamp,
+          query.nonce,
+          encrypted.encrypt
+        );
+
+        if (!isValid) {
+          this.logger.warn({ query }, 'Invalid webhook signature');
+          return { status: 401, body: 'Invalid signature' };
+        }
+      }
+
+      // Decrypt message
+      const decryptedContent = decryptMessage(
+        encrypted.encrypt,
+        this.config.encodingAESKey
+      );
+
+      this.logger.debug({ content: decryptedContent }, 'Decrypted message');
+
+      // Parse decrypted content
+      const content: RuliuDecryptedContent = JSON.parse(decryptedContent);
+
+      // Convert to message event
+      const event = this.parseMessageEvent(content);
+
+      if (event) {
+        // Route to message handler
+        await this.callbacks.onMessage(event);
+      }
+
+      // Return success response (Ruliu expects "success")
+      return { status: 200, body: 'success' };
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed to handle webhook');
+      return { status: 500, body: 'Internal error' };
+    }
+  }
+
+  /**
+   * Parse decrypted content to message event.
+   */
+  private parseMessageEvent(content: RuliuDecryptedContent): RuliuMessageEvent | null {
+    // Skip non-message types
+    if (content.msgType !== 'text' && content.msgType !== 'markdown') {
+      this.logger.debug({ msgType: content.msgType }, 'Skipping non-text message');
+      return null;
+    }
+
+    // Determine chat type
+    const chatType = content.groupId ? 'group' : 'direct';
+
+    // Parse message content
+    const messageContent = content.content;
+    let wasMentioned = false;
+
+    // Check for @mentions in the content
+    // Ruliu format: @username or @[robotName]
+    if (this.config.robotName) {
+      const mentionPattern = new RegExp(`@\\[?${this.config.robotName}\\]?`, 'i');
+      wasMentioned = mentionPattern.test(messageContent);
+    }
+
+    // Build message event
+    const event: RuliuMessageEvent = {
+      fromuser: content.fromUsername,
+      mes: messageContent,
+      chatType,
+      groupId: content.groupId ? parseInt(content.groupId, 10) : undefined,
+      messageId: content.msgId,
+      timestamp: content.createTime,
+      wasMentioned,
+    };
+
+    return event;
+  }
+
+  /**
+   * Handle URL verification request from Ruliu.
+   * This is called when setting up the webhook URL.
+   *
+   * @param body - Request body with challenge
+   * @param query - Query parameters
+   * @returns Response with decrypted challenge
+   */
+  handleUrlVerification(
+    body: RuliuEncryptedMessage | string,
+    query: { signature?: string; timestamp?: string; nonce?: string }
+  ): { status: number; body: string } {
+    try {
+      // Parse body if string
+      const encrypted: RuliuEncryptedMessage =
+        typeof body === 'string' ? JSON.parse(body) : body;
+
+      // Verify signature
+      if (query.signature && query.timestamp && query.nonce) {
+        const isValid = verifySignature(
+          query.signature,
+          this.config.checkToken,
+          query.timestamp,
+          query.nonce,
+          encrypted.encrypt
+        );
+
+        if (!isValid) {
+          this.logger.warn({ query }, 'Invalid URL verification signature');
+          return { status: 401, body: 'Invalid signature' };
+        }
+      }
+
+      // Decrypt and return the challenge
+      const decrypted = decryptMessage(
+        encrypted.encrypt,
+        this.config.encodingAESKey
+      );
+
+      this.logger.info('URL verification successful');
+      return { status: 200, body: decrypted };
+    } catch (error) {
+      this.logger.error({ err: error }, 'Failed URL verification');
+      return { status: 500, body: 'Internal error' };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 and Phase 3 of the Ruliu (如流) platform adapter integration:

- **RuliuChannel**: HTTP Webhook-based channel implementation extending `BaseChannel`
- **RuliuWebhookHandler**: Processes incoming webhook messages with signature verification and AES decryption

## Changes

| File | Change |
|------|--------|
| `src/channels/ruliu-channel.ts` | New: RuliuChannel implementation |
| `src/platforms/ruliu/ruliu-webhook-handler.ts` | New: Webhook handler for message processing |
| `src/channels/index.ts` | Export RuliuChannel |
| `src/platforms/ruliu/index.ts` | Export RuliuWebhookHandler |

## Features

- ✅ HTTP Webhook-based event receiving
- ✅ Message deduplication
- ✅ Signature verification and AES decryption
- ✅ Multiple reply modes:
  - `ignore`: Discard all messages
  - `record`: Only record, don't respond
  - `mention-only`: Reply only when @mentioned
  - `mention-and-watch`: @mention + watch list + follow-up window
  - `proactive`: Respond to all messages
- ✅ Follow-up mode for conversation context
- ✅ Text and Markdown support

## Configuration

```yaml
# disclaude.config.yaml
ruliu:
  enabled: true
  apiHost: "https://apiin.im.baidu.com"
  checkToken: "your-check-token"
  encodingAESKey: "your-encoding-aes-key"
  appKey: "your-app-key"
  appSecret: "your-app-secret"
  robotName: "MyBot"
  replyMode: "mention-and-watch"
  followUp: true
  followUpWindow: 300
  webhookPort: 8080
  webhookPath: "/webhook/ruliu"
```

## Test Results

- ✅ All 4 ruliu-crypto tests pass
- ✅ TypeScript compilation successful
- ✅ Lint check passes

## Related

- Issue #725: feat: 如流(Ruliu)平台适配器集成

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)