### PR TITLE
feat(pilot): enhance image analyzer MCP prompt for seamless multimodal experience (Issue #656)

### DIFF
--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -97,9 +97,9 @@ describe('MessageBuilder', () => {
 
       const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
 
-      expect(result).toContain('Image attachment(s) detected');
-      expect(result).toContain('analyze_image');
-      expect(result).toContain('image analyzer MCP');
+      expect(result).toContain('Image Analysis Guide');
+      expect(result).toContain('mcp__4_5v_mcp__analyze_image');
+      expect(result).toContain('visual analysis');
     });
 
     it('should not include image analyzer hint when no image analyzer MCP is configured', async () => {
@@ -116,8 +116,8 @@ describe('MessageBuilder', () => {
 
       const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
 
-      expect(result).not.toContain('Image attachment(s) detected');
-      expect(result).not.toContain('analyze_image');
+      expect(result).not.toContain('Image Analysis Guide');
+      expect(result).not.toContain('mcp__4_5v_mcp__analyze_image');
     });
 
     it('should not include image analyzer hint for non-image attachments', async () => {
@@ -136,7 +136,7 @@ describe('MessageBuilder', () => {
 
       const result = getAttachmentsInfo(new MessageBuilder(), textAttachment);
 
-      expect(result).not.toContain('Image attachment(s) detected');
+      expect(result).not.toContain('Image Analysis Guide');
     });
 
     it('should return empty string for no attachments', () => {
@@ -167,7 +167,7 @@ describe('MessageBuilder', () => {
         }];
 
         const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
-        expect(result).toContain('analyze_image');
+        expect(result).toContain('Image Analysis Guide');
       }
     });
   });

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -236,13 +236,25 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       .join('\n');
 
     // Issue #809: Check if there are image attachments and image analyzer MCP is configured
+    // Issue #656: Enhanced prompt for seamless multimodal experience
     const hasImageAttachment = attachments.some(att =>
       att.mimeType?.startsWith('image/')
     );
     const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
       ? `
 
-**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
+## 🖼️ Image Analysis Guide
+
+The user has attached image(s). To provide the best multimodal experience:
+
+1. **For visual analysis** (understanding content, describing scenes, analyzing UI, etc.):
+   - Use the \`mcp__4_5v_mcp__analyze_image\` tool with the image path
+   - This provides dedicated vision capabilities with detailed analysis
+
+2. **For code screenshots** or **document images**:
+   - You can also use the Read tool if it supports viewing images
+
+3. **Best practice**: Analyze images proactively without waiting for the user to ask. If the user's message involves visual content, use the image analysis tool first to understand what they're showing you.`
       : '';
 
     return `


### PR DESCRIPTION
## Summary

- Enhanced the image analysis guidance prompt in MessageBuilder to provide a more seamless multimodal experience when image attachments are detected
- The new prompt provides clearer guidance on when and how to use the `analyze_image` tool from the image analyzer MCP server
- Encourages proactive image analysis without requiring user to explicitly ask

## Changes

### Updated Prompt Structure
- Added dedicated "Image Analysis Guide" section with emoji header
- Clear guidance for different use cases:
  1. **Visual analysis** - understanding content, describing scenes, analyzing UI
  2. **Code screenshots and document images** - alternative approaches
  3. **Best practice** - analyze images proactively without waiting for user prompts

### Before
```
**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the `analyze_image` tool from the image analyzer MCP server for better results.
```

### After
```
## 🖼️ Image Analysis Guide

The user has attached image(s). To provide the best multimodal experience:

1. **For visual analysis** (understanding content, describing scenes, analyzing UI, etc.):
   - Use the `mcp__4_5v_mcp__analyze_image` tool with the image path
   - This provides dedicated vision capabilities with detailed analysis

2. **For code screenshots** or **document images**:
   - You can also use the Read tool if it supports viewing images

3. **Best practice**: Analyze images proactively without waiting for the user to ask.
```

## Benefits

- ✅ **Better UX**: Agent automatically analyzes images without waiting for explicit prompts
- ✅ **Clearer guidance**: Tool selection is now context-aware
- ✅ **Proactive behavior**: Encourages agent to take initiative on image analysis

## Test Results

- ✅ All 14 tests in `message-builder.test.ts` pass

## Related

- Addresses #656 (增强多模态图片支持，优化 UI 设计和 PPT 制作工作流)
- Builds on #809 (original image analyzer MCP hint implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)