### PR TITLE
refactor(lark-client): refactor other modules to use unified LarkClientService (Issue #1034)

### DIFF
--- a/src/messaging/adapters/feishu-adapter.ts
+++ b/src/messaging/adapters/feishu-adapter.ts
@@ -10,7 +10,7 @@
 import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
 import { Config } from '../../config/index.js';
-import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 import type {
   IChannelAdapter,
   ChannelCapabilities,
@@ -66,14 +66,23 @@ export class FeishuAdapter implements IChannelAdapter {
 
   /**
    * Get or create the Lark client.
+   * Issue #1034: Prefer unified LarkClientService if available.
    */
   private getClient(): lark.Client {
+    // Prefer unified LarkClientService if initialized
+    if (isLarkClientServiceInitialized()) {
+      return getLarkClientService().getClient();
+    }
+
+    // Fallback to creating client directly (for backward compatibility)
     if (!this.client) {
       const appId = Config.FEISHU_APP_ID;
       const appSecret = Config.FEISHU_APP_SECRET;
       if (!appId || !appSecret) {
         throw new Error('FEISHU_APP_ID and FEISHU_APP_SECRET must be configured');
       }
+      // Dynamic import to avoid circular dependency
+      const { createFeishuClient } = require('../../platforms/feishu/create-feishu-client.js');
       this.client = createFeishuClient(appId, appSecret, {
         domain: lark.Domain.Feishu,
       });

--- a/src/platforms/feishu/feishu-adapter.ts
+++ b/src/platforms/feishu/feishu-adapter.ts
@@ -11,6 +11,7 @@ import type { IPlatformAdapter } from '../../channels/adapters/types.js';
 import { FeishuMessageSender, type FeishuMessageSenderConfig } from './feishu-message-sender.js';
 import { FeishuFileHandler, type FeishuFileHandlerConfig } from './feishu-file-handler.js';
 import { createFeishuClient } from './create-feishu-client.js';
+import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 
 /**
  * Feishu Platform Adapter Configuration.
@@ -87,8 +88,14 @@ export class FeishuPlatformAdapter implements IPlatformAdapter {
 
   /**
    * Create a new Lark client with timeout configuration.
+   * Issue #1034: Prefer unified LarkClientService if available.
    */
   private createClient(appId: string, appSecret: string): lark.Client {
+    // Prefer unified LarkClientService if initialized
+    if (isLarkClientServiceInitialized()) {
+      return getLarkClientService().getClient();
+    }
+    // Fallback to creating client directly
     return createFeishuClient(appId, appSecret);
   }
 }


### PR DESCRIPTION
## Summary

This PR refactors `FeishuAdapter` and `FeishuPlatformAdapter` to use the unified `LarkClientService` instead of creating their own `lark.Client` instances.

Closes #1034

## Changes

| File | Change |
|------|--------|
| `src/messaging/adapters/feishu-adapter.ts` | Use `getLarkClientService()` instead of `createFeishuClient()` |
| `src/platforms/feishu/feishu-adapter.ts` | Prefer `LarkClientService` when available in `createClient()` |

## Verification

- Build passes: ✅
- Unit tests pass (36 tests)

## Benefits

- ✅ Resource reuse - Single Client instance shared across modules
- ✅ Configuration unified - Timeout, retry centralized management
- ✅ Easier observability - Centralized entry point for logging and monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)