### PR TITLE
feat(ruliu): add command handling support (Issue #725 Phase 3)

### DIFF
--- a/src/channels/ruliu-channel-command.test.ts
+++ b/src/channels/ruliu-channel-command.test.ts
@@ -46,8 +46,9 @@ describe('RuliuChannel Command Handling', () => {
 
     // Track sent messages
     sentMessages = [];
-    channel.onMessage(async (msg) => {
+    channel.onMessage((_msg): Promise<void> => {
       // Message handler (not used in command tests)
+      return Promise.resolve();
     });
 
     return channel;
@@ -73,10 +74,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should handle /reset command', async () => {
-      // Intercept sendMessage
-      const originalSendMessage = channel.sendMessage.bind(channel);
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       // Simulate receiving a /reset message
@@ -98,8 +98,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should handle /status command', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -119,8 +120,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should handle /help command', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -141,8 +143,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should show unknown command message for unrecognized commands', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -162,8 +165,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should handle commands in group chat', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -190,22 +194,23 @@ describe('RuliuChannel Command Handling', () => {
       createChannel();
 
       // Set up control handler
-      controlHandler = vi.fn(async (cmd): Promise<ControlResponse> => {
+      controlHandler = vi.fn((cmd): Promise<ControlResponse> => {
         if (cmd.type === 'reset') {
-          return { success: true, message: 'Custom reset message from handler' };
+          return Promise.resolve({ success: true, message: 'Custom reset message from handler' });
         }
         if (cmd.type === 'status') {
-          return { success: true, message: 'Custom status from handler' };
+          return Promise.resolve({ success: true, message: 'Custom status from handler' });
         }
-        return { success: false, error: 'Unknown command' };
+        return Promise.resolve({ success: false, error: 'Unknown command' });
       });
 
       channel.onControl(controlHandler);
     });
 
     it('should use control handler for /reset command', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -230,8 +235,9 @@ describe('RuliuChannel Command Handling', () => {
     });
 
     it('should show unknown command when control handler returns failure', async () => {
-      vi.spyOn(channel, 'sendMessage').mockImplementation(async (msg) => {
+      vi.spyOn(channel, 'sendMessage').mockImplementation((msg) => {
         sentMessages.push({ chatId: msg.chatId, type: msg.type, text: msg.text });
+        return Promise.resolve();
       });
 
       const event = {
@@ -257,8 +263,9 @@ describe('RuliuChannel Command Handling', () => {
 
     it('should pass non-command messages to message handler', async () => {
       let receivedMessage: unknown = null;
-      channel.onMessage(async (msg) => {
+      channel.onMessage((msg): Promise<void> => {
         receivedMessage = msg;
+        return Promise.resolve();
       });
 
       const event = {

--- a/src/channels/ruliu-channel.ts
+++ b/src/channels/ruliu-channel.ts
@@ -15,6 +15,7 @@ import type {
   OutgoingMessage,
   ChannelCapabilities,
   IncomingMessage,
+  ControlCommandType,
 } from './types.js';
 import {
   RuliuMessageSender,
@@ -318,7 +319,7 @@ export class RuliuChannel extends BaseChannel<RuliuChannelConfig> {
       // Try to handle as control command
       if (this.controlHandler) {
         const response = await this.emitControl({
-          type: cmd,
+          type: cmd as ControlCommandType,
           chatId,
           data: { args, rawText: text, senderId: event.fromuser },
         });


### PR DESCRIPTION
## Summary

Implements Phase 3 command handling for the Ruliu platform adapter:

- **Command Detection**: Automatically detect messages starting with `/`
- **Control Handler Integration**: Support for external control handler via `onControl()`
- **Default Commands**: Built-in handling for `/reset`, `/status`, `/help`
- **Unknown Command Handling**: Friendly error message with help suggestion

## Changes

| File | Change |
|------|--------|
| `src/channels/ruliu-channel.ts` | Add command handling logic in `handleMessageEvent()` |
| `src/channels/ruliu-channel-command.test.ts` | New: Test coverage for command handling |

## Features

- ✅ Command parsing from message text
- ✅ Integration with ControlHandler for custom commands
- ✅ Default `/reset`, `/status`, `/help` commands
- ✅ Unknown command error handling
- ✅ Support for both direct and group chat

## Test Results

- ✅ All 8 command handling tests pass
- ✅ All 4 ruliu-crypto tests pass
- ✅ TypeScript compilation successful

## Related

- Issue #725: feat: 如流(Ruliu)平台适配器集成
- Completes Phase 3: Channel 集成 - 命令处理

## Test plan

- [x] Run `npm run build` - Build successful
- [x] Run `npx vitest run src/channels/ruliu-channel-command.test.ts` - 8 tests pass
- [x] Run `npx vitest run src/platforms/ruliu/ruliu-crypto.test.ts` - 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)