### PR TITLE
feat(mcp): add create_discussion_chat tool for PR Scanner Phase 2 (Issue #393)

### DIFF
--- a/examples/schedules/pr-scanner.example.md
+++ b/examples/schedules/pr-scanner.example.md
@@ -51,9 +51,10 @@ gh pr list --repo hs3180/disclaude --state open --json number,title,author,updat
    ```
 
 2. **尝试创建群聊** (Phase 2):
-   - 如果有 `create_discussion_chat` MCP 工具可用，为该 PR 创建独立群聊
+   - 调用 `create_discussion_chat` MCP 工具为该 PR 创建独立群聊
    - 群聊名称: `PR #{number}: {title 前30字符}`
-   - 如果创建失败或工具不可用，使用配置的 `chatId` 发送通知
+   - 获取返回的 chatId 用于后续通知
+   - 如果创建失败，回退到使用配置的 `chatId` 发送通知
 
 3. 发送 PR 信息通知：
    - PR 标题和编号
@@ -91,13 +92,31 @@ PR #{number}: {title}
 
 ## 群聊创建说明 (Phase 2)
 
-当前 MCP 工具暂不支持创建群聊，因此使用 Phase 1 模式（发送到配置的 chatId）。
+现在可以使用 `create_discussion_chat` MCP 工具为每个新 PR 创建独立群聊：
 
-未来当 `create_discussion_chat` MCP 工具可用时，可以：
-1. 为每个新 PR 创建独立群聊
-2. 邀请 PR 作者和相关人员
-3. 在群聊中发送 PR 信息卡片
-4. 支持通过命令执行 PR 操作
+### 群聊创建步骤
+
+1. 调用 `create_discussion_chat` 工具：
+   ```json
+   {
+     "topic": "PR #{number}: {title前30字符}"
+   }
+   ```
+
+2. 工具返回新创建的 chatId
+
+3. 使用 `send_user_feedback` 将 PR 信息发送到新群聊
+
+### 完整流程
+
+```
+对于每个新 PR:
+1. 获取 PR 详细信息
+2. 调用 create_discussion_chat({ topic: "PR #xxx: ..." })
+3. 获取返回的 chatId
+4. 调用 send_user_feedback({ content: ..., format: "card", chatId: 新chatId })
+5. 更新历史记录，记录 PR 和 chatId 的对应关系
+```
 
 ## 错误处理
 
@@ -117,7 +136,7 @@ PR #{number}: {title}
 | Phase | 功能 | 状态 |
 |-------|------|------|
 | Phase 1 | 基本扫描 + 通知 | ✅ 可用 |
-| Phase 2 | 为每个 PR 创建群聊 | ⏳ 需要 MCP 工具 |
+| Phase 2 | 为每个 PR 创建群聊 | ✅ 可用 (使用 create_discussion_chat MCP 工具) |
 | Phase 3 | 交互式操作按钮 | ❌ 不计划实现 |
 
 详见: `docs/designs/pr-scanner-design.md`

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -13,6 +13,7 @@ import {
   wait_for_interaction,
   send_interactive_message,
   setMessageSentCallback,
+  create_discussion_chat,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 
@@ -28,6 +29,7 @@ export {
   generateInteractionPrompt,
   getActionPrompts,
 } from './tools/interactive-message.js';
+export { create_discussion_chat } from './tools/create-chat.js';
 
 // Start IPC server on module load for cross-process communication
 // This allows the main process to query interactive contexts
@@ -335,6 +337,59 @@ In actionPrompts, you can use these placeholders:
       required: ['card', 'actionPrompts', 'chatId'],
     },
     handler: send_interactive_message,
+  },
+  create_discussion_chat: {
+    description: `Create a new discussion group chat in Feishu.
+
+This tool creates a new group chat that can be used for discussions about specific topics, such as PR reviews, issue discussions, etc.
+
+---
+
+## Parameters
+
+- **topic**: (Optional) The chat topic/name. If not provided, a default name with timestamp will be generated.
+- **members**: (Optional) Array of member open_ids to add to the chat initially.
+
+---
+
+## Return Value
+
+Returns an object with:
+- **success**: Whether the chat was created successfully
+- **message**: Status message
+- **chatId**: The ID of the created chat (on success)
+
+---
+
+## Usage Example
+
+\`\`\`json
+{
+  "topic": "PR #123: Feature Discussion",
+  "members": ["ou_xxx", "ou_yyy"]
+}
+\`\`\`
+
+---
+
+## Use Cases
+
+1. **PR Scanner**: Create a dedicated chat for each new PR
+2. **Issue Discussion**: Create a chat for discussing complex issues
+3. **Team Collaboration**: Create temporary chats for specific tasks
+
+---
+
+⚠️ **Note**: The bot will be automatically added as a member of the created chat.`,
+    parameters: {
+      type: 'object',
+      properties: {
+        topic: { type: 'string', description: 'Chat topic/name (optional, auto-generated if not provided)' },
+        members: { type: 'array', items: { type: 'string' }, description: 'Initial member open_ids (optional)' },
+      },
+      required: [],
+    },
+    handler: create_discussion_chat,
   },
 };
 
