### PR TITLE
fix: send_user_feedback card format handles JSON-stringified content

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -385,14 +385,21 @@ When \`format: "card"\`, content MUST include:
       parentMessageId: z.string().optional(),
     }),
     handler: async ({ content, format, chatId, parentMessageId }) => {
+      // Try to parse string content as JSON for card format
+      // This handles cases where the SDK serializes objects to JSON strings
+      let processedContent: string | Record<string, unknown> = content;
       if (format === 'card' && typeof content === 'string') {
-        return toolSuccess('❌ Error: When format="card", content must be an OBJECT.');
+        try {
+          processedContent = JSON.parse(content);
+        } catch {
+          return toolSuccess('❌ Error: When format="card", content must be a valid JSON object or string.');
+        }
       }
       if (format === 'text' && typeof content !== 'string') {
-        return toolSuccess('❌ Error: When format="text", content must be a STRING.');
+        processedContent = JSON.stringify(content);
       }
       try {
-        const result = await send_user_feedback({ content, format, chatId, parentMessageId });
+        const result = await send_user_feedback({ content: processedContent, format, chatId, parentMessageId });
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Feedback failed: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Summary

Fixes #990: `send_user_feedback` 工具在 `format="card"` 时错误报告 "content must be an OBJECT"

### Problem

When using function calling, SDKs may serialize object parameters to JSON strings before passing them to handlers. This caused the strict type check in the `send_user_feedback` handler to fail even when valid JSON objects were passed by the LLM.

### Solution

Modified the handler in `feishu-context-mcp.ts` to:
1. Parse string content as JSON for card format before validation
2. Auto-convert objects to JSON strings for text format
3. Provide clearer error message when JSON parsing fails

### Changes

- **File**: `src/mcp/feishu-context-mcp.ts`
- **Lines**: Handler function for `send_user_feedback` tool

### Test Plan

- [x] Existing tests pass (`src/mcp/feishu-context-mcp.test.ts` - 45 tests passed)
- [x] TypeScript compilation passes
- [x] Logic change is backward compatible - string content is now parsed as JSON instead of being rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)