### PR TITLE
fix(test): resolve type check errors in test files (Issue #941)

### DIFF
--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -45,6 +45,14 @@ function createMockServices(): CommandServices {
     disableSchedule: () => Promise.resolve(false),
     runSchedule: () => Promise.resolve(false),
     isScheduleRunning: () => false,
+    // Cooldown management (Issue #869)
+    getScheduleCooldownStatus: () => Promise.resolve({
+      isInCooldown: false,
+      lastExecutionTime: null,
+      cooldownEndsAt: null,
+      remainingMs: 0,
+    }),
+    clearScheduleCooldown: () => Promise.resolve(false),
     // Task management methods (Issue #468)
     startTask: () => Promise.resolve({ id: 'task_test', prompt: 'test', status: 'running', progress: 0, chatId: 'oc_test', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }),
     getCurrentTask: () => Promise.resolve(null),

--- a/src/schedule/cooldown-manager.test.ts
+++ b/src/schedule/cooldown-manager.test.ts
@@ -4,6 +4,8 @@
  * Issue #869: Cooldown period for scheduled tasks.
  */
 
+/// <reference types="vitest/globals" />
+
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';


### PR DESCRIPTION
## Summary

Fixes type check errors introduced by PR #874 (feat(schedule): add cooldown period for scheduled tasks):

1. **cooldown-manager.test.ts**: Added `/// <reference types="vitest/globals" />` directive to resolve vitest global type errors (`describe`, `it`, `expect`, etc.)

2. **command-registry.test.ts**: Added missing mock methods `getScheduleCooldownStatus` and `clearScheduleCooldown` to the `createMockServices()` function

## Changes

| File | Change |
|------|--------|
| `src/schedule/cooldown-manager.test.ts` | Added vitest globals type reference directive |
| `src/nodes/commands/command-registry.test.ts` | Added cooldown mock methods to CommandServices |

## Test Results

- ✅ Type check passes: `npm run type-check`
- ✅ All related tests pass (32 tests)

## Related

- Fixes #941
- Related to #869 (cooldown period feature)
- Caused by PR #874

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)