### PR TITLE
fix: allow string content for send_user_feedback with format="card"

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -385,9 +385,9 @@ When \`format: "card"\`, content MUST include:
       parentMessageId: z.string().optional(),
     }),
     handler: async ({ content, format, chatId, parentMessageId }) => {
-      if (format === 'card' && typeof content === 'string') {
-        return toolSuccess('❌ Error: When format="card", content must be an OBJECT.');
-      }
+      // Note: We allow string content for format="card" because the underlying
+      // send_user_feedback function can parse JSON strings and validate card structure.
+      // This fixes issue #990 where MCP/function-calling layers serialize objects to strings.
       if (format === 'text' && typeof content !== 'string') {
         return toolSuccess('❌ Error: When format="text", content must be a STRING.');
       }


### PR DESCRIPTION
## Summary

- Remove premature type check that rejected string content for `format="card"` in `send_user_feedback` tool handler
- The underlying `send_user_feedback` function already supports parsing JSON strings and validating card structure
- This fixes the issue where MCP/function-calling layers serialize objects to strings during transmission

## Problem

When using `send_user_feedback` with `format="card"`, the tool handler was rejecting string content with error "content must be an OBJECT", even when valid JSON was provided. This happened because some MCP/function-calling transport layers serialize complex objects to JSON strings.

## Solution

Remove the premature type check in the handler. The underlying `send_user_feedback` function in `src/mcp/tools/send-message.ts` already has logic to:
1. Parse JSON strings (line 78-80)
2. Validate card structure using `isValidFeishuCard` (line 79)
3. Return appropriate error messages for invalid JSON or card structure

## Test Results

- ✅ All 45 existing tests in `feishu-context-mcp.test.ts` pass
- ✅ All 1734 tests in the full test suite pass
- ✅ Existing test case "should send valid card JSON string" (line 247-266) validates this fix

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)