### PR TITLE
fix(test): increase timeout for TaskFileWatcher tests in CI environments

### DIFF
--- a/src/task/task-file-watcher.test.ts
+++ b/src/task/task-file-watcher.test.ts
@@ -118,7 +118,8 @@ const simulateFileCreation = (dirName: string, content: string) => {
 };
 
 // Helper to wait for callback to be called
-const waitForCallback = (fn: ReturnType<typeof vi.fn>, timeout = 3000) => {
+// Increased default timeout from 3000ms to 5000ms for CI environments (Issue #980)
+const waitForCallback = (fn: ReturnType<typeof vi.fn>, timeout = 5000) => {
   return new Promise<void>((resolve, reject) => {
     const startTime = Date.now();
     const check = () => {
@@ -223,8 +224,9 @@ describe('TaskFileWatcher', () => {
       });
 
       await watcher.start();
-      // Wait for initial scan to complete
-      await new Promise(resolve => setTimeout(resolve, 50));
+      // Wait for initial scan to complete and mainLoop to enter waitForNewTask state
+      // Increased from 50ms to 100ms to prevent timeout in CI environments (Issue #980)
+      await new Promise(resolve => setTimeout(resolve, 100));
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary

- Increased `beforeEach` wait time from 50ms to 100ms to allow `mainLoop` to enter `waitForNewTask` state before test operations
- Increased `waitForCallback` default timeout from 3000ms to 5000ms to accommodate slower CI environments

## Root Cause Analysis

The test "should not process the same file twice" was timing out in CI environments due to a race condition:

1. The `beforeEach` hook only waited 50ms after starting the watcher
2. In CI environments with higher load, 50ms may not be enough for `mainLoop` to complete initial scan and enter `waitForNewTask` state
3. When `simulateFileCreation` was called before `watchCallback` was set, the callback was never triggered
4. This caused `waitForCallback` to hang until the test framework's 10000ms timeout

## Test Results

All 1666 tests pass locally:
```
 Test Files  91 passed (91)
      Tests  1666 passed (1666)
```

Fixes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)