@@ -664,6 +719,65 @@ In actionPrompts, you can use these placeholders:
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Interactive message failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'create_discussion_chat',
+    description: `Create a new discussion group chat in Feishu.
+
+This tool creates a new group chat that can be used for discussions about specific topics, such as PR reviews, issue discussions, etc.
+
+---
+
+## Parameters
+
+- **topic**: (Optional) The chat topic/name. If not provided, a default name with timestamp will be generated.
+- **members**: (Optional) Array of member open_ids to add to the chat initially.
+
+---
+
+## Return Value
+
+Returns an object with:
+- **success**: Whether the chat was created successfully
+- **message**: Status message
+- **chatId**: The ID of the created chat (on success)
+
+---
+
+## Usage Example
+
+\`\`\`json
+{
+  "topic": "PR #123: Feature Discussion",
+  "members": ["ou_xxx", "ou_yyy"]
+}
+\`\`\`
+
+---
+
+## Use Cases
+
+1. **PR Scanner**: Create a dedicated chat for each new PR
+2. **Issue Discussion**: Create a chat for discussing complex issues
+3. **Team Collaboration**: Create temporary chats for specific tasks
+
+---
+
+⚠️ **Note**: The bot will be automatically added as a member of the created chat.`,
+    parameters: z.object({
+      topic: z.string().optional(),
+      members: z.array(z.string()).optional(),
+    }),
+    handler: async ({ topic, members }) => {
+      try {
+        const result = await create_discussion_chat({ topic, members });
+        return toolSuccess(result.success
+          ? `${result.message}${result.chatId ? ` Chat ID: ${result.chatId}` : ''}`
+          : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Chat creation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -21,7 +21,7 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction } from './feishu-context-mcp.js';
+import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction, create_discussion_chat } from './feishu-context-mcp.js';
 
 const logger = createLogger('FeishuMCPServer');
 
@@ -130,6 +130,25 @@ async function handleMessage(message: unknown) {
                   required: ['messageId', 'chatId'],
                 },
               },
+              {
+                name: 'create_discussion_chat',
+                description: 'Create a new discussion group chat in Feishu. Used for PR discussions, issue discussions, etc.',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    topic: {
+                      type: 'string',
+                      description: 'Chat topic/name (optional, auto-generated if not provided)',
+                    },
+                    members: {
+                      type: 'array',
+                      items: { type: 'string' },
+                      description: 'Initial member open_ids (optional)',
+                    },
+                  },
+                  required: [],
+                },
+              },
             ],
           },
         };
