### PR TITLE
fix(ipc): add Unix Socket IPC for cross-process interactive contexts (Issue #894)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -17,6 +17,7 @@ import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.
 import { getCommandRegistry } from '../../nodes/commands/command-registry.js';
 import { resolvePendingInteraction } from '../../mcp/feishu-context-mcp.js';
 import { generateInteractionPrompt } from '../../mcp/tools/interactive-message.js';
+import { getIpcClient } from '../../ipc/unix-socket-client.js';
 import { filteredMessageForwarder } from '../../feishu/filtered-message-forwarder.js';
 import type { FilterReason } from '../../config/types.js';
 import { stripLeadingMentions } from '../../utils/mention-parser.js';
@@ -567,13 +568,33 @@ export class MessageHandler {
 
     // Always emit card action as a message to the agent
     try {
-      // Try to get a pre-defined prompt template first
-      const promptFromTemplate = generateInteractionPrompt(
-        message_id,
-        action.value,
-        action.text,
-        action.type
-      );
+      // Try to get a pre-defined prompt template via IPC first (cross-process),
+      // then fall back to local function (same-process)
+      let promptFromTemplate: string | undefined;
+
+      const ipcClient = getIpcClient();
+      if (ipcClient.isConnected()) {
+        // Cross-process: query via IPC
+        promptFromTemplate = await ipcClient.generateInteractionPrompt(
+          message_id,
+          action.value,
+          action.text,
+          action.type
+        );
+        if (promptFromTemplate) {
+          logger.debug({ messageId: message_id }, 'Got prompt template via IPC');
+        }
+      }
+
+      // Fallback to local function (same-process)
+      if (!promptFromTemplate) {
+        promptFromTemplate = generateInteractionPrompt(
+          message_id,
+          action.value,
+          action.text,
+          action.type
+        );
+      }
 
       // Use the template prompt if available, otherwise use default message
       const messageContent = promptFromTemplate || (() => {
@@ -612,13 +633,30 @@ export class MessageHandler {
     try {
       // Try to handle via InteractionManager
       const handled = await this.interactionManager.handleAction(event, async (defaultEvent) => {
-        // Try to get a pre-defined prompt template first
-        const promptFromTemplate = generateInteractionPrompt(
-          defaultEvent.message_id,
-          defaultEvent.action.value,
-          defaultEvent.action.text,
-          defaultEvent.action.type
-        );
+        // Try to get a pre-defined prompt template via IPC first (cross-process),
+        // then fall back to local function (same-process)
+        let promptFromTemplate: string | undefined;
+
+        const ipcClient = getIpcClient();
+        if (ipcClient.isConnected()) {
+          // Cross-process: query via IPC
+          promptFromTemplate = await ipcClient.generateInteractionPrompt(
+            defaultEvent.message_id,
+            defaultEvent.action.value,
+            defaultEvent.action.text,
+            defaultEvent.action.type
+          );
+        }
+
+        // Fallback to local function (same-process)
+        if (!promptFromTemplate) {
+          promptFromTemplate = generateInteractionPrompt(
+            defaultEvent.message_id,
+            defaultEvent.action.value,
+            defaultEvent.action.text,
+            defaultEvent.action.type
+          );
+        }
 
         // Use the template prompt if available, otherwise use default message
         const messageContent = promptFromTemplate || (() => {

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -1,0 +1,9 @@
+/**
+ * IPC module for cross-process communication.
+ *
+ * @module ipc
+ */
+
+export * from './protocol.js';
+export * from './unix-socket-server.js';
+export * from './unix-socket-client.js';

--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Tests for IPC module - Unix Socket cross-process communication.
+ *
+ * @module ipc/ipc.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { unlinkSync, existsSync } from 'fs';
+import { UnixSocketIpcServer, createInteractiveMessageHandler } from './unix-socket-server.js';
+import { UnixSocketIpcClient, getIpcClient, resetIpcClient } from './unix-socket-client.js';
+import type { IpcConfig } from './protocol.js';
+
+// Generate a unique socket path for each test
+function generateSocketPath(): string {
+  return join(tmpdir(), `disclaude-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+}
+
+describe('UnixSocketIpcServer', () => {
+  let server: UnixSocketIpcServer;
+  let socketPath: string;
+  let handler: ReturnType<typeof createInteractiveMessageHandler>;
+
+  const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
+
+  beforeEach(() => {
+    socketPath = generateSocketPath();
+    mockContexts.clear();
+
+    handler = createInteractiveMessageHandler(
+      (messageId) => mockContexts.get(messageId)?.actionPrompts,
+      (messageId, chatId, actionPrompts) => {
+        mockContexts.set(messageId, { chatId, actionPrompts });
+      },
+      (messageId) => mockContexts.delete(messageId),
+      (messageId, actionValue, actionText) => {
+        const context = mockContexts.get(messageId);
+        if (!context) return undefined;
+        const template = context.actionPrompts[actionValue];
+        if (!template) return undefined;
+        return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
+      },
+      () => {
+        let cleaned = 0;
+        for (const [key, value] of mockContexts) {
+          mockContexts.delete(key);
+          cleaned++;
+        }
+        return cleaned;
+      }
+    );
+
+    server = new UnixSocketIpcServer(handler, { socketPath });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should start and stop successfully', async () => {
+    expect(server.isRunning()).toBe(false);
+
+    await server.start();
+    expect(server.isRunning()).toBe(true);
+    expect(server.getSocketPath()).toBe(socketPath);
+
+    await server.stop();
+    expect(server.isRunning()).toBe(false);
+  });
+
+  it('should clean up socket file on stop', async () => {
+    await server.start();
+    expect(existsSync(socketPath)).toBe(true);
+
+    await server.stop();
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  it('should handle multiple start calls gracefully', async () => {
+    await server.start();
+    await server.start(); // Should not throw
+    expect(server.isRunning()).toBe(true);
+  });
+
+  it('should handle multiple stop calls gracefully', async () => {
+    await server.start();
+    await server.stop();
+    await server.stop(); // Should not throw
+    expect(server.isRunning()).toBe(false);
+  });
+});
+
+describe('UnixSocketIpcClient', () => {
+  let server: UnixSocketIpcServer;
+  let client: UnixSocketIpcClient;
+  let socketPath: string;
+  const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
+
+  beforeEach(async () => {
+    socketPath = generateSocketPath();
+    mockContexts.clear();
+
+    const handler = createInteractiveMessageHandler(
+      (messageId) => mockContexts.get(messageId)?.actionPrompts,
+      (messageId, chatId, actionPrompts) => {
+        mockContexts.set(messageId, { chatId, actionPrompts });
+      },
+      (messageId) => mockContexts.delete(messageId),
+      (messageId, actionValue, actionText) => {
+        const context = mockContexts.get(messageId);
+        if (!context) return undefined;
+        const template = context.actionPrompts[actionValue];
+        if (!template) return undefined;
+        return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
+      },
+      () => 0
+    );
+
+    server = new UnixSocketIpcServer(handler, { socketPath });
+    client = new UnixSocketIpcClient({ socketPath, timeout: 2000 });
+
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    await server.stop();
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should connect and disconnect', async () => {
+    expect(client.isConnected()).toBe(false);
+
+    await client.connect();
+    expect(client.isConnected()).toBe(true);
+
+    await client.disconnect();
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it('should ping the server', async () => {
+    const result = await client.ping();
+    expect(result).toBe(true);
+  });
+
+  it('should register and get action prompts', async () => {
+    await client.sendRequest('register_action_prompts', {
+      messageId: 'test-msg-1',
+      chatId: 'test-chat',
+      actionPrompts: { confirm: 'You confirmed!', cancel: 'You cancelled!' },
+    });
+
+    const result = await client.sendRequest('get_action_prompts', {
+      messageId: 'test-msg-1',
+    });
+
+    expect(result.prompts).toEqual({
+      confirm: 'You confirmed!',
+      cancel: 'You cancelled!',
+    });
+  });
+
+  it('should return null for non-existent prompts', async () => {
+    const result = await client.sendRequest('get_action_prompts', {
+      messageId: 'non-existent',
+    });
+
+    expect(result.prompts).toBeNull();
+  });
+
+  it('should generate interaction prompt', async () => {
+    await client.sendRequest('register_action_prompts', {
+      messageId: 'test-msg-2',
+      chatId: 'test-chat',
+      actionPrompts: { confirm: 'User clicked {{actionText}} button' },
+    });
+
+    const result = await client.sendRequest('generate_interaction_prompt', {
+      messageId: 'test-msg-2',
+      actionValue: 'confirm',
+      actionText: 'Confirm',
+      actionType: 'button',
+    });
+
+    expect(result.prompt).toBe('User clicked Confirm button');
+  });
+
+  it('should return null for non-existent prompt template', async () => {
+    const result = await client.sendRequest('generate_interaction_prompt', {
+      messageId: 'non-existent',
+      actionValue: 'unknown',
+    });
+
+    expect(result.prompt).toBeNull();
+  });
+
+  it('should unregister action prompts', async () => {
+    await client.sendRequest('register_action_prompts', {
+      messageId: 'test-msg-3',
+      chatId: 'test-chat',
+      actionPrompts: { test: 'Test prompt' },
+    });
+
+    const before = await client.sendRequest('get_action_prompts', {
+      messageId: 'test-msg-3',
+    });
+    expect(before.prompts).not.toBeNull();
+
+    await client.sendRequest('unregister_action_prompts', {
+      messageId: 'test-msg-3',
+    });
+
+    const after = await client.sendRequest('get_action_prompts', {
+      messageId: 'test-msg-3',
+    });
+    expect(after.prompts).toBeNull();
+  });
+
+  it('should handle generateInteractionPrompt helper method', async () => {
+    await client.sendRequest('register_action_prompts', {
+      messageId: 'test-msg-4',
+      chatId: 'test-chat',
+      actionPrompts: { approve: 'Approved!', reject: 'Rejected!' },
+    });
+
+    const prompt = await client.generateInteractionPrompt(
+      'test-msg-4',
+      'approve',
+      'Approve',
+      'button'
+    );
+
+    expect(prompt).toBe('Approved!');
+  });
+
+  it('should handle getActionPrompts helper method', async () => {
+    await client.sendRequest('register_action_prompts', {
+      messageId: 'test-msg-5',
+      chatId: 'test-chat',
+      actionPrompts: { test: 'Test' },
+    });
+
+    const prompts = await client.getActionPrompts('test-msg-5');
+    expect(prompts).toEqual({ test: 'Test' });
+  });
+});
+
+describe('IPC Singleton', () => {
+  beforeEach(() => {
+    resetIpcClient();
+  });
+
+  afterEach(() => {
+    resetIpcClient();
+  });
+
+  it('should return the same client instance', () => {
+    const client1 = getIpcClient();
+    const client2 = getIpcClient();
+    expect(client1).toBe(client2);
+  });
+
+  it('should reset client on resetIpcClient', () => {
+    const client1 = getIpcClient();
+    resetIpcClient();
+    const client2 = getIpcClient();
+    expect(client1).not.toBe(client2);
+  });
+});

--- a/src/ipc/protocol.ts
+++ b/src/ipc/protocol.ts
@@ -1,0 +1,90 @@
+/**
+ * IPC Protocol definitions for cross-process communication.
+ *
+ * @module ipc/protocol
+ */
+
+/**
+ * IPC request types
+ */
+export type IpcRequestType =
+  | 'get_action_prompts'
+  | 'register_action_prompts'
+  | 'unregister_action_prompts'
+  | 'generate_interaction_prompt'
+  | 'cleanup_expired_contexts'
+  | 'ping';
+
+/**
+ * Base IPC request
+ */
+export interface IpcRequest<T extends IpcRequestType = IpcRequestType> {
+  type: T;
+  id: string;
+  payload: IpcRequestPayloads[T];
+}
+
+/**
+ * Base IPC response
+ */
+export interface IpcResponse<T extends IpcRequestType = IpcRequestType> {
+  id: string;
+  success: boolean;
+  result?: IpcResponseResults[T];
+  error?: string;
+}
+
+/**
+ * Request payloads by type
+ */
+export interface IpcRequestPayloads {
+  get_action_prompts: { messageId: string };
+  register_action_prompts: {
+    messageId: string;
+    chatId: string;
+    actionPrompts: Record<string, string>;
+  };
+  unregister_action_prompts: { messageId: string };
+  generate_interaction_prompt: {
+    messageId: string;
+    actionValue: string;
+    actionText?: string;
+    actionType?: string;
+    formData?: Record<string, unknown>;
+  };
+  cleanup_expired_contexts: Record<string, never>;
+  ping: Record<string, never>;
+}
+
+/**
+ * Response results by type
+ */
+export interface IpcResponseResults {
+  get_action_prompts: { prompts: Record<string, string> | null };
+  register_action_prompts: { success: boolean };
+  unregister_action_prompts: { success: boolean };
+  generate_interaction_prompt: { prompt: string | null };
+  cleanup_expired_contexts: { cleaned: number };
+  ping: { pong: true };
+}
+
+/**
+ * Default Unix socket path for interactive message IPC
+ */
+export const DEFAULT_IPC_SOCKET_PATH = '/tmp/disclaude-interactive.ipc';
+
+/**
+ * IPC configuration
+ */
+export interface IpcConfig {
+  socketPath: string;
+  timeout: number;
+}
+
+/**
+ * Default IPC configuration
+ */
+export const DEFAULT_IPC_CONFIG: IpcConfig = {
+  socketPath: DEFAULT_IPC_SOCKET_PATH,
+  timeout: 5000, // 5 seconds
+};

--- a/src/ipc/unix-socket-client.ts
+++ b/src/ipc/unix-socket-client.ts
@@ -1,0 +1,288 @@
+/**
+ * Unix Socket IPC Client for cross-process communication.
+ *
+ * Provides a Unix domain socket client that allows the main process
+ * to query the interactive contexts stored in the MCP process.
+ *
+ * @module ipc/unix-socket-client
+ */
+
+import { createConnection, type Socket } from 'net';
+import { createLogger } from '../utils/logger.js';
+import type {
+  IpcRequest,
+  IpcResponse,
+  IpcRequestType,
+  IpcRequestPayloads,
+  IpcResponseResults,
+  IpcConfig,
+} from './protocol.js';
+
+const logger = createLogger('IpcClient');
+
+/**
+ * Pending request tracker
+ */
+interface PendingRequest {
+  resolve: (response: IpcResponse) => void;
+  reject: (error: Error) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Unix Socket IPC Client
+ */
+export class UnixSocketIpcClient {
+  private socketPath: string;
+  private timeout: number;
+  private socket: Socket | null = null;
+  private buffer = '';
+  private pendingRequests: Map<string, PendingRequest> = new Map();
+  private isConnecting = false;
+
+  constructor(config?: Partial<IpcConfig>) {
+    this.socketPath = config?.socketPath ?? '/tmp/disclaude-interactive.ipc';
+    this.timeout = config?.timeout ?? 5000;
+  }
+
+  /**
+   * Connect to the IPC server
+   */
+  async connect(): Promise<void> {
+    if (this.socket?.writable) {
+      return;
+    }
+
+    if (this.isConnecting) {
+      // Wait for existing connection attempt
+      return new Promise((resolve, reject) => {
+        const checkInterval = setInterval(() => {
+          if (this.socket?.writable) {
+            clearInterval(checkInterval);
+            resolve();
+          } else if (!this.isConnecting) {
+            clearInterval(checkInterval);
+            reject(new Error('Connection failed'));
+          }
+        }, 50);
+      });
+    }
+
+    this.isConnecting = true;
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.socket = createConnection(this.socketPath, () => {
+          this.isConnecting = false;
+          logger.debug({ path: this.socketPath }, 'IPC client connected');
+          resolve();
+        });
+
+        this.socket.on('data', (data) => {
+          this.handleData(data.toString());
+        });
+
+        this.socket.on('error', (error) => {
+          this.isConnecting = false;
+          logger.debug({ err: error }, 'IPC client connection error');
+          reject(error);
+        });
+
+        this.socket.on('close', () => {
+          this.socket = null;
+          this.isConnecting = false;
+          logger.debug('IPC client disconnected');
+        });
+      } catch (error) {
+        this.isConnecting = false;
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Disconnect from the IPC server
+   */
+  async disconnect(): Promise<void> {
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+
+    // Reject all pending requests
+    for (const [_id, pending] of this.pendingRequests) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error('Disconnected'));
+    }
+    this.pendingRequests.clear();
+  }
+
+  /**
+   * Check if connected
+   */
+  isConnected(): boolean {
+    return this.socket?.writable ?? false;
+  }
+
+  /**
+   * Send a request and wait for response
+   */
+  async sendRequest<T extends IpcRequestType>(
+    type: T,
+    payload: IpcRequestPayloads[T]
+  ): Promise<IpcResponseResults[T]> {
+    // Ensure connected
+    if (!this.isConnected()) {
+      await this.connect();
+    }
+
+    const id = this.generateRequestId();
+    const request: IpcRequest<T> = { type, id, payload };
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request timeout: ${type}`));
+      }, this.timeout);
+
+      this.pendingRequests.set(id, {
+        resolve: (response: IpcResponse) => {
+          if (response.success && response.result !== undefined) {
+            resolve(response.result as IpcResponseResults[T]);
+          } else {
+            reject(new Error(response.error ?? 'Request failed'));
+          }
+        },
+        reject,
+        timeout,
+      });
+
+      try {
+        this.socket!.write(JSON.stringify(request) + '\n');
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        clearTimeout(timeout);
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Generate interaction prompt via IPC
+   */
+  async generateInteractionPrompt(
+    messageId: string,
+    actionValue: string,
+    actionText?: string,
+    actionType?: string,
+    formData?: Record<string, unknown>
+  ): Promise<string | undefined> {
+    try {
+      const result = await this.sendRequest('generate_interaction_prompt', {
+        messageId,
+        actionValue,
+        actionText,
+        actionType,
+        formData,
+      });
+      return result.prompt ?? undefined;
+    } catch (error) {
+      logger.debug({ err: error, messageId }, 'Failed to generate prompt via IPC');
+      return undefined;
+    }
+  }
+
+  /**
+   * Get action prompts via IPC
+   */
+  async getActionPrompts(messageId: string): Promise<Record<string, string> | undefined> {
+    try {
+      const result = await this.sendRequest('get_action_prompts', { messageId });
+      return result.prompts ?? undefined;
+    } catch (error) {
+      logger.debug({ err: error, messageId }, 'Failed to get prompts via IPC');
+      return undefined;
+    }
+  }
+
+  /**
+   * Ping the server to check connectivity
+   */
+  async ping(): Promise<boolean> {
+    try {
+      const result = await this.sendRequest('ping', {});
+      return result.pong;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Handle incoming data
+   */
+  private handleData(data: string): void {
+    this.buffer += data;
+
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (line.trim()) {
+        this.handleResponse(line);
+      }
+    }
+  }
+
+  /**
+   * Handle an incoming response
+   */
+  private handleResponse(data: string): void {
+    let response: IpcResponse;
+
+    try {
+      response = JSON.parse(data);
+    } catch {
+      logger.debug({ data }, 'Invalid IPC response JSON');
+      return;
+    }
+
+    const pending = this.pendingRequests.get(response.id);
+    if (pending) {
+      clearTimeout(pending.timeout);
+      this.pendingRequests.delete(response.id);
+      pending.resolve(response);
+    } else {
+      logger.debug({ id: response.id }, 'Received response for unknown request');
+    }
+  }
+
+  /**
+   * Generate a unique request ID
+   */
+  private generateRequestId(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  }
+}
+
+// Singleton instance for convenience
+let clientInstance: UnixSocketIpcClient | null = null;
+
+/**
+ * Get the singleton IPC client instance
+ */
+export function getIpcClient(config?: Partial<IpcConfig>): UnixSocketIpcClient {
+  if (!clientInstance) {
+    clientInstance = new UnixSocketIpcClient(config);
+  }
+  return clientInstance;
+}
+
+/**
+ * Reset the singleton instance (for testing)
+ */
+export function resetIpcClient(): void {
+  if (clientInstance) {
+    clientInstance.disconnect().catch(() => {});
+    clientInstance = null;
+  }
+}

--- a/src/ipc/unix-socket-server.ts
+++ b/src/ipc/unix-socket-server.ts
@@ -1,0 +1,309 @@
+/**
+ * Unix Socket IPC Server for cross-process communication.
+ *
+ * Provides a Unix domain socket server that allows other processes
+ * to query the interactive contexts stored in this process.
+ *
+ * @module ipc/unix-socket-server
+ */
+
+import { createServer, type Socket, type Server } from 'net';
+import { unlinkSync, existsSync } from 'fs';
+import { createLogger } from '../utils/logger.js';
+import type {
+  IpcRequest,
+  IpcResponse,
+  IpcConfig,
+  IpcRequestPayloads,
+} from './protocol.js';
+
+const logger = createLogger('IpcServer');
+
+/**
+ * Handler function type for processing IPC requests
+ */
+export type IpcRequestHandler = (request: IpcRequest) => Promise<IpcResponse>;
+
+/**
+ * Unix Socket IPC Server
+ */
+export class UnixSocketIpcServer {
+  private server: Server | null = null;
+  private socketPath: string;
+  private handler: IpcRequestHandler;
+  private activeConnections: Set<Socket> = new Set();
+  private isShuttingDown = false;
+
+  constructor(handler: IpcRequestHandler, config?: Partial<IpcConfig>) {
+    this.socketPath = config?.socketPath ?? '/tmp/disclaude-interactive.ipc';
+    this.handler = handler;
+  }
+
+  /**
+   * Start the IPC server
+   */
+  async start(): Promise<void> {
+    if (this.server) {
+      logger.warn('IPC server already running');
+      return;
+    }
+
+    // Clean up existing socket file
+    if (existsSync(this.socketPath)) {
+      try {
+        unlinkSync(this.socketPath);
+        logger.debug({ path: this.socketPath }, 'Removed existing socket file');
+      } catch (error) {
+        logger.warn({ err: error, path: this.socketPath }, 'Failed to remove existing socket file');
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server = createServer((socket) => {
+        this.handleConnection(socket);
+      });
+
+      this.server.on('error', (error) => {
+        logger.error({ err: error }, 'IPC server error');
+        if (!this.server!.listening) {
+          reject(error);
+        }
+      });
+
+      this.server.listen(this.socketPath, () => {
+        logger.info({ path: this.socketPath }, 'IPC server started');
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Stop the IPC server
+   */
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    this.isShuttingDown = true;
+
+    // Close all active connections
+    for (const socket of this.activeConnections) {
+      try {
+        socket.destroy();
+      } catch {
+        // Ignore errors during shutdown
+      }
+    }
+    this.activeConnections.clear();
+
+    return new Promise((resolve) => {
+      this.server!.close(() => {
+        // Clean up socket file
+        if (existsSync(this.socketPath)) {
+          try {
+            unlinkSync(this.socketPath);
+            logger.debug({ path: this.socketPath }, 'Removed socket file on shutdown');
+          } catch {
+            // Ignore errors during cleanup
+          }
+        }
+        this.server = null;
+        this.isShuttingDown = false;
+        logger.info('IPC server stopped');
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Get the socket path
+   */
+  getSocketPath(): string {
+    return this.socketPath;
+  }
+
+  /**
+   * Check if the server is running
+   */
+  isRunning(): boolean {
+    return this.server?.listening ?? false;
+  }
+
+  /**
+   * Handle a new connection
+   */
+  private handleConnection(socket: Socket): void {
+    if (this.isShuttingDown) {
+      socket.destroy();
+      return;
+    }
+
+    this.activeConnections.add(socket);
+    logger.debug({ remoteAddress: socket.remoteAddress }, 'New IPC connection');
+
+    let buffer = '';
+
+    socket.on('data', (data) => {
+      buffer += data.toString();
+
+      // Try to parse complete messages (newline-delimited JSON)
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? ''; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.trim()) {
+          this.handleMessage(socket, line);
+        }
+      }
+    });
+
+    socket.on('error', (error) => {
+      logger.debug({ err: error }, 'Socket error');
+    });
+
+    socket.on('close', () => {
+      this.activeConnections.delete(socket);
+      logger.debug('IPC connection closed');
+    });
+  }
+
+  /**
+   * Handle an incoming message
+   */
+  private async handleMessage(socket: Socket, data: string): Promise<void> {
+    let request: IpcRequest;
+    let response: IpcResponse;
+
+    try {
+      request = JSON.parse(data);
+    } catch {
+      response = {
+        id: 'unknown',
+        success: false,
+        error: 'Invalid JSON',
+      };
+      this.sendResponse(socket, response);
+      return;
+    }
+
+    try {
+      response = await this.handler(request);
+    } catch (error) {
+      logger.error({ err: error, requestId: request.id }, 'Handler error');
+      response = {
+        id: request.id,
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+
+    this.sendResponse(socket, response);
+  }
+
+  /**
+   * Send a response to the client
+   */
+  private sendResponse(socket: Socket, response: IpcResponse): void {
+    try {
+      socket.write(JSON.stringify(response) + '\n');
+    } catch (error) {
+      logger.debug({ err: error }, 'Failed to send response');
+    }
+  }
+}
+
+/**
+ * Create an IPC request handler for interactive message contexts
+ */
+export function createInteractiveMessageHandler(
+  getActionPrompts: (messageId: string) => Record<string, string> | undefined,
+  registerActionPrompts: (messageId: string, chatId: string, actionPrompts: Record<string, string>) => void,
+  unregisterActionPrompts: (messageId: string) => boolean,
+  generateInteractionPrompt: (
+    messageId: string,
+    actionValue: string,
+    actionText?: string,
+    actionType?: string,
+    formData?: Record<string, unknown>
+  ) => string | undefined,
+  cleanupExpiredContexts: () => number
+): IpcRequestHandler {
+  return async (request: IpcRequest): Promise<IpcResponse> => {
+    switch (request.type) {
+      case 'get_action_prompts': {
+        const payload = request.payload as IpcRequestPayloads['get_action_prompts'];
+        const prompts = getActionPrompts(payload.messageId);
+        return {
+          id: request.id,
+          success: true,
+          result: { prompts: prompts ?? null },
+        };
+      }
+
+      case 'register_action_prompts': {
+        const payload = request.payload as IpcRequestPayloads['register_action_prompts'];
+        registerActionPrompts(
+          payload.messageId,
+          payload.chatId,
+          payload.actionPrompts
+        );
+        return {
+          id: request.id,
+          success: true,
+          result: { success: true },
+        };
+      }
+
+      case 'unregister_action_prompts': {
+        const payload = request.payload as IpcRequestPayloads['unregister_action_prompts'];
+        const success = unregisterActionPrompts(payload.messageId);
+        return {
+          id: request.id,
+          success: true,
+          result: { success },
+        };
+      }
+
+      case 'generate_interaction_prompt': {
+        const payload = request.payload as IpcRequestPayloads['generate_interaction_prompt'];
+        const prompt = generateInteractionPrompt(
+          payload.messageId,
+          payload.actionValue,
+          payload.actionText,
+          payload.actionType,
+          payload.formData
+        );
+        return {
+          id: request.id,
+          success: true,
+          result: { prompt: prompt ?? null },
+        };
+      }
+
+      case 'cleanup_expired_contexts': {
+        const cleaned = cleanupExpiredContexts();
+        return {
+          id: request.id,
+          success: true,
+          result: { cleaned },
+        };
+      }
+
+      case 'ping': {
+        return {
+          id: request.id,
+          success: true,
+          result: { pong: true },
+        };
+      }
+
+      default:
+        return {
+          id: request.id,
+          success: false,
+          error: `Unknown request type: ${(request as { type: string }).type}`,
+        };
+    }
+  };
+}

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -14,6 +14,7 @@ import {
   send_interactive_message,
   setMessageSentCallback,
 } from './tools/index.js';
+import { startIpcServer } from './tools/interactive-message.js';
 
 // Re-export for backward compatibility
 export type { MessageSentCallback } from './tools/types.js';
@@ -27,6 +28,13 @@ export {
   generateInteractionPrompt,
   getActionPrompts,
 } from './tools/interactive-message.js';
+
+// Start IPC server on module load for cross-process communication
+// This allows the main process to query interactive contexts
+startIpcServer().catch((error) => {
+  // Log error but don't fail - IPC is optional enhancement
+  console.error('[feishu-context-mcp] Failed to start IPC server:', error);
+});
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -14,6 +14,10 @@ import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import { getMessageSentCallback } from './send-message.js';
+import {
+  UnixSocketIpcServer,
+  createInteractiveMessageHandler,
+} from '../../ipc/unix-socket-server.js';
 import type { SendInteractiveResult, ActionPromptMap, InteractiveMessageContext } from './types.js';
 
 const logger = createLogger('InteractiveMessage');
@@ -256,4 +260,66 @@ export async function send_interactive_message(params: {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return { success: false, error: errorMessage, message: `❌ Failed to send interactive message: ${errorMessage}` };
   }
+}
+
+// ============================================================================
+// IPC Server for Cross-Process Communication
+// ============================================================================
+
+let ipcServer: UnixSocketIpcServer | null = null;
+
+/**
+ * Start the IPC server for cross-process communication.
+ * This allows other processes (e.g., the main bot process) to query
+ * the interactive contexts stored in this process.
+ */
+export async function startIpcServer(): Promise<void> {
+  if (ipcServer) {
+    logger.debug('IPC server already running');
+    return;
+  }
+
+  const handler = createInteractiveMessageHandler(
+    getActionPrompts,
+    registerActionPrompts,
+    unregisterActionPrompts,
+    generateInteractionPrompt,
+    cleanupExpiredContexts
+  );
+
+  ipcServer = new UnixSocketIpcServer(handler);
+
+  try {
+    await ipcServer.start();
+    logger.info({ path: ipcServer.getSocketPath() }, 'IPC server started for cross-process communication');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to start IPC server');
+    ipcServer = null;
+    throw error;
+  }
+}
+
+/**
+ * Stop the IPC server.
+ */
+export async function stopIpcServer(): Promise<void> {
+  if (ipcServer) {
+    await ipcServer.stop();
+    ipcServer = null;
+    logger.info('IPC server stopped');
+  }
+}
+
+/**
+ * Check if the IPC server is running.
+ */
+export function isIpcServerRunning(): boolean {
+  return ipcServer?.isRunning() ?? false;
+}
+
+/**
+ * Get the IPC server socket path.
+ */
+export function getIpcServerSocketPath(): string | null {
+  return ipcServer?.getSocketPath() ?? null;
 }


### PR DESCRIPTION
## Summary

- Implements Unix Socket IPC mechanism for cross-process communication
- Fixes Issue #894 - 飞书卡片按钮点击无响应

## Problem

When using interactive cards (`send_interactive_message`), the action prompts were registered in the MCP process memory, but the card action handler (`handleCardAction`) runs in the main process. Due to process memory isolation, the main process could not access the registered prompts, causing interactive card buttons to not respond correctly.

## Solution

Implemented Unix Socket IPC (Inter-Process Communication) mechanism:

### New Files

| File | Description |
|------|-------------|
| `src/ipc/protocol.ts` | IPC request/response type definitions |
| `src/ipc/unix-socket-server.ts` | Unix Socket server (runs in MCP process) |
| `src/ipc/unix-socket-client.ts` | Unix Socket client (used by main process) |
| `src/ipc/ipc.test.ts` | 15 unit tests for IPC module |

### Modified Files

| File | Change |
|------|--------|
| `src/mcp/tools/interactive-message.ts` | Added IPC server startup functions |
| `src/mcp/feishu-context-mcp.ts` | Auto-start IPC server on module load |
| `src/channels/feishu/message-handler.ts` | Use IPC client to query prompts cross-process |

## Architecture

```
┌─────────────────┐         ┌─────────────────┐
│   MCP 进程       │         │   Bot 主进程     │
│                 │         │                 │
│ interactiveContexts        │ handleCardAction│
│     Map         │         │                 │
│       ↓         │         │       ↓         │
│ IPC Server ◄────┼─────────┼───── IPC Client │
│ (Unix Socket)   │         │                 │
└─────────────────┘         └─────────────────┘
```

## Features

- **Automatic IPC server startup**: Server starts when feishu-context-mcp module loads
- **Graceful fallback**: If IPC unavailable, falls back to same-process function
- **Request types supported**:
  - `get_action_prompts` - Get prompts for a message
  - `register_action_prompts` - Register prompts
  - `unregister_action_prompts` - Unregister prompts
  - `generate_interaction_prompt` - Generate prompt from template
  - `cleanup_expired_contexts` - Cleanup old contexts
  - `ping` - Health check

## Test Results

- ✅ 15 IPC tests pass
- ✅ TypeScript compilation passes
- ✅ Lint check passes

## Related

- Fixes #894
- Owner feedback: "使用 Unix Socket 是可靠稳定的方案"

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)