### PR TITLE
fix(ipc): start IPC server in FeishuChannel.doStart() (Issue #992)

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -24,6 +24,8 @@ import {
   MessageHandler as FeishuMessageHandler,
   type MessageCallbacks,
 } from './feishu/index.js';
+// Issue #992: Import IPC server for cross-process interactive contexts
+import { startIpcServer, stopIpcServer } from '../mcp/tools/interactive-message.js';
 import type {
   FeishuEventData,
   FeishuCardActionEventData,
@@ -212,6 +214,16 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #959: Start WebSocket reconnection watchdog
     this.startReconnectWatchdog();
 
+    // Issue #992: Start IPC server for cross-process interactive contexts
+    // This must be called during channel startup, not at module load time,
+    // to avoid test timeouts (see PR #982)
+    try {
+      await startIpcServer();
+      logger.info('IPC server started for cross-process interactive contexts');
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to start IPC server, interactive cards may not work across processes');
+    }
+
     logger.info('FeishuChannel started');
   }
 
@@ -227,6 +239,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     // Clean up old attachments to prevent memory leaks
     attachmentManager.cleanupOldAttachments();
+
+    // Issue #992: Stop IPC server
+    stopIpcServer();
 
     logger.info('FeishuChannel stopped');
     return Promise.resolve();


### PR DESCRIPTION
## Summary
- Fix `startIpcServer()` never being called, which caused interactive card callbacks to fail
- Start IPC server in `FeishuChannel.doStart()` during channel startup
- Stop IPC server in `FeishuChannel.doStop()` for proper cleanup

## Problem
The `startIpcServer()` function was defined in `interactive-message.ts` but never called anywhere in the codebase. This caused:
- Interactive card callbacks to fail after service restarts
- Cross-process communication for interactive contexts to not work

**Root Cause**: PR #982 removed the module-load-time IPC server startup to fix test timeouts, but didn't add the startup call in an alternative location.

## Solution
Start the IPC server in `FeishuChannel.doStart()` during channel startup instead of at module load time. This:
- ✅ Ensures IPC server runs when needed for interactive card callbacks
- ✅ Avoids test timeout issues from module-load-time initialization
- ✅ Properly cleans up IPC server in `doStop()`

## Changes
1. Import `startIpcServer` and `stopIpcServer` from `../mcp/tools/interactive-message.js`
2. Call `startIpcServer()` in `doStart()` after WebSocket client starts (with error handling)
3. Call `stopIpcServer()` in `doStop()` for proper cleanup

## Test Plan
- [x] All 122 channel tests pass
- [x] All 13 IPC tests pass  
- [x] All 16 interactive-message tests pass
- [x] The specific test from PR #982 (`src/feishu/index.test.ts`) still passes quickly (~369ms, not timing out)
- [x] Type check passes

Fixes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)