### PR TITLE
fix(nodes): enable Worker Node card action routing via WebSocket

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -48,6 +48,24 @@ export interface FeishuChannelConfig extends ChannelConfig {
   appId?: string;
   /** Feishu App Secret */
   appSecret?: string;
+  /**
+   * Route card action to Worker Node if applicable.
+   * Issue #935: Returns true if the action was routed to a Worker Node.
+   */
+  routeCardAction?: (message: {
+    chatId: string;
+    cardMessageId: string;
+    actionType: string;
+    actionValue: string;
+    actionText?: string;
+    userId?: string;
+    action?: {
+      type: string;
+      value: string;
+      text?: string;
+      trigger?: string;
+    };
+  }) => Promise<boolean>;
 }
 
 /**
@@ -100,6 +118,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       sendMessage: async (message) => {
         await this.sendMessage(message as OutgoingMessage);
       },
+      // Issue #935: Route card action to Worker Node if applicable
+      routeCardAction: config.routeCardAction,
     };
 
     this.feishuMessageHandler = new FeishuMessageHandler({

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -53,6 +53,24 @@ export interface MessageCallbacks {
     data: { args: string[]; rawText: string; senderOpenId?: string };
   }) => Promise<{ success: boolean; message?: string }>;
   sendMessage: (message: { chatId: string; type: string; text?: string; card?: Record<string, unknown>; description?: string; threadId?: string; filePath?: string }) => Promise<void>;
+  /**
+   * Route card action to Worker Node if applicable.
+   * Issue #935: Returns true if the action was routed to a Worker Node.
+   */
+  routeCardAction?: (message: {
+    chatId: string;
+    cardMessageId: string;
+    actionType: string;
+    actionValue: string;
+    actionText?: string;
+    userId?: string;
+    action?: {
+      type: string;
+      value: string;
+      text?: string;
+      trigger?: string;
+    };
+  }) => Promise<boolean>;
 }
 
 /**
@@ -553,6 +571,31 @@ export class MessageHandler {
       },
       'Card action received'
     );
+
+    // Issue #935: Try to route card action to Worker Node first
+    // If the card was sent by a Worker Node, forward the action to that node
+    if (this.callbacks.routeCardAction) {
+      const routed = await this.callbacks.routeCardAction({
+        chatId: chat_id,
+        cardMessageId: message_id,
+        actionType: action.type,
+        actionValue: action.value,
+        actionText: action.text,
+        userId: user?.sender_id?.open_id,
+        action: {
+          type: action.type,
+          value: action.value,
+          text: action.text,
+          trigger: action.trigger,
+        },
+      });
+
+      if (routed) {
+        logger.debug({ messageId: message_id, chatId: chat_id }, 'Card action routed to Worker Node');
+        // The Worker Node will handle the action, we're done here
+        return;
+      }
+    }
 
     // First, try to resolve any pending wait_for_interaction calls
     const resolved = resolvePendingInteraction(

--- a/src/nodes/card-action-router.ts
+++ b/src/nodes/card-action-router.ts
@@ -1,0 +1,265 @@
+/**
+ * CardActionRouter - Routes card action callbacks to Worker Nodes.
+ *
+ * When a Worker Node sends a card, Primary Node records the chatId -> nodeId mapping.
+ * When a card action callback is received, Primary Node looks up the mapping
+ * and forwards the action to the appropriate Worker Node.
+ *
+ * Issue #935: WebSocket bidirectional communication for card actions.
+ *
+ * @module nodes/card-action-router
+ */
+
+import { createLogger } from '../utils/logger.js';
+import type { CardActionMessage } from '../types/websocket-messages.js';
+
+const logger = createLogger('CardActionRouter');
+
+/**
+ * Entry for tracking which node handles cards for a chat.
+ */
+interface CardContextEntry {
+  /** Node ID that sent the card */
+  nodeId: string;
+  /** Timestamp when the entry was created */
+  createdAt: number;
+  /** Whether the node is a remote Worker Node (not local) */
+  isRemote: boolean;
+}
+
+/**
+ * Configuration for CardActionRouter.
+ */
+export interface CardActionRouterConfig {
+  /** Maximum age of context entries in milliseconds (default: 24 hours) */
+  maxAge?: number;
+  /** Callback to send card action to a remote node */
+  sendToRemoteNode: (nodeId: string, message: CardActionMessage) => Promise<boolean>;
+  /** Callback to check if a node is connected */
+  isNodeConnected: (nodeId: string) => boolean;
+}
+
+/**
+ * CardActionRouter - Routes card action callbacks to the appropriate node.
+ *
+ * This class manages the mapping between chatId and the node that handles
+ * card interactions for that chat. When a Worker Node sends a card, it
+ * registers the chat context. When a card action is received, the router
+ * forwards it to the appropriate node.
+ *
+ * @example
+ * ```typescript
+ * const router = new CardActionRouter({
+ *   sendToRemoteNode: async (nodeId, message) => {
+ *     // Send via WebSocket
+ *     return true;
+ *   },
+ *   isNodeConnected: (nodeId) => {
+ *     // Check if node is connected
+ *     return true;
+ *   },
+ * });
+ *
+ * // When Worker Node sends a card
+ * router.registerChatContext(chatId, nodeId, true);
+ *
+ * // When card action is received
+ * const handled = await router.routeCardAction({
+ *   type: 'card_action',
+ *   chatId,
+ *   cardMessageId,
+ *   actionType: 'button',
+ *   actionValue: 'confirm',
+ * });
+ * ```
+ */
+export class CardActionRouter {
+  private readonly maxAge: number;
+  private readonly sendToRemoteNode: (nodeId: string, message: CardActionMessage) => Promise<boolean>;
+  private readonly isNodeConnected: (nodeId: string) => boolean;
+  private readonly contextMap = new Map<string, CardContextEntry>();
+
+  // Cleanup interval (1 hour)
+  private readonly cleanupInterval = 60 * 60 * 1000;
+  private cleanupTimer?: NodeJS.Timeout;
+
+  constructor(config: CardActionRouterConfig) {
+    this.maxAge = config.maxAge ?? 24 * 60 * 60 * 1000; // Default: 24 hours
+    this.sendToRemoteNode = config.sendToRemoteNode;
+    this.isNodeConnected = config.isNodeConnected;
+
+    // Start periodic cleanup
+    this.startCleanupTimer();
+
+    logger.info({ maxAge: this.maxAge }, 'CardActionRouter created');
+  }
+
+  /**
+   * Register a chat context for card routing.
+   * Called when a node sends a card to a chat.
+   *
+   * @param chatId - Chat ID where the card was sent
+   * @param nodeId - Node ID that sent the card
+   * @param isRemote - Whether the node is a remote Worker Node
+   */
+  registerChatContext(chatId: string, nodeId: string, isRemote: boolean): void {
+    this.contextMap.set(chatId, {
+      nodeId,
+      createdAt: Date.now(),
+      isRemote,
+    });
+
+    logger.debug({ chatId, nodeId, isRemote }, 'Chat context registered for card routing');
+  }
+
+  /**
+   * Unregister a chat context.
+   *
+   * @param chatId - Chat ID to unregister
+   */
+  unregisterChatContext(chatId: string): void {
+    const removed = this.contextMap.delete(chatId);
+    if (removed) {
+      logger.debug({ chatId }, 'Chat context unregistered from card routing');
+    }
+  }
+
+  /**
+   * Get the node ID handling cards for a chat.
+   *
+   * @param chatId - Chat ID to look up
+   * @returns Node ID and whether it's remote, or undefined if not registered
+   */
+  getChatContext(chatId: string): { nodeId: string; isRemote: boolean } | undefined {
+    const entry = this.contextMap.get(chatId);
+    if (!entry) {
+      return undefined;
+    }
+
+    // Check if entry is expired
+    if (Date.now() - entry.createdAt > this.maxAge) {
+      this.contextMap.delete(chatId);
+      logger.debug({ chatId }, 'Chat context expired');
+      return undefined;
+    }
+
+    return { nodeId: entry.nodeId, isRemote: entry.isRemote };
+  }
+
+  /**
+   * Route a card action to the appropriate node.
+   *
+   * @param message - Card action message to route
+   * @returns True if the action was handled (routed to remote or no routing needed)
+   */
+  async routeCardAction(message: CardActionMessage): Promise<boolean> {
+    const { chatId } = message;
+    const context = this.getChatContext(chatId);
+
+    if (!context) {
+      // No registered context, let local handler process it
+      logger.debug({ chatId }, 'No card context registered, using local handler');
+      return false;
+    }
+
+    const { nodeId, isRemote } = context;
+
+    if (!isRemote) {
+      // Local node, no routing needed
+      logger.debug({ chatId, nodeId }, 'Card context is local, no routing needed');
+      return false;
+    }
+
+    // Check if remote node is still connected
+    if (!this.isNodeConnected(nodeId)) {
+      logger.warn({ chatId, nodeId }, 'Remote node not connected, falling back to local handler');
+      this.contextMap.delete(chatId);
+      return false;
+    }
+
+    // Route to remote node
+    logger.info({ chatId, nodeId, actionType: message.actionType }, 'Routing card action to remote node');
+
+    try {
+      const sent = await this.sendToRemoteNode(nodeId, message);
+      if (sent) {
+        logger.debug({ chatId, nodeId }, 'Card action routed successfully');
+        return true;
+      } else {
+        logger.warn({ chatId, nodeId }, 'Failed to route card action');
+        return false;
+      }
+    } catch (error) {
+      logger.error({ err: error, chatId, nodeId }, 'Error routing card action');
+      return false;
+    }
+  }
+
+  /**
+   * Clear all registered contexts.
+   */
+  clear(): void {
+    this.contextMap.clear();
+    logger.info('All card contexts cleared');
+  }
+
+  /**
+   * Stop the router and cleanup resources.
+   */
+  stop(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+    this.clear();
+    logger.info('CardActionRouter stopped');
+  }
+
+  /**
+   * Start the cleanup timer.
+   */
+  private startCleanupTimer(): void {
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupExpired();
+    }, this.cleanupInterval);
+  }
+
+  /**
+   * Cleanup expired entries.
+   */
+  private cleanupExpired(): void {
+    const now = Date.now();
+    let cleaned = 0;
+
+    for (const [chatId, entry] of this.contextMap) {
+      if (now - entry.createdAt > this.maxAge) {
+        this.contextMap.delete(chatId);
+        cleaned++;
+      }
+    }
+
+    if (cleaned > 0) {
+      logger.debug({ count: cleaned }, 'Cleaned up expired card contexts');
+    }
+  }
+
+  /**
+   * Get statistics about the router.
+   */
+  getStats(): { totalContexts: number; oldestEntryAge: number | null } {
+    let oldestAge: number | null = null;
+    const now = Date.now();
+
+    for (const entry of this.contextMap.values()) {
+      const age = now - entry.createdAt;
+      if (oldestAge === null || age > oldestAge) {
+        oldestAge = age;
+      }
+    }
+
+    return {
+      totalContexts: this.contextMap.size,
+      oldestEntryAge: oldestAge,
+    };
+  }
+}

