### PR TITLE
feat(feishu): support reading packed conversation records and quoted replies

### DIFF
--- a/src/channels/feishu/message-handler-issue846.test.ts
+++ b/src/channels/feishu/message-handler-issue846.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Tests for Issue #846: Support reading packed conversation records and quoted replies.
+ *
+ * This test file covers:
+ * 1. Parsing chat_record message type (forwarded conversations)
+ * 2. Extracting reply context from root_id and parent_id fields
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before importing
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn(() => ({})),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('../../config/constants.js', () => ({
+  DEDUPLICATION: { MAX_MESSAGE_AGE: 300000 },
+  REACTIONS: { TYPING: 'Typing' },
+  CHAT_HISTORY: { MAX_CONTEXT_LENGTH: 5000 },
+}));
+
+vi.mock('../../feishu/message-logger.js', () => ({
+  messageLogger: {
+    isMessageProcessed: vi.fn().mockReturnValue(false),
+    logIncomingMessage: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../file-transfer/inbound/index.js', () => ({
+  attachmentManager: {
+    getAttachments: vi.fn().mockReturnValue([]),
+  },
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('../../platforms/feishu/feishu-file-handler.js', () => ({
+  FeishuFileHandler: vi.fn(() => ({
+    handleFileMessage: vi.fn().mockResolvedValue({ success: false }),
+    buildUploadPrompt: vi.fn().mockReturnValue(''),
+  })),
+}));
+
+vi.mock('../../platforms/feishu/feishu-message-sender.js', () => ({
+  FeishuMessageSender: vi.fn(() => ({
+    sendText: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
+vi.mock('../../platforms/feishu/interaction-manager.js', () => ({
+  InteractionManager: vi.fn(() => ({
+    handleAction: vi.fn(),
+  })),
+}));
+
+vi.mock('../../platforms/feishu/create-feishu-client.js', () => ({
+  createFeishuClient: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../nodes/commands/command-registry.js', () => ({
+  getCommandRegistry: vi.fn(() => ({
+    has: vi.fn().mockReturnValue(false),
+  })),
+}));
+
+vi.mock('../../mcp/feishu-context-mcp.js', () => ({
+  resolvePendingInteraction: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../mcp/tools/interactive-message.js', () => ({
+  generateInteractionPrompt: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock('../../ipc/unix-socket-client.js', () => ({
+  getIpcClient: vi.fn().mockReturnValue({
+    isConnected: vi.fn().mockReturnValue(false),
+  }),
+}));
+
+vi.mock('../../feishu/filtered-message-forwarder.js', () => ({
+  filteredMessageForwarder: {
+    setMessageSender: vi.fn(),
+    forward: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../utils/mention-parser.js', () => ({
+  stripLeadingMentions: vi.fn().mockReturnValue(''),
+}));
+
+import { MessageHandler } from './message-handler.js';
+
+describe('MessageHandler - Issue #846', () => {
+  let handler: MessageHandler;
+  let mockCallbacks: {
+    emitMessage: ReturnType<typeof vi.fn>;
+    emitControl: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+    routeCardAction: ReturnType<typeof vi.fn>;
+  };
+  let mockPassiveModeManager: { isPassiveModeDisabled: ReturnType<typeof vi.fn> };
+  let mockMentionDetector: { isBotMentioned: ReturnType<typeof vi.fn> };
+  let mockInteractionManager: { handleAction: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCallbacks = {
+      emitMessage: vi.fn().mockResolvedValue(undefined),
+      emitControl: vi.fn().mockResolvedValue({ success: false }),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      routeCardAction: vi.fn().mockResolvedValue(false),
+    };
+
+    mockPassiveModeManager = {
+      isPassiveModeDisabled: vi.fn().mockReturnValue(false),
+    };
+
+    mockMentionDetector = {
+      isBotMentioned: vi.fn().mockReturnValue(true), // Bot is mentioned by default
+    };
+
+    mockInteractionManager = {
+      handleAction: vi.fn().mockResolvedValue(false),
+    };
+
+    handler = new MessageHandler({
+      appId: 'test-app-id',
+      appSecret: 'test-app-secret',
+      passiveModeManager: mockPassiveModeManager as unknown as import('./passive-mode.js').PassiveModeManager,
+      mentionDetector: mockMentionDetector as unknown as import('./mention-detector.js').MentionDetector,
+      interactionManager: mockInteractionManager as unknown as import('../../platforms/feishu/interaction-manager.js').InteractionManager,
+      callbacks: mockCallbacks,
+      isRunning: () => true,
+      hasControlHandler: () => false,
+    });
+
+    handler.initialize();
+  });
+
+  describe('chat_record message type (packed conversation)', () => {
+    it('should parse chat_record message with multiple forwarded messages', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user A' }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+          {
+            message_id: 'msg_2',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user B' }),
+            create_time: 1700000001000,
+            sender: { sender_id: { open_id: 'user_b' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      // Should indicate this is a forwarded conversation
+      expect(emittedMessage.content).toContain('转发了一段聊天记录');
+      expect(emittedMessage.content).toContain('Hello from user A');
+      expect(emittedMessage.content).toContain('Hello from user B');
+      expect(emittedMessage.messageType).toBe('chat_record');
+    });
+
+    it('should handle chat_record with post messages', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'post',
+            content: JSON.stringify({
+              content: [[{ tag: 'text', text: 'Rich text content' }]],
+            }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      expect(emittedMessage.content).toContain('Rich text content');
+    });
+  });
+
+  describe('reply context (root_id and parent_id)', () => {
+    it('should include reply context prefix when message has root_id', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'This is a reply' }),
+            create_time: Date.now(),
+            root_id: 'root_message_id',
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      // Should include reply context prefix
+      expect(emittedMessage.content).toContain('回复');
+      expect(emittedMessage.content).toContain('root_message_id');
+      expect(emittedMessage.content).toContain('This is a reply');
+      expect(emittedMessage.metadata?.replyContext).toBeDefined();
+    });
+
+    it('should include both root_id and parent_id when both are present', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'This is a nested reply' }),
+            create_time: Date.now(),
+            root_id: 'root_message_id',
+            parent_id: 'parent_message_id',
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      // Should include both IDs in the prefix
+      expect(emittedMessage.content).toContain('根消息ID');
+      expect(emittedMessage.content).toContain('父消息ID');
+      expect(emittedMessage.content).toContain('root_message_id');
+      expect(emittedMessage.content).toContain('parent_message_id');
+      expect(emittedMessage.metadata?.replyContext).toEqual({
+        rootId: 'root_message_id',
+        parentId: 'parent_message_id',
+      });
+    });
+
+    it('should not include reply prefix when message has no root_id or parent_id', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'This is a regular message' }),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      // Should NOT include reply context
+      expect(emittedMessage.content).not.toContain('回复');
+      expect(emittedMessage.content).toBe('This is a regular message');
+      expect(emittedMessage.metadata?.replyContext).toBeUndefined();
+    });
+
+    it('should handle parent_id only (without root_id)', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Reply with only parent_id' }),
+            create_time: Date.now(),
+            parent_id: 'parent_message_id',
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+
+      // Should use parent_id as root_id fallback
+      expect(emittedMessage.content).toContain('回复');
+      expect(emittedMessage.content).toContain('parent_message_id');
+      expect(emittedMessage.metadata?.replyContext).toBeDefined();
+    });
+  });
+});

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -26,6 +26,7 @@ import type {
   FeishuMessageEvent,
   FeishuCardActionEvent,
   FeishuCardActionEventData,
+  FeishuChatRecordContent,
 } from '../../types/platform.js';
 import type { PassiveModeManager } from './passive-mode.js';
 import type { MentionDetector } from './mention-detector.js';
@@ -273,6 +274,98 @@ export class MessageHandler {
   }
 
   /**
+   * Parse chat_record message content to extract forwarded conversation.
+   * Issue #846: Support reading packed conversation records
+   * @param content - JSON string content from chat_record message
+   * @returns Formatted text representation of the conversation, or null if parsing fails
+   */
+  private parseChatRecordContent(content: string): string | null {
+    try {
+      const parsed = JSON.parse(content) as FeishuChatRecordContent;
+
+      if (!parsed.messages || !Array.isArray(parsed.messages)) {
+        logger.debug({ content }, 'chat_record content missing messages array');
+        return null;
+      }
+
+      const formattedMessages: string[] = [];
+
+      for (const msg of parsed.messages) {
+        // Try to extract text from each message
+        let msgText = '';
+        try {
+          const msgContent = JSON.parse(msg.content);
+          if (msg.message_type === 'text') {
+            msgText = msgContent.text?.trim() || '';
+          } else if (msg.message_type === 'post') {
+            // Extract text from post content
+            if (msgContent.content && Array.isArray(msgContent.content)) {
+              for (const row of msgContent.content) {
+                if (Array.isArray(row)) {
+                  for (const segment of row) {
+                    if (segment?.tag === 'text' && segment.text) {
+                      msgText += segment.text;
+                    }
+                  }
+                }
+              }
+              msgText = msgText.trim();
+            }
+          }
+        } catch {
+          // If parsing fails, use raw content
+          msgText = msg.content;
+        }
+
+        if (msgText) {
+          const senderId = msg.sender?.sender_id?.open_id || msg.sender?.sender_id?.user_id || '未知用户';
+          const timestamp = msg.create_time ? new Date(msg.create_time).toLocaleString('zh-CN') : '';
+          formattedMessages.push(`[${senderId}] ${timestamp}\n${msgText}`);
+        }
+      }
+
+      return formattedMessages.join('\n\n---\n\n');
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to parse chat_record content');
+      return null;
+    }
+  }
+
+  /**
+   * Extract reply context from message's root_id and parent_id fields.
+   * Issue #846: Support reading quoted/reply message content
+   * @param message - The Feishu message object
+   * @returns Reply context info or undefined if not a reply
+   */
+  private extractReplyContext(message: FeishuMessageEvent['message']): { rootId: string; parentId?: string } | undefined {
+    if (!message.root_id && !message.parent_id) {
+      return undefined;
+    }
+
+    return {
+      rootId: message.root_id || message.parent_id!,
+      parentId: message.parent_id,
+    };
+  }
+
+  /**
+   * Format reply context prefix for AI understanding.
+   * Issue #846: Support reading quoted/reply message content
+   * @param replyContext - The extracted reply context
+   * @returns Formatted prefix string
+   */
+  private formatReplyContextPrefix(replyContext: { rootId: string; parentId?: string } | undefined): string {
+    if (!replyContext) {
+      return '';
+    }
+
+    if (replyContext.parentId && replyContext.rootId !== replyContext.parentId) {
+      return `[此消息是对话中的回复，根消息ID: ${replyContext.rootId}，父消息ID: ${replyContext.parentId}]\n`;
+    }
+    return `[此消息是对话中的回复，回复的消息ID: ${replyContext.rootId}]\n`;
+  }
+
+  /**
    * Handle incoming message event from WebSocket.
    */
   async handleMessageReceive(data: FeishuEventData): Promise<void> {
@@ -292,7 +385,7 @@ export class MessageHandler {
       return;
     }
 
-    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions } = message;
+    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, root_id, parent_id } = message;
 
     // Bot replies to user message by setting parent_id = message_id
     // Feishu automatically handles thread affiliation
@@ -377,6 +470,47 @@ export class MessageHandler {
           }],
         });
       }
