### PR TITLE
fix(schedule): add missing await in scheduler cooldown methods

### DIFF
--- a/src/schedule/scheduler.ts
+++ b/src/schedule/scheduler.ts
@@ -372,7 +372,7 @@ ${task.prompt}`;
     remainingMs: number;
   } | null> {
     if (!this.cooldownManager) { return null; }
-    return this.cooldownManager.getCooldownStatus(taskId, cooldownPeriod);
+    return await this.cooldownManager.getCooldownStatus(taskId, cooldownPeriod);
   }
 
   /**
@@ -383,6 +383,6 @@ ${task.prompt}`;
    */
   async clearCooldown(taskId: string): Promise<boolean> {
     if (!this.cooldownManager) { return false; }
-    return this.cooldownManager.clearCooldown(taskId);
+    return await this.cooldownManager.clearCooldown(taskId);
   }
 }


### PR DESCRIPTION
## Summary

- Add `await` expressions to async methods `getCooldownStatus` and `clearCooldown` in `scheduler.ts`
- Fixes #952 - `require-await` lint errors

## Problem

PR #945 fixed the same issue in `schedule-management.ts`, but the corresponding methods in `scheduler.ts` were not updated. These methods call async functions from `cooldownManager` without using `await`, triggering the `require-await` ESLint rule.

**Before:**
```typescript
async getCooldownStatus(...) {
  return this.cooldownManager.getCooldownStatus(taskId, cooldownPeriod);
}

async clearCooldown(...) {
  return this.cooldownManager.clearCooldown(taskId);
}
```

**After:**
```typescript
async getCooldownStatus(...) {
  return await this.cooldownManager.getCooldownStatus(taskId, cooldownPeriod);
}

async clearCooldown(...) {
  return await this.cooldownManager.clearCooldown(taskId);
}
```

## Test Plan

- [x] Lint check passes (0 errors, no more require-await errors in scheduler.ts)
- [x] Type check passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)