### PR TITLE
fix: resolve merge conflicts for PR #883 (Issue #532)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -12,6 +12,7 @@ import {
   update_card,
   wait_for_interaction,
   send_interactive_message,
+  ask_user,
   setMessageSentCallback,
   generate_summary,
   generate_qa_pairs,
@@ -34,6 +35,7 @@ export {
   stopIpcServer,
   isIpcServerRunning,
 } from './tools/interactive-message.js';
+export { ask_user } from './tools/ask-user.js';
 
 function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
   return { content: [{ type: 'text', text }] };
@@ -334,6 +336,116 @@ In actionPrompts, you can use these placeholders:
       required: ['card', 'actionPrompts', 'chatId'],
     },
     handler: send_interactive_message,
+  },
+  ask_user: {
+    description: `Ask the user a question with predefined options (Human-in-the-Loop).
+
+This tool provides a simple way for agents to ask users questions and receive responses.
+When the user selects an option, you will receive a message with the selection context.
+
+---
+
+## 🎯 常用场景
+
+### 1. PR 审核流程
+\`\`\`json
+{
+  "question": "发现新的 PR #123: Fix authentication bug\\n\\n请选择处理方式:",
+  "options": [
+    { "text": "✓ 合并", "value": "merge", "style": "primary", "action": "合并此 PR" },
+    { "text": "✗ 关闭", "value": "close", "style": "danger", "action": "关闭此 PR" },
+    { "text": "⏳ 等待", "value": "wait", "action": "稍后再处理" }
+  ],
+  "context": "PR #123 from scheduled scan",
+  "title": "🔔 PR 审核请求",
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+### 2. 确认操作
+\`\`\`json
+{
+  "question": "确定要删除这个文件吗？此操作不可撤销。",
+  "options": [
+    { "text": "确认删除", "value": "confirm", "style": "danger", "action": "执行删除操作" },
+    { "text": "取消", "value": "cancel", "action": "取消删除操作" }
+  ],
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+### 3. 选择方向
+\`\`\`json
+{
+  "question": "请选择实现方案:",
+  "options": [
+    { "text": "方案 A (推荐)", "value": "option_a", "style": "primary", "action": "使用方案 A 实现" },
+    { "text": "方案 B", "value": "option_b", "action": "使用方案 B 实现" },
+    { "text": "方案 C", "value": "option_c", "action": "使用方案 C 实现" }
+  ],
+  "context": "Issue #456 功能实现",
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+---
+
+## Parameters
+
+- **question**: The question text (supports Markdown)
+- **options**: Array of options (1-5 recommended)
+  - **text**: Button display text
+  - **value**: Unique value for this option (optional, defaults to option_N)
+  - **style**: Button style - "primary" (blue), "default" (white), "danger" (red)
+  - **action**: Description of what to do when this option is selected
+- **context**: Additional context information (optional)
+- **title**: Card title (optional, default: "🤖 Agent 提问")
+- **chatId**: Target chat ID
+- **parentMessageId**: Optional, for thread reply
+
+---
+
+## How It Works
+
+1. You call ask_user with a question and options
+2. A card with buttons is sent to the user
+3. When the user clicks a button, you receive a message like:
+   \`[用户操作] 用户选择了「合并」选项。\n\n**上下文**: PR #123\n\n**请执行**: 合并此 PR\`
+4. You continue execution based on the selection
+
+---
+
+## Best Practices
+
+1. **Include context**: Always provide enough context for future reference
+2. **Clear actions**: Specify what action to take for each option
+3. **Limit options**: 2-4 options work best for quick decisions
+4. **Use styles**: Use "primary" for recommended, "danger" for destructive actions`,
+    parameters: {
+      type: 'object',
+      properties: {
+        question: { type: 'string' },
+        options: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' },
+              value: { type: 'string' },
+              style: { type: 'string', enum: ['primary', 'default', 'danger'] },
+              action: { type: 'string' },
+            },
+            required: ['text'],
+          },
+        },
+        context: { type: 'string' },
+        title: { type: 'string' },
+        chatId: { type: 'string' },
+        parentMessageId: { type: 'string' },
+      },
+      required: ['question', 'options', 'chatId'],
+    },
+    handler: ask_user,
   },
 };
 
@@ -663,6 +775,113 @@ In actionPrompts, you can use these placeholders:
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ Interactive message failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'ask_user',
+    description: `Ask the user a question with predefined options (Human-in-the-Loop).
+
+This tool provides a simple way for agents to ask users questions and receive responses.
+When the user selects an option, you will receive a message with the selection context.
+
+---
+
+## 🎯 常用场景
+
+### 1. PR 审核流程
+\`\`\`json
+{
+  "question": "发现新的 PR #123: Fix authentication bug\\n\\n请选择处理方式:",
+  "options": [
+    { "text": "✓ 合并", "value": "merge", "style": "primary", "action": "合并此 PR" },
+    { "text": "✗ 关闭", "value": "close", "style": "danger", "action": "关闭此 PR" },
+    { "text": "⏳ 等待", "value": "wait", "action": "稍后再处理" }
+  ],
+  "context": "PR #123 from scheduled scan",
+  "title": "🔔 PR 审核请求",
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+### 2. 确认操作
+\`\`\`json
+{
+  "question": "确定要删除这个文件吗？此操作不可撤销。",
+  "options": [
+    { "text": "确认删除", "value": "confirm", "style": "danger", "action": "执行删除操作" },
+    { "text": "取消", "value": "cancel", "action": "取消删除操作" }
+  ],
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+### 3. 选择方向
+\`\`\`json
+{
+  "question": "请选择实现方案:",
+  "options": [
+    { "text": "方案 A (推荐)", "value": "option_a", "style": "primary", "action": "使用方案 A 实现" },
+    { "text": "方案 B", "value": "option_b", "action": "使用方案 B 实现" },
+    { "text": "方案 C", "value": "option_c", "action": "使用方案 C 实现" }
+  ],
+  "context": "Issue #456 功能实现",
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+---
+
+## Parameters
+
+- **question**: The question text (supports Markdown)
+- **options**: Array of options (1-5 recommended)
+  - **text**: Button display text
+  - **value**: Unique value for this option (optional, defaults to option_N)
+  - **style**: Button style - "primary" (blue), "default" (white), "danger" (red)
+  - **action**: Description of what to do when this option is selected
+- **context**: Additional context information (optional)
+- **title**: Card title (optional, default: "🤖 Agent 提问")
+- **chatId**: Target chat ID
+- **parentMessageId**: Optional, for thread reply
+
+---
+
+## How It Works
+
+1. You call ask_user with a question and options
+2. A card with buttons is sent to the user
+3. When the user clicks a button, you receive a message like:
+   \`[用户操作] 用户选择了「合并」选项。\n\n**上下文**: PR #123\n\n**请执行**: 合并此 PR\`
+4. You continue execution based on the selection
+
+---
+
+## Best Practices
+
+1. **Include context**: Always provide enough context for future reference
+2. **Clear actions**: Specify what action to take for each option
+3. **Limit options**: 2-4 options work best for quick decisions
+4. **Use styles**: Use "primary" for recommended, "danger" for destructive actions`,
+    parameters: z.object({
+      question: z.string(),
+      options: z.array(z.object({
+        text: z.string(),
+        value: z.string().optional(),
+        style: z.enum(['primary', 'default', 'danger']).optional(),
+        action: z.string().optional(),
+      })),
+      context: z.string().optional(),
+      title: z.string().optional(),
+      chatId: z.string(),
+      parentMessageId: z.string().optional(),
+    }),
+    handler: async ({ question, options, context, title, chatId, parentMessageId }) => {
+      try {
+        const result = await ask_user({ question, options, context, title, chatId, parentMessageId });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Ask user failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/ask-user.test.ts
+++ b/src/mcp/tools/ask-user.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for ask_user tool.
+ *
+ * @module mcp/tools/ask-user.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ask_user } from './ask-user.js';
+import * as interactiveMessage from './interactive-message.js';
+
+// Mock the send_interactive_message function
+vi.mock('./interactive-message.js', () => ({
+  send_interactive_message: vi.fn(),
+}));
+
+const mockSendInteractiveMessage = vi.mocked(interactiveMessage.send_interactive_message);
+
+describe('ask_user', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('parameter validation', () => {
+    it('should fail when question is missing', async () => {
+      const result = await ask_user({
+        question: '',
+        options: [{ text: 'Option 1' }],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('question is required');
+    });
+
+    it('should fail when options is empty', async () => {
+      const result = await ask_user({
+        question: 'Test question?',
+        options: [],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('non-empty array');
+    });
+
+    it('should fail when options is missing', async () => {
+      const result = await ask_user({
+        question: 'Test question?',
+        options: undefined as unknown as [],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('non-empty array');
+    });
+
+    it('should fail when chatId is missing', async () => {
+      const result = await ask_user({
+        question: 'Test question?',
+        options: [{ text: 'Option 1' }],
+        chatId: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('chatId is required');
+    });
+
+    it('should fail when option text is missing', async () => {
+      const result = await ask_user({
+        question: 'Test question?',
+        options: [{ text: '' }],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("missing 'text'");
+    });
+  });
+
+  describe('successful execution', () => {
+    it('should send interactive message with correct card structure', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await ask_user({
+        question: 'What is your choice?',
+        options: [
+          { text: 'Option A', value: 'a' },
+          { text: 'Option B', value: 'b' },
+        ],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe('msg_123');
+      expect(mockSendInteractiveMessage).toHaveBeenCalledTimes(1);
+
+      // Verify the call arguments
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      expect(callArgs.chatId).toBe('oc_test');
+
+      // Verify card structure
+      expect(callArgs.card).toHaveProperty('config');
+      expect(callArgs.card).toHaveProperty('header');
+      expect(callArgs.card).toHaveProperty('elements');
+    });
+
+    it('should build action prompts with context', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'How to handle this PR?',
+        options: [
+          { text: 'Merge', value: 'merge', action: 'Execute gh pr merge' },
+          { text: 'Close', value: 'close', style: 'danger', action: 'Execute gh pr close' },
+        ],
+        context: 'PR #123: Fix bug',
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+
+      // Verify action prompts include context
+      expect(callArgs.actionPrompts['merge']).toContain('PR #123: Fix bug');
+      expect(callArgs.actionPrompts['merge']).toContain('Execute gh pr merge');
+      expect(callArgs.actionPrompts['close']).toContain('Execute gh pr close');
+    });
+
+    it('should use default title when not provided', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Test?',
+        options: [{ text: 'OK' }],
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      const card = callArgs.card as { header: { title: { content: string } } };
+      expect(card.header.title.content).toBe('🤖 Agent 提问');
+    });
+
+    it('should use custom title when provided', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Test?',
+        options: [{ text: 'OK' }],
+        title: '🔔 Custom Title',
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      const card = callArgs.card as { header: { title: { content: string } } };
+      expect(card.header.title.content).toBe('🔔 Custom Title');
+    });
+
+    it('should apply button styles correctly', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Delete this file?',
+        options: [
+          { text: 'Confirm', value: 'confirm', style: 'primary' },
+          { text: 'Delete', value: 'delete', style: 'danger' },
+          { text: 'Cancel', value: 'cancel', style: 'default' },
+        ],
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      const card = callArgs.card as { elements: Array<{ actions?: Array<{ type: string }> }> };
+      const actions = card.elements[1].actions as Array<{ type: string }>;
+
+      expect(actions[0].type).toBe('primary');
+      expect(actions[1].type).toBe('danger');
+      expect(actions[2].type).toBe('default');
+    });
+
+    it('should generate default value when not provided', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Test?',
+        options: [
+          { text: 'First' },
+          { text: 'Second' },
+        ],
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+
+      // Should have generated values based on index
+      expect(callArgs.actionPrompts).toHaveProperty('option_First');
+      expect(callArgs.actionPrompts).toHaveProperty('option_Second');
+    });
+
+    it('should pass parentMessageId for thread reply', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Test?',
+        options: [{ text: 'OK' }],
+        chatId: 'oc_test',
+        parentMessageId: 'parent_123',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      expect(callArgs.parentMessageId).toBe('parent_123');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should propagate errors from send_interactive_message', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: false,
+        message: 'Failed to send',
+        error: 'Network error',
+      });
+
+      const result = await ask_user({
+        question: 'Test?',
+        options: [{ text: 'OK' }],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+
+    it('should handle exceptions', async () => {
+      mockSendInteractiveMessage.mockRejectedValueOnce(new Error('Unexpected error'));
+
+      const result = await ask_user({
+        question: 'Test?',
+        options: [{ text: 'OK' }],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unexpected error');
+    });
+  });
+
+  describe('action prompt generation', () => {
+    it('should include context and action in prompts', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Choose a plan:',
+        options: [
+          {
+            text: 'Plan A',
+            value: 'plan_a',
+            style: 'primary',
+            action: 'Implement using approach A',
+          },
+        ],
+        context: 'Issue #789: Feature implementation',
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      const prompt = callArgs.actionPrompts['plan_a'];
+
+      expect(prompt).toContain('[用户操作]');
+      expect(prompt).toContain('Plan A');
+      expect(prompt).toContain('Issue #789: Feature implementation');
+      expect(prompt).toContain('Implement using approach A');
+    });
+
+    it('should work without context and action', async () => {
+      mockSendInteractiveMessage.mockResolvedValueOnce({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      await ask_user({
+        question: 'Simple question?',
+        options: [{ text: 'Yes', value: 'yes' }],
+        chatId: 'oc_test',
+      });
+
+      const [[callArgs]] = mockSendInteractiveMessage.mock.calls;
+      const prompt = callArgs.actionPrompts['yes'];
+
+      expect(prompt).toContain('[用户操作]');
+      expect(prompt).toContain('Yes');
+      // Should not throw when context/action are missing
+    });
+  });
+});

--- a/src/mcp/tools/ask-user.ts
+++ b/src/mcp/tools/ask-user.ts
@@ -1,0 +1,228 @@
+/**
+ * Ask User tool implementation.
+ *
+ * This tool provides a simplified interface for agents to ask users questions
+ * with predefined options. It builds on top of send_interactive_message.
+ *
+ * @module mcp/tools/ask-user
+ */
+
+import { createLogger } from '../../utils/logger.js';
+import { send_interactive_message } from './interactive-message.js';
+import type { AskUserResult, AskUserOptions } from './types.js';
+
+const logger = createLogger('AskUser');
+
+/**
+ * Build a Feishu card structure for a question with options.
+ */
+function buildQuestionCard(
+  question: string,
+  options: AskUserOptions[],
+  title?: string
+): Record<string, unknown> {
+  const buttons = options.map((opt, index) => ({
+    tag: 'button',
+    text: { tag: 'plain_text', content: opt.text },
+    value: opt.value || `option_${index}`,
+    type: opt.style === 'danger' ? 'danger' :
+          opt.style === 'primary' ? 'primary' : 'default',
+  }));
+
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: title || '🤖 Agent 提问' },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: question,
+      },
+      {
+        tag: 'action',
+        actions: buttons,
+      },
+    ],
+  };
+}
+
+/**
+ * Build action prompts from options.
+ *
+ * Each prompt includes context about what action to take when the user
+ * selects that option. This enables the agent to continue execution
+ * based on the user's choice.
+ */
+function buildActionPrompts(
+  options: AskUserOptions[],
+  context?: string
+): Record<string, string> {
+  const prompts: Record<string, string> = {};
+
+  for (const opt of options) {
+    const value = opt.value || `option_${opt.text}`;
+    const contextPart = context ? `\n\n**上下文**: ${context}` : '';
+    const actionPart = opt.action
+      ? `\n\n**请执行**: ${opt.action}`
+      : '';
+
+    prompts[value] = `[用户操作] 用户选择了「${opt.text}」选项。${contextPart}${actionPart}`;
+  }
+
+  return prompts;
+}
+
+/**
+ * Ask the user a question with predefined options.
+ *
+ * This tool provides a Human-in-the-Loop capability for agents.
+ * When the user selects an option, the agent receives a message
+ * with the selection and can continue execution accordingly.
+ *
+ * @example
+ * ```typescript
+ * // Simple question
+ * await ask_user({
+ *   question: '如何处理这个 PR？',
+ *   options: [
+ *     { text: '合并', value: 'merge', action: '执行 gh pr merge' },
+ *     { text: '关闭', value: 'close', style: 'danger', action: '执行 gh pr close' },
+ *     { text: '等待', value: 'wait' },
+ *   ],
+ *   context: 'PR #123: Fix bug in authentication',
+ *   chatId: 'oc_xxx',
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // PR Review workflow (MVP use case from Issue #532)
+ * await ask_user({
+ *   question: `发现新的 PR:\n\n**PR #123**: Fix authentication bug\n\n作者: @developer\n\n请选择处理方式:`,
+ *   options: [
+ *     { text: '✓ 合并', value: 'merge', style: 'primary', action: '合并此 PR' },
+ *     { text: '✗ 关闭', value: 'close', style: 'danger', action: '关闭此 PR' },
+ *     { text: '⏳ 等待', value: 'wait', action: '标记为等待中，稍后再处理' },
+ *     { text: '📝 请求修改', value: 'request_changes', action: '请求作者修改' },
+ *   ],
+ *   context: 'PR #123 from scheduled scan',
+ *   title: '🔔 PR 审核请求',
+ *   chatId: 'oc_xxx',
+ * });
+ * ```
+ */
+export async function ask_user(params: {
+  /** The question to ask the user */
+  question: string;
+  /** Available options for the user to choose from */
+  options: AskUserOptions[];
+  /** Optional context information to include in the response */
+  context?: string;
+  /** Optional title for the card (default: "🤖 Agent 提问") */
+  title?: string;
+  /** Target chat ID */
+  chatId: string;
+  /** Optional parent message ID for thread reply */
+  parentMessageId?: string;
+}): Promise<AskUserResult> {
+  const { question, options, context, title, chatId, parentMessageId } = params;
+
+  logger.info({
+    chatId,
+    questionLength: question?.length ?? 0,
+    optionCount: options?.length ?? 0,
+    hasContext: !!context,
+  }, 'ask_user called');
+
+  try {
+    // Validate required parameters
+    if (!question || typeof question !== 'string') {
+      return {
+        success: false,
+        error: 'question is required and must be a string',
+        message: '❌ 问题不能为空',
+      };
+    }
+
+    if (!options || !Array.isArray(options) || options.length === 0) {
+      return {
+        success: false,
+        error: 'options is required and must be a non-empty array',
+        message: '❌ 必须提供至少一个选项',
+      };
+    }
+
+    if (options.length > 5) {
+      logger.warn({ optionCount: options.length }, 'More than 5 options may not display well on mobile');
+    }
+
+    if (!chatId) {
+      return {
+        success: false,
+        error: 'chatId is required',
+        message: '❌ chatId 不能为空',
+      };
+    }
+
+    // Validate each option
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i];
+      if (!opt.text) {
+        return {
+          success: false,
+          error: `Option ${i} is missing 'text' field`,
+          message: `❌ 选项 ${i + 1} 缺少显示文本`,
+        };
+      }
+    }
+
+    // Build card and action prompts
+    const card = buildQuestionCard(question, options, title);
+    const actionPrompts = buildActionPrompts(options, context);
+
+    logger.debug({
+      chatId,
+      cardStructure: JSON.stringify(card).slice(0, 200),
+      promptKeys: Object.keys(actionPrompts),
+    }, 'Built card and prompts');
+
+    // Send the interactive message
+    const result = await send_interactive_message({
+      card,
+      actionPrompts,
+      chatId,
+      parentMessageId,
+    });
+
+    if (result.success) {
+      logger.info({
+        chatId,
+        messageId: result.messageId,
+        optionCount: options.length,
+      }, 'Question sent successfully');
+
+      return {
+        success: true,
+        message: `✅ 问题已发送，等待用户选择 (${options.length} 个选项)`,
+        messageId: result.messageId,
+      };
+    } else {
+      return {
+        success: false,
+        error: result.error,
+        message: result.message || '❌ 发送问题失败',
+      };
+    }
+
+  } catch (error) {
+    logger.error({ err: error, chatId }, 'ask_user failed');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      error: errorMessage,
+      message: `❌ 发送问题失败: ${errorMessage}`,
+    };
+  }
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -14,6 +14,8 @@ export type {
   ActionPromptMap,
   InteractiveMessageContext,
   SendInteractiveResult,
+  AskUserOptions,
+  AskUserResult,
 } from './types.js';
 
 export { send_user_feedback, setMessageSentCallback, getMessageSentCallback } from './send-message.js';
@@ -27,6 +29,7 @@ export {
   generateInteractionPrompt,
   cleanupExpiredContexts,
 } from './interactive-message.js';
+export { ask_user } from './ask-user.js';
 
 // Study Guide Generator (NotebookLM M4)
 export {

--- a/src/mcp/tools/types.ts
+++ b/src/mcp/tools/types.ts
@@ -97,3 +97,27 @@ export interface SendInteractiveResult {
   messageId?: string;
   error?: string;
 }
+
+/**
+ * Option for ask_user tool.
+ */
+export interface AskUserOptions {
+  /** Display text for the option (shown on button) */
+  text: string;
+  /** Value returned when this option is selected (defaults to option_N if not provided) */
+  value?: string;
+  /** Visual style of the button */
+  style?: 'primary' | 'default' | 'danger';
+  /** Action description for the agent to execute when this option is selected */
+  action?: string;
+}
+
+/**
+ * Result type for ask_user tool.
+ */
+export interface AskUserResult {
+  success: boolean;
+  message: string;
+  messageId?: string;
+  error?: string;
+}


### PR DESCRIPTION
## Summary

Resolves merge conflicts in PR #883 to enable merging the `ask_user` tool implementation for Issue #532.

### Problem

PR #883 (feat: add ask_user tool for Human-in-the-Loop interactions) had merge conflicts with the main branch after the NotebookLM study guide tools were merged.

### Solution

Rebased the branch on top of main and resolved conflicts in:
- `src/mcp/tools/index.ts` - Combined exports for both ask_user and study guide generator
- `src/mcp/feishu-context-mcp.ts` - Combined tool definitions for both features

### Changes

The conflict resolution preserves all functionality from both branches:
1. **ask_user tool** - Human-in-the-Loop interaction capability
2. **Study Guide Generator tools** - NotebookLM M4 features (generate_summary, generate_qa_pairs, generate_flashcards, generate_quiz, create_study_guide)

### Test Results

- ✅ 1750 tests pass
- ✅ TypeScript compilation passes
- ✅ Build succeeds

## Original PR Description

Add a new `ask_user` MCP tool that provides a simplified interface for agents to ask users questions with predefined options. This implements the Human-in-the-Loop capability requested in Issue #532.

Fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)