+      return;
+    }
+
+    // Handle chat_record (packed/forwarded conversation) messages
+    // Issue #846: Support reading packed conversation records
+    if (message_type === 'chat_record') {
+      logger.info(
+        { chatId: chat_id, messageType: message_type, messageId: message_id },
+        'Processing chat_record message'
+      );
+
+      const parsedChatRecord = this.parseChatRecordContent(content);
+      if (!parsedChatRecord) {
+        logger.warn({ messageId: message_id }, 'Failed to parse chat_record content');
+        await this.forwardFilteredMessage('unsupported', message_id, chat_id, content, this.extractOpenId(sender), { messageType: message_type });
+        return;
+      }
+
+      await messageLogger.logIncomingMessage(
+        message_id,
+        this.extractOpenId(sender) || 'unknown',
+        chat_id,
+        `[聊天记录转发]\n${parsedChatRecord}`,
+        message_type,
+        create_time
+      );
+
+      // Add typing reaction
+      await this.addTypingReaction(message_id);
+
+      // Emit as incoming message with chat record content
+      await this.callbacks.emitMessage({
+        messageId: message_id,
+        chatId: chat_id,
+        userId: this.extractOpenId(sender),
+        content: `[用户转发了一段聊天记录]\n\n${parsedChatRecord}`,
+        messageType: message_type,
+        timestamp: create_time,
+        threadId,
+        metadata: { isChatRecord: true },
+      });
       return;
     }
 