--- a/src/nodes/exec-node-registry.ts
+++ b/src/nodes/exec-node-registry.ts
@@ -270,6 +270,23 @@ export class ExecNodeRegistry extends EventEmitter {
   }
 
   /**
+   * Check if a remote node is connected.
+   * Issue #935: Used by CardActionRouter to check node availability.
+   */
+  isNodeConnected(nodeId: string): boolean {
+    const node = this.execNodes.get(nodeId);
+    if (!node) {
+      return false;
+    }
+    // Local node is always "connected" if enabled
+    if (node.isLocal) {
+      return this.localExecEnabled;
+    }
+    // Remote node is connected if WebSocket is open
+    return node.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /**
    * Get the local node ID.
    */
   getLocalNodeId(): string {

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -32,13 +32,14 @@
 import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as lark from '@larksuiteoapi/node-sdk';
+import WebSocket from 'ws';
 import { Config } from '../config/index.js';
 import { AgentFactory, AgentPool } from '../agents/index.js';
 import { createLogger } from '../utils/logger.js';
 import type { IChannel, IncomingMessage, ControlCommand, ControlResponse } from '../channels/index.js';
 import { FeishuChannel } from '../channels/feishu-channel.js';
 import { RestChannel } from '../channels/rest-channel.js';
-import type { PromptMessage, CommandMessage, FeedbackMessage } from '../types/websocket-messages.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage, CardActionMessage } from '../types/websocket-messages.js';
 import type { FileRef } from '../file-transfer/types.js';
 import type { FileStorageConfig } from '../file-transfer/node-transfer/file-storage.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
@@ -71,6 +72,8 @@ import { getTaskStateManager } from '../utils/task-state-manager.js';
 import { ScheduleManagement } from './schedule-management.js';
 // Issue #893: Removed triggerNextStepRecommendation - now using in-prompt guidance
 import { buildCommandServices } from './command-services.js';
+// Issue #935: Card action routing to Worker Nodes
+import { CardActionRouter } from './card-action-router.js';
 
 const logger = createLogger('PrimaryNode');
 
@@ -114,6 +117,8 @@ export class PrimaryNode extends EventEmitter {
   private messageRouter: UnifiedMessageRouter;
   private wsServerService?: WebSocketServerService;
   private schedulerService?: SchedulerService;
+  // Issue #935: Card action routing to Worker Nodes
+  private cardActionRouter: CardActionRouter;
   // Schedule management (Issue #469, #695)
   private scheduleManager?: ScheduleManager;
   private scheduleFileScanner?: ScheduleFileScanner;
@@ -163,6 +168,16 @@ export class PrimaryNode extends EventEmitter {
       adminChatId: process.env.ADMIN_CHAT_ID || config.adminChatId
     });
 
+    // Issue #935: Initialize CardActionRouter for Worker Node card routing
+    this.cardActionRouter = new CardActionRouter({
+      sendToRemoteNode: async (nodeId: string, message: CardActionMessage) => {
+        return this.sendCardActionToRemoteNode(nodeId, message);
+      },
+      isNodeConnected: (nodeId: string) => {
+        return this.execNodeRegistry.isNodeConnected(nodeId);
+      },
+    });
+
     // Issue #463: Initialize CommandRegistry with default commands
     const commandRegistry = getCommandRegistry();
     registerDefaultCommands(commandRegistry, () => commandRegistry.generateHelpText());
@@ -182,6 +197,19 @@ export class PrimaryNode extends EventEmitter {
         id: 'feishu',
         appId,
         appSecret,
+        // Issue #935: Route card actions to Worker Nodes
+        routeCardAction: async (message) => {
+          return this.routeCardAction({
+            type: 'card_action',
+            chatId: message.chatId,
+            cardMessageId: message.cardMessageId,
+            actionType: message.actionType,
+            actionValue: message.actionValue,
+            actionText: message.actionText,
+            userId: message.userId,
+            action: message.action,
+          });
+        },
       });
 
       // Initialize TaskFlowOrchestrator for Feishu channel
@@ -710,6 +738,51 @@ export class PrimaryNode extends EventEmitter {
   }
 
   // ============================================================================
+  // Card Action Routing (Issue #935)
+  // ============================================================================
+
+  /**
+   * Route a card action to the appropriate handler.
+   * If the card was sent by a Worker Node, forward the action to that node.
+   *
+   * @param message - Card action message to route
+   * @returns True if the action was routed to a Worker Node, false otherwise
+   */
+  async routeCardAction(message: CardActionMessage): Promise<boolean> {
+    return this.cardActionRouter.routeCardAction(message);
+  }
+
+  /**
+   * Send a card action message to a remote Worker Node.
+   * Used by CardActionRouter to forward card actions.
+   *
+   * @param nodeId - Target Worker Node ID
+   * @param message - Card action message to send
+   * @returns True if the message was sent successfully
+   */
+  private async sendCardActionToRemoteNode(nodeId: string, message: CardActionMessage): Promise<boolean> {
+    const node = this.execNodeRegistry.getNode(nodeId);
+    if (!node || node.isLocal || !node.ws) {
+      logger.warn({ nodeId }, 'Remote node not found or not connected');
+      return false;
+    }
+
+    if (node.ws.readyState !== WebSocket.OPEN) {
+      logger.warn({ nodeId }, 'Remote node WebSocket not open');
+      return false;
+    }
+
+    try {
+      node.ws.send(JSON.stringify(message));
+      logger.debug({ nodeId, chatId: message.chatId }, 'Card action sent to remote Worker Node');
+      return true;
+    } catch (error) {
+      logger.error({ err: error, nodeId }, 'Failed to send card action to remote Worker Node');
+      return false;
+    }
+  }
+
+  // ============================================================================
   // Public Message API
   // ============================================================================
 
@@ -771,6 +844,10 @@ export class PrimaryNode extends EventEmitter {
       },
       getCapabilities: () => this.getCapabilities(),
       getChannelIds: () => this.messageRouter.getChannels().map(c => c.id),
+      // Issue #935: Register card context for Worker Node routing
+      registerCardContext: (chatId: string, nodeId: string, isRemote: boolean) => {
+        this.cardActionRouter.registerChatContext(chatId, nodeId, isRemote);
+      },
     });
 
     // Start WebSocket server

