### PR TITLE
feat(config): support REST channel configuration from config file

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -307,6 +307,15 @@ export class Config {
   }
 
   /**
+   * Get REST channel configuration.
+   *
+   * @returns REST channel configuration object
+   */
+  static getRestChannelConfig(): import('./types.js').RestChannelConfig {
+    return fileConfigOnly.channels?.rest || {};
+  }
+
+  /**
    * Get logging configuration.
    *
    * @returns Logging configuration object

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -170,6 +170,10 @@ export interface RestChannelConfig extends ConfigChannelConfig {
   authToken?: string;
   /** Enable CORS */
   enableCors?: boolean;
+  /** File storage directory (default: ./data/rest-files) */
+  fileStorageDir?: string;
+  /** Maximum file size in bytes (default: 100MB) */
+  maxFileSize?: number;
 }
 
 /**

--- a/src/nodes/primary-node.test.ts
+++ b/src/nodes/primary-node.test.ts
@@ -14,6 +14,7 @@ vi.mock('../config/index.js', () => ({
     getWorkspaceDir: () => '/tmp/test-workspace',
     getAgentConfig: () => ({ model: 'test-model' }),
     getChannelsConfig: () => ({ rest: { port: 3000, enabled: true } }),
+    getRestChannelConfig: () => ({ port: 3000, enabled: true }),
   },
 }));
 

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -241,14 +241,26 @@ export class PrimaryNode extends EventEmitter {
     }
 
     // Create REST channel if enabled
-    if (config.enableRestChannel !== false) {
+    // Priority: PrimaryNodeConfig > Config file > Defaults
+    const restChannelConfig = Config.getRestChannelConfig();
+    const isRestEnabled = config.enableRestChannel ?? restChannelConfig.enabled ?? true;
+
+    if (isRestEnabled) {
       const restChannel = new RestChannel({
         id: 'rest',
-        port: config.restPort || 3000,
-        authToken: config.restAuthToken,
+        port: config.restPort ?? restChannelConfig.port ?? 3000,
+        host: restChannelConfig.host,
+        apiPrefix: restChannelConfig.apiPrefix,
+        authToken: config.restAuthToken ?? restChannelConfig.authToken,
+        enableCors: restChannelConfig.enableCors,
+        fileStorageDir: restChannelConfig.fileStorageDir,
+        maxFileSize: restChannelConfig.maxFileSize,
       });
       this.registerChannel(restChannel);
-      logger.info({ port: config.restPort || 3000 }, 'REST channel registered');
+      logger.info(
+        { port: config.restPort ?? restChannelConfig.port ?? 3000 },
+        'REST channel registered'
+      );
     }
 
     logger.info({


### PR DESCRIPTION
## Summary

- Add `fileStorageDir` and `maxFileSize` fields to `RestChannelConfig` in `src/config/types.ts`
- Add `getRestChannelConfig()` method to `Config` class for reading REST channel config
- Update `PrimaryNode` to use config file for REST channel settings with priority: `PrimaryNodeConfig` > Config file > Defaults

## Changes

| File | Change |
|------|--------|
| `src/config/types.ts` | Add `fileStorageDir` and `maxFileSize` fields to `RestChannelConfig` |
| `src/config/index.ts` | Add `getRestChannelConfig()` method |
| `src/nodes/primary-node.ts` | Use config file for REST channel configuration |
| `src/nodes/primary-node.test.ts` | Update mock to include `getRestChannelConfig` |

## Configuration Example

Users can now configure REST channel in `disclaude.config.yaml`:

```yaml
channels:
  rest:
    enabled: true
    port: 3000
    host: "0.0.0.0"
    apiPrefix: "/api"
    authToken: "your-secret-token"  # 可选
    enableCors: true
    fileStorageDir: "./data/rest-files"
    maxFileSize: 104857600  # 100MB
```

## Test Results

```
✓ src/channels/rest-channel.test.ts (45 tests)
✓ src/config/ (91 tests)
✓ src/nodes/primary-node.test.ts (8 tests)
 Test Files  95 passed (95)
 Tests  1712 passed (1712)
```

Fixes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)