### PR TITLE
fix(mcp): remove module-load IPC server startup to prevent test timeout

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -14,8 +14,6 @@ import {
   send_interactive_message,
   setMessageSentCallback,
 } from './tools/index.js';
-import { startIpcServer } from './tools/interactive-message.js';
-
 // Re-export for backward compatibility
 export type { MessageSentCallback } from './tools/types.js';
 export { setMessageSentCallback };
@@ -27,14 +25,10 @@ export {
   send_interactive_message,
   generateInteractionPrompt,
   getActionPrompts,
+  startIpcServer,
+  stopIpcServer,
+  isIpcServerRunning,
 } from './tools/interactive-message.js';
-
-// Start IPC server on module load for cross-process communication
-// This allows the main process to query interactive contexts
-startIpcServer().catch((error) => {
-  // Log error but don't fail - IPC is optional enhancement
-  console.error('[feishu-context-mcp] Failed to start IPC server:', error);
-});
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };


### PR DESCRIPTION
## Summary

- Removed `startIpcServer()` call from module top level in `feishu-context-mcp.ts`
- IPC server is now available via exports but not auto-started
- This fixes test timeout issues in CI environments

## Root Cause Analysis

The test "should export TaskFlowOrchestrator class" was timing out in CI environments due to IPC server startup at module load time.

**Import chain:**
\`\`\`
src/feishu/index.ts 
  → task-flow-orchestrator.ts 
    → task/index.ts 
      → mcp/feishu-context-mcp.ts
\`\`\`

In \`feishu-context-mcp.ts\`, \`startIpcServer()\` was called at module top level. This Unix socket server initialization could be slow in CI environments with high load.

## The Fix

- Remove the \`startIpcServer()\` call from module top level
- IPC server is now available via exports but not auto-started
- Consumers can explicitly call \`startIpcServer()\` when needed
- The local \`generateInteractionPrompt\` function serves as fallback (already implemented in message-handler.ts)

## Test Results

- ✅ All 1666 tests pass
- ✅ \`src/feishu/index.test.ts\` completes in ~12ms (was timing out at 10000ms)

Fixes #979

## Test Plan

- [x] All existing tests pass (1666 tests)
- [x] The specific failing test now passes quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)