### PR TITLE
fix(schedule): add missing await in cooldown methods

### DIFF
--- a/src/nodes/schedule-management.ts
+++ b/src/nodes/schedule-management.ts
@@ -188,7 +188,7 @@ export class ScheduleManagement {
   } | null> {
     const scheduler = this.deps.schedulerService?.getScheduler();
     if (!scheduler) { return null; }
-    return scheduler.getCooldownStatus(taskId, cooldownPeriod);
+    return await scheduler.getCooldownStatus(taskId, cooldownPeriod);
   }
 
   /**
@@ -198,6 +198,6 @@ export class ScheduleManagement {
   async clearScheduleCooldown(taskId: string): Promise<boolean> {
     const scheduler = this.deps.schedulerService?.getScheduler();
     if (!scheduler) { return false; }
-    return scheduler.clearCooldown(taskId);
+    return await scheduler.clearCooldown(taskId);
   }
 }


### PR DESCRIPTION
## Summary

- Add `await` expressions to async methods `getScheduleCooldownStatus` and `clearScheduleCooldown` in `schedule-management.ts`
- Fixes `require-await` lint errors introduced in Issue #869 cooldown feature

## Details

The async methods were calling other async methods without `await`, which triggers the `require-await` lint rule. This PR adds the missing `await` keywords.

**Before:**
```typescript
async getScheduleCooldownStatus(...) {
  return scheduler.getCooldownStatus(taskId, cooldownPeriod);
}

async clearScheduleCooldown(...) {
  return scheduler.clearCooldown(taskId);
}
```

**After:**
```typescript
async getScheduleCooldownStatus(...) {
  return await scheduler.getCooldownStatus(taskId, cooldownPeriod);
}

async clearScheduleCooldown(...) {
  return await scheduler.clearCooldown(taskId);
}
```

## Test Plan

- [x] Lint check passes (no more require-await errors)
- [x] Type check passes (no new type errors)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)