### PR TITLE
feat(config): support REST Channel configuration from config file

### DIFF
--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -209,6 +209,48 @@ describe('Config', () => {
     });
   });
 
+  describe('getRestChannelConfig()', () => {
+    it('should return an object', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(typeof restConfig).toBe('object');
+    });
+
+    it('should have optional port property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.port === undefined || typeof restConfig.port === 'number').toBe(true);
+    });
+
+    it('should have optional host property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.host === undefined || typeof restConfig.host === 'string').toBe(true);
+    });
+
+    it('should have optional apiPrefix property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.apiPrefix === undefined || typeof restConfig.apiPrefix === 'string').toBe(true);
+    });
+
+    it('should have optional authToken property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.authToken === undefined || typeof restConfig.authToken === 'string').toBe(true);
+    });
+
+    it('should have optional enableCors property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.enableCors === undefined || typeof restConfig.enableCors === 'boolean').toBe(true);
+    });
+
+    it('should have optional fileStorageDir property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.fileStorageDir === undefined || typeof restConfig.fileStorageDir === 'string').toBe(true);
+    });
+
+    it('should have optional maxFileSize property', () => {
+      const restConfig = Config.getRestChannelConfig();
+      expect(restConfig.maxFileSize === undefined || typeof restConfig.maxFileSize === 'number').toBe(true);
+    });
+  });
+
   describe('getAgentConfig()', () => {
     it('should throw error when no API key is configured', () => {
       // This test assumes no API keys are set in the test environment

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -346,4 +346,14 @@ export class Config {
   static getDebugConfig(): import('./types.js').DebugConfig {
     return fileConfigOnly.messaging?.debug || {};
   }
+
+  /**
+   * Get REST channel configuration from config file.
+   * @see Issue #1028
+   *
+   * @returns REST channel configuration object
+   */
+  static getRestChannelConfig(): import('./types.js').RestChannelConfig {
+    return fileConfigOnly.channels?.rest || {};
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -170,6 +170,10 @@ export interface RestChannelConfig extends ConfigChannelConfig {
   authToken?: string;
   /** Enable CORS */
   enableCors?: boolean;
+  /** File storage directory (default: ./data/rest-files) */
+  fileStorageDir?: string;
+  /** Maximum file size in bytes (default: 100MB) */
+  maxFileSize?: number;
 }
 
 /**

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -242,13 +242,20 @@ export class PrimaryNode extends EventEmitter {
 
     // Create REST channel if enabled
     if (config.enableRestChannel !== false) {
+      // Issue #1028: Use full REST channel config from config file if available
+      const restConfig = config.restChannelConfig || {};
       const restChannel = new RestChannel({
         id: 'rest',
-        port: config.restPort || 3000,
-        authToken: config.restAuthToken,
+        port: config.restPort || restConfig.port || 3000,
+        host: restConfig.host,
+        apiPrefix: restConfig.apiPrefix,
+        authToken: config.restAuthToken || restConfig.authToken,
+        enableCors: restConfig.enableCors,
+        fileStorageDir: restConfig.fileStorageDir,
+        maxFileSize: restConfig.maxFileSize,
       });
       this.registerChannel(restChannel);
-      logger.info({ port: config.restPort || 3000 }, 'REST channel registered');
+      logger.info({ port: config.restPort || restConfig.port || 3000 }, 'REST channel registered');
     }
 
     logger.info({

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -6,6 +6,7 @@
 
 import type { FileStorageConfig } from '../file-transfer/node-transfer/file-storage.js';
 import type { IChannel } from '../channels/index.js';
+import type { RestChannelConfig } from '../channels/rest-channel.js';
 
 /**
  * Node type identifier.
@@ -44,6 +45,12 @@ export interface PrimaryNodeConfig extends BaseNodeConfig {
   enableRestChannel?: boolean;
   /** REST channel auth token */
   restAuthToken?: string;
+  /**
+   * Full REST channel configuration from config file.
+   * Takes precedence over restPort and restAuthToken if provided.
+   * @see Issue #1028
+   */
+  restChannelConfig?: RestChannelConfig;
   /** Feishu App ID */
   appId?: string;
   /** Feishu App Secret */

--- a/src/runners/primary-runner.ts
+++ b/src/runners/primary-runner.ts
@@ -16,14 +16,17 @@ const logger = createLogger('PrimaryRunner');
  * Get Primary Node configuration from CLI args.
  */
 export function getPrimaryNodeConfig(globalArgs: GlobalArgs): PrimaryNodeConfig {
-  const channelsConfig = Config.getChannelsConfig();
+  // Issue #1028: Get full REST channel config from config file
+  const restChannelConfig = Config.getRestChannelConfig();
   return {
     type: 'primary',
     port: globalArgs.port,
     host: globalArgs.host,
     restPort: globalArgs.restPort,
     enableRestChannel: globalArgs.enableRestChannel,
-    restAuthToken: channelsConfig?.rest?.authToken,
+    restAuthToken: restChannelConfig?.authToken,
+    // Pass full REST channel config for all options (port, host, apiPrefix, etc.)
+    restChannelConfig,
     enableLocalExec: true, // Primary node always has local execution
   };
 }


### PR DESCRIPTION
## Summary

This PR adds support for configuring REST Channel options from `disclaude.config.yaml`.

Closes #1028

### Changes

| File | Change |
|------|--------|
| `src/config/types.ts` | Add `fileStorageDir` and `maxFileSize` fields to `RestChannelConfig` |
| `src/config/index.ts` | Add `getRestChannelConfig()` method |
| `src/nodes/types.ts` | Add `restChannelConfig` field to `PrimaryNodeConfig` |
| `src/runners/primary-runner.ts` | Read full REST channel config from config file |
| `src/nodes/primary-node.ts` | Use full REST channel config when creating RestChannel |
| `src/config/index.test.ts` | Add tests for `getRestChannelConfig()` |

### Configuration Example

```yaml
channels:
  rest:
    enabled: true
    port: 3000
    host: "0.0.0.0"
    apiPrefix: "/api"
    authToken: "your-secret-token"  # optional
    enableCors: true
    fileStorageDir: "./data/rest-files"
    maxFileSize: 104857600  # 100MB
```

## Test Plan

- [x] Unit tests pass (53 tests in config module)
- [x] TypeScript compilation succeeds
- [ ] Manual testing with config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)