### PR TITLE
fix(test): increase integration test timeout to 180s (Issue #1017)

### DIFF
--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -33,8 +33,9 @@ _COMMON_SH_LOADED=1
 REST_PORT="${REST_PORT:-3099}"
 HOST="${HOST:-127.0.0.1}"
 API_URL="http://${HOST}:${REST_PORT}"
-# Timeout for API requests - increased to 60s for AI processing
-TIMEOUT="${TIMEOUT:-30}"
+# Timeout for API requests - increased to 180s for AI processing (Issue #1017)
+# AI models (especially GLM) can take significant time to respond
+TIMEOUT="${TIMEOUT:-180}"
 # Default to test config file for integration tests (no MCP servers)
 CONFIG_PATH="${CONFIG_PATH:-${PROJECT_ROOT}/disclaude.config.test.yaml}"
 SERVER_PID=""

--- a/tests/integration/rest-channel-test.sh
+++ b/tests/integration/rest-channel-test.sh
@@ -13,7 +13,7 @@
 #   ./tests/integration/rest-channel-test.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Request timeout (default: 30)
+#   --timeout SECONDS   Request timeout (default: 180)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -33,7 +33,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Set defaults before sourcing common.sh
 REST_PORT="${REST_PORT:-3099}"
 HOST="${HOST:-127.0.0.1}"
-TIMEOUT="${TIMEOUT:-30}"
+TIMEOUT="${TIMEOUT:-180}"
 CONFIG_PATH="${DISCLAUDE_CONFIG:-}"
 
 # Source common functions

--- a/tests/integration/run-all-tests.sh
+++ b/tests/integration/run-all-tests.sh
@@ -14,7 +14,7 @@
 #   ./tests/integration/run-all-tests.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Request timeout (default: 60)
+#   --timeout SECONDS   Request timeout (default: 180)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -30,7 +30,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Set defaults before sourcing common.sh
 REST_PORT="${REST_PORT:-3099}"
-TIMEOUT="${TIMEOUT:-60}"
+TIMEOUT="${TIMEOUT:-180}"
 
 # Source common functions
 source "$SCRIPT_DIR/common.sh"

--- a/tests/integration/use-case-1-basic-reply.sh
+++ b/tests/integration/use-case-1-basic-reply.sh
@@ -14,7 +14,7 @@
 #   ./tests/integration/use-case-1-basic-reply.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Request timeout (default: 30)
+#   --timeout SECONDS   Request timeout (default: 180)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -30,7 +30,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Set defaults before sourcing common.sh
 REST_PORT="${REST_PORT:-3099}"
-TIMEOUT="${TIMEOUT:-30}"
+TIMEOUT="${TIMEOUT:-180}"
 
 # Source common functions
 source "$SCRIPT_DIR/common.sh"

--- a/tests/integration/use-case-2-task-execution.sh
+++ b/tests/integration/use-case-2-task-execution.sh
@@ -13,7 +13,7 @@
 #   ./tests/integration/use-case-2-task-execution.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Request timeout (default: 60)
+#   --timeout SECONDS   Request timeout (default: 180)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -29,7 +29,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Set defaults before sourcing common.sh
 REST_PORT="${REST_PORT:-3099}"
-TIMEOUT="${TIMEOUT:-60}"
+TIMEOUT="${TIMEOUT:-180}"
 
 # Source common functions
 source "$SCRIPT_DIR/common.sh"

--- a/tests/integration/use-case-3-multi-turn.sh
+++ b/tests/integration/use-case-3-multi-turn.sh
@@ -14,7 +14,7 @@
 #   ./use-case-3-multi-turn.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Maximum wait time for response (default: 60)
+#   --timeout SECONDS   Maximum wait time for response (default: 180)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -29,7 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VERBOSE=false
 DRY_RUN=false
-TIMEOUT="${TIMEOUT:-60}"
+TIMEOUT="${TIMEOUT:-180}"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary

- Increase default timeout for all integration tests from 30-60s to 180s
- This accommodates AI model response latency, especially for GLM API

## Problem

The CI monitoring tests were failing with "HTTP 000" errors because AI processing time exceeded the 120s timeout limit. The server logs showed AI was actually processing the requests correctly, but the response took longer than the test timeout.

## Solution

Increase the default timeout across all integration test scripts to 180 seconds, giving sufficient time for AI models to respond even under high latency conditions.

## Changes

| File | Old Timeout | New Timeout |
|------|-------------|-------------|
| common.sh | 30s | 180s |
| rest-channel-test.sh | 30s | 180s |
| run-all-tests.sh | 60s | 180s |
| use-case-1-basic-reply.sh | 30s | 180s |
| use-case-2-task-execution.sh | 60s | 180s |
| use-case-3-multi-turn.sh | 60s | 180s |

## Test Plan

- [ ] CI tests should pass with the new timeout
- [ ] Verify no regression in test functionality

Fixes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)