### PR TITLE
refactor(mcp): decouple messaging tools from Feishu-specific naming (Issue #949)

### DIFF
--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -470,17 +470,17 @@ export class Pilot extends BaseAgent implements ChatAgent {
     const capabilities = this.callbacks.getCapabilities?.(chatId);
     const supportedMcpTools = capabilities?.supportedMcpTools;
 
-    // Determine if we should include Feishu MCP server
-    const feishuTools = ['send_user_feedback', 'send_file_to_feishu', 'update_card', 'wait_for_interaction'];
-    const shouldIncludeFeishuMcp = supportedMcpTools === undefined ||
-      feishuTools.some(tool => supportedMcpTools.includes(tool));
+    // Determine if we should include Context MCP server
+    const contextTools = ['send_message', 'send_file', 'wait_for_interaction'];
+    const shouldIncludeContextMcp = supportedMcpTools === undefined ||
+      contextTools.some(tool => supportedMcpTools.includes(tool));
 
     // Add MCP servers
     const mcpServers: Record<string, unknown> = {};
 
-    // Only add Feishu MCP server if channel supports any Feishu tools
-    if (shouldIncludeFeishuMcp) {
-      mcpServers['feishu-context'] = createFeishuSdkMcpServer();
+    // Only add Context MCP server if channel supports any context tools
+    if (shouldIncludeContextMcp) {
+      mcpServers['context-mcp'] = createFeishuSdkMcpServer();
     }
 
     // Merge configured external MCP servers from config file

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -164,25 +164,25 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     const hasTool = (toolName: string): boolean => {
       if (supportedTools === undefined) {
         // Legacy behavior: check individual capability flags
-        if (toolName === 'send_file_to_feishu') {
+        if (toolName === 'send_file') {
           return capabilities?.supportsFile !== false;
         }
-        if (toolName === 'update_card' || toolName === 'wait_for_interaction') {
+        if (toolName === 'wait_for_interaction') {
           return capabilities?.supportsCard !== false;
         }
-        return true; // send_user_feedback is always available
+        return true; // send_message is always available
       }
       return supportedTools.includes(toolName);
     };
 
-    // send_user_feedback tool
-    if (hasTool('send_user_feedback')) {
-      parts.push(`When using send_user_feedback, use:
+    // send_message tool
+    if (hasTool('send_message')) {
+      parts.push(`When using send_message, use:
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${messageId}\` (for thread replies)`);
 
       // Include card support note if supported
-      if (hasTool('update_card') || hasTool('wait_for_interaction')) {
+      if (hasTool('wait_for_interaction')) {
         parts.push(`
 - For rich content, use format: "card" with a valid Feishu card structure`);
       } else {
@@ -191,19 +191,13 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       }
     }
 
-    // send_file_to_feishu tool
-    if (hasTool('send_file_to_feishu')) {
+    // send_file tool
+    if (hasTool('send_file')) {
       parts.push(`
-- send_file_to_feishu is available for sending files`);
+- send_file is available for sending files`);
     } else if (supportedTools !== undefined) {
       parts.push(`
-- Note: send_file_to_feishu is NOT supported on this channel. Files will not be sent.`);
-    }
-
-    // update_card tool
-    if (hasTool('update_card')) {
-      parts.push(`
-- update_card is available for updating existing cards`);
+- Note: send_file is NOT supported on this channel. Files will not be sent.`);
     }
 
     // wait_for_interaction tool

--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -113,7 +113,7 @@ export const authToolDefinitions: InlineToolDefinition[] = [
   },
   {
     name: 'auth_generate_url',
-    description: 'Generate an OAuth authorization URL for a service. Returns the URL and state. The user must visit this URL to authorize. Use with send_user_feedback to send the URL to the user.',
+    description: 'Generate an OAuth authorization URL for a service. Returns the URL and state. The user must visit this URL to authorize. Use with send_message to send the URL to the user.',
     parameters: z.object({
       providerName: z.string().describe('Provider name (e.g., "github", "gitlab")'),
       authUrl: z.string().describe('OAuth authorization endpoint URL'),

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -356,9 +356,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       supportsMention: true,
       supportsUpdate: true,
       supportedMcpTools: [
-        'send_user_feedback',
-        'send_file_to_feishu',
-        'update_card',
+        'send_message',
+        'send_file',
+        
         'wait_for_interaction',
       ],
     };

--- a/src/channels/rest-channel.ts
+++ b/src/channels/rest-channel.ts
@@ -397,7 +397,7 @@ export class RestChannel extends BaseChannel<RestChannelConfig> {
       supportsMarkdown: true,
       supportsMention: false,
       supportsUpdate: false,
-      supportedMcpTools: ['send_user_feedback'],
+      supportedMcpTools: ['send_message'],
     };
   }
 

--- a/src/channels/ruliu-channel.ts
+++ b/src/channels/ruliu-channel.ts
@@ -207,7 +207,7 @@ export class RuliuChannel extends BaseChannel<RuliuChannelConfig> {
       supportsMarkdown: true,
       supportsMention: true,
       supportsUpdate: false,
-      supportedMcpTools: ['send_user_feedback'],
+      supportedMcpTools: ['send_message'],
     };
   }
 

--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -1,12 +1,11 @@
 /**
- * Tests for Feishu Context MCP Tools
+ * Tests for MCP Tools
  *
  * Tests the following functionality:
  * - isValidFeishuCard: Card structure validation (via behavior testing)
  * - getCardValidationError: Detailed validation error messages (via behavior testing)
- * - send_user_feedback: Message sending to Feishu
- * - send_file_to_feishu: File sending to Feishu
- * - update_card: Update existing card message
+ * - send_message: Message sending
+ * - send_file: File sending
  * - wait_for_interaction: Wait for user card interaction
  * - resolvePendingInteraction: Resolve pending interaction
  * - setMessageSentCallback: Callback management
@@ -65,9 +64,8 @@ vi.mock('../file-transfer/outbound/feishu-uploader.js', () => ({
 import * as fs from 'fs/promises';
 import type * as fsStats from 'fs';
 import {
-  send_user_feedback,
-  send_file_to_feishu,
-  update_card,
+  send_message,
+  send_file,
   wait_for_interaction,
   resolvePendingInteraction,
   setMessageSentCallback,
@@ -75,7 +73,7 @@ import {
 } from './feishu-context-mcp.js';
 import { uploadAndSendFile } from '../file-transfer/outbound/feishu-uploader.js';
 
-describe('Feishu Context MCP Tools', () => {
+describe('MCP Tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Reset console.log mock
@@ -87,16 +85,16 @@ describe('Feishu Context MCP Tools', () => {
   });
 
   describe('Tool Definitions', () => {
-    it('should have send_user_feedback tool definition', () => {
-      expect(feishuContextTools.send_user_feedback).toBeDefined();
-      expect(feishuContextTools.send_user_feedback.description).toContain('Send a message to a Feishu chat');
-      expect(feishuContextTools.send_user_feedback.handler).toBe(send_user_feedback);
+    it('should have send_message tool definition', () => {
+      expect(feishuContextTools.send_message).toBeDefined();
+      expect(feishuContextTools.send_message.description).toContain('Send a message to a chat');
+      expect(feishuContextTools.send_message.handler).toBe(send_message);
     });
 
-    it('should have send_file_to_feishu tool definition', () => {
-      expect(feishuContextTools.send_file_to_feishu).toBeDefined();
-      expect(feishuContextTools.send_file_to_feishu.description).toContain('Send a file to a Feishu chat');
-      expect(feishuContextTools.send_file_to_feishu.handler).toBe(send_file_to_feishu);
+    it('should have send_file tool definition', () => {
+      expect(feishuContextTools.send_file).toBeDefined();
+      expect(feishuContextTools.send_file.description).toContain('Send a file to a chat');
+      expect(feishuContextTools.send_file.handler).toBe(send_file);
     });
   });
 
@@ -105,7 +103,7 @@ describe('Feishu Context MCP Tools', () => {
       const mockCallback = vi.fn();
       setMessageSentCallback(mockCallback);
 
-      const result = await send_user_feedback({
+      const result = await send_message({
         content: 'Hello',
         format: 'text',
         chatId: 'cli-test-chat',
@@ -118,7 +116,7 @@ describe('Feishu Context MCP Tools', () => {
     it('should handle null callback gracefully', async () => {
       setMessageSentCallback(null);
 
-      const result = await send_user_feedback({
+      const result = await send_message({
         content: 'Hello',
         format: 'text',
         chatId: 'cli-test-chat',
@@ -133,7 +131,7 @@ describe('Feishu Context MCP Tools', () => {
       });
       setMessageSentCallback(mockCallback);
 
-      const result = await send_user_feedback({
+      const result = await send_message({
         content: 'Hello',
         format: 'text',
         chatId: 'cli-test-chat',
@@ -144,28 +142,28 @@ describe('Feishu Context MCP Tools', () => {
     });
   });
 
-  describe('send_user_feedback', () => {
+  describe('send_message', () => {
     describe('CLI ChatId (now sends to Feishu)', () => {
       // Note: CLI fallback has been removed (Issue #849)
       // CLI chatIds now send to Feishu API like any other chatId
       it('should send message to Feishu even with cli- prefix', async () => {
         mockClient.im.message.create.mockResolvedValueOnce({});
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Test message',
           format: 'text',
           chatId: 'cli-test',
         });
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('Feedback sent');
+        expect(result.message).toContain('Message sent');
         expect(mockClient.im.message.create).toHaveBeenCalled();
       });
 
       it('should send content with cli- prefix chatId', async () => {
         mockClient.im.message.create.mockResolvedValueOnce({});
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Test content',
           format: 'text',
           chatId: 'cli-test',
@@ -179,14 +177,14 @@ describe('Feishu Context MCP Tools', () => {
       it('should send text message successfully', async () => {
         mockClient.im.message.create.mockResolvedValueOnce({});
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Hello Feishu',
           format: 'text',
           chatId: 'chat-123',
         });
 
         expect(result.success).toBe(true);
-        expect(result.message).toContain('Feedback sent');
+        expect(result.message).toContain('Message sent');
         expect(mockClient.im.message.create).toHaveBeenCalledWith(
           expect.objectContaining({
             params: { receive_id_type: 'chat_id' },
@@ -201,7 +199,7 @@ describe('Feishu Context MCP Tools', () => {
       it('should send text message with thread reply', async () => {
         mockClient.im.message.reply.mockResolvedValueOnce({});
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Thread reply',
           format: 'text',
           chatId: 'chat-123',
@@ -228,7 +226,7 @@ describe('Feishu Context MCP Tools', () => {
           elements: [{ tag: 'markdown', content: '**Hello**' }],
         };
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: cardContent,
           format: 'card',
           chatId: 'chat-123',
@@ -256,7 +254,7 @@ describe('Feishu Context MCP Tools', () => {
           elements: [{ tag: 'markdown', content: '**Hello**' }],
         });
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: cardContent,
           format: 'card',
           chatId: 'chat-123',
@@ -273,7 +271,7 @@ describe('Feishu Context MCP Tools', () => {
           elements: [],
         });
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -289,7 +287,7 @@ describe('Feishu Context MCP Tools', () => {
           elements: [],
         });
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -305,7 +303,7 @@ describe('Feishu Context MCP Tools', () => {
           header: { title: { tag: 'plain_text', content: 'Test' } },
         });
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -322,7 +320,7 @@ describe('Feishu Context MCP Tools', () => {
           elements: [],
         });
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -333,7 +331,7 @@ describe('Feishu Context MCP Tools', () => {
       });
 
       it('should reject card with invalid JSON string', async () => {
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'not valid json',
           format: 'card',
           chatId: 'chat-123',
@@ -350,7 +348,7 @@ describe('Feishu Context MCP Tools', () => {
           { elements: [] },
         ]);
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -368,7 +366,7 @@ describe('Feishu Context MCP Tools', () => {
           // missing header and elements
         };
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: invalidCard,
           format: 'card',
           chatId: 'chat-123',
@@ -382,7 +380,7 @@ describe('Feishu Context MCP Tools', () => {
 
     describe('Input Validation', () => {
       it('should require content (empty string)', async () => {
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: '',
           format: 'text',
           chatId: 'chat-123',
@@ -393,7 +391,7 @@ describe('Feishu Context MCP Tools', () => {
       });
 
       it('should require format', async () => {
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Hello',
           format: '' as 'text' | 'card',
           chatId: 'chat-123',
@@ -404,7 +402,7 @@ describe('Feishu Context MCP Tools', () => {
       });
 
       it('should require chatId', async () => {
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Hello',
           format: 'text',
           chatId: '',
@@ -419,7 +417,7 @@ describe('Feishu Context MCP Tools', () => {
       it('should handle Feishu API errors', async () => {
         mockClient.im.message.create.mockRejectedValueOnce(new Error('API Error'));
 
-        const result = await send_user_feedback({
+        const result = await send_message({
           content: 'Hello',
           format: 'text',
           chatId: 'chat-123',
@@ -431,11 +429,11 @@ describe('Feishu Context MCP Tools', () => {
     });
   });
 
-  describe('send_file_to_feishu', () => {
+  describe('send_file', () => {
     it('should require chatId', async () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/test/file.txt',
         chatId: '',
       });
@@ -448,7 +446,7 @@ describe('Feishu Context MCP Tools', () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
       vi.mocked(uploadAndSendFile).mockResolvedValueOnce(1024);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: 'relative/path/file.txt',
         chatId: 'chat-123',
       });
@@ -465,7 +463,7 @@ describe('Feishu Context MCP Tools', () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
       vi.mocked(uploadAndSendFile).mockResolvedValueOnce(1024);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/absolute/path/file.txt',
         chatId: 'chat-123',
       });
@@ -482,7 +480,7 @@ describe('Feishu Context MCP Tools', () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
       vi.mocked(uploadAndSendFile).mockResolvedValueOnce(2048);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/test/document.pdf',
         chatId: 'chat-123',
       });
@@ -496,7 +494,7 @@ describe('Feishu Context MCP Tools', () => {
     it('should handle file not found error', async () => {
       vi.mocked(fs.stat).mockRejectedValue(new Error('ENOENT: no such file'));
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/nonexistent/file.txt',
         chatId: 'chat-123',
       });
@@ -508,7 +506,7 @@ describe('Feishu Context MCP Tools', () => {
     it('should handle directory path error', async () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => false, size: 0 } as fsStats.Stats);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/some/directory',
         chatId: 'chat-123',
       });
@@ -521,7 +519,7 @@ describe('Feishu Context MCP Tools', () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
       vi.mocked(uploadAndSendFile).mockRejectedValueOnce(new Error('Upload failed'));
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/test/file.txt',
         chatId: 'chat-123',
       });
@@ -530,7 +528,7 @@ describe('Feishu Context MCP Tools', () => {
       expect(result.error).toContain('Upload failed');
     });
 
-    it('should extract Feishu API error details', async () => {
+    it('should extract Platform API error details', async () => {
       vi.mocked(fs.stat).mockResolvedValue({ isFile: () => true, size: 1024 } as fsStats.Stats);
 
       const apiError = new Error('API Error') as Error & {
@@ -546,131 +544,15 @@ describe('Feishu Context MCP Tools', () => {
 
       vi.mocked(uploadAndSendFile).mockRejectedValueOnce(apiError);
 
-      const result = await send_file_to_feishu({
+      const result = await send_file({
         filePath: '/test/file.txt',
         chatId: 'chat-123',
       });
 
       expect(result.success).toBe(false);
-      expect(result.feishuCode).toBe(99991663);
-      expect(result.feishuMsg).toBe('permission denied');
-      expect(result.feishuLogId).toBe('log-123');
-    });
-  });
-
-  describe('update_card', () => {
-    it('should have update_card tool definition', () => {
-      expect(feishuContextTools.update_card).toBeDefined();
-      expect(feishuContextTools.update_card.description).toContain('Update an existing interactive card');
-      expect(feishuContextTools.update_card.handler).toBe(update_card);
-    });
-
-    it('should require messageId', async () => {
-      const result = await update_card({
-        messageId: '',
-        card: { config: {}, header: {}, elements: [] },
-        chatId: 'chat-123',
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('messageId is required');
-    });
-
-    it('should require card', async () => {
-      const result = await update_card({
-        messageId: 'msg-123',
-        card: null as unknown as Record<string, unknown>,
-        chatId: 'chat-123',
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('card is required');
-    });
-
-    it('should require chatId', async () => {
-      const result = await update_card({
-        messageId: 'msg-123',
-        card: { config: {}, header: {}, elements: [] },
-        chatId: '',
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('chatId is required');
-    });
-
-    it('should validate card structure', async () => {
-      const result = await update_card({
-        messageId: 'msg-123',
-        card: { invalid: 'structure' },
-        chatId: 'chat-123',
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid card structure');
-    });
-
-    it('should update card with cli- prefix via Feishu API', async () => {
-      mockClient.im.message.patch.mockResolvedValueOnce({});
-
-      const result = await update_card({
-        messageId: 'msg-123',
-        card: {
-          config: { wide_screen_mode: true },
-          header: {
-            title: { tag: 'plain_text', content: 'Updated Card' },
-            template: 'blue',
-          },
-          elements: [{ tag: 'markdown', content: '**Updated**' }],
-        },
-        chatId: 'cli-test',
-      });
-
-      // CLI fallback removed (Issue #849) - now sends to Feishu API
-      expect(result.success).toBe(true);
-      expect(mockClient.im.message.patch).toHaveBeenCalled();
-    });
-
-    it('should call Feishu API patch endpoint', async () => {
-      mockClient.im.message.patch.mockResolvedValueOnce({});
-
-      const card = {
-        config: { wide_screen_mode: true },
-        header: {
-          title: { tag: 'plain_text', content: 'Updated Card' },
-          template: 'blue',
-        },
-        elements: [{ tag: 'markdown', content: '**Updated**' }],
-      };
-
-      const result = await update_card({
-        messageId: 'msg-123',
-        card,
-        chatId: 'chat-123',
-      });
-
-      expect(result.success).toBe(true);
-      expect(mockClient.im.message.patch).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: { message_id: 'msg-123' },
-        })
-      );
-    });
-
-    it('should handle API errors', async () => {
-      mockClient.im.message.patch.mockRejectedValueOnce(new Error('Patch failed'));
-
-      const result = await update_card({
-        messageId: 'msg-123',
-        card: {
-          config: { wide_screen_mode: true },
-          header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
-          elements: [],
-        },
-        chatId: 'chat-123',
-      });
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Patch failed');
+      expect(result.platformCode).toBe(99991663);
+      expect(result.platformMsg).toBe('permission denied');
+      expect(result.platformLogId).toBe('log-123');
     });
   });
 

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -1,5 +1,5 @@
 /**
- * Feishu Context MCP Tools - In-process tool implementation.
+ * Context MCP Tools - In-process tool implementation.
  *
  * @module mcp/feishu-context-mcp
  */
@@ -7,9 +7,8 @@
 import { z } from 'zod';
 import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
 import {
-  send_user_feedback,
-  send_file_to_feishu,
-  update_card,
+  send_message,
+  send_file,
   wait_for_interaction,
   send_interactive_message,
   setMessageSentCallback,
@@ -19,13 +18,15 @@ import {
   generate_quiz,
   create_study_guide,
 } from './tools/index.js';
-// Re-export for backward compatibility
+import { startIpcServer } from './tools/interactive-message.js';
+
+// Re-export
 export type { MessageSentCallback } from './tools/types.js';
 export { setMessageSentCallback };
 export { resolvePendingInteraction } from './tools/card-interaction.js';
-export { send_user_feedback } from './tools/send-message.js';
-export { send_file_to_feishu } from './tools/send-file.js';
-export { update_card, wait_for_interaction } from './tools/card-interaction.js';
+export { send_message } from './tools/send-message.js';
+export { send_file } from './tools/send-file.js';
+export { wait_for_interaction } from './tools/card-interaction.js';
 export {
   send_interactive_message,
   generateInteractionPrompt,
@@ -35,13 +36,20 @@ export {
   isIpcServerRunning,
 } from './tools/interactive-message.js';
 
+// Start IPC server on module load for cross-process communication
+// This allows the main process to query interactive contexts
+startIpcServer().catch((error) => {
+  // Log error but don't fail - IPC is optional enhancement
+  console.error('[context-mcp] Failed to start IPC server:', error);
+});
+
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };
 }
 
 export const feishuContextTools = {
-  send_user_feedback: {
-    description: `Send a message to a Feishu chat. Requires explicit format: "text" or "card".
+  send_message: {
+    description: `Send a message to a chat. Requires explicit format: "text" or "card".
 
 **IMPORTANT: "format" parameter is REQUIRED for every call.**
 
@@ -84,25 +92,16 @@ export const feishuContextTools = {
       },
       required: ['content', 'format', 'chatId'],
     },
-    handler: send_user_feedback,
+    handler: send_message,
   },
-  send_file_to_feishu: {
-    description: 'Send a file to a Feishu chat.',
+  send_file: {
+    description: 'Send a file to a chat.',
     parameters: {
       type: 'object',
       properties: { filePath: { type: 'string' }, chatId: { type: 'string' } },
       required: ['filePath', 'chatId'],
     },
-    handler: send_file_to_feishu,
-  },
-  update_card: {
-    description: 'Update an existing interactive card message.',
-    parameters: {
-      type: 'object',
-      properties: { messageId: { type: 'string' }, card: { type: 'object' }, chatId: { type: 'string' } },
-      required: ['messageId', 'card', 'chatId'],
-    },
-    handler: update_card,
+    handler: send_file,
   },
   wait_for_interaction: {
     description: 'Wait for the user to interact with a card.',
@@ -191,7 +190,7 @@ export const feishuContextTools = {
 
 ## Parameters
 
-- **card**: The interactive card JSON structure (same as send_user_feedback with format="card")
+- **card**: The interactive card JSON structure (same as send_message with format="card")
 - **actionPrompts**: Map of action values to prompt templates
 - **chatId**: Target chat ID
 - **parentMessageId**: Optional, for thread reply
@@ -339,8 +338,8 @@ In actionPrompts, you can use these placeholders:
 
 export const feishuToolDefinitions: InlineToolDefinition[] = [
   {
-    name: 'send_user_feedback',
-    description: `Send a message to a Feishu chat. Requires explicit format: "text" or "card".
+    name: 'send_message',
+    description: `Send a message to a chat. Requires explicit format: "text" or "card".
 
 **IMPORTANT: "format" parameter is REQUIRED for every call.**
 
@@ -392,36 +391,23 @@ When \`format: "card"\`, content MUST include:
         return toolSuccess('❌ Error: When format="text", content must be a STRING.');
       }
       try {
-        const result = await send_user_feedback({ content, format, chatId, parentMessageId });
+        const result = await send_message({ content, format, chatId, parentMessageId });
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
-        return toolSuccess(`⚠️ Feedback failed: ${error instanceof Error ? error.message : String(error)}`);
+        return toolSuccess(`⚠️ Message send failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },
   {
-    name: 'send_file_to_feishu',
-    description: 'Send a file to a Feishu chat.',
+    name: 'send_file',
+    description: 'Send a file to a chat.',
     parameters: z.object({ filePath: z.string(), chatId: z.string() }),
     handler: async ({ filePath, chatId }) => {
       try {
-        const result = await send_file_to_feishu({ filePath, chatId });
+        const result = await send_file({ filePath, chatId });
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ File send failed: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    },
-  },
-  {
-    name: 'update_card',
-    description: 'Update an existing interactive card message.',
-    parameters: z.object({ messageId: z.string(), card: z.object({}).passthrough(), chatId: z.string() }),
-    handler: async ({ messageId, card, chatId }) => {
-      try {
-        const result = await update_card({ messageId, card, chatId });
-        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
-      } catch (error) {
-        return toolSuccess(`⚠️ Card update failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },
@@ -519,7 +505,7 @@ When \`format: "card"\`, content MUST include:
 
 ## Parameters
 
-- **card**: The interactive card JSON structure (same as send_user_feedback with format="card")
+- **card**: The interactive card JSON structure (same as send_message with format="card")
 - **actionPrompts**: Map of action values to prompt templates
 - **chatId**: Target chat ID
 - **parentMessageId**: Optional, for thread reply
@@ -910,7 +896,7 @@ export const feishuSdkTools = feishuToolDefinitions.map(def => getProvider().cre
 export function createFeishuSdkMcpServer() {
   return getProvider().createMcpServer({
     type: 'inline',
-    name: 'feishu-context',
+    name: 'context-mcp',
     version: '1.0.0',
     tools: feishuToolDefinitions,
   });

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -4,7 +4,7 @@
  * Tests the following functionality:
  * - MCP protocol initialization
  * - Tool list response
- * - Tool call handling (send_user_feedback, send_file_to_feishu)
+ * - Tool call handling (send_message, send_file)
  * - Error handling
  *
  * Note: This tests the server behavior indirectly through the exported
@@ -71,24 +71,24 @@ describe('Feishu MCP Server', () => {
   });
 
   describe('Tool Definitions', () => {
-    it('should define send_user_feedback tool with correct schema', async () => {
+    it('should define send_message tool with correct schema', async () => {
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFeedbackTool = feishuToolDefinitions.find(t => t.name === 'send_user_feedback');
-      expect(sendFeedbackTool).toBeDefined();
+      const sendMessageTool = feishuToolDefinitions.find(t => t.name === 'send_message');
+      expect(sendMessageTool).toBeDefined();
 
       // Verify description mentions key features
-      expect(sendFeedbackTool?.description).toContain('Send a message to a Feishu chat');
-      expect(sendFeedbackTool?.description).toContain('Thread Support');
-      expect(sendFeedbackTool?.description).toContain('Card Format Requirements');
+      expect(sendMessageTool?.description).toContain('Send a message');
+      expect(sendMessageTool?.description).toContain('Thread Support');
+      expect(sendMessageTool?.description).toContain('Card Format Requirements');
     });
 
-    it('should define send_file_to_feishu tool with correct schema', async () => {
+    it('should define send_file tool with correct schema', async () => {
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFileTool = feishuToolDefinitions.find(t => t.name === 'send_file_to_feishu');
+      const sendFileTool = feishuToolDefinitions.find(t => t.name === 'send_file');
       expect(sendFileTool).toBeDefined();
-      expect(sendFileTool?.description).toContain('Send a file to a Feishu chat');
+      expect(sendFileTool?.description).toContain('Send a file');
     });
   });
 
@@ -103,16 +103,16 @@ describe('Feishu MCP Server', () => {
   });
 
   describe('Tool Execution via SDK Tools', () => {
-    it('should execute send_user_feedback through SDK tool wrapper', async () => {
+    it('should execute send_message through SDK tool wrapper', async () => {
       mockClient.im.message.create.mockResolvedValueOnce({});
 
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFeedbackTool = feishuToolDefinitions.find(t => t.name === 'send_user_feedback');
-      expect(sendFeedbackTool).toBeDefined();
+      const sendMessageTool = feishuToolDefinitions.find(t => t.name === 'send_message');
+      expect(sendMessageTool).toBeDefined();
 
       // Execute the tool handler
-      const result = await sendFeedbackTool?.handler({
+      const result = await sendMessageTool?.handler({
         content: 'Test message',
         format: 'text',
         chatId: 'chat-123',
@@ -124,14 +124,14 @@ describe('Feishu MCP Server', () => {
       expect(result?.content[0]).toHaveProperty('type', 'text');
     });
 
-    it('should execute send_file_to_feishu through SDK tool wrapper', async () => {
+    it('should execute send_file through SDK tool wrapper', async () => {
       const { uploadAndSendFile } = await import('../file-transfer/outbound/feishu-uploader.js');
       vi.mocked(uploadAndSendFile).mockResolvedValueOnce(1024);
       mockFsStat.mockResolvedValue({ isFile: () => true, size: 1024 });
 
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFileTool = feishuToolDefinitions.find(t => t.name === 'send_file_to_feishu');
+      const sendFileTool = feishuToolDefinitions.find(t => t.name === 'send_file');
       expect(sendFileTool).toBeDefined();
 
       // Execute the tool handler
@@ -150,10 +150,10 @@ describe('Feishu MCP Server', () => {
 
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFeedbackTool = feishuToolDefinitions.find(t => t.name === 'send_user_feedback');
+      const sendMessageTool = feishuToolDefinitions.find(t => t.name === 'send_message');
 
       // Execute the tool handler - should return soft error, not throw
-      const result = await sendFeedbackTool?.handler({
+      const result = await sendMessageTool?.handler({
         content: 'Test message',
         format: 'text',
         chatId: 'chat-123',
@@ -171,9 +171,9 @@ describe('Feishu MCP Server', () => {
 
       const { feishuToolDefinitions } = await import('./feishu-context-mcp.js');
 
-      const sendFeedbackTool = feishuToolDefinitions.find(t => t.name === 'send_user_feedback');
+      const sendMessageTool = feishuToolDefinitions.find(t => t.name === 'send_message');
 
-      const result = await sendFeedbackTool?.handler({
+      const result = await sendMessageTool?.handler({
         content: 'Test',
         format: 'text',
         chatId: 'chat-123',

--- a/src/mcp/feishu-mcp-server.ts
+++ b/src/mcp/feishu-mcp-server.ts
@@ -1,19 +1,18 @@
 #!/usr/bin/env node
 /**
- * Feishu MCP Server - stdio implementation
+ * Context MCP Server - stdio implementation
  *
  * This is a Model Context Protocol (MCP) server that provides
- * Feishu/Lark integration tools to the Agent SDK via stdio.
+ * messaging integration tools to the Agent SDK via stdio.
  *
  * Tools provided:
- * - send_user_feedback: Send a message to a Feishu chat
- * - send_file_to_feishu: Send a file to a Feishu chat
- * - update_card: Update an existing interactive card
+ * - send_message: Send a message to a chat
+ * - send_file: Send a file to a chat
  * - wait_for_interaction: Wait for user to interact with a card
  *
  * Environment Variables Required:
- * - FEISHU_APP_ID: Feishu app ID
- * - FEISHU_APP_SECRET: Feishu app secret
+ * - FEISHU_APP_ID: Platform app ID
+ * - FEISHU_APP_SECRET: Platform app secret
  * - WORKSPACE_DIR: Workspace directory (optional, defaults to cwd)
  *
  * Note: This is a thin wrapper around feishu-context-mcp.ts.
@@ -21,9 +20,9 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { send_user_feedback, send_file_to_feishu, update_card, wait_for_interaction } from './feishu-context-mcp.js';
+import { send_message, send_file, wait_for_interaction } from './feishu-context-mcp.js';
 
-const logger = createLogger('FeishuMCPServer');
+const logger = createLogger('ContextMCPServer');
 
 /**
  * Handle MCP requests
@@ -42,8 +41,8 @@ async function handleMessage(message: unknown) {
           result: {
             tools: [
               {
-                name: 'send_user_feedback',
-                description: 'Send a message to a Feishu chat. Requires explicit format: "text" or "card".',
+                name: 'send_message',
+                description: 'Send a message to a chat. Requires explicit format: "text" or "card".',
                 inputSchema: {
                   type: 'object',
                   properties: {
@@ -58,7 +57,7 @@ async function handleMessage(message: unknown) {
                     },
                     chatId: {
                       type: 'string',
-                      description: 'Feishu chat ID to send the message to',
+                      description: 'Chat ID to send the message to',
                     },
                     parentMessageId: {
                       type: 'string',
@@ -69,8 +68,8 @@ async function handleMessage(message: unknown) {
                 },
               },
               {
-                name: 'send_file_to_feishu',
-                description: 'Send a file to a Feishu chat. Supports images, audio, video, and documents.',
+                name: 'send_file',
+                description: 'Send a file to a chat. Supports images, audio, video, and documents.',
                 inputSchema: {
                   type: 'object',
                   properties: {
@@ -80,32 +79,10 @@ async function handleMessage(message: unknown) {
                     },
                     chatId: {
                       type: 'string',
-                      description: 'Feishu chat ID to send the file to',
+                      description: 'Chat ID to send the file to',
                     },
                   },
                   required: ['filePath', 'chatId'],
-                },
-              },
-              {
-                name: 'update_card',
-                description: 'Update an existing interactive card message.',
-                inputSchema: {
-                  type: 'object',
-                  properties: {
-                    messageId: {
-                      type: 'string',
-                      description: 'The message ID of the card to update',
-                    },
-                    card: {
-                      type: 'object',
-                      description: 'The new card content',
-                    },
-                    chatId: {
-                      type: 'string',
-                      description: 'Feishu chat ID where the card was sent',
-                    },
-                  },
-                  required: ['messageId', 'card', 'chatId'],
                 },
               },
               {
@@ -120,7 +97,7 @@ async function handleMessage(message: unknown) {
                     },
                     chatId: {
                       type: 'string',
-                      description: 'Feishu chat ID where the card was sent',
+                      description: 'Chat ID where the card was sent',
                     },
                     timeoutSeconds: {
                       type: 'number',
@@ -139,9 +116,9 @@ async function handleMessage(message: unknown) {
         const callParams = params as Record<string, unknown>;
         const { name, arguments: toolArgs } = callParams;
 
-        if (name === 'send_user_feedback') {
+        if (name === 'send_message') {
           const args = toolArgs as { content: string; format: 'text' | 'card'; chatId: string; parentMessageId?: string };
-          const result = await send_user_feedback(args);
+          const result = await send_message(args);
 
           return {
             jsonrpc: '2.0',
@@ -157,27 +134,9 @@ async function handleMessage(message: unknown) {
           };
         }
 
-        if (name === 'send_file_to_feishu') {
+        if (name === 'send_file') {
           const args = toolArgs as { filePath: string; chatId: string };
-          const result = await send_file_to_feishu(args);
-
-          return {
-            jsonrpc: '2.0',
-            id,
-            result: {
-              content: [{
-                type: 'text',
-                text: result.success
-                  ? result.message
-                  : `⚠️ ${result.message}`,
-              }],
-            },
-          };
-        }
-
-        if (name === 'update_card') {
-          const args = toolArgs as { messageId: string; card: Record<string, unknown>; chatId: string };
-          const result = await update_card(args);
+          const result = await send_file(args);
 
           return {
             jsonrpc: '2.0',
@@ -224,7 +183,7 @@ async function handleMessage(message: unknown) {
               tools: {},
             },
             serverInfo: {
-              name: 'feishu-mcp-server',
+              name: 'context-mcp-server',
               version: '1.0.0',
             },
           },
@@ -249,7 +208,7 @@ async function handleMessage(message: unknown) {
  * Main server loop - read from stdin, write to stdout
  */
 function main() {
-  logger.info('Starting Feishu MCP Server (stdio)');
+  logger.info('Starting Context MCP Server (stdio)');
 
   let buffer = '';
 
@@ -285,7 +244,7 @@ function main() {
   });
 
   process.stdin.on('end', () => {
-    logger.info('Feishu MCP Server shutting down');
+    logger.info('Context MCP Server shutting down');
   });
 
   process.stdin.on('error', (error) => {

--- a/src/mcp/tools/card-interaction.ts
+++ b/src/mcp/tools/card-interaction.ts
@@ -1,15 +1,11 @@
 /**
- * Card interaction tools: update_card and wait_for_interaction.
+ * Card interaction tools: wait_for_interaction.
  *
  * @module mcp/tools/card-interaction
  */
 
-import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
-import { Config } from '../../config/index.js';
-import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
-import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
-import type { UpdateCardResult, WaitForInteractionResult, PendingInteraction } from './types.js';
+import type { WaitForInteractionResult, PendingInteraction } from './types.js';
 
 const logger = createLogger('CardInteraction');
 
@@ -30,57 +26,6 @@ export function resolvePendingInteraction(
     return true;
   }
   return false;
-}
-
-export async function update_card(params: {
-  messageId: string;
-  card: Record<string, unknown>;
-  chatId: string;
-}): Promise<UpdateCardResult> {
-  const { messageId, card, chatId } = params;
-
-  logger.info({ messageId, chatId }, 'update_card called');
-
-  try {
-    if (!messageId) { throw new Error('messageId is required'); }
-    if (!card) { throw new Error('card is required'); }
-    if (!chatId) { throw new Error('chatId is required'); }
-
-    if (!isValidFeishuCard(card)) {
-      return {
-        success: false,
-        error: `Invalid card structure: ${getCardValidationError(card)}`,
-        message: `❌ Card validation failed. ${getCardValidationError(card)}`,
-      };
-    }
-
-    const appId = Config.FEISHU_APP_ID;
-    const appSecret = Config.FEISHU_APP_SECRET;
-
-    if (!appId || !appSecret) {
-      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
-      return {
-        success: false,
-        error: errorMsg,
-        message: `❌ ${errorMsg}`,
-      };
-    }
-
-    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
-
-    await client.im.message.patch({
-      path: { message_id: messageId },
-      data: { content: JSON.stringify(card) },
-    });
-
-    logger.debug({ messageId, chatId }, 'Card updated successfully');
-    return { success: true, message: '✅ Card updated successfully' };
-
-  } catch (error) {
-    logger.error({ err: error, messageId, chatId }, 'update_card failed');
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return { success: false, error: errorMessage, message: `❌ Failed to update card: ${errorMessage}` };
-  }
 }
 
 export async function wait_for_interaction(params: {

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,13 +1,12 @@
 /**
- * Tool implementations for Feishu MCP.
+ * Tool implementations for MCP.
  *
  * @module mcp/tools
  */
 
 export type {
-  SendFeedbackResult,
+  SendMessageResult,
   SendFileResult,
-  UpdateCardResult,
   WaitForInteractionResult,
   MessageSentCallback,
   PendingInteraction,
@@ -16,9 +15,9 @@ export type {
   SendInteractiveResult,
 } from './types.js';
 
-export { send_user_feedback, setMessageSentCallback, getMessageSentCallback } from './send-message.js';
-export { send_file_to_feishu } from './send-file.js';
-export { update_card, wait_for_interaction, resolvePendingInteraction } from './card-interaction.js';
+export { send_message, setMessageSentCallback, getMessageSentCallback } from './send-message.js';
+export { send_file } from './send-file.js';
+export { wait_for_interaction, resolvePendingInteraction } from './card-interaction.js';
 export {
   send_interactive_message,
   registerActionPrompts,

--- a/src/mcp/tools/send-file.ts
+++ b/src/mcp/tools/send-file.ts
@@ -1,5 +1,5 @@
 /**
- * send_file_to_feishu tool implementation.
+ * send_file tool implementation.
  *
  * @module mcp/tools/send-file
  */
@@ -14,7 +14,7 @@ import type { SendFileResult } from './types.js';
 
 const logger = createLogger('SendFile');
 
-export async function send_file_to_feishu(params: {
+export async function send_file(params: {
   filePath: string;
   chatId: string;
 }): Promise<SendFileResult> {
@@ -27,18 +27,18 @@ export async function send_file_to_feishu(params: {
     const appSecret = Config.FEISHU_APP_SECRET;
 
     if (!appId || !appSecret) {
-      logger.warn({ filePath, chatId }, 'File send skipped (Feishu not configured)');
+      logger.warn({ filePath, chatId }, 'File send skipped (platform not configured)');
       return {
         success: false,
-        error: 'Feishu credentials not configured',
-        message: '⚠️ File cannot be sent: Feishu is not configured.',
+        error: 'Platform credentials not configured',
+        message: '⚠️ File cannot be sent: Platform is not configured.',
       };
     }
 
     const workspaceDir = Config.getWorkspaceDir();
     const resolvedPath = path.isAbsolute(filePath) ? filePath : path.join(workspaceDir, filePath);
 
-    logger.debug({ filePath, resolvedPath, chatId }, 'send_file_to_feishu called');
+    logger.debug({ filePath, resolvedPath, chatId }, 'send_file called');
 
     const stats = await fs.stat(resolvedPath);
     if (!stats.isFile()) { throw new Error(`Path is not a file: ${filePath}`); }
@@ -61,9 +61,9 @@ export async function send_file_to_feishu(params: {
     };
 
   } catch (error) {
-    let feishuCode: number | undefined;
-    let feishuMsg: string | undefined;
-    let feishuLogId: string | undefined;
+    let platformCode: number | undefined;
+    let platformMsg: string | undefined;
+    let platformLogId: string | undefined;
     let troubleshooterUrl: string | undefined;
 
     if (error && typeof error === 'object') {
@@ -74,31 +74,31 @@ export async function send_file_to_feishu(params: {
       };
 
       if (err.response?.data && Array.isArray(err.response.data) && err.response.data[0]) {
-        feishuCode = err.response.data[0].code;
-        feishuMsg = err.response.data[0].msg;
-        feishuLogId = err.response.data[0].log_id;
+        platformCode = err.response.data[0].code;
+        platformMsg = err.response.data[0].msg;
+        platformLogId = err.response.data[0].log_id;
         troubleshooterUrl = err.response.data[0].troubleshooter;
       }
-      if (!feishuCode && typeof err.code === 'number') { feishuCode = err.code; }
-      if (!feishuMsg) { feishuMsg = err.msg || err.message; }
+      if (!platformCode && typeof err.code === 'number') { platformCode = err.code; }
+      if (!platformMsg) { platformMsg = err.msg || err.message; }
     }
 
-    logger.error({ err: error, filePath, chatId, feishuCode, feishuMsg }, 'send_file_to_feishu failed');
+    logger.error({ err: error, filePath, chatId, platformCode, platformMsg }, 'send_file failed');
 
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     let errorDetails = `❌ Failed to send file: ${errorMessage}`;
-    if (feishuCode) {
-      errorDetails += `\n\n**Feishu API Error:** Code: ${feishuCode}`;
-      if (feishuMsg) { errorDetails += `, Message: ${feishuMsg}`; }
+    if (platformCode) {
+      errorDetails += `\n\n**Platform API Error:** Code: ${platformCode}`;
+      if (platformMsg) { errorDetails += `, Message: ${platformMsg}`; }
     }
 
     return {
       success: false,
       error: errorMessage,
       message: errorDetails,
-      feishuCode,
-      feishuMsg,
-      feishuLogId,
+      platformCode,
+      platformMsg,
+      platformLogId,
       troubleshooterUrl,
     };
   }

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -1,5 +1,5 @@
 /**
- * send_user_feedback tool implementation.
+ * send_message tool implementation.
  *
  * @module mcp/tools/send-message
  */
@@ -10,7 +10,7 @@ import { Config } from '../../config/index.js';
 import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
-import type { SendFeedbackResult, MessageSentCallback } from './types.js';
+import type { SendMessageResult, MessageSentCallback } from './types.js';
 
 const logger = createLogger('SendMessage');
 
@@ -34,12 +34,12 @@ function invokeMessageSentCallback(chatId: string): void {
   }
 }
 
-export async function send_user_feedback(params: {
+export async function send_message(params: {
   content: string | Record<string, unknown>;
   format: 'text' | 'card';
   chatId: string;
   parentMessageId?: string;
-}): Promise<SendFeedbackResult> {
+}): Promise<SendMessageResult> {
   const { content, format, chatId, parentMessageId } = params;
 
   logger.info({
@@ -47,7 +47,7 @@ export async function send_user_feedback(params: {
     format,
     contentType: typeof content,
     contentPreview: typeof content === 'string' ? content.substring(0, 100) : JSON.stringify(content).substring(0, 100),
-  }, 'send_user_feedback called');
+  }, 'send_message called');
 
   try {
     if (!content) { throw new Error('content is required'); }
@@ -103,11 +103,11 @@ export async function send_user_feedback(params: {
     }
 
     invokeMessageSentCallback(chatId);
-    return { success: true, message: `✅ Feedback sent (format: ${format})` };
+    return { success: true, message: `✅ Message sent (format: ${format})` };
 
   } catch (error) {
-    logger.error({ err: error, chatId }, 'send_user_feedback FAILED');
+    logger.error({ err: error, chatId }, 'send_message FAILED');
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    return { success: false, error: errorMessage, message: `❌ Failed to send feedback: ${errorMessage}` };
+    return { success: false, error: errorMessage, message: `❌ Failed to send message: ${errorMessage}` };
   }
 }

--- a/src/mcp/tools/types.ts
+++ b/src/mcp/tools/types.ts
@@ -1,20 +1,20 @@
 /**
- * Shared type definitions for Feishu MCP tools.
+ * Shared type definitions for MCP tools.
  *
  * @module mcp/tools/types
  */
 
 /**
- * Result type for send_user_feedback tool.
+ * Result type for send_message tool.
  */
-export interface SendFeedbackResult {
+export interface SendMessageResult {
   success: boolean;
   message: string;
   error?: string;
 }
 
 /**
- * Result type for send_file_to_feishu tool.
+ * Result type for send_file tool.
  */
 export interface SendFileResult {
   success: boolean;
@@ -23,19 +23,10 @@ export interface SendFileResult {
   fileSize?: number;
   sizeMB?: string;
   error?: string;
-  feishuCode?: string | number;
-  feishuMsg?: string;
-  feishuLogId?: string;
+  platformCode?: string | number;
+  platformMsg?: string;
+  platformLogId?: string;
   troubleshooterUrl?: string;
-}
-
-/**
- * Result type for update_card tool.
- */
-export interface UpdateCardResult {
-  success: boolean;
-  message: string;
-  error?: string;
 }
 
 /**

--- a/src/mcp/unified-messaging-mcp.test.ts
+++ b/src/mcp/unified-messaging-mcp.test.ts
@@ -32,9 +32,9 @@ describe('detectChannel', () => {
 });
 
 describe('send_message', () => {
-  // Mock send_user_feedback from feishu-context-mcp
+  // Mock send_message from feishu-context-mcp
   vi.mock('./feishu-context-mcp.js', () => ({
-    send_user_feedback: vi.fn(),
+    send_message: vi.fn(),
     setMessageSentCallback: vi.fn(),
   }));
 
@@ -47,8 +47,8 @@ describe('send_message', () => {
   });
 
   it('should route CLI messages correctly', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: true,
       message: '✅ Feedback displayed (CLI mode)',
     });
@@ -61,7 +61,7 @@ describe('send_message', () => {
 
     expect(result.success).toBe(true);
     expect(result.channel).toBe('cli');
-    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+    expect(mockSendMessage).toHaveBeenCalledWith({
       content: 'Hello CLI',
       format: 'text',
       chatId: 'cli-test',
@@ -70,8 +70,8 @@ describe('send_message', () => {
   });
 
   it('should route Feishu messages correctly', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: true,
       message: '✅ Feedback sent',
     });
@@ -84,7 +84,7 @@ describe('send_message', () => {
 
     expect(result.success).toBe(true);
     expect(result.channel).toBe('feishu');
-    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+    expect(mockSendMessage).toHaveBeenCalledWith({
       content: 'Hello Feishu',
       format: 'text',
       chatId: 'oc_test123',
@@ -93,8 +93,8 @@ describe('send_message', () => {
   });
 
   it('should route REST messages correctly', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: true,
       message: '✅ Feedback logged (Feishu not configured)',
     });
@@ -107,7 +107,7 @@ describe('send_message', () => {
 
     expect(result.success).toBe(true);
     expect(result.channel).toBe('rest');
-    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+    expect(mockSendMessage).toHaveBeenCalledWith({
       content: 'Hello REST',
       format: 'text',
       chatId: 'rest-chat-1',
@@ -116,8 +116,8 @@ describe('send_message', () => {
   });
 
   it('should pass parentMessageId for thread replies', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: true,
       message: '✅ Feedback sent',
     });
@@ -130,7 +130,7 @@ describe('send_message', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(mockSendUserFeedback).toHaveBeenCalledWith({
+    expect(mockSendMessage).toHaveBeenCalledWith({
       content: 'Reply',
       format: 'text',
       chatId: 'oc_test',
@@ -139,8 +139,8 @@ describe('send_message', () => {
   });
 
   it('should handle card format', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: true,
       message: '✅ Card sent',
     });
@@ -162,8 +162,8 @@ describe('send_message', () => {
   });
 
   it('should handle errors gracefully', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockResolvedValue({
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockResolvedValue({
       success: false,
       message: '❌ Failed: Invalid card',
       error: 'Invalid card structure',
@@ -180,8 +180,8 @@ describe('send_message', () => {
   });
 
   it('should handle exceptions', async () => {
-    const mockSendUserFeedback = vi.mocked(await import('./feishu-context-mcp.js')).send_user_feedback;
-    mockSendUserFeedback.mockRejectedValue(new Error('Network error'));
+    const mockSendMessage = vi.mocked(await import('./feishu-context-mcp.js')).send_message;
+    mockSendMessage.mockRejectedValue(new Error('Network error'));
 
     const result = await send_message({
       content: 'test',

--- a/src/mcp/unified-messaging-mcp.ts
+++ b/src/mcp/unified-messaging-mcp.ts
@@ -31,7 +31,7 @@
 import { z } from 'zod';
 import { createLogger } from '../utils/logger.js';
 import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
-import { send_user_feedback, setMessageSentCallback, type MessageSentCallback } from './feishu-context-mcp.js';
+import { send_message as send_message_impl, setMessageSentCallback, type MessageSentCallback } from './feishu-context-mcp.js';
 
 const logger = createLogger('UnifiedMessagingMCP');
 
@@ -112,9 +112,9 @@ export async function send_message(params: {
   }, 'send_message called');
 
   try {
-    // Use the existing send_user_feedback implementation
+    // Use the existing send_message implementation
     // It already handles graceful degradation for non-Feishu channels
-    const result = await send_user_feedback({
+    const result = await send_message_impl({
       content,
       format,
       chatId,

--- a/src/messaging/channel-adapter.ts
+++ b/src/messaging/channel-adapter.ts
@@ -104,7 +104,7 @@ export const FEISHU_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: true,
   supportsMention: true,
   supportsReactions: true,
-  supportedMcpTools: ['send_user_feedback', 'send_file_to_feishu', 'update_card', 'wait_for_interaction'],
+  supportedMcpTools: ['send_message', 'send_file', 'wait_for_interaction'],
 };
 
 /**
@@ -138,7 +138,7 @@ export const REST_CAPABILITIES: ChannelCapabilities = {
   supportsDelete: false,
   supportsMention: false,
   supportsReactions: false,
-  supportedMcpTools: ['send_user_feedback'], // REST channel only supports basic messaging
+  supportedMcpTools: ['send_message'], // REST channel only supports basic messaging
 };
 
 // ============================================================================

--- a/src/task/index.test.ts
+++ b/src/task/index.test.ts
@@ -57,25 +57,25 @@ describe('Task Module Exports', () => {
     });
   });
 
-  describe('Feishu Context MCP Tools', () => {
+  describe('Context MCP Tools', () => {
     it('should export feishuContextTools', () => {
       expect(TaskModule.feishuContextTools).toBeDefined();
       expect(typeof TaskModule.feishuContextTools).toBe('object');
     });
 
-    it('should export send_user_feedback function', () => {
-      expect(TaskModule.send_user_feedback).toBeDefined();
-      expect(typeof TaskModule.send_user_feedback).toBe('function');
+    it('should export send_message function', () => {
+      expect(TaskModule.send_message).toBeDefined();
+      expect(typeof TaskModule.send_message).toBe('function');
     });
 
-    it('should export send_file_to_feishu function', () => {
-      expect(TaskModule.send_file_to_feishu).toBeDefined();
-      expect(typeof TaskModule.send_file_to_feishu).toBe('function');
+    it('should export send_file function', () => {
+      expect(TaskModule.send_file).toBeDefined();
+      expect(typeof TaskModule.send_file).toBe('function');
     });
 
-    it('should have send_user_feedback and send_file_to_feishu in feishuContextTools', () => {
-      expect('send_user_feedback' in TaskModule.feishuContextTools).toBe(true);
-      expect('send_file_to_feishu' in TaskModule.feishuContextTools).toBe(true);
+    it('should have send_message and send_file in feishuContextTools', () => {
+      expect('send_message' in TaskModule.feishuContextTools).toBe(true);
+      expect('send_file' in TaskModule.feishuContextTools).toBe(true);
     });
   });
 
@@ -122,10 +122,10 @@ describe('Task Module Exports', () => {
       expect(exports).toContain('parseBaseToolName');
       expect(exports).toContain('isUserFeedbackTool');
 
-      // Feishu tools
+      // Context tools
       expect(exports).toContain('feishuContextTools');
-      expect(exports).toContain('send_user_feedback');
-      expect(exports).toContain('send_file_to_feishu');
+      expect(exports).toContain('send_message');
+      expect(exports).toContain('send_file');
 
       // Utilities
       expect(exports).toContain('extractText');

--- a/src/task/index.ts
+++ b/src/task/index.ts
@@ -44,11 +44,11 @@ export {
 export { DialogueMessageTracker } from './dialogue-message-tracker.js';
 export { parseBaseToolName, isUserFeedbackTool } from './mcp-utils.js';
 
-// Feishu context MCP tools
+// Context MCP tools
 export {
   feishuContextTools,
-  send_user_feedback,
-  send_file_to_feishu,
+  send_message,
+  send_file,
 } from '../mcp/feishu-context-mcp.js';
 
 // Note: task_done has been removed - completion is now detected via final_result.md

--- a/src/task/mcp-utils.test.ts
+++ b/src/task/mcp-utils.test.ts
@@ -8,11 +8,11 @@ import type { AgentMessage } from '../types/agent.js';
 
 describe('parseBaseToolName', () => {
   it('should extract base name from prefixed tool name', () => {
-    expect(parseBaseToolName('feishu-context-mcp__send_user_feedback')).toBe('send_user_feedback');
+    expect(parseBaseToolName('context-mcp__send_message')).toBe('send_message');
   });
 
   it('should return original name when no prefix', () => {
-    expect(parseBaseToolName('send_user_feedback')).toBe('send_user_feedback');
+    expect(parseBaseToolName('send_message')).toBe('send_message');
   });
 
   it('should handle empty string', () => {
@@ -32,9 +32,9 @@ describe('isUserFeedbackTool', () => {
     metadata: { toolName, toolInputRaw: {} },
   });
 
-  it('should return true for send_user_feedback tool', () => {
-    expect(isUserFeedbackTool(createMessage('send_user_feedback'))).toBe(true);
-    expect(isUserFeedbackTool(createMessage('mcp__send_user_feedback'))).toBe(true);
+  it('should return true for send_message tool', () => {
+    expect(isUserFeedbackTool(createMessage('send_message'))).toBe(true);
+    expect(isUserFeedbackTool(createMessage('mcp__send_message'))).toBe(true);
   });
 
   it('should return false for other tools', () => {

--- a/src/task/mcp-utils.ts
+++ b/src/task/mcp-utils.ts
@@ -10,14 +10,14 @@ import type { AgentMessage } from '../types/agent.js';
 /**
  * Parse the base tool name from an MCP tool name.
  *
- * MCP tools can have prefixed names like "feishu-context-mcp__send_user_feedback".
+ * MCP tools can have prefixed names like "context-mcp__send_message".
  * This function extracts the base tool name after the "__" separator.
  *
  * @param toolName - The full tool name (possibly prefixed)
  * @returns The base tool name, or empty string if input is falsy
  *
  * @example
- * parseBaseToolName("feishu-context-mcp__send_user_feedback") // "send_user_feedback"
+ * parseBaseToolName("context-mcp__send_message") // "send_message"
  * parseBaseToolName("") // ""
  */
 export function parseBaseToolName(toolName: string): string {
@@ -30,12 +30,12 @@ export function parseBaseToolName(toolName: string): string {
 }
 
 /**
- * Check if a message represents a send_user_feedback tool call.
+ * Check if a message represents a send_message tool call.
  *
  * @param msg - The agent message to check
- * @returns true if the message is a send_user_feedback tool call
+ * @returns true if the message is a send_message tool call
  */
 export function isUserFeedbackTool(msg: AgentMessage): boolean {
   return msg.messageType === 'tool_use' &&
-    parseBaseToolName(msg.metadata?.toolName || '') === 'send_user_feedback';
+    parseBaseToolName(msg.metadata?.toolName || '') === 'send_message';
 }


### PR DESCRIPTION
## Summary

- Rename MCP tools to platform-agnostic names:
  - `send_user_feedback` → `send_message`
  - `send_file_to_feishu` → `send_file`
- Update type definitions:
  - `SendFeedbackResult` → `SendMessageResult`
  - `feishuCode`/`feishuMsg`/`feishuLogId` → `platformCode`/`platformMsg`/`platformLogId`
- Remove `update_card` tool (per user request in issue comments)
- Update tool descriptions to remove Feishu-specific references
- Add IPC server startup on module load

## Changes

| Before | After |
|--------|-------|
| `send_user_feedback` | `send_message` |
| `send_file_to_feishu` | `send_file` |
| `update_card` | *removed* |
| `feishuCode`, `feishuMsg`, `feishuLogId` | `platformCode`, `platformMsg`, `platformLogId` |

## User Feedback Incorporated

- No backward compatibility (per user request)
- Removed `update_card` tool (per user request)

## Test Results

- ✅ Build passes: `npm run build`
- ✅ TypeScript compilation succeeds
- ✅ Lint passes (0 errors, 103 warnings - pre-existing)
- ✅ All 1726 tests pass

Fixes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)