### PR TITLE
fix(pilot): add output format guidance to prevent raw JSON in responses (Issue #962)

### DIFF
--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -3,6 +3,7 @@
  *
  * Issue #809: Tests for image analyzer MCP hint in buildAttachmentsInfo.
  * Issue #955: Tests for persisted history context in session restoration.
+ * Issue #962: Tests for output format guidance to prevent raw JSON in responses.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -168,6 +169,48 @@ describe('MessageBuilder', () => {
         const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
         expect(result).toContain('analyze_image');
       }
+    });
+  });
+
+  describe('buildOutputFormatGuidance (Issue #962)', () => {
+    it('should include output format guidance in regular messages', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+      }, 'chat-123');
+
+      expect(result).toContain('Output Format Requirements');
+      expect(result).toContain('Never output raw JSON');
+    });
+
+    it('should include correct and wrong format examples', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+      }, 'chat-123');
+
+      expect(result).toContain('✅ Correct Format');
+      expect(result).toContain('❌ Wrong Format');
+    });
+
+    it('should not include output format guidance for skill commands', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: '/reset',
+        messageId: 'msg-123',
+      }, 'chat-123');
+
+      expect(result).not.toContain('Output Format Requirements');
+    });
+
+    it('should include guidance for converting JSON to readable format', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+        senderOpenId: 'user-123',
+      }, 'chat-123');
+
+      expect(result).toContain('Convert JSON objects to readable text');
+      expect(result).toContain('Markdown tables instead of raw JSON');
     });
   });
 });

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -5,6 +5,7 @@
  * Handles building enhanced content with Feishu context.
  *
  * Issue #893: Added in-prompt next-step guidance.
+ * Issue #962: Added output format guidance to prevent raw JSON in responses.
  */
 
 import { Config } from '../../config/index.js';
@@ -21,6 +22,7 @@ import type { MessageData } from './types.js';
  * - Attachments info
  * - Chat history context
  * - Next-step guidance (Issue #893)
+ * - Output format guidance (Issue #962)
  */
 export class MessageBuilder {
   /**
@@ -94,6 +96,9 @@ ${msg.persistedHistoryContext}
     // Build next-step guidance section (Issue #893)
     const nextStepGuidance = this.buildNextStepGuidance(capabilities);
 
+    // Build output format guidance section (Issue #962)
+    const outputFormatGuidance = this.buildOutputFormatGuidance();
+
     // For regular messages: context FIRST, then user message
     if (msg.senderOpenId) {
       const mentionSection = capabilities?.supportsMention !== false
@@ -123,6 +128,7 @@ ${persistedHistorySection}${chatHistorySection}${mentionSection}
 ## Tools
 ${toolsSection}
 ${nextStepGuidance}
+${outputFormatGuidance}
 
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
@@ -136,6 +142,7 @@ ${persistedHistorySection}${chatHistorySection}
 ## Tools
 ${toolsSection}
 ${nextStepGuidance}
+${outputFormatGuidance}
 
 --- User Message ---
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
@@ -336,5 +343,44 @@ At the end of your response, proactively suggest 2-3 relevant next steps the use
 - Make suggestions specific and actionable
 - Format as a simple list
 - Always include suggestions, even for simple questions (e.g., "Want to know more about X?", "Try this related feature")`;
+  }
+
+  /**
+   * Build output format guidance section for the prompt.
+   *
+   * Issue #962: Prevents raw JSON objects from appearing in model output.
+   * Some models (like GLM-5) may output JSON objects directly instead of
+   * formatting them as readable Markdown. This guidance ensures structured
+   * data is always presented in a human-readable format.
+   *
+   * @returns Output format guidance string
+   */
+  private buildOutputFormatGuidance(): string {
+    return `
+
+---
+
+## Output Format Requirements
+
+**IMPORTANT: Never output raw JSON objects in your response.**
+
+When you need to present structured data (status, metrics, analysis results, etc.), always format it as **readable Markdown**:
+
+### ✅ Correct Format
+\`\`\`markdown
+> **储蓄率**: ❌ 入不敷出，储蓄率为负，建议审视支出结构
+\`\`\`
+
+### ❌ Wrong Format (Never do this)
+\`\`\`markdown
+> **储蓄率**: { "status": "bad", "comment": "入不敷出..." }
+\`\`\`
+
+### Guidelines
+
+- Convert JSON objects to readable text, tables, or formatted lists
+- Use emoji and formatting (bold, italic) to highlight important information
+- If you have structured data internally, extract and present the key values
+- For complex data, use Markdown tables instead of raw JSON`;
   }
 }


### PR DESCRIPTION
## Summary

- Added output format guidance in `MessageBuilder` to prevent raw JSON objects in model responses
- Instructs models (especially GLM-5) to format structured data as readable Markdown
- Includes correct/wrong format examples with Chinese context

## Problem

Issue #962 reported that GLM-5 model outputs raw JSON objects directly in text instead of formatting them as readable Markdown:

```markdown
> **储蓄率**: { {
        "status": "bad",
        "comment": "入不敷出，储蓄率为负，建议审视支出结构"
    }
}
```

Expected:
```markdown
> **储蓄率**: ❌ 入不敷出，储蓄率为负，建议审视支出结构
```

## Solution

Added `buildOutputFormatGuidance()` method that injects clear formatting instructions:

1. **Explicit prohibition**: "Never output raw JSON objects in your response"
2. **Correct format examples**: Shows how structured data should be presented
3. **Wrong format examples**: Shows what to avoid
4. **Guidelines**: Specific instructions for converting JSON to readable format

## Changes

| File | Change |
|------|--------|
| `src/agents/pilot/message-builder.ts` | Added `buildOutputFormatGuidance()` method |
| `src/agents/pilot/message-builder.test.ts` | Added 4 unit tests for output format guidance |

## Test Results

- ✅ 14 tests pass (10 existing + 4 new)
- ✅ TypeScript compilation passes
- ✅ No new lint errors

Fixes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)