### PR TITLE
fix(mcp): handle JSON string content for card format in send_user_feedback (Issue #990)

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -72,6 +72,7 @@ import {
   resolvePendingInteraction,
   setMessageSentCallback,
   feishuContextTools,
+  feishuToolDefinitions,
 } from './feishu-context-mcp.js';
 import { uploadAndSendFile } from '../file-transfer/outbound/feishu-uploader.js';
 
@@ -773,6 +774,114 @@ describe('Feishu Context MCP Tools', () => {
       // Clean up first wait
       resolvePendingInteraction('msg-dup', 'cancel', 'button', 'user-1');
       await firstWait;
+    });
+  });
+
+  describe('feishuToolDefinitions handlers', () => {
+    // Import the tool definitions for handler testing
+    // These tests verify the handler wrapper logic (Issue #990)
+    describe('send_user_feedback handler', () => {
+      it('should parse valid JSON string for card format', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+        const cardJson = JSON.stringify({
+          config: { wide_screen_mode: true },
+          header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
+          elements: [{ tag: 'markdown', content: '**Hello**' }],
+        });
+
+        const result = await handler({
+          content: cardJson,
+          format: 'card',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('✅');
+        expect(mockClient.im.message.create).toHaveBeenCalled();
+      });
+
+      it('should reject invalid JSON string for card format', async () => {
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+
+        const result = await handler({
+          content: 'not valid json',
+          format: 'card',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('❌');
+        expect(result.content[0].text).toContain('must be an OBJECT');
+      });
+
+      it('should reject JSON string that is not an object for card format', async () => {
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+
+        const result = await handler({
+          content: JSON.stringify(['array', 'not', 'object']),
+          format: 'card',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('❌');
+        // The parsed array fails validation in send_user_feedback
+        expect(result.content[0].text).toContain('Invalid content type');
+      });
+
+      it('should accept object content for card format', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+        const cardObject = {
+          config: { wide_screen_mode: true },
+          header: { title: { tag: 'plain_text', content: 'Test' }, template: 'blue' },
+          elements: [{ tag: 'markdown', content: '**Hello**' }],
+        };
+
+        const result = await handler({
+          content: cardObject,
+          format: 'card',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('✅');
+      });
+
+      it('should convert object to string for text format', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+
+        const result = await handler({
+          content: { key: 'value' },
+          format: 'text',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('✅');
+        // Verify the content was stringified
+        expect(mockClient.im.message.create).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              content: JSON.stringify({ text: '{"key":"value"}' }),
+            }),
+          })
+        );
+      });
+
+      it('should accept string content for text format', async () => {
+        mockClient.im.message.create.mockResolvedValueOnce({});
+
+        const handler = feishuToolDefinitions.find(d => d.name === 'send_user_feedback')!.handler;
+
+        const result = await handler({
+          content: 'plain text message',
+          format: 'text',
+          chatId: 'chat-123',
+        });
+
+        expect(result.content[0].text).toContain('✅');
+      });
     });
   });
 });

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -385,11 +385,22 @@ When \`format: "card"\`, content MUST include:
       parentMessageId: z.string().optional(),
     }),
     handler: async ({ content, format, chatId, parentMessageId }) => {
+      // For card format, try to parse string content as JSON (some MCP implementations serialize objects)
       if (format === 'card' && typeof content === 'string') {
-        return toolSuccess('❌ Error: When format="card", content must be an OBJECT.');
+        try {
+          const parsed = JSON.parse(content);
+          if (typeof parsed === 'object' && parsed !== null) {
+            content = parsed;
+          } else {
+            return toolSuccess('❌ Error: When format="card", content must be an OBJECT.');
+          }
+        } catch {
+          return toolSuccess('❌ Error: When format="card", content must be an OBJECT (or valid JSON string).');
+        }
       }
       if (format === 'text' && typeof content !== 'string') {
-        return toolSuccess('❌ Error: When format="text", content must be a STRING.');
+        // Convert object to string for text format
+        content = JSON.stringify(content);
       }
       try {
         const result = await send_user_feedback({ content, format, chatId, parentMessageId });


### PR DESCRIPTION
## Summary

Fixes #990 - `send_user_feedback` tool now correctly handles JSON string content when `format="card"`.

## Problem

When using `send_user_feedback` with `format="card"`, the tool would reject valid JSON string content with error:

```
Error: When format="card", content must be an OBJECT.
```

This happened because some MCP implementations serialize complex objects as JSON strings before passing them to the handler, causing the type check to fail even when the content is valid JSON.

## Solution

Modified the handler in `feishu-context-mcp.ts` to:
- **For card format**: Attempt `JSON.parse()` when content is a string, only reject if parsing fails or result is not an object
- **For text format**: Auto-convert objects to JSON strings (more lenient behavior)

## Changes

| File | Change |
|------|--------|
| `src/mcp/feishu-context-mcp.ts` | Updated handler to parse JSON strings for card format |
| `src/mcp/feishu-context-mcp.test.ts` | Added 6 tests for handler behavior |

## Test Results

- ✅ All 1740 tests pass
- ✅ TypeScript compilation passes
- ✅ 6 new tests for handler behavior

## Test Plan

- [x] JSON string with valid card structure is accepted
- [x] Invalid JSON string is rejected with clear error
- [x] JSON array (not object) is rejected
- [x] Object content for card format still works
- [x] Object content for text format is auto-converted
- [x] String content for text format still works

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)