### PR TITLE
fix(test): increase default timeout for use-case-1 integration test (Issue #1055)

### DIFF
--- a/tests/integration/use-case-1-basic-reply.sh
+++ b/tests/integration/use-case-1-basic-reply.sh
@@ -14,7 +14,7 @@
 #   ./tests/integration/use-case-1-basic-reply.sh [options]
 #
 # Options:
-#   --timeout SECONDS   Request timeout (default: 30)
+#   --timeout SECONDS   Request timeout (default: 60)
 #   --port PORT         REST API port (default: 3099)
 #   --verbose           Enable verbose output
 #   --dry-run           Show test plan without executing
@@ -30,7 +30,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Set defaults before sourcing common.sh
 REST_PORT="${REST_PORT:-3099}"
-TIMEOUT="${TIMEOUT:-30}"
+TIMEOUT="${TIMEOUT:-60}"
 
 # Source common functions
 source "$SCRIPT_DIR/common.sh"


### PR DESCRIPTION
## Summary
- Increase the default timeout from 30s to 60s in `use-case-1-basic-reply.sh` to match other integration test scripts
- This prevents HTTP 000 connection failures when AI response takes longer than 30s

## Root Cause Analysis
The issue was caused by inconsistent timeout settings across integration test scripts:

| Script | Default Timeout |
|--------|-----------------|
| `use-case-1-basic-reply.sh` | 30s ❌ |
| `use-case-2-task-execution.sh` | 60s ✅ |
| `use-case-3-multi-turn.sh` | 60s ✅ |
| `run-all-tests.sh` | 60s ✅ |

The curl `--max-time` option was set to 30s, while the REST Channel's sync request timeout is 240s. When AI processing exceeds 30s, curl times out and returns HTTP 000.

## Test Results
- Dry-run shows correct timeout: `Timeout: 60s`
- No code changes, only configuration adjustment

Fixes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)