@@ -519,6 +653,10 @@ export class MessageHandler {
     // Add typing reaction only for messages that will be processed
     await this.addTypingReaction(message_id);
 
+    // Issue #846: Extract reply context if this is a reply message
+    const replyContext = this.extractReplyContext({ root_id, parent_id } as FeishuMessageEvent['message']);
+    const replyPrefix = this.formatReplyContextPrefix(replyContext);
+
     // Get chat history context for passive mode
     const isPassiveModeTrigger = this.isGroupChat(chat_type) && botMentioned;
     let chatHistoryContext: string | undefined;
@@ -531,16 +669,26 @@ export class MessageHandler {
       );
     }
 
+    // Build metadata object
+    const metadata: Record<string, unknown> = {};
+    if (chatHistoryContext) {
+      metadata.chatHistoryContext = chatHistoryContext;
+    }
+    if (replyContext) {
+      metadata.replyContext = replyContext;
+    }
+
     // Emit as incoming message
+    // Issue #846: Include reply context prefix in content if this is a reply
     await this.callbacks.emitMessage({
       messageId: message_id,
       chatId: chat_id,
       userId: this.extractOpenId(sender),
-      content: text,
+      content: replyPrefix + text,
       messageType: message_type,
       timestamp: create_time,
       threadId,
-      metadata: chatHistoryContext ? { chatHistoryContext } : undefined,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
     });
   }
 

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -10,6 +10,18 @@ export interface FeishuMessageEvent {
     content: string;
     message_type: string;
     create_time?: number;
+    /**
+     * Root message ID for reply threads.
+     * Present when this message is a reply to another message.
+     * Issue #846: Support reading quoted/reply message content
+     */
+    root_id?: string;
+    /**
+     * Parent message ID for nested replies.
+     * Present when this message is a reply to another message.
+     * Issue #846: Support reading quoted/reply message content
+     */
+    parent_id?: string;
     mentions?: Array<{
       key: string;
       id: {
@@ -30,6 +42,41 @@ export interface FeishuMessageEvent {
     };
     tenant_key?: string;
   };
+}
+
+/**
+ * Chat record message structure for forwarded/packed conversations.
+ * Issue #846: Support reading packed conversation records
+ */
+export interface FeishuChatRecordContent {
+  /** List of messages in the packed conversation */
+  messages: Array<{
+    message_id: string;
+    content: string;
+    message_type: string;
+    create_time?: number;
+    sender?: {
+      sender_id?: {
+        open_id?: string;
+        user_id?: string;
+      };
+    };
+  }>;
+}
+
+/**
+ * Parsed chat record message with extracted text content.
+ * Issue #846: Support reading packed conversation records
+ */
+export interface ParsedChatRecord {
+  /** Original messages from the packed conversation */
+  messages: Array<{
+    senderId?: string;
+    content: string;
+    timestamp?: number;
+  }>;
+  /** Formatted text representation for AI context */
+  formattedText: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Issue #846: Support reading packed conversation records and quoted reply content from Feishu messages.

### Changes

1. **chat_record message type support**
   - Parse forwarded/packed conversation messages (`chat_record` type)
   - Extract text content from each message in the forwarded conversation
   - Format as readable context for AI understanding with sender info and timestamps

2. **Reply context detection**
   - Detect `root_id` and `parent_id` fields in incoming messages
   - Add context prefix to message content indicating it's a reply
   - Include reply metadata for downstream processing

### Use Cases

- **Forwarded conversations**: User forwards a chat history and asks bot to process/summarize it
- **Reply context**: Bot understands when a message is a reply to another message

### Testing

- Added comprehensive tests for:
  - chat_record parsing with multiple messages
  - chat_record with post messages (rich text)
  - Reply context with root_id only
  - Reply context with both root_id and parent_id
  - Regular messages without reply context

## Test plan

- [x] Unit tests pass (1740 tests)
- [x] Type check passes
- [ ] Manual testing with forwarded conversations
- [ ] Manual testing with reply messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)