@@ -205,6 +224,24 @@ async function handleMessage(message: unknown) {
                 type: 'text',
                 text: result.success
                   ? `${result.message}\nAction: ${result.actionValue}\nType: ${result.actionType}\nUser: ${result.userId}`
+                  : `⚠️ ${result.message}`,
+              }],
+            },
+          };
+        }
+
+        if (name === 'create_discussion_chat') {
+          const args = toolArgs as { topic?: string; members?: string[] };
+          const result = await create_discussion_chat(args);
+
+          return {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              content: [{
+                type: 'text',
+                text: result.success
+                  ? `${result.message}${result.chatId ? ` Chat ID: ${result.chatId}` : ''}`
                   : `⚠️ ${result.message}`,
               }],
             },

--- a/src/mcp/tools/create-chat.ts
+++ b/src/mcp/tools/create-chat.ts
@@ -1,0 +1,80 @@
+/**
+ * Create Discussion Chat MCP Tool
+ *
+ * Creates a new group chat in Feishu for discussion purposes.
+ * Used by scheduled tasks like PR Scanner to create dedicated chat groups.
+ *
+ * @see Issue #393 - PR Scanner Phase 2
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { createDiscussionChat, type CreateDiscussionOptions } from '../../platforms/feishu/chat-ops.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('create-chat');
+
+/**
+ * Result type for create_discussion_chat tool.
+ */
+export interface CreateChatResult {
+  success: boolean;
+  message: string;
+  chatId?: string;
+}
+
+/**
+ * Create a new discussion group chat.
+ *
+ * @param params - Chat creation parameters
+ * @returns Result with chat ID on success
+ */
+export async function create_discussion_chat(params: {
+  /** Chat topic/name (optional, auto-generated if not provided) */
+  topic?: string;
+  /** Initial member open_ids (optional) */
+  members?: string[];
+}): Promise<CreateChatResult> {
+  const { topic, members } = params;
+
+  try {
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      return {
+        success: false,
+        message: 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET.',
+      };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+
+    const options: CreateDiscussionOptions = {};
+    if (topic) {
+      options.topic = topic;
+    }
+    if (members && members.length > 0) {
+      options.members = members;
+    }
+
+    const chatId = await createDiscussionChat(client, options);
+
+    logger.info({ chatId, topic }, 'Discussion chat created via MCP tool');
+
+    return {
+      success: true,
+      message: 'Discussion chat created successfully.',
+      chatId,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error({ err: error, topic }, 'Failed to create discussion chat');
+
+    return {
+      success: false,
+      message: `Failed to create discussion chat: ${errorMessage}`,
+    };
+  }
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -27,3 +27,5 @@ export {
   generateInteractionPrompt,
   cleanupExpiredContexts,
 } from './interactive-message.js';
+
+export { create_discussion_chat, type CreateChatResult } from './create-chat.js';


### PR DESCRIPTION
## Summary

- Add `create_discussion_chat` MCP tool to enable creating group chats in Feishu
- This tool is required for PR Scanner Phase 2 (Issue #393)
- Update `pr-scanner.example.md` with Phase 2 usage instructions

## Changes

### New MCP Tool: `create_discussion_chat`
- Creates a new group chat with optional topic and members
- Returns the chat ID for subsequent message operations
- Integrates with existing `ChatOps.createDiscussionChat()` function

### Updated Files
- `src/mcp/tools/create-chat.ts` - New tool implementation
- `src/mcp/tools/index.ts` - Export new tool
- `src/mcp/feishu-context-mcp.ts` - Register tool for inline SDK use
- `src/mcp/feishu-mcp-server.ts` - Register tool for stdio MCP server
- `examples/schedules/pr-scanner.example.md` - Update with Phase 2 instructions

## Implementation Status

| Phase | 功能 | 状态 |
|-------|------|------|
| Phase 1 | 基本扫描 + 通知 | ✅ 可用 |
| Phase 2 | 为每个 PR 创建群聊 | ✅ 可用 |
| Phase 3 | 交互式操作按钮 | ❌ 不计划实现 |

## Test Plan

- [x] Build passes: `npm run build`
- [x] All MCP tests pass: `npx vitest run src/mcp`
- [x] Lint passes for new files

Fixes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)