### PR TITLE
feat(mcp): add create_group tool and PR scanner scheduled task (Issue #393)

### DIFF
--- a/schedules/pr-scanner.md
+++ b/schedules/pr-scanner.md
@@ -1,0 +1,126 @@
+---
+name: "PR 扫描器"
+cron: "0 */30 * * * *"
+enabled: true
+blocking: true
+chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+createdAt: "2026-03-07T00:00:00.000Z"
+---
+
+# PR 扫描任务
+
+每30分钟扫描仓库的 open PR，发现新 PR 时创建群聊通知。
+
+## 执行步骤
+
+### 1. 获取当前 open PR 列表
+
+```bash
+gh pr list --repo hs3180/disclaude --state open --json number,title,author,createdAt,headRefName,additions,deletions,changedFiles
+```
+
+### 2. 加载已处理的 PR 记录
+
+读取 `workspace/data/processed-prs.json` 文件，获取已处理过的 PR 编号列表。
+
+如果文件不存在，创建一个空记录：
+```json
+{
+  "processedPRs": [],
+  "lastScanTime": null
+}
+```
+
+### 3. 识别新 PR
+
+对比当前 open PR 列表与已处理记录，找出未处理的新 PR。
+
+### 4. 为每个新 PR 创建讨论群聊
+
+对于每个新 PR：
+
+1. **创建群聊**：
+   使用 `create_group` 工具创建群聊：
+   ```json
+   {
+     "name": "PR #{{number}}: {{title}}",
+     "description": "讨论 PR #{{number}}"
+   }
+   ```
+
+2. **获取 PR 详细信息**：
+   ```bash
+   gh pr view {{number}} --repo hs3180/disclaude
+   ```
+
+3. **发送 PR 信息卡片**：
+   使用 `send_message` 工具发送 PR 信息到新创建的群聊：
+   ```json
+   {
+     "chatId": "{{新建群聊的chatId}}",
+     "format": "card",
+     "content": {
+       "config": { "wide_screen_mode": true },
+       "header": {
+         "title": { "tag": "plain_text", "content": "PR #{{number}}" },
+         "template": "blue"
+       },
+       "elements": [
+         {
+           "tag": "div",
+           "text": { "tag": "lark_md", "content": "**{{title}}**\n\n作者: {{author}}\n创建时间: {{createdAt}}\n变更: +{{additions}} -{{deletions}} ({{changedFiles}} files)" }
+         },
+         {
+           "tag": "action",
+           "actions": [
+             {
+               "tag": "button",
+               "text": { "tag": "plain_text", "content": "查看 PR" },
+               "type": "primary",
+               "url": "https://github.com/hs3180/disclaude/pull/{{number}}"
+             }
+           ]
+         }
+       ]
+     }
+   }
+   ```
+
+### 5. 更新已处理 PR 记录
+
+将新处理的 PR 编号添加到 `workspace/data/processed-prs.json`：
+```json
+{
+  "processedPRs": [{{所有已处理的PR编号}}],
+  "lastScanTime": "{{当前时间ISO格式}}"
+}
+```
+
+## 数据文件
+
+`workspace/data/processed-prs.json` 用于跟踪已处理的 PR，避免重复创建群聊。
+
+## 错误处理
+
+1. 如果 `gh pr list` 失败，记录错误并跳过本次执行
+2. 如果 `create_group` 失败，记录错误但继续处理其他 PR
+3. 如果 `send_message` 失败，记录错误但继续处理其他 PR
+4. 如果读取/写入 `processed-prs.json` 失败，创建新文件
+
+## 示例输出
+
+```
+🔍 PR 扫描完成
+- 发现 5 个 open PR
+- 已处理 4 个
+- 新 PR: 1 个 (#1025)
+
+✅ 为 PR #1025 创建讨论群聊
+- 群聊 ID: oc_xxx
+- 已发送 PR 信息卡片
+```
+
+## 相关
+
+- Issue #393: 定时扫描 PR 并创建讨论群聊
+- Scheduler 模块

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -17,6 +17,7 @@ import {
   generate_flashcards,
   generate_quiz,
   create_study_guide,
+  create_group,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 
@@ -877,6 +878,49 @@ Part of NotebookLM features - generates comprehensive study materials including:
         return Promise.resolve(toolSuccess(output));
       } catch (error) {
         return Promise.resolve(toolSuccess(`⚠️ Study guide creation failed: ${error instanceof Error ? error.message : String(error)}`));
+      }
+    },
+  },
+  // Group Management (Issue #393)
+  {
+    name: 'create_group',
+    description: `Create a new Feishu group chat.
+
+Use this tool to create a new group chat for discussions, notifications, or collaboration.
+
+## Parameters
+- **name**: Group name/topic (optional, auto-generated if not provided)
+- **members**: Initial member open_ids (optional)
+- **description**: Purpose/description (optional, for your reference only)
+
+## Example
+\`\`\`json
+{
+  "name": "PR #123 Discussion",
+  "members": ["ou_xxx", "ou_yyy"],
+  "description": "Discussing the implementation of feature X"
+}
+\`\`\`
+
+## Returns
+- **chatId**: The created group's chat ID (can be used with send_message)
+- **name**: The group name
+
+## Use Cases
+- Create discussion groups for new PRs
+- Create topic groups for specific topics
+- Create ad-hoc collaboration groups`,
+    parameters: z.object({
+      name: z.string().optional(),
+      members: z.array(z.string()).optional(),
+      description: z.string().optional(),
+    }),
+    handler: async ({ name, members, description }) => {
+      try {
+        const result = await create_group({ name, members, description });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.error || 'Failed to create group'}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Group creation failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/create-group.ts
+++ b/src/mcp/tools/create-group.ts
@@ -1,0 +1,92 @@
+/**
+ * create_group tool implementation.
+ *
+ * Creates a new Feishu group chat and registers it with GroupService.
+ *
+ * @module mcp/tools/create-group
+ * @see Issue #393 - 定时扫描 PR 并创建讨论群聊
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getGroupService } from '../../platforms/feishu/group-service.js';
+
+const logger = createLogger('CreateGroup');
+
+export interface CreateGroupResult {
+  success: boolean;
+  chatId?: string;
+  name?: string;
+  error?: string;
+  message: string;
+}
+
+/**
+ * Create a new Feishu group chat.
+ *
+ * @param params - Group creation parameters
+ * @returns Result with chat ID and status
+ */
+export async function create_group(params: {
+  /** Group name/topic (optional, auto-generated if not provided) */
+  name?: string;
+  /** Initial member open_ids (optional) */
+  members?: string[];
+  /** Purpose/description for the group (optional) */
+  description?: string;
+}): Promise<CreateGroupResult> {
+  const { name, members, description } = params;
+
+  logger.info({
+    name,
+    memberCount: members?.length || 0,
+    hasDescription: !!description,
+  }, 'create_group called');
+
+  try {
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+      logger.error(errorMsg);
+      return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
+    }
+
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const groupService = getGroupService();
+
+    // Create the group using GroupService
+    const groupInfo = await groupService.createGroup(client, {
+      topic: name,
+      members,
+    });
+
+    logger.info({ chatId: groupInfo.chatId, name: groupInfo.name }, 'Group created successfully');
+
+    // Build success message
+    let message = '✅ Group created successfully!\n';
+    message += `**Chat ID**: \`${groupInfo.chatId}\`\n`;
+    message += `**Name**: ${groupInfo.name}\n`;
+    if (groupInfo.initialMembers.length > 0) {
+      message += `**Members**: ${groupInfo.initialMembers.length} user(s)`;
+    }
+    if (description) {
+      message += `\n**Description**: ${description}`;
+    }
+
+    return {
+      success: true,
+      chatId: groupInfo.chatId,
+      name: groupInfo.name,
+      message,
+    };
+
+  } catch (error) {
+    logger.error({ err: error, name }, 'create_group FAILED');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return { success: false, error: errorMessage, message: `❌ Failed to create group: ${errorMessage}` };
+  }
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -51,3 +51,7 @@ export type {
   StudyGuideOptions,
   StudyGuideResult,
 } from './study-guide-generator.js';
+
+// Group Management
+export { create_group } from './create-group.js';
+export type { CreateGroupResult } from './create-group.js';


### PR DESCRIPTION
## Summary

Implements Issue #393 - 定时扫描 PR 并创建讨论群聊

### New MCP Tool: create_group

- Add `create_group` MCP tool to enable agents to create Feishu group chats
- Exposes GroupService.createGroup() functionality to agents
- Returns chatId for use with send_message tool

### New Scheduled Task: PR Scanner

- Add `schedules/pr-scanner.md` - scans open PRs every 30 minutes
- Creates discussion groups for new PRs
- Tracks processed PRs to avoid duplicates

## Changes

| File | Change |
|------|--------|
| `src/mcp/tools/create-group.ts` | New file - create_group MCP tool implementation |
| `src/mcp/tools/index.ts` | Export create_group and CreateGroupResult |
| `src/mcp/feishu-context-mcp.ts` | Register create_group tool definition |
| `schedules/pr-scanner.md` | New file - PR scanner scheduled task |

## Test Results

- ✅ All 1712 tests pass
- ✅ TypeScript compilation passes
- ✅ Lint check passes (0 errors)

Fixes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)