### PR TITLE
fix(lint): resolve ESLint errors blocking CI

### DIFF
--- a/src/channels/rest-channel.test.ts
+++ b/src/channels/rest-channel.test.ts
@@ -13,8 +13,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RestChannel } from './rest-channel.js';
-import http from 'node:http';
-import type { IncomingMessage, ServerResponse, Server } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { EventEmitter } from 'node:events';
 
 // Mock logger
@@ -61,12 +60,16 @@ vi.mock('../file-transfer/index.js', () => ({
 class MockServer extends EventEmitter {
   listen = vi.fn((_port: number, _host: string, callback?: () => void) => {
     // Call callback immediately (synchronously) to avoid timer dependency
-    if (callback) callback();
+    if (callback) {
+      callback();
+    }
     return this;
   });
 
   close = vi.fn((callback?: () => void) => {
-    if (callback) callback();
+    if (callback) {
+      callback();
+    }
     return this;
   });
 }

--- a/src/services/lark-client-service.test.ts
+++ b/src/services/lark-client-service.test.ts
@@ -73,7 +73,7 @@ vi.mock('../utils/error-handler.js', () => ({
 }));
 
 vi.mock('../utils/retry.js', () => ({
-  retry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+  retry: vi.fn((fn: () => Promise<unknown>) => fn()),
 }));
 
 vi.mock('../file-transfer/outbound/feishu-uploader.js', () => ({


### PR DESCRIPTION
## Summary
Fix ESLint errors in test files that were causing CI failures for all PRs based on main branch.

## Changes
1. **rest-channel.test.ts**:
   - Remove unused `http` import
   - Remove unused `Server` type import
   - Fix curly style (`if (callback) callback();` → `if (callback) { callback(); }`)

2. **lark-client-service.test.ts**:
   - Remove unnecessary `async` keyword from mock function (function already returns Promise)

## Root Cause
The main branch has lint errors that cause the "Lint & Type Check" CI job to fail. This blocks all PRs from being merged even if they are otherwise correct.

## Test Results
- ✅ `npm run lint`: 0 errors (95 warnings remain, but are pre-existing)
- ✅ `npx vitest run src/channels/rest-channel.test.ts`: 32 tests passed
- ✅ `npx vitest run src/services/lark-client-service.test.ts`: 23 tests passed

## Note
This PR only fixes lint errors. TypeScript errors in main branch (related to Issue #1060) are addressed separately by PR #1061.

🤖 Generated with [Claude Code](https://claude.com/claude-code)