### PR TITLE
fix(test): resolve token-store.test.ts timeout and ENOTEMPTY errors

### DIFF
--- a/src/auth/token-store.test.ts
+++ b/src/auth/token-store.test.ts
@@ -18,12 +18,18 @@ describe('TokenStore', () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'token-store-test-'));
     const storagePath = path.join(tempDir, 'tokens.json');
     store = new TokenStore(storagePath);
-  });
+  }, 30000); // Increase timeout for CI environments with slow file I/O
 
   afterEach(async () => {
-    // Clean up temp directory
-    await fs.rm(tempDir, { recursive: true, force: true });
-  });
+    // Clean up temp directory with retry logic to handle ENOTEMPTY errors
+    // This can happen when the file system hasn't fully released file handles
+    await fs.rm(tempDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  }, 30000); // Increase timeout for CI environments with slow file I/O
 
   describe('setToken and getToken', () => {
     it('should store and retrieve a token', async () => {


### PR DESCRIPTION
## Summary
- Add `maxRetries` and `retryDelay` options to `fs.rm` in `afterEach` hook to handle ENOTEMPTY errors when the file system hasn't fully released file handles
- Increase `beforeEach`/`afterEach` timeout to 30000ms for CI environments with slow file I/O operations

## Root Cause
The tests were failing with two related issues:
1. **ENOTEMPTY errors**: `fs.rm(tempDir, { recursive: true, force: true })` was failing because the file system hadn't fully released file handles from TokenStore's atomic write operations (write to `.tmp` file then rename)
2. **Timeout errors**: The default 10000ms timeout was insufficient for CI environments with slow file I/O

## Test Results
```
 ✓ src/auth/token-store.test.ts (15 tests) 378ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Fixes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)