### PR TITLE
fix(ipc): add Unix Socket IPC for cross-process interactive contexts (Issue #894)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -17,6 +17,7 @@ import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.
 import { getCommandRegistry } from '../../nodes/commands/command-registry.js';
 import { resolvePendingInteraction } from '../../mcp/feishu-context-mcp.js';
 import { generateInteractionPrompt } from '../../mcp/tools/interactive-message.js';
+import { getIpcClient } from '../../ipc/unix-socket-client.js';
 import { filteredMessageForwarder } from '../../feishu/filtered-message-forwarder.js';
 import type { FilterReason } from '../../config/types.js';
 import { stripLeadingMentions } from '../../utils/mention-parser.js';
@@ -567,13 +568,33 @@ export class MessageHandler {
 
     // Always emit card action as a message to the agent
     try {
-      // Try to get a pre-defined prompt template first
-      const promptFromTemplate = generateInteractionPrompt(
-        message_id,
-        action.value,
-        action.text,
-        action.type
-      );
+      // Try to get a pre-defined prompt template via IPC first (cross-process),
+      // then fall back to local function (same-process)
+      let promptFromTemplate: string | undefined;
+
+      const ipcClient = getIpcClient();
+      if (ipcClient.isConnected()) {
+        // Cross-process: query via IPC
+        promptFromTemplate = await ipcClient.generateInteractionPrompt(
+          message_id,
+          action.value,
+          action.text,
+          action.type
+        ) ?? undefined;
+        if (promptFromTemplate) {
+          logger.debug({ messageId: message_id }, 'Got prompt template via IPC');
+        }
+      }
+
+      // Fallback to local function (same-process)
+      if (!promptFromTemplate) {
+        promptFromTemplate = generateInteractionPrompt(
+          message_id,
+          action.value,
+          action.text,
+          action.type
+        );
+      }
 
       // Use the template prompt if available, otherwise use default message
       const messageContent = promptFromTemplate || (() => {
@@ -612,13 +633,30 @@ export class MessageHandler {
     try {
       // Try to handle via InteractionManager
       const handled = await this.interactionManager.handleAction(event, async (defaultEvent) => {
-        // Try to get a pre-defined prompt template first
-        const promptFromTemplate = generateInteractionPrompt(
-          defaultEvent.message_id,
-          defaultEvent.action.value,
-          defaultEvent.action.text,
-          defaultEvent.action.type
-        );
+        // Try to get a pre-defined prompt template via IPC first (cross-process),
+        // then fall back to local function (same-process)
+        let promptFromTemplate: string | undefined;
+
+        const ipcClient = getIpcClient();
+        if (ipcClient.isConnected()) {
+          // Cross-process: query via IPC
+          promptFromTemplate = await ipcClient.generateInteractionPrompt(
+            defaultEvent.message_id,
+            defaultEvent.action.value,
+            defaultEvent.action.text,
+            defaultEvent.action.type
+          ) ?? undefined;
+        }
+
+        // Fallback to local function (same-process)
+        if (!promptFromTemplate) {
+          promptFromTemplate = generateInteractionPrompt(
+            defaultEvent.message_id,
+            defaultEvent.action.value,
+            defaultEvent.action.text,
+            defaultEvent.action.type
+          );
+        }
 
         // Use the template prompt if available, otherwise use default message
         const messageContent = promptFromTemplate || (() => {

--- a/src/ipc/index.ts
+++ b/src/ipc/index.ts
@@ -1,0 +1,12 @@
+/**
+ * IPC module for cross-process communication.
+ *
+ * This module provides Unix Socket based IPC for sharing state between
+ * the MCP process and the main bot process.
+ *
+ * @module ipc
+ */
+
+export * from './protocol.js';
+export * from './unix-socket-server.js';
+export * from './unix-socket-client.js';

--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for IPC module - Unix Socket cross-process communication.
+ *
+ * @module ipc/ipc.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { unlinkSync, existsSync } from 'fs';
+import { UnixSocketIpcServer, createInteractiveMessageHandler } from './unix-socket-server.js';
+import { UnixSocketIpcClient, getIpcClient, resetIpcClient } from './unix-socket-client.js';
+
+// Generate a unique socket path for each test
+function generateSocketPath(): string {
+  return join(tmpdir(), `disclaude-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+}
+
+describe('UnixSocketIpcServer', () => {
+  let server: UnixSocketIpcServer;
+  let socketPath: string;
+  let handler: ReturnType<typeof createInteractiveMessageHandler>;
+
+  const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
+
+  beforeEach(() => {
+    socketPath = generateSocketPath();
+    mockContexts.clear();
+
+    handler = createInteractiveMessageHandler({
+      getActionPrompts: (messageId) => mockContexts.get(messageId)?.actionPrompts,
+      registerActionPrompts: (messageId, chatId, actionPrompts) => {
+        mockContexts.set(messageId, { chatId, actionPrompts });
+      },
+      unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
+      generateInteractionPrompt: (messageId, actionValue, actionText) => {
+        const context = mockContexts.get(messageId);
+        if (!context) {
+          return undefined;
+        }
+        const template = context.actionPrompts[actionValue];
+        if (!template) {
+          return undefined;
+        }
+        return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
+      },
+      cleanupExpiredContexts: () => {
+        let cleaned = 0;
+        for (const [key] of mockContexts) {
+          mockContexts.delete(key);
+          cleaned++;
+        }
+        return cleaned;
+      },
+    });
+
+    server = new UnixSocketIpcServer(handler, { socketPath });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should start and stop successfully', async () => {
+    expect(server.isRunning()).toBe(false);
+
+    await server.start();
+    expect(server.isRunning()).toBe(true);
+    expect(server.getSocketPath()).toBe(socketPath);
+
+    await server.stop();
+    expect(server.isRunning()).toBe(false);
+  });
+
+  it('should clean up socket file on stop', async () => {
+    await server.start();
+    expect(existsSync(socketPath)).toBe(true);
+
+    await server.stop();
+    expect(existsSync(socketPath)).toBe(false);
+  });
+
+  it('should handle multiple start calls gracefully', async () => {
+    await server.start();
+    await server.start(); // Should not throw
+    expect(server.isRunning()).toBe(true);
+  });
+
+  it('should handle stop when not running', async () => {
+    await server.stop(); // Should not throw
+    expect(server.isRunning()).toBe(false);
+  });
+});
+
+describe('UnixSocketIpcClient', () => {
+  let server: UnixSocketIpcServer;
+  let client: UnixSocketIpcClient;
+  let socketPath: string;
+  const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
+
+  beforeEach(async () => {
+    socketPath = generateSocketPath();
+    mockContexts.clear();
+
+    const handler = createInteractiveMessageHandler({
+      getActionPrompts: (messageId) => mockContexts.get(messageId)?.actionPrompts,
+      registerActionPrompts: (messageId, chatId, actionPrompts) => {
+        mockContexts.set(messageId, { chatId, actionPrompts });
+      },
+      unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
+      generateInteractionPrompt: (messageId, actionValue, actionText) => {
+        const context = mockContexts.get(messageId);
+        if (!context) {
+          return undefined;
+        }
+        const template = context.actionPrompts[actionValue];
+        if (!template) {
+          return undefined;
+        }
+        return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
+      },
+      cleanupExpiredContexts: () => 0,
+    });
+
+    server = new UnixSocketIpcServer(handler, { socketPath });
+    client = new UnixSocketIpcClient({ socketPath, timeout: 2000 });
+
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await client.disconnect();
+    await server.stop();
+    if (existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('should connect and disconnect', async () => {
+    expect(client.isConnected()).toBe(false);
+
+    await client.connect();
+    expect(client.isConnected()).toBe(true);
+
+    await client.disconnect();
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it('should ping the server', async () => {
+    const result = await client.ping();
+    expect(result).toBe(true);
+  });
+
+  it('should handle multiple connect calls', async () => {
+    await client.connect();
+    await client.connect(); // Should not throw
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it('should get action prompts', async () => {
+    mockContexts.set('msg-1', {
+      chatId: 'chat-1',
+      actionPrompts: { confirm: 'Confirmed!', cancel: 'Cancelled!' },
+    });
+
+    const prompts = await client.getActionPrompts('msg-1');
+    expect(prompts).toEqual({ confirm: 'Confirmed!', cancel: 'Cancelled!' });
+  });
+
+  it('should return null for non-existent prompts', async () => {
+    const prompts = await client.getActionPrompts('non-existent');
+    expect(prompts).toBeNull();
+  });
+
+  it('should generate interaction prompt', async () => {
+    mockContexts.set('msg-2', {
+      chatId: 'chat-1',
+      actionPrompts: { confirm: 'User clicked {{actionText}}' },
+    });
+
+    const prompt = await client.generateInteractionPrompt('msg-2', 'confirm', 'Confirm');
+    expect(prompt).toBe('User clicked Confirm');
+  });
+
+  it('should return null for non-existent prompt template', async () => {
+    const prompt = await client.generateInteractionPrompt('non-existent', 'confirm');
+    expect(prompt).toBeNull();
+  });
+});
+
+describe('getIpcClient singleton', () => {
+  beforeEach(() => {
+    resetIpcClient();
+  });
+
+  afterEach(() => {
+    resetIpcClient();
+  });
+
+  it('should return the same instance', () => {
+    const client1 = getIpcClient();
+    const client2 = getIpcClient();
+    expect(client1).toBe(client2);
+  });
+
+  it('should reset to a new instance', () => {
+    const client1 = getIpcClient();
+    resetIpcClient();
+    const client2 = getIpcClient();
+    expect(client1).not.toBe(client2);
+  });
+});

--- a/src/ipc/protocol.ts
+++ b/src/ipc/protocol.ts
@@ -1,0 +1,92 @@
+/**
+ * IPC Protocol definitions for cross-process communication.
+ *
+ * Defines the message format and types for Unix Socket IPC.
+ *
+ * @module ipc/protocol
+ */
+
+/**
+ * IPC request types.
+ */
+export type IpcRequestType =
+  | 'ping'
+  | 'getActionPrompts'
+  | 'registerActionPrompts'
+  | 'unregisterActionPrompts'
+  | 'generateInteractionPrompt'
+  | 'cleanupExpiredContexts';
+
+/**
+ * IPC request payload types.
+ */
+export interface IpcRequestPayloads {
+  ping: Record<string, never>;
+  getActionPrompts: { messageId: string };
+  registerActionPrompts: {
+    messageId: string;
+    chatId: string;
+    actionPrompts: Record<string, string>;
+  };
+  unregisterActionPrompts: { messageId: string };
+  generateInteractionPrompt: {
+    messageId: string;
+    actionValue: string;
+    actionText?: string;
+    actionType?: string;
+    formData?: Record<string, unknown>;
+  };
+  cleanupExpiredContexts: Record<string, never>;
+}
+
+/**
+ * IPC response payload types.
+ */
+export interface IpcResponsePayloads {
+  ping: { pong: true };
+  getActionPrompts: { prompts: Record<string, string> | null };
+  registerActionPrompts: { success: true };
+  unregisterActionPrompts: { success: boolean };
+  generateInteractionPrompt: { prompt: string | null };
+  cleanupExpiredContexts: { cleaned: number };
+}
+
+/**
+ * Generic IPC request structure.
+ */
+export interface IpcRequest<T extends IpcRequestType = IpcRequestType> {
+  type: T;
+  id: string;
+  payload: IpcRequestPayloads[T];
+}
+
+/**
+ * Generic IPC response structure.
+ */
+export interface IpcResponse<T extends IpcRequestType = IpcRequestType> {
+  id: string;
+  success: boolean;
+  payload?: IpcResponsePayloads[T];
+  error?: string;
+}
+
+/**
+ * IPC configuration.
+ */
+export interface IpcConfig {
+  /** Unix socket file path */
+  socketPath: string;
+  /** Connection timeout in milliseconds */
+  timeout: number;
+  /** Maximum retry attempts */
+  maxRetries: number;
+}
+
+/**
+ * Default IPC configuration.
+ */
+export const DEFAULT_IPC_CONFIG: IpcConfig = {
+  socketPath: '/tmp/disclaude-interactive.ipc',
+  timeout: 5000,
+  maxRetries: 3,
+};

--- a/src/ipc/unix-socket-client.ts
+++ b/src/ipc/unix-socket-client.ts
@@ -1,0 +1,290 @@
+/**
+ * Unix Socket IPC Client for cross-process communication.
+ *
+ * Provides a Unix domain socket client that connects to the IPC server
+ * to query interactive contexts from the MCP process.
+ *
+ * @module ipc/unix-socket-client
+ */
+
+import { existsSync } from 'fs';
+import { createConnection, type Socket } from 'net';
+import { createLogger } from '../utils/logger.js';
+import {
+  DEFAULT_IPC_CONFIG,
+  type IpcConfig,
+  type IpcRequest,
+  type IpcRequestPayloads,
+  type IpcRequestType,
+  type IpcResponse,
+  type IpcResponsePayloads,
+} from './protocol.js';
+
+const logger = createLogger('IpcClient');
+
+/**
+ * Pending request tracker.
+ */
+interface PendingRequest {
+  resolve: (response: IpcResponse) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+}
+
+/**
+ * Unix Socket IPC Client.
+ */
+export class UnixSocketIpcClient {
+  private socketPath: string;
+  private timeout: number;
+  private socket: Socket | null = null;
+  private connected = false;
+  private connecting = false;
+  private buffer = '';
+  private pendingRequests: Map<string, PendingRequest> = new Map();
+  private requestId = 0;
+
+  constructor(config?: Partial<IpcConfig>) {
+    this.socketPath = config?.socketPath ?? DEFAULT_IPC_CONFIG.socketPath;
+    this.timeout = config?.timeout ?? DEFAULT_IPC_CONFIG.timeout;
+  }
+
+  /**
+   * Connect to the IPC server.
+   */
+  // eslint-disable-next-line require-await
+  async connect(): Promise<void> {
+    if (this.connected) {
+      return;
+    }
+
+    if (this.connecting) {
+      // Wait for existing connection attempt
+      return new Promise((resolve, reject) => {
+        const checkConnected = () => {
+          if (this.connected) {
+            resolve();
+          } else if (!this.connecting) {
+            reject(new Error('Connection failed'));
+          } else {
+            setTimeout(checkConnected, 50);
+          }
+        };
+        checkConnected();
+      });
+    }
+
+    // Check if socket file exists
+    if (!existsSync(this.socketPath)) {
+      throw new Error(`Socket file not found: ${this.socketPath}`);
+    }
+
+    this.connecting = true;
+
+    return new Promise((resolve, reject) => {
+      this.socket = createConnection(this.socketPath);
+
+      const timeoutId = setTimeout(() => {
+        this.socket?.destroy();
+        this.connecting = false;
+        reject(new Error('Connection timeout'));
+      }, this.timeout);
+
+      this.socket.on('connect', () => {
+        clearTimeout(timeoutId);
+        this.connected = true;
+        this.connecting = false;
+        logger.debug({ path: this.socketPath }, 'Connected to IPC server');
+        resolve();
+      });
+
+      this.socket.on('error', (error) => {
+        clearTimeout(timeoutId);
+        this.connecting = false;
+        logger.debug({ err: error }, 'IPC connection error');
+        reject(error);
+      });
+
+      this.socket.on('data', (data) => {
+        this.handleData(data.toString());
+      });
+
+      this.socket.on('close', () => {
+        this.connected = false;
+        this.connecting = false;
+        this.socket = null;
+        logger.debug('IPC connection closed');
+
+        // Reject all pending requests
+        for (const [id, pending] of this.pendingRequests) {
+          clearTimeout(pending.timeout);
+          pending.reject(new Error('Connection closed'));
+          this.pendingRequests.delete(id);
+        }
+      });
+    });
+  }
+
+  /**
+   * Disconnect from the IPC server.
+   */
+  // eslint-disable-next-line require-await
+  async disconnect(): Promise<void> {
+    if (this.socket) {
+      this.socket.destroy();
+      this.socket = null;
+    }
+    this.connected = false;
+    this.connecting = false;
+    this.buffer = '';
+    this.pendingRequests.clear();
+    logger.debug('Disconnected from IPC server');
+  }
+
+  /**
+   * Check if connected to the IPC server.
+   */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Send a request and wait for response.
+   */
+  async request<T extends IpcRequestType>(
+    type: T,
+    payload: IpcRequestPayloads[T]
+  ): Promise<IpcResponsePayloads[T]> {
+    if (!this.connected) {
+      await this.connect();
+    }
+
+    const id = `${++this.requestId}`;
+    const request: IpcRequest<T> = { type, id, payload };
+
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Request timeout: ${type}`));
+      }, this.timeout);
+
+      this.pendingRequests.set(id, {
+        resolve: (response) => {
+          clearTimeout(timeoutId);
+          if (response.success) {
+            resolve(response.payload as IpcResponsePayloads[T]);
+          } else {
+            reject(new Error(response.error ?? 'Unknown error'));
+          }
+        },
+        reject,
+        timeout: timeoutId,
+      });
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.socket!.write(`${JSON.stringify(request)}\n`);
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        clearTimeout(timeoutId);
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Ping the server.
+   */
+  async ping(): Promise<boolean> {
+    try {
+      const response = await this.request('ping', {});
+      return response.pong === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get action prompts for a message.
+   */
+  async getActionPrompts(messageId: string): Promise<Record<string, string> | null> {
+    try {
+      const response = await this.request('getActionPrompts', { messageId });
+      return response.prompts;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Generate interaction prompt via IPC.
+   */
+  async generateInteractionPrompt(
+    messageId: string,
+    actionValue: string,
+    actionText?: string,
+    actionType?: string,
+    formData?: Record<string, unknown>
+  ): Promise<string | null> {
+    try {
+      const response = await this.request('generateInteractionPrompt', {
+        messageId,
+        actionValue,
+        actionText,
+        actionType,
+        formData,
+      });
+      return response.prompt;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Handle incoming data.
+   */
+  private handleData(data: string): void {
+    this.buffer += data;
+
+    const lines = this.buffer.split('\n');
+    this.buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (line.trim()) {
+        try {
+          const response: IpcResponse = JSON.parse(line);
+          const pending = this.pendingRequests.get(response.id);
+          if (pending) {
+            this.pendingRequests.delete(response.id);
+            pending.resolve(response);
+          }
+        } catch (error) {
+          logger.debug({ err: error, line }, 'Failed to parse IPC response');
+        }
+      }
+    }
+  }
+}
+
+// Singleton instance
+let ipcClientInstance: UnixSocketIpcClient | null = null;
+
+/**
+ * Get the global IPC client instance.
+ */
+export function getIpcClient(): UnixSocketIpcClient {
+  if (!ipcClientInstance) {
+    ipcClientInstance = new UnixSocketIpcClient();
+  }
+  return ipcClientInstance;
+}
+
+/**
+ * Reset the global IPC client (for testing).
+ */
+export function resetIpcClient(): void {
+  if (ipcClientInstance) {
+    ipcClientInstance.disconnect().catch(() => {});
+  }
+  ipcClientInstance = null;
+}

--- a/src/ipc/unix-socket-server.ts
+++ b/src/ipc/unix-socket-server.ts
@@ -1,0 +1,310 @@
+/**
+ * Unix Socket IPC Server for cross-process communication.
+ *
+ * Provides a Unix domain socket server that allows other processes
+ * to query the interactive contexts stored in this process.
+ *
+ * @module ipc/unix-socket-server
+ */
+
+import { unlinkSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { createServer, type Server, type Socket } from 'net';
+import { createLogger } from '../utils/logger.js';
+import {
+  DEFAULT_IPC_CONFIG,
+  type IpcConfig,
+  type IpcRequest,
+  type IpcRequestPayloads,
+  type IpcResponse,
+} from './protocol.js';
+
+const logger = createLogger('IpcServer');
+
+/**
+ * Handler function type for processing IPC requests.
+ */
+export type IpcRequestHandler = (request: IpcRequest) => Promise<IpcResponse>;
+
+/**
+ * Handler functions for interactive message operations.
+ */
+export interface InteractiveMessageHandlers {
+  getActionPrompts: (messageId: string) => Record<string, string> | undefined;
+  registerActionPrompts: (
+    messageId: string,
+    chatId: string,
+    actionPrompts: Record<string, string>
+  ) => void;
+  unregisterActionPrompts: (messageId: string) => boolean;
+  generateInteractionPrompt: (
+    messageId: string,
+    actionValue: string,
+    actionText?: string,
+    actionType?: string,
+    formData?: Record<string, unknown>
+  ) => string | undefined;
+  cleanupExpiredContexts: () => number;
+}
+
+/**
+ * Create an IPC request handler from interactive message handlers.
+ */
+export function createInteractiveMessageHandler(
+  handlers: InteractiveMessageHandlers
+): IpcRequestHandler {
+  // eslint-disable-next-line require-await
+  return async (request: IpcRequest): Promise<IpcResponse> => {
+    try {
+      switch (request.type) {
+        case 'ping':
+          return { id: request.id, success: true, payload: { pong: true } };
+
+        case 'getActionPrompts': {
+          const { messageId } = request.payload as IpcRequestPayloads['getActionPrompts'];
+          const prompts = handlers.getActionPrompts(messageId);
+          return {
+            id: request.id,
+            success: true,
+            payload: { prompts: prompts ?? null },
+          };
+        }
+
+        case 'registerActionPrompts': {
+          const { messageId, chatId, actionPrompts } =
+            request.payload as IpcRequestPayloads['registerActionPrompts'];
+          handlers.registerActionPrompts(messageId, chatId, actionPrompts);
+          return { id: request.id, success: true, payload: { success: true } };
+        }
+
+        case 'unregisterActionPrompts': {
+          const { messageId } = request.payload as IpcRequestPayloads['unregisterActionPrompts'];
+          const success = handlers.unregisterActionPrompts(messageId);
+          return { id: request.id, success: true, payload: { success } };
+        }
+
+        case 'generateInteractionPrompt': {
+          const { messageId, actionValue, actionText, actionType, formData } =
+            request.payload as IpcRequestPayloads['generateInteractionPrompt'];
+          const prompt = handlers.generateInteractionPrompt(
+            messageId,
+            actionValue,
+            actionText,
+            actionType,
+            formData
+          );
+          return {
+            id: request.id,
+            success: true,
+            payload: { prompt: prompt ?? null },
+          };
+        }
+
+        case 'cleanupExpiredContexts': {
+          const cleaned = handlers.cleanupExpiredContexts();
+          return { id: request.id, success: true, payload: { cleaned } };
+        }
+
+        default:
+          return {
+            id: request.id,
+            success: false,
+            error: `Unknown request type: ${(request as { type: string }).type}`,
+          };
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      logger.error({ err: error, request }, 'Error handling IPC request');
+      return { id: request.id, success: false, error: errorMessage };
+    }
+  };
+}
+
+/**
+ * Unix Socket IPC Server.
+ */
+export class UnixSocketIpcServer {
+  private server: Server | null = null;
+  private socketPath: string;
+  private handler: IpcRequestHandler;
+  private activeConnections: Set<Socket> = new Set();
+  private isShuttingDown = false;
+
+  constructor(handler: IpcRequestHandler, config?: Partial<IpcConfig>) {
+    this.socketPath = config?.socketPath ?? DEFAULT_IPC_CONFIG.socketPath;
+    this.handler = handler;
+  }
+
+  /**
+   * Start the IPC server.
+   */
+  // eslint-disable-next-line require-await
+  async start(): Promise<void> {
+    if (this.server) {
+      logger.warn('IPC server already running');
+      return;
+    }
+
+    // Ensure socket directory exists
+    const socketDir = dirname(this.socketPath);
+    if (!existsSync(socketDir)) {
+      try {
+        mkdirSync(socketDir, { recursive: true });
+      } catch (error) {
+        logger.warn({ err: error, path: socketDir }, 'Failed to create socket directory');
+      }
+    }
+
+    // Clean up existing socket file
+    if (existsSync(this.socketPath)) {
+      try {
+        unlinkSync(this.socketPath);
+        logger.debug({ path: this.socketPath }, 'Removed existing socket file');
+      } catch (error) {
+        logger.warn({ err: error, path: this.socketPath }, 'Failed to remove existing socket file');
+      }
+    }
+
+    return new Promise((resolve, reject) => {
+      this.server = createServer((socket) => {
+        this.handleConnection(socket);
+      });
+
+      this.server.on('error', (error) => {
+        logger.error({ err: error }, 'IPC server error');
+        if (!this.server?.listening) {
+          reject(error);
+        }
+      });
+
+      this.server.listen(this.socketPath, () => {
+        logger.info({ path: this.socketPath }, 'IPC server started');
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Stop the IPC server.
+   */
+  // eslint-disable-next-line require-await
+  async stop(): Promise<void> {
+    if (!this.server) {
+      return;
+    }
+
+    this.isShuttingDown = true;
+
+    // Close all active connections
+    for (const socket of this.activeConnections) {
+      try {
+        socket.destroy();
+      } catch {
+        // Ignore errors during cleanup
+      }
+    }
+    this.activeConnections.clear();
+
+    return new Promise((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+
+      this.server.close(() => {
+        // Clean up socket file
+        if (existsSync(this.socketPath)) {
+          try {
+            unlinkSync(this.socketPath);
+            logger.debug({ path: this.socketPath }, 'Removed socket file');
+          } catch {
+            // Ignore cleanup errors
+          }
+        }
+        this.server = null;
+        this.isShuttingDown = false;
+        logger.info('IPC server stopped');
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Check if the server is running.
+   */
+  isRunning(): boolean {
+    return this.server?.listening ?? false;
+  }
+
+  /**
+   * Get the socket path.
+   */
+  getSocketPath(): string {
+    return this.socketPath;
+  }
+
+  /**
+   * Handle a new connection.
+   */
+  private handleConnection(socket: Socket): void {
+    if (this.isShuttingDown) {
+      socket.destroy();
+      return;
+    }
+
+    this.activeConnections.add(socket);
+    logger.debug({ remoteAddress: socket.remoteAddress }, 'New IPC connection');
+
+    let buffer = '';
+
+    socket.on('data', (data) => {
+      buffer += data.toString();
+
+      // Process complete messages (newline-delimited JSON)
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? ''; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (line.trim()) {
+          void this.handleMessage(socket, line);
+        }
+      }
+    });
+
+    socket.on('close', () => {
+      this.activeConnections.delete(socket);
+      logger.debug('IPC connection closed');
+    });
+
+    socket.on('error', (error) => {
+      logger.debug({ err: error }, 'IPC connection error');
+      this.activeConnections.delete(socket);
+    });
+  }
+
+  /**
+   * Handle an incoming message.
+   */
+  private async handleMessage(socket: Socket, data: string): Promise<void> {
+    let request: IpcRequest;
+    try {
+      request = JSON.parse(data);
+    } catch {
+      logger.warn({ data }, 'Invalid JSON received');
+      return;
+    }
+
+    try {
+      const response = await this.handler(request);
+      socket.write(`${JSON.stringify(response)}\n`);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const response: IpcResponse = {
+        id: request.id,
+        success: false,
+        error: errorMessage,
+      };
+      socket.write(`${JSON.stringify(response)}\n`);
+    }
+  }
+}

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -14,6 +14,7 @@ import {
   send_interactive_message,
   setMessageSentCallback,
 } from './tools/index.js';
+import { startIpcServer } from './tools/interactive-message.js';
 
 // Re-export for backward compatibility
 export type { MessageSentCallback } from './tools/types.js';
@@ -27,6 +28,13 @@ export {
   generateInteractionPrompt,
   getActionPrompts,
 } from './tools/interactive-message.js';
+
+// Start IPC server on module load for cross-process communication
+// This allows the main process to query interactive contexts
+startIpcServer().catch((error) => {
+  // Log error but don't fail - IPC is optional enhancement
+  console.error('[feishu-context-mcp] Failed to start IPC server:', error);
+});
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -14,6 +14,10 @@ import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import { getMessageSentCallback } from './send-message.js';
+import {
+  UnixSocketIpcServer,
+  createInteractiveMessageHandler,
+} from '../../ipc/unix-socket-server.js';
 import type { SendInteractiveResult, ActionPromptMap, InteractiveMessageContext } from './types.js';
 
 const logger = createLogger('InteractiveMessage');
@@ -256,4 +260,66 @@ export async function send_interactive_message(params: {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     return { success: false, error: errorMessage, message: `❌ Failed to send interactive message: ${errorMessage}` };
   }
+}
+
+// ============================================================================
+// IPC Server for Cross-Process Communication
+// ============================================================================
+
+let ipcServer: UnixSocketIpcServer | null = null;
+
+/**
+ * Start the IPC server for cross-process communication.
+ * This allows other processes (e.g., the main bot process) to query
+ * the interactive contexts stored in this process.
+ */
+export async function startIpcServer(): Promise<void> {
+  if (ipcServer) {
+    logger.debug('IPC server already running');
+    return;
+  }
+
+  const handler = createInteractiveMessageHandler({
+    getActionPrompts,
+    registerActionPrompts,
+    unregisterActionPrompts,
+    generateInteractionPrompt,
+    cleanupExpiredContexts,
+  });
+
+  ipcServer = new UnixSocketIpcServer(handler);
+
+  try {
+    await ipcServer.start();
+    logger.info({ path: ipcServer.getSocketPath() }, 'IPC server started for cross-process communication');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to start IPC server');
+    ipcServer = null;
+    throw error;
+  }
+}
+
+/**
+ * Stop the IPC server.
+ */
+export async function stopIpcServer(): Promise<void> {
+  if (ipcServer) {
+    await ipcServer.stop();
+    ipcServer = null;
+    logger.info('IPC server stopped');
+  }
+}
+
+/**
+ * Check if the IPC server is running.
+ */
+export function isIpcServerRunning(): boolean {
+  return ipcServer?.isRunning() ?? false;
+}
+
+/**
+ * Get the IPC server socket path.
+ */
+export function getIpcServerSocketPath(): string | null {
+  return ipcServer?.getSocketPath() ?? null;
 }


### PR DESCRIPTION
## Summary

- Add Unix Socket IPC module for cross-process communication
- Fix interactive message feature when MCP and main process run separately
- Add `src/ipc/` module with server, client, and protocol definitions

## Problem

The interactive message feature was not working when MCP process and Bot main process are running separately. The root cause is that the `interactiveContexts` Map is stored in MCP process memory, but the main process's `handleCardAction()` cannot access it due to process isolation.

## Solution

Implemented Unix Socket IPC for cross-process communication:

1. Created `src/ipc/` module with:
   - `protocol.ts`: IPC request/response type definitions
   - `unix-socket-server.ts`: Unix Socket server (runs in MCP process)
   - `unix-socket-client.ts`: Unix Socket client (runs in main process)

2. Modified `interactive-message.ts`:
   - Added `startIpcServer()` to start IPC server on module load
   - Server listens on `/tmp/disclaude-interactive.ipc`

3. Modified `message-handler.ts`:
   - Uses IPC client to query action prompts across processes
   - Falls back to local function if IPC is not available

4. Modified `feishu-context-mcp.ts`:
   - Starts IPC server on module load

## Architecture

```
┌─────────────────┐         ┌─────────────────┐
│   MCP Process    │         │   Main Process   │
│                 │  Unix  │                 │
│ IPC Server      │◄───────►│ IPC Client      │
│ (port: /tmp/..) │  Socket │                 │
│       ↓         │         │       ↓         │
│ interactive     │         │ handleCardAction│
│ Contexts Map    │         │                 │
└─────────────────┘         └─────────────────┘
```

## Test Plan

- [x] Unit tests for IPC server and client (13 tests passing)
- [x] TypeScript compilation passes
- [x] Lint checks pass

Fixes #894

🤖 Generated with [Claude Code](https://claude.com/claude-code)