### PR TITLE
fix(pilot): restore session context from persisted chat history on restart (Issue #955)

### DIFF
--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -34,7 +34,9 @@
 
 import type { StreamingUserMessage, QueryHandle } from '../../sdk/index.js';
 import { Config } from '../../config/index.js';
+import { SESSION_RESTORE } from '../../config/constants.js';
 import { createFeishuSdkMcpServer } from '../../mcp/feishu-context-mcp.js';
+import { messageLogger } from '../../feishu/message-logger.js';
 import { BaseAgent } from '../base-agent.js';
 import type { ChatAgent, UserInput } from '../types.js';
 import type { AgentMessage } from '../../types/agent.js';
@@ -77,6 +79,11 @@ export class Pilot extends BaseAgent implements ChatAgent {
   // Message builder (Issue #697)
   private readonly messageBuilder: MessageBuilder;
 
+  // Session restoration (Issue #955)
+  private persistedHistoryContext?: string;
+  private historyLoaded = false;
+  private historyLoadPromise?: Promise<void>;
+
   constructor(config: PilotConfig) {
     super(config);
 
@@ -108,6 +115,78 @@ export class Pilot extends BaseAgent implements ChatAgent {
    */
   getChatId(): string {
     return this.boundChatId;
+  }
+
+  /**
+   * Load persisted chat history from MessageLogger (Issue #955).
+   *
+   * This method loads recent chat history from the file-based message logs
+   * to restore context after service restart. The history is loaded once
+   * and cached for the lifetime of this Pilot instance.
+   *
+   * @returns Promise that resolves when history is loaded
+   */
+  private async loadPersistedHistory(): Promise<void> {
+    // If already loading, wait for the existing promise
+    if (this.historyLoadPromise) {
+      return this.historyLoadPromise;
+    }
+
+    // If already loaded, return immediately
+    if (this.historyLoaded) {
+      return;
+    }
+
+    // Start loading history
+    this.historyLoadPromise = this.doLoadPersistedHistory();
+    try {
+      await this.historyLoadPromise;
+    } finally {
+      this.historyLoadPromise = undefined;
+    }
+  }
+
+  /**
+   * Internal method to perform the actual history loading.
+   */
+  private async doLoadPersistedHistory(): Promise<void> {
+    try {
+      this.logger.info(
+        { chatId: this.boundChatId, days: SESSION_RESTORE.HISTORY_DAYS },
+        'Loading persisted chat history for session restoration'
+      );
+
+      const history = await messageLogger.getChatHistory(
+        this.boundChatId,
+        SESSION_RESTORE.HISTORY_DAYS
+      );
+
+      if (history && history.trim()) {
+        // Truncate if too long
+        this.persistedHistoryContext = history.length > SESSION_RESTORE.MAX_CONTEXT_LENGTH
+          ? history.slice(-SESSION_RESTORE.MAX_CONTEXT_LENGTH)
+          : history;
+
+        this.logger.info(
+          { chatId: this.boundChatId, historyLength: this.persistedHistoryContext.length },
+          'Persisted chat history loaded successfully'
+        );
+      } else {
+        this.logger.debug(
+          { chatId: this.boundChatId },
+          'No persisted chat history found'
+        );
+      }
+
+      this.historyLoaded = true;
+    } catch (error) {
+      this.logger.error(
+        { err: error, chatId: this.boundChatId },
+        'Failed to load persisted chat history'
+      );
+      // Mark as loaded even on error to prevent retry loops
+      this.historyLoaded = true;
+    }
   }
 
   /**
@@ -317,7 +396,7 @@ export class Pilot extends BaseAgent implements ChatAgent {
     }
 
     this.logger.info(
-      { chatId, messageId, textLength: text.length, hasAttachments: !!attachments, hasChatHistory: !!chatHistoryContext },
+      { chatId, messageId, textLength: text.length, hasAttachments: !!attachments, hasChatHistory: !!chatHistoryContext, hasPersistedHistory: !!this.persistedHistoryContext },
       'processMessage called'
     );
 
@@ -334,8 +413,10 @@ export class Pilot extends BaseAgent implements ChatAgent {
     const capabilities = this.callbacks.getCapabilities?.(chatId);
 
     // Build the user message using MessageBuilder (Issue #697)
+    // Issue #955: Include persisted history context for session restoration
     const enhancedContent = this.messageBuilder.buildEnhancedContent({
-      text, messageId, senderOpenId, attachments, chatHistoryContext
+      text, messageId, senderOpenId, attachments, chatHistoryContext,
+      persistedHistoryContext: this.persistedHistoryContext,
     }, chatId, capabilities);
 
     const userMessage: StreamingUserMessage = {
@@ -361,9 +442,17 @@ export class Pilot extends BaseAgent implements ChatAgent {
    *
    * Creates a MessageChannel and Query, using the channel's generator for streaming input.
    * Issue #590 Phase 3: Filters MCP servers based on channel capabilities.
+   * Issue #955: Triggers background loading of persisted chat history.
    */
   private startAgentLoop(): void {
     const chatId = this.boundChatId;
+
+    // Issue #955: Trigger background loading of persisted history
+    if (!this.historyLoaded) {
+      this.loadPersistedHistory().catch((err) => {
+        this.logger.error({ err, chatId }, 'Failed to load persisted history in background');
+      });
+    }
 
     // Get channel capabilities for MCP server filtering (Issue #590 Phase 3)
     const capabilities = this.callbacks.getCapabilities?.(chatId);
@@ -586,6 +675,10 @@ export class Pilot extends BaseAgent implements ChatAgent {
 
     // Reset restart state
     this.restartManager.reset(this.boundChatId);
+
+    // Clear persisted history context (Issue #955)
+    this.persistedHistoryContext = undefined;
+    this.historyLoaded = false;
   }
 
   /**

--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -2,6 +2,7 @@
  * Tests for MessageBuilder class.
  *
  * Issue #809: Tests for image analyzer MCP hint in buildAttachmentsInfo.
+ * Issue #955: Tests for persisted history context in session restoration.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -23,6 +24,54 @@ describe('MessageBuilder', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('buildEnhancedContent with persistedHistoryContext (Issue #955)', () => {
+    it('should include persisted history section when provided', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+        persistedHistoryContext: 'Previous conversation content here...',
+      }, 'chat-123');
+
+      expect(result).toContain('Previous Session Context');
+      expect(result).toContain('service was recently restarted');
+      expect(result).toContain('Previous conversation content here...');
+    });
+
+    it('should not include persisted history section when not provided', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+      }, 'chat-123');
+
+      expect(result).not.toContain('Previous Session Context');
+    });
+
+    it('should include both persisted history and chat history when both are provided', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+        persistedHistoryContext: 'Persisted history...',
+        chatHistoryContext: 'Chat history from passive mode...',
+      }, 'chat-123');
+
+      expect(result).toContain('Previous Session Context');
+      expect(result).toContain('Persisted history...');
+      expect(result).toContain('Recent Chat History');
+      expect(result).toContain('Chat history from passive mode...');
+    });
+
+    it('should not include persisted history for skill commands', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: '/reset',
+        messageId: 'msg-123',
+        persistedHistoryContext: 'Previous conversation...',
+      }, 'chat-123');
+
+      expect(result).not.toContain('Previous Session Context');
+      expect(result).toContain('/reset');
+    });
   });
 
   describe('buildAttachmentsInfo (Issue #809)', () => {

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -54,6 +54,22 @@ ${msg.chatHistoryContext}
 `
       : '';
 
+    // Build persisted history section for session restoration (Issue #955)
+    const persistedHistorySection = msg.persistedHistoryContext
+      ? `
+
+---
+
+## Previous Session Context
+
+The service was recently restarted. Here's the conversation history from your previous session:
+
+${msg.persistedHistoryContext}
+
+---
+`
+      : '';
+
     if (isSkillCommand) {
       // For skill commands: command first, then minimal context for skill to use
       const contextInfo = msg.senderOpenId
@@ -100,7 +116,7 @@ To notify the user in your FINAL response, use:
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
 **Sender Open ID:** ${msg.senderOpenId}
-${chatHistorySection}${mentionSection}
+${persistedHistorySection}${chatHistorySection}${mentionSection}
 
 ---
 
@@ -116,7 +132,7 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
-${chatHistorySection}
+${persistedHistorySection}${chatHistorySection}
 ## Tools
 ${toolsSection}
 ${nextStepGuidance}

--- a/src/agents/pilot/types.ts
+++ b/src/agents/pilot/types.ts
@@ -81,4 +81,6 @@ export interface MessageData {
   attachments?: FileRef[];
   /** Chat history context for passive mode (Issue #517) */
   chatHistoryContext?: string;
+  /** Persisted history context for session restoration (Issue #955) */
+  persistedHistoryContext?: string;
 }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -75,6 +75,17 @@ export const CHAT_HISTORY = {
 } as const;
 
 /**
+ * Session restoration configuration (Issue #955)
+ */
+export const SESSION_RESTORE = {
+  /** Number of days to look back for chat history */
+  HISTORY_DAYS: 7,
+
+  /** Maximum characters for restored session context */
+  MAX_CONTEXT_LENGTH: 4000,
+} as const;
+
+/**
  * Error codes that should trigger a retry
  */
 export const RETRYABLE_ERROR_CODES = [


### PR DESCRIPTION
## Summary

- Load persisted chat history from `MessageLogger` when ChatAgent starts
- Include loaded history in prompt via `persistedHistoryContext` parameter
- Clear history on `/reset` to allow users to start fresh

## Problem

When the service restarts (due to config errors, crashes, or manual restart), all session context is lost because ChatAgent sessions are stored in memory. Users lose conversation context and ongoing tasks cannot be continued.

## Solution

Based on owner feedback: "实际上我们保存了聊天记录，只需要在初始化 ChatAgent 时载入最近的聊天记录即可"

This PR loads the already-persisted chat history from `MessageLogger` when ChatAgent starts:

1. **Added `loadPersistedHistory()` method in Pilot** - Loads recent chat history from file-based message logs
2. **Trigger background loading** - When `startAgentLoop()` is called
3. **Include in prompt** - Via `persistedHistoryContext` in MessageBuilder
4. **Clear on reset** - `/reset` clears history to allow fresh start

## Changes

| File | Change |
|------|--------|
| `src/config/constants.ts` | Added `SESSION_RESTORE` constants (7 days history, 4000 chars max) |
| `src/agents/pilot/index.ts` | Added history loading logic with caching |
| `src/agents/pilot/message-builder.ts` | Added "Previous Session Context" section |
| `src/agents/pilot/types.ts` | Added `persistedHistoryContext` to MessageData |
| `src/agents/pilot/message-builder.test.ts` | Added 4 tests for persisted history |

## Test Results

- ✅ All 1648 tests pass (4 new tests added)
- ✅ TypeScript compilation passes
- ✅ ESLint passes (no new errors)

## Example Output

When a user sends a message after service restart:

```
You are responding in a Feishu chat.

**Chat ID:** oc_xxx
**Message ID:** msg_xxx

---

## Previous Session Context

The service was recently restarted. Here's the conversation history from your previous session:

[2026-03-06T10:00:00.000Z] 📥 User (message_id: xxx)
**Sender**: ou_xxx
**Type**: text

算账算的如何了

---

[2026-03-06T10:00:05.000Z] 📤 Bot (message_id: yyy)
...

---

## Tools
...

--- User Message ---
继续帮我算账
```

Fixes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)