### PR TITLE
fix(lint): remove unnecessary async keywords in primary-node.ts (Issue #964)

### DIFF
--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -170,7 +170,7 @@ export class PrimaryNode extends EventEmitter {
 
     // Issue #935: Initialize CardActionRouter for Worker Node card routing
     this.cardActionRouter = new CardActionRouter({
-      sendToRemoteNode: async (nodeId: string, message: CardActionMessage) => {
+      sendToRemoteNode: (nodeId: string, message: CardActionMessage) => {
         return this.sendCardActionToRemoteNode(nodeId, message);
       },
       isNodeConnected: (nodeId: string) => {
@@ -198,7 +198,7 @@ export class PrimaryNode extends EventEmitter {
         appId,
         appSecret,
         // Issue #935: Route card actions to Worker Nodes
-        routeCardAction: async (message) => {
+        routeCardAction: (message) => {
           return this.routeCardAction({
             type: 'card_action',
             chatId: message.chatId,
@@ -748,7 +748,7 @@ export class PrimaryNode extends EventEmitter {
    * @param message - Card action message to route
    * @returns True if the action was routed to a Worker Node, false otherwise
    */
-  async routeCardAction(message: CardActionMessage): Promise<boolean> {
+  routeCardAction(message: CardActionMessage): Promise<boolean> {
     return this.cardActionRouter.routeCardAction(message);
   }
 
@@ -760,25 +760,25 @@ export class PrimaryNode extends EventEmitter {
    * @param message - Card action message to send
    * @returns True if the message was sent successfully
    */
-  private async sendCardActionToRemoteNode(nodeId: string, message: CardActionMessage): Promise<boolean> {
+  private sendCardActionToRemoteNode(nodeId: string, message: CardActionMessage): Promise<boolean> {
     const node = this.execNodeRegistry.getNode(nodeId);
     if (!node || node.isLocal || !node.ws) {
       logger.warn({ nodeId }, 'Remote node not found or not connected');
-      return false;
+      return Promise.resolve(false);
     }
 
     if (node.ws.readyState !== WebSocket.OPEN) {
       logger.warn({ nodeId }, 'Remote node WebSocket not open');
-      return false;
+      return Promise.resolve(false);
     }
 
     try {
       node.ws.send(JSON.stringify(message));
       logger.debug({ nodeId, chatId: message.chatId }, 'Card action sent to remote Worker Node');
-      return true;
+      return Promise.resolve(true);
     } catch (error) {
       logger.error({ err: error, nodeId }, 'Failed to send card action to remote Worker Node');
-      return false;
+      return Promise.resolve(false);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes ESLint `require-await` errors in `primary-node.ts` by removing unnecessary `async` keywords.

### Problem

PR #956 introduced async methods without await expressions, causing 4 lint errors:
```
173:7   error  Async method 'sendToRemoteNode' has no 'await' expression
201:9   error  Async method 'routeCardAction' has no 'await' expression  
751:3   error  Async method 'routeCardAction' has no 'await' expression
763:3   error  Async method 'sendCardActionToRemoteNode' has no 'await' expression
```

### Solution

| Location | Fix |
|----------|-----|
| Line 173 | Remove `async` from callback - returns Promise directly |
| Line 201 | Remove `async` from callback - returns Promise directly |
| Line 751 | Remove `async` from method - returns Promise directly |
| Line 763 | Remove `async`, use `Promise.resolve()` for synchronous returns |

### Changes

- Removed `async` keyword from 3 arrow function callbacks that return Promises
- Removed `async` keyword from `routeCardAction()` method
- Removed `async` keyword from `sendCardActionToRemoteNode()` and wrapped return values with `Promise.resolve()`

## Test plan

- [x] ESLint check passes (0 errors, 89 pre-existing warnings)
- [x] TypeScript compilation passes
- [x] Unit tests pass (8 tests in primary-node.test.ts)

Fixes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)