--- a/src/nodes/websocket-server-service.ts
+++ b/src/nodes/websocket-server-service.ts
@@ -46,6 +46,11 @@ export interface WebSocketServerServiceConfig {
   getCapabilities: () => NodeCapabilities;
   /** Get channels callback */
   getChannelIds: () => string[];
+  /**
+   * Register card context for routing callbacks to Worker Nodes.
+   * Issue #935: Called when a Worker Node sends a card message.
+   */
+  registerCardContext?: (chatId: string, nodeId: string, isRemote: boolean) => void;
 }
 
 /**
@@ -65,6 +70,8 @@ export class WebSocketServerService extends EventEmitter {
   private readonly getCapabilities: () => NodeCapabilities;
   private readonly getChannelIds: () => string[];
   private readonly fileStorageConfig?: FileStorageConfig;
+  // Issue #935: Card context registration callback
+  private readonly registerCardContext?: (chatId: string, nodeId: string, isRemote: boolean) => void;
 
   private httpServer?: http.Server;
   private wss?: WebSocketServer;
@@ -81,6 +88,7 @@ export class WebSocketServerService extends EventEmitter {
     this.handleFeedback = config.handleFeedback;
     this.getCapabilities = config.getCapabilities;
     this.getChannelIds = config.getChannelIds;
+    this.registerCardContext = config.registerCardContext;
   }
 
   /**
@@ -174,6 +182,17 @@ export class WebSocketServerService extends EventEmitter {
 
         // Handle feedback message (from Worker Nodes)
         const feedbackMsg = message as FeedbackMessage;
+
+        // Issue #935: Register card context for remote Worker Nodes
+        // This enables routing card action callbacks back to the correct Worker Node
+        if (feedbackMsg.type === 'card' && currentNodeId && this.registerCardContext) {
+          this.registerCardContext(feedbackMsg.chatId, currentNodeId, true);
+          logger.debug(
+            { chatId: feedbackMsg.chatId, nodeId: currentNodeId },
+            'Card context registered for remote Worker Node'
+          );
+        }
+
         this.handleFeedback(feedbackMsg);
       } catch (error) {
         logger.error({ err: error }, 'Failed to parse message');

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -33,7 +33,7 @@ import {
 } from '../schedule/index.js';
 import { TaskFlowOrchestrator } from '../feishu/task-flow-orchestrator.js';
 import { TaskTracker } from '../utils/task-tracker.js';
-import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage } from '../types/websocket-messages.js';
+import type { PromptMessage, CommandMessage, FeedbackMessage, RegisterMessage, CardActionMessage } from '../types/websocket-messages.js';
 import { FileClient } from '../file-transfer/node-transfer/file-client.js';
 import type { WorkerNodeConfig, NodeCapabilities } from './types.js';
 
@@ -363,7 +363,7 @@ export class WorkerNode {
 
     this.ws.on('message', async (data) => {
       try {
-        const message = JSON.parse(data.toString()) as PromptMessage | CommandMessage;
+        const message = JSON.parse(data.toString()) as PromptMessage | CommandMessage | CardActionMessage;
 
         // Handle command messages
         if (message.type === 'command') {
@@ -421,6 +421,67 @@ export class WorkerNode {
             logger.error({ err, chatId }, 'Execution failed');
             sendFeedback({ type: 'error', chatId, error: err.message, threadId });
             sendFeedback({ type: 'done', chatId, threadId });
+          }
+          return;
+        }
+
+        // Issue #935: Handle card action messages from Primary Node
+        if (message.type === 'card_action') {
+          const cardActionMsg = message as CardActionMessage;
+          const { chatId, cardMessageId, actionType, actionValue, actionText, userId } = cardActionMsg;
+          logger.info(
+            { chatId, cardMessageId, actionType, actionValue, userId },
+            'Received card action from Primary Node'
+          );
+
+          // Import the necessary functions to handle card actions
+          const { resolvePendingInteraction } = await import('../mcp/feishu-context-mcp.js');
+          const { generateInteractionPrompt } = await import('../mcp/tools/interactive-message.js');
+
+          // Try to resolve any pending wait_for_interaction calls
+          const resolved = resolvePendingInteraction(
+            cardMessageId,
+            actionValue,
+            actionType,
+            userId || 'unknown'
+          );
+
+          if (resolved) {
+            logger.debug({ cardMessageId }, 'Card action resolved pending interaction');
+          }
+
+          // Get the agent for this chatId and process the card action
+          const ctx = this.activeFeedbackChannels.get(chatId);
+          if (ctx) {
+            // Generate prompt from template if available
+            const promptFromTemplate = generateInteractionPrompt(
+              cardMessageId,
+              actionValue,
+              actionText,
+              actionType
+            );
+
+            // Use the template prompt if available, otherwise use default message
+            const messageContent = promptFromTemplate || (() => {
+              const buttonText = actionText || actionValue;
+              return `User clicked '${buttonText}' button`;
+            })();
+
+            // Get the agent and process the card action as a message
+            const agent = this.agentPool?.getOrCreateChatAgent(chatId);
+            if (agent) {
+              agent.processMessage(
+                chatId,
+                messageContent,
+                `${cardMessageId}-${actionValue}`,
+                userId,
+                undefined, // no attachments
+                undefined  // no chat history context
+              );
+              logger.debug({ chatId, cardMessageId }, 'Card action processed by agent');
+            }
+          } else {
+            logger.warn({ chatId }, 'No active feedback channel for card action');
           }
           return;
         }

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -89,3 +89,48 @@ export interface FeedbackMessage {
   /** MIME type */
   mimeType?: string;
 }
+
+/**
+ * Message sent from Communication Node to Execution Node when a card action occurs.
+ * This enables Worker Node to receive card interaction callbacks from Primary Node.
+ *
+ * Issue #935: WebSocket bidirectional communication for card actions.
+ */
+export interface CardActionMessage {
+  type: 'card_action';
+  /** Chat ID where the card was displayed */
+  chatId: string;
+  /** The card message ID in Feishu */
+  cardMessageId: string;
+  /** Action type (button, select_static, etc.) */
+  actionType: string;
+  /** Action value from the button/menu */
+  actionValue: string;
+  /** Display text of the action (optional) */
+  actionText?: string;
+  /** User who triggered the action */
+  userId?: string;
+  /** Full action data for complex interactions */
+  action?: {
+    type: string;
+    value: string;
+    text?: string;
+    trigger?: string;
+  };
+}
+
+/**
+ * Message sent from Communication Node to Execution Node for card context registration.
+ * After a card is sent successfully, Primary Node notifies Worker Node of the message ID.
+ *
+ * Issue #935: WebSocket bidirectional communication for card actions.
+ */
+export interface CardContextMessage {
+  type: 'card_context';
+  /** Chat ID where the card was sent */
+  chatId: string;
+  /** The card message ID returned by Feishu */
+  cardMessageId: string;
+  /** Node ID that sent the card (for routing callbacks) */
+  nodeId: string;
+}


### PR DESCRIPTION
## Summary

- Add `CardActionMessage` type for Primary Node -> Worker Node communication
- Add `CardActionRouter` to track chatId -> nodeId mapping for card routing
- When Worker Node sends a card, Primary Node registers the context
- When card action callback arrives, Primary Node routes it to Worker Node
- Worker Node processes the card action locally with interaction context

## Problem

Worker Node as a pure execution node can only connect to Primary Node via WebSocket, but cannot communicate with Channel (e.g., Feishu) indirectly. This causes card interaction callbacks to not be properly routed back to Worker Node when users click card buttons.

## Solution

Implement WebSocket bidirectional communication enhancement (Issue #935 Scheme A):

```
飞书 ←→ Primary Node ←WebSocket→ Worker Node
          ↑                        ↑
     Channel 通信              只能发送 Feedback
     (双向交互)                (单向，无法接收回调)
                    ↓ 新增 ↓
          Primary Node 可以转发 CardActionMessage 给 Worker Node
```

## Architecture

1. **CardActionRouter** - Tracks which Worker Node handles cards for each chatId
2. **CardActionMessage** - New WebSocket message type for routing card actions
3. **Card context registration** - When Worker sends card, Primary records context
4. **Card action routing** - When user clicks button, Primary routes to correct Worker

## Test Plan

- [x] TypeScript compilation passes
- [x] All 1644 existing tests pass
- [ ] Manual testing with Worker Node setup

Fixes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)