### PR TITLE
fix(commands): register SkillCommand to enable /skill commands (Issue #455)

### DIFF
--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -44,6 +44,7 @@ import {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  SkillCommand,
 } from './commands/index.js';
 
 // Re-export all command classes for backward compatibility
@@ -68,6 +69,7 @@ export {
   TaskCommand,
   TopicGroupCommand,
   ExpertCommand,
+  SkillCommand,
 };
 
 /**
@@ -101,4 +103,6 @@ export function registerDefaultCommands(
   registry.register(new TopicGroupCommand());
   // Issue #535: Expert registration and skill management
   registry.register(new ExpertCommand());
+  // Issue #455: Skill Agent management command
+  registry.register(new SkillCommand());
 }


### PR DESCRIPTION
## Summary

- Fix SkillCommand not being registered in `registerDefaultCommands()`
- Enable Feishu control commands for Skill Agent System: `/skill run`, `/skill list`, `/skill status`, `/skill stop`, `/skill stop-all`

## Problem

Issue #455 (Skill Agent System) was mostly implemented:
- ✅ `SkillAgent` class implemented
- ✅ `SkillAgentManager` implemented  
- ✅ `SkillCommand` implemented with all subcommands
- ✅ Service interfaces defined
- ✅ Service methods implemented in `command-services.ts`
- ✅ `SkillAgentManager` initialized in `PrimaryNode`

**But** `SkillCommand` was never registered in `registerDefaultCommands()`, so users couldn't use the `/skill` commands through Feishu.

## Solution

Register `SkillCommand` in `registerDefaultCommands()` function in `builtin-commands.ts`.

## Changes

| File | Change |
|------|--------|
| `src/nodes/commands/builtin-commands.ts` | Import, export, and register SkillCommand |

## Test Results

- ✅ Build passes
- ✅ All command tests pass (41 tests)
- ✅ All skill-agent tests pass (35 tests)

## Usage

After this fix, users can use the following commands in Feishu:

```
/skill run <skill-name> [--timeout 60] [--key=value]
/skill list
/skill status <agent-id>
/skill stop <agent-id>
/skill stop-all
```

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)