### PR TITLE
refactor(architecture): extract shared types and constants to @disclaude/core (Issue #1039)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pm2:monit": "pm2 monit"
   },
   "dependencies": {
+    "@disclaude/core": "*",
     "@anthropic-ai/claude-agent-sdk": "0.2.62",
     "@anthropic-ai/sdk": "^0.78.0",
     "@larksuiteoapi/node-sdk": "^1.34.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,8 +15,12 @@
     "build": "tsc -b",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "uuid": "^11.1.0"
+  },
   "devDependencies": {
+    "@types/node": "^22.15.21",
+    "@types/uuid": "^10.0.0",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,0 +1,100 @@
+/**
+ * Application-wide constants.
+ */
+
+/**
+ * Message deduplication constants
+ */
+export const DEDUPLICATION = {
+  /** Maximum number of message IDs to keep in memory */
+  MAX_PROCESSED_IDS: 1000,
+
+  /** Maximum age of messages to process (milliseconds) */
+  MAX_MESSAGE_AGE: 60 * 1000, // 1 minute
+
+  /** Message deduplication record expiration time (milliseconds) */
+  RECORD_EXPIRATION_MS: 2 * 60 * 1000, // 2 minutes
+} as const;
+
+/**
+ * Dialogue/Agent loop configuration
+ */
+export const DIALOGUE = {
+  /** Maximum number of iterations in the dialogue loop */
+  MAX_ITERATIONS: 20,
+} as const;
+
+/**
+ * Message logging configuration
+ */
+export const MESSAGE_LOGGING = {
+  /** Directory for message logs */
+  LOGS_DIR: 'chat',
+
+  /** Regex to extract message IDs from MD files */
+  MD_PARSE_REGEX: /message_id:\s*([^\)]+)/g,
+} as const;
+
+/**
+ * Reaction emoji constants for message feedback
+ */
+export const REACTIONS = {
+  /** Emoji to indicate the bot is typing/processing (👀 = 正在查看/处理中) */
+  TYPING: 'Typing',
+} as const;
+
+/**
+ * Feishu API configuration constants (Issue #498, #507)
+ */
+export const FEISHU_API = {
+  /** Request timeout in milliseconds (30 seconds) */
+  REQUEST_TIMEOUT_MS: 30 * 1000,
+
+  /** Retry configuration for transient errors */
+  RETRY: {
+    /** Maximum number of retry attempts */
+    MAX_RETRIES: 3,
+    /** Initial delay in milliseconds before first retry */
+    INITIAL_DELAY_MS: 1000,
+    /** Maximum delay in milliseconds between retries */
+    MAX_DELAY_MS: 10000,
+    /** Multiplier for exponential backoff */
+    BACKOFF_MULTIPLIER: 2,
+  },
+} as const;
+
+/**
+ * Chat history configuration for passive mode (Issue #517)
+ */
+export const CHAT_HISTORY = {
+  /** Maximum characters for chat history context */
+  MAX_CONTEXT_LENGTH: 8000,
+
+  /** Maximum number of messages to include in context */
+  MAX_MESSAGES: 50,
+} as const;
+
+/**
+ * Session restoration configuration (Issue #955)
+ */
+export const SESSION_RESTORE = {
+  /** Number of days to look back for chat history */
+  HISTORY_DAYS: 7,
+
+  /** Maximum characters for restored session context */
+  MAX_CONTEXT_LENGTH: 4000,
+} as const;
+
+/**
+ * Error codes that should trigger a retry
+ */
+export const RETRYABLE_ERROR_CODES = [
+  'ETIMEDOUT',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EPROTO',
+] as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,14 +3,19 @@
  *
  * Shared core utilities, types, and interfaces for disclaude.
  *
- * This package will contain:
- * - Type definitions
- * - Utility functions
- * - Constants
- * - Public interfaces
+ * This package contains:
+ * - Type definitions (platform, websocket, file)
+ * - Constants (deduplication, dialogue, api config)
  *
- * Code will be migrated from src/ in subsequent PRs.
+ * Note: Utility functions (logger, error-handler, retry) will be migrated
+ * in a subsequent PR after resolving their dependencies.
  */
 
-// Placeholder - code will be migrated from src/ in subsequent issues
+// Types
+export * from './types/index.js';
+
+// Constants
+export * from './constants/index.js';
+
+// Version
 export const CORE_VERSION = '0.0.1';

--- a/packages/core/src/types/file.ts
+++ b/packages/core/src/types/file.ts
@@ -1,0 +1,217 @@
+/**
+ * Unified file transfer types.
+ *
+ * This module consolidates file-related types from across the codebase.
+ *
+ * @see Issue #194 - Refactor: 统一文件传输系统架构
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Base file reference - unique identifier for files in the system.
+ *
+ * This is the unified type that replaces both FileReference and FileAttachment.
+ */
+export interface FileRef {
+  /** Unique file identifier (UUID) */
+  id: string;
+
+  /** Original file name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File size in bytes */
+  size?: number;
+
+  /** File source: user upload or agent generated */
+  source: 'user' | 'agent';
+
+  /**
+   * Local storage path.
+   * - For downloaded user files: where the file is stored locally
+   * - For agent files: where the file was created
+   */
+  localPath?: string;
+
+  /**
+   * Platform-specific file key.
+   * - Feishu: file_key from the platform
+   * - Other platforms: platform-specific identifier
+   */
+  platformKey?: string;
+
+  /** Creation timestamp */
+  createdAt: number;
+
+  /** Expiration timestamp (optional, for auto cleanup) */
+  expiresAt?: number;
+}
+
+/**
+ * Inbound attachment - file uploaded by user.
+ *
+ * Used when a user sends a file/image to the system.
+ */
+export interface InboundAttachment extends FileRef {
+  source: 'user';
+
+  /** Chat/conversation ID where the file was uploaded */
+  chatId: string;
+
+  /** Message ID that contained the file */
+  messageId?: string;
+
+  /** File type classification */
+  fileType: 'image' | 'file' | 'media';
+}
+
+/**
+ * Outbound file - file to be sent to user.
+ *
+ * Used when the agent generates a file to send to the user.
+ */
+export interface OutboundFile extends FileRef {
+  source: 'agent';
+
+  /** Target chat/conversation ID */
+  chatId?: string;
+
+  /** Thread ID for threaded replies */
+  threadId?: string;
+}
+
+/**
+ * File upload request - exec node uploads file to comm node.
+ */
+export interface FileUploadRequest {
+  /** File name */
+  fileName: string;
+
+  /** MIME type */
+  mimeType?: string;
+
+  /** File content (base64 encoded) */
+  content: string;
+
+  /** Associated chatId (optional) */
+  chatId?: string;
+}
+
+/**
+ * File upload response.
+ */
+export interface FileUploadResponse {
+  /** File reference after successful upload */
+  fileRef: FileRef;
+}
+
+/**
+ * File download response.
+ */
+export interface FileDownloadResponse {
+  /** File reference */
+  fileRef: FileRef;
+
+  /** File content (base64 encoded) */
+  content: string;
+}
+
+/**
+ * File storage info (internal use by comm node).
+ */
+export interface StoredFile {
+  /** File reference */
+  ref: FileRef;
+
+  /** Local storage path */
+  localPath: string;
+}
+
+/**
+ * Factory function to create a FileRef.
+ */
+export function createFileRef(
+  fileName: string,
+  source: 'user' | 'agent',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    platformKey?: string;
+    chatId?: string;
+    messageId?: string;
+    fileType?: 'image' | 'file' | 'media';
+    expiresInMs?: number;
+  }
+): FileRef {
+  const now = Date.now();
+  return {
+    id: uuidv4(),
+    fileName,
+    mimeType: options?.mimeType,
+    size: options?.size,
+    source,
+    localPath: options?.localPath,
+    platformKey: options?.platformKey,
+    createdAt: now,
+    expiresAt: options?.expiresInMs ? now + options.expiresInMs : undefined,
+  };
+}
+
+/**
+ * Factory function to create an InboundAttachment.
+ */
+export function createInboundAttachment(
+  fileName: string,
+  chatId: string,
+  fileType: 'image' | 'file' | 'media',
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    platformKey?: string;
+    messageId?: string;
+    expiresInMs?: number;
+  }
+): InboundAttachment {
+  const fileRef = createFileRef(fileName, 'user', {
+    ...options,
+    chatId,
+    fileType,
+  });
+
+  return {
+    ...fileRef,
+    source: 'user',
+    chatId,
+    messageId: options?.messageId,
+    fileType,
+  };
+}
+
+/**
+ * Factory function to create an OutboundFile.
+ */
+export function createOutboundFile(
+  fileName: string,
+  options?: {
+    mimeType?: string;
+    size?: number;
+    localPath?: string;
+    chatId?: string;
+    threadId?: string;
+    expiresInMs?: number;
+  }
+): OutboundFile {
+  const fileRef = createFileRef(fileName, 'agent', options);
+
+  return {
+    ...fileRef,
+    source: 'agent',
+    chatId: options?.chatId,
+    threadId: options?.threadId,
+  };
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Core type definitions for disclaude.
+ */
+
+// File transfer types
+export type {
+  FileRef,
+  InboundAttachment,
+  OutboundFile,
+  FileUploadRequest,
+  FileUploadResponse,
+  FileDownloadResponse,
+  StoredFile,
+} from './file.js';
+
+export { createFileRef, createInboundAttachment, createOutboundFile } from './file.js';
+
+// Platform types (Feishu-specific)
+export type {
+  FeishuMessageEvent,
+  FeishuEventData,
+  FeishuCardActionEvent,
+  FeishuCardActionEventData,
+  InteractionContext,
+  InteractionHandler,
+  FeishuChatMemberAddedEvent,
+  FeishuChatMemberAddedEventData,
+  FeishuP2PChatEnteredEvent,
+  FeishuP2PChatEnteredEventData,
+} from './platform.js';
+
+// WebSocket message types
+export type {
+  PromptMessage,
+  CommandMessage,
+  RegisterMessage,
+  ExecNodeInfo,
+  FeedbackMessage,
+  CardActionMessage,
+  CardContextMessage,
+} from './websocket-messages.js';

--- a/packages/core/src/types/platform.ts
+++ b/packages/core/src/types/platform.ts
@@ -1,0 +1,179 @@
+/**
+ * Feishu message event structure.
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/events/receive_v1
+ */
+export interface FeishuMessageEvent {
+  message: {
+    message_id: string;
+    chat_id: string;
+    chat_type?: 'p2p' | 'group' | 'topic';
+    content: string;
+    message_type: string;
+    create_time?: number;
+    mentions?: Array<{
+      key: string;
+      id: {
+        open_id: string;
+        union_id: string;
+        user_id: string;
+      };
+      name: string;
+      tenant_key: string;
+    }>;
+  };
+  sender: {
+    sender_type?: string;
+    sender_id?: {
+      open_id?: string;
+      union_id?: string;
+      user_id?: string;
+    };
+    tenant_key?: string;
+  };
+}
+
+/**
+ * Feishu WebSocket event data wrapper.
+ */
+export interface FeishuEventData {
+  event?: FeishuMessageEvent;
+  [key: string]: unknown;
+}
+
+/**
+ * Feishu card action event structure.
+ * Triggered when user interacts with card buttons, menus, etc.
+ * @see https://open.feishu.cn/document/client-docs/bot-v3/events/card-action-trigger
+ */
+export interface FeishuCardActionEvent {
+  /** The action that was triggered */
+  action: {
+    /** Action type: button, menu, date_picker, etc. */
+    type: string;
+    /** Action value set when creating the card */
+    value: string;
+    /** What triggered the action: button, menu, date, etc. */
+    trigger: 'button' | 'menu' | 'date' | 'input' | 'static';
+    /** For menu/dropdown: the selected option */
+    option?: string;
+    /**
+     * Button or option text displayed to user.
+     * Used to generate user-friendly prompt when action is triggered.
+     * Issue #525: Simple card interaction without promptTemplate
+     */
+    text?: string;
+  };
+  /** The message containing the card */
+  message_id: string;
+  /** Chat ID */
+  chat_id: string;
+  /** User who triggered the action */
+  user: {
+    sender_id: {
+      open_id: string;
+      union_id?: string;
+      user_id?: string;
+    };
+  };
+  /** Tenant key */
+  tenant_key?: string;
+  /** Token for updating the card */
+  token?: string;
+  /** Open message ID for card update */
+  open_message_id?: string;
+  /** Open card ID */
+  open_card_id?: string;
+}
+
+/**
+ * Feishu card action event data wrapper.
+ */
+export interface FeishuCardActionEventData {
+  event?: FeishuCardActionEvent;
+  [key: string]: unknown;
+}
+
+/**
+ * Interaction context stored for pending interactions.
+ */
+export interface InteractionContext {
+  /** Unique interaction ID */
+  id: string;
+  /** Chat ID where interaction was created */
+  chatId: string;
+  /** Message ID of the card */
+  messageId: string;
+  /** Action keys expected in this interaction */
+  expectedActions: string[];
+  /** Timestamp when interaction was created */
+  createdAt: number;
+  /** Timestamp when interaction expires */
+  expiresAt: number;
+  /** Additional metadata */
+  metadata?: Record<string, unknown>;
+  /** Callback to handle the interaction */
+  handler?: (action: FeishuCardActionEvent) => Promise<void>;
+}
+
+/**
+ * Interaction handler function type.
+ */
+export type InteractionHandler = (action: FeishuCardActionEvent) => Promise<void>;
+
+/**
+ * Feishu chat member added event.
+ * Triggered when members (including bot) are added to a chat.
+ * @see https://open.feishu.cn/document/client-docs/bot-v3/events/chat-member-added
+ */
+export interface FeishuChatMemberAddedEvent {
+  /** Chat ID */
+  chat_id: string;
+  /** Timestamp */
+  timestamp: string;
+  /** Members added to the chat */
+  members: Array<{
+    member_id_type: string;
+    member_id: string;
+    name?: string;
+    tenant_key?: string;
+  }>;
+  /** Operator who added the members */
+  operator: {
+    operator_id_type: string;
+    operator_id: string;
+    tenant_key?: string;
+  };
+}
+
+/**
+ * Feishu chat member added event data wrapper.
+ */
+export interface FeishuChatMemberAddedEventData {
+  event?: FeishuChatMemberAddedEvent;
+  [key: string]: unknown;
+}
+
+/**
+ * Feishu P2P chat entered event.
+ * Triggered when a user starts a private chat with the bot.
+ * @see https://open.feishu.cn/document/client-docs/bot-v3/events/bot-p2p-chat-entered
+ */
+export interface FeishuP2PChatEnteredEvent {
+  /** User who entered the chat */
+  user: {
+    open_id: string;
+    union_id?: string;
+    user_id?: string;
+    tenant_key?: string;
+  };
+  /** Timestamp */
+  timestamp: string;
+}
+
+/**
+ * Feishu P2P chat entered event data wrapper.
+ */
+export interface FeishuP2PChatEnteredEventData {
+  event?: FeishuP2PChatEnteredEvent;
+  [key: string]: unknown;
+}

--- a/packages/core/src/types/websocket-messages.ts
+++ b/packages/core/src/types/websocket-messages.ts
@@ -1,0 +1,136 @@
+/**
+ * WebSocket message types for Communication Node and Execution Node communication.
+ *
+ * These types define the message format exchanged between the two nodes:
+ * - Communication Node sends: PromptMessage, CommandMessage
+ * - Execution Node sends: FeedbackMessage
+ */
+
+import type { FileRef } from './file.js';
+
+/**
+ * Message sent from Communication Node to Execution Node when a user sends a prompt.
+ */
+export interface PromptMessage {
+  type: 'prompt';
+  chatId: string;
+  prompt: string;
+  messageId: string;
+  senderOpenId?: string;
+  /** Thread root message ID for thread replies */
+  threadId?: string;
+  /** File attachments (if any) */
+  attachments?: FileRef[];
+  /** Chat history context for passive mode (Issue #517) */
+  chatHistoryContext?: string;
+}
+
+/**
+ * Message sent from Communication Node to Execution Node for control commands.
+ */
+export interface CommandMessage {
+  type: 'command';
+  command: 'reset' | 'restart' | 'list-nodes' | 'switch-node';
+  chatId: string;
+  /** Target exec node ID for switch-node command */
+  targetNodeId?: string;
+}
+
+/**
+ * Message sent from Execution Node to Communication Node for registration.
+ */
+export interface RegisterMessage {
+  type: 'register';
+  /** Unique identifier for this exec node */
+  nodeId: string;
+  /** Human-readable name for this exec node */
+  name?: string;
+}
+
+/**
+ * Information about a connected execution node.
+ */
+export interface ExecNodeInfo {
+  /** Unique identifier */
+  nodeId: string;
+  /** Human-readable name */
+  name: string;
+  /** Connection status */
+  status: 'connected' | 'disconnected';
+  /** Number of active chats assigned */
+  activeChats: number;
+  /** Connection time */
+  connectedAt: Date;
+}
+
+/**
+ * Message sent from Execution Node to Communication Node for feedback.
+ */
+export interface FeedbackMessage {
+  type: 'text' | 'card' | 'file' | 'done' | 'error';
+  chatId: string;
+  text?: string;
+  card?: Record<string, unknown>;
+  error?: string;
+  /** Thread root message ID for thread replies */
+  threadId?: string;
+
+  // ===== File transfer fields =====
+
+  /** File reference */
+  fileRef?: FileRef;
+
+  /** File name (redundant field for convenience) */
+  fileName?: string;
+
+  /** File size (bytes) */
+  fileSize?: number;
+
+  /** MIME type */
+  mimeType?: string;
+}
+
+/**
+ * Message sent from Communication Node to Execution Node when a card action occurs.
+ * This enables Worker Node to receive card interaction callbacks from Primary Node.
+ *
+ * Issue #935: WebSocket bidirectional communication for card actions.
+ */
+export interface CardActionMessage {
+  type: 'card_action';
+  /** Chat ID where the card was displayed */
+  chatId: string;
+  /** The card message ID in Feishu */
+  cardMessageId: string;
+  /** Action type (button, select_static, etc.) */
+  actionType: string;
+  /** Action value from the button/menu */
+  actionValue: string;
+  /** Display text of the action (optional) */
+  actionText?: string;
+  /** User who triggered the action */
+  userId?: string;
+  /** Full action data for complex interactions */
+  action?: {
+    type: string;
+    value: string;
+    text?: string;
+    trigger?: string;
+  };
+}
+
+/**
+ * Message sent from Communication Node to Execution Node for card context registration.
+ * After a card is sent successfully, Primary Node notifies Worker Node of the message ID.
+ *
+ * Issue #935: WebSocket bidirectional communication for card actions.
+ */
+export interface CardContextMessage {
+  type: 'card_context';
+  /** Chat ID where the card was sent */
+  chatId: string;
+  /** The card message ID returned by Feishu */
+  cardMessageId: string;
+  /** Node ID that sent the card (for routing callbacks) */
+  nodeId: string;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022"],
+    "types": ["node"],
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary

This PR implements **Phase 2** of Issue #1037 by extracting shared code to `@disclaude/core` package.

Closes #1039

## Changes

| File | Change |
|------|--------|
| `packages/core/src/types/file.ts` | New file - File transfer types from `src/file-transfer/types.ts` |
| `packages/core/src/types/platform.ts` | New file - Platform types from `src/types/platform.ts` |
| `packages/core/src/types/websocket-messages.ts` | New file - WebSocket message types from `src/types/websocket-messages.ts` |
| `packages/core/src/types/index.ts` | New file - Type exports index |
| `packages/core/src/constants/index.ts` | New file - Constants from `src/config/constants.ts` |
| `packages/core/package.json` | Update dependencies (uuid) |
| `packages/core/tsconfig.json` | Add Node.js types |
| `package.json` | Add @disclaude/core as dependency |

## Types Moved

### File Types
- `FileRef`, `InboundAttachment`, `OutboundFile`
- `FileUploadRequest`, `FileUploadResponse`, `FileDownloadResponse`
- `createFileRef`, `createInboundAttachment`, `createOutboundFile`

### Platform Types (Feishu)
- `FeishuMessageEvent`, `FeishuCardActionEvent`
- `InteractionContext`, `InteractionHandler`
- `FeishuChatMemberAddedEvent`, `FeishuP2PChatEnteredEvent`

### WebSocket Message Types
- `PromptMessage`, `CommandMessage`, `RegisterMessage`
- `FeedbackMessage`, `ExecNodeInfo`
- `CardActionMessage`, `CardContextMessage`

### Constants
- `DEDUPLICATION`, `DIALOGUE`, `MESSAGE_LOGGING`
- `REACTIONS`, `FEISHU_API`, `CHAT_HISTORY`
- `SESSION_RESTORE`, `RETRYABLE_ERROR_CODES`

## Verification

- [x] All 1712 tests pass
- [x] TypeScript compilation succeeds
- [x] Core package builds successfully

## Next Steps

- Update `src/` files to import from `@disclaude/core` instead of local paths
- Move utility functions (`logger`, `error-handler`, `retry`) to `@disclaude/core`
- Continue with #1040, #1041, #1042 to separate process-specific code

## Related

- Depends on: #1038 (PR #1046)
- Parent Issue: #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)