### PR TITLE
fix(mcp): handle JSON string content for card format in send_user_feedback

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -385,14 +385,27 @@ When \`format: "card"\`, content MUST include:
       parentMessageId: z.string().optional(),
     }),
     handler: async ({ content, format, chatId, parentMessageId }) => {
+      // Normalize content: if format="card" and content is a string, try to parse it as JSON
+      // This handles cases where LLM serializes objects to JSON strings during function calling
+      let normalizedContent: string | Record<string, unknown> = content;
       if (format === 'card' && typeof content === 'string') {
-        return toolSuccess('❌ Error: When format="card", content must be an OBJECT.');
+        try {
+          const parsed = JSON.parse(content);
+          if (typeof parsed === 'object' && parsed !== null) {
+            normalizedContent = parsed;
+          } else {
+            return toolSuccess('❌ Error: When format="card", content must be an OBJECT (parsed to non-object).');
+          }
+        } catch {
+          return toolSuccess('❌ Error: When format="card", content must be an OBJECT (invalid JSON).');
+        }
       }
       if (format === 'text' && typeof content !== 'string') {
-        return toolSuccess('❌ Error: When format="text", content must be a STRING.');
+        // Convert object to string for text format
+        normalizedContent = JSON.stringify(content);
       }
       try {
-        const result = await send_user_feedback({ content, format, chatId, parentMessageId });
+        const result = await send_user_feedback({ content: normalizedContent, format, chatId, parentMessageId });
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Feedback failed: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Summary

Fixes an issue where `send_user_feedback` tool incorrectly rejected valid card content when `format="card"`.

### Problem

When LLM calls the `send_user_feedback` tool with `format="card"`, the `content` parameter may be serialized as a JSON string during function calling, even though the original input was an object. This caused the tool to incorrectly return:
```
❌ Error: When format="card", content must be an OBJECT.
```

### Solution

- When `format="card"` and `content` is a string, attempt to parse it as JSON
- Only return error if parsing fails or result is not a valid object
- Also handle object-to-string conversion for `format="text"` case

### Changes

| File | Change |
|------|--------|
| `src/mcp/feishu-context-mcp.ts` | Added JSON parsing for string content in card format handler |

### Test Results

- ✅ All 1734 tests pass

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)