### PR TITLE
docs(mcp): improve send_message tool description for card format clarity

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -87,7 +87,7 @@ describe('MCP Tools', () => {
   describe('Tool Definitions', () => {
     it('should have send_message tool definition', () => {
       expect(feishuContextTools.send_message).toBeDefined();
-      expect(feishuContextTools.send_message.description).toContain('Send a message to a chat');
+      expect(feishuContextTools.send_message.description).toContain('Send a simple message to a chat');
       expect(feishuContextTools.send_message.handler).toBe(send_message);
     });
 

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -49,27 +49,23 @@ function toolSuccess(text: string): { content: Array<{ type: 'text'; text: strin
 
 export const feishuContextTools = {
   send_message: {
-    description: `Send a message to a chat. Requires explicit format: "text" or "card".
+    description: `Send a simple message to a chat.
 
-**IMPORTANT: "format" parameter is REQUIRED for every call.**
+**For interactive cards with buttons/actions, use \`send_interactive_message\` instead.**
 
 ---
 
-## Correct Usage Examples
+## Usage
 
-### Text Message
+### Text Message (Recommended)
 \`\`\`json
 {"content": "Hello world", "format": "text", "chatId": "oc_xxx"}
 \`\`\`
 
-### Card Message
+### Display-Only Card (No interactions)
 \`\`\`json
 {
-  "content": {
-    "config": {"wide_screen_mode": true},
-    "header": {"title": {"tag": "plain_text", "content": "Title"}, "template": "blue"},
-    "elements": [{"tag": "markdown", "content": "**Bold** text"}]
-  },
+  "content": {"config": {}, "header": {"title": {"tag": "plain_text", "content": "Title"}}, "elements": []},
   "format": "card",
   "chatId": "oc_xxx"
 }
@@ -77,9 +73,11 @@ export const feishuContextTools = {
 
 ---
 
-**Thread Support:** Use parentMessageId to reply to a specific message.
+## ⚠️ Important Notes
 
-⚠️ **Markdown Tables NOT Supported** - Use column_set instead.
+- **Interactive cards**: Use \`send_interactive_message\` with actionPrompts
+- **Card content**: Must be an OBJECT (not JSON string)
+- **Thread reply**: Use parentMessageId parameter
 
 **Reference:** https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags`,
     parameters: {
@@ -339,20 +337,20 @@ In actionPrompts, you can use these placeholders:
 export const feishuToolDefinitions: InlineToolDefinition[] = [
   {
     name: 'send_message',
-    description: `Send a message to a chat. Requires explicit format: "text" or "card".
+    description: `Send a simple message to a chat.
 
-**IMPORTANT: "format" parameter is REQUIRED for every call.**
+**For interactive cards with buttons/actions, use \`send_interactive_message\` instead.**
 
 ---
 
-## Correct Usage Examples
+## Usage
 
-### Text Message
+### Text Message (Recommended)
 \`\`\`json
 {"content": "Hello", "format": "text", "chatId": "oc_xxx"}
 \`\`\`
 
-### Card Message
+### Display-Only Card (No interactions)
 \`\`\`json
 {
   "content": {"config": {}, "header": {"title": {"tag": "plain_text", "content": "Title"}}, "elements": []},
@@ -363,18 +361,11 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
 
 ---
 
-## Card Format Requirements
+## ⚠️ Important Notes
 
-When \`format: "card"\`, content MUST include:
-- \`config\`: Object
-- \`header\`: Object with \`title\`
-- \`elements\`: Array of card elements
-
----
-
-**Thread Support:** Use parentMessageId to reply to a specific message.
-
-⚠️ **Markdown Tables NOT Supported** - Use column_set instead.
+- **Interactive cards**: Use \`send_interactive_message\` with actionPrompts
+- **Card content**: Must be an OBJECT (not JSON string)
+- **Thread reply**: Use parentMessageId parameter
 
 **Reference:** https://open.feishu.cn/document/common-capabilities/message-card/message-cards-content/using-markdown-tags`,
     parameters: z.object({

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -78,9 +78,9 @@ describe('Feishu MCP Server', () => {
       expect(sendMessageTool).toBeDefined();
 
       // Verify description mentions key features
-      expect(sendMessageTool?.description).toContain('Send a message');
-      expect(sendMessageTool?.description).toContain('Thread Support');
-      expect(sendMessageTool?.description).toContain('Card Format Requirements');
+      expect(sendMessageTool?.description).toContain('Send a simple message');
+      expect(sendMessageTool?.description).toContain('send_interactive_message');
+      expect(sendMessageTool?.description).toContain('Important Notes');
     });
 
     it('should define send_file tool with correct schema', async () => {


### PR DESCRIPTION
## Summary

This PR improves the `send_message` tool description to guide agents to use the correct tool for interactive cards, following **Plan B** from Issue #990.

### Changes

1. **Renamed description**: "Send a message" → "Send a simple message"
2. **Added prominent guidance**: "For interactive cards with buttons/actions, use `send_interactive_message` instead"
3. **Simplified examples**: 
   - Text message marked as "(Recommended)"
   - Card example marked as "Display-Only Card (No interactions)"
4. **Removed redundant sections**: "Card Format Requirements" (already validated by the tool)
5. **Added "Important Notes" section** with clear guidance:
   - Interactive cards → use `send_interactive_message` with actionPrompts
   - Card content must be an OBJECT (not JSON string)
   - Thread reply via parentMessageId parameter

### Why Plan B?

As discussed in the issue comments:
- "格式检查是重要的，但必须正确"
- "应该改善的是 prompt(tool description)的精确性和正面示例"
- "分离单一 tool 的职责简化单一 tool description 的 token 量"

This approach keeps the validation logic intact while providing clearer guidance to LLMs.

### Test Results

- ✅ All 1726 tests pass
- ✅ TypeScript compilation passes
- ✅ Updated test assertions to match new description

Fixes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)