### PR TITLE
refactor(lark-client): use unified LarkClientService in MCP tools (Issue #1030)

### DIFF
--- a/src/mcp/feishu-context-mcp.test.ts
+++ b/src/mcp/feishu-context-mcp.test.ts
@@ -45,6 +45,14 @@ vi.mock('../config/index.js', () => ({
   },
 }));
 
+// Mock LarkClientService (Issue #1030)
+vi.mock('../services/index.js', () => ({
+  getLarkClientService: vi.fn(() => ({
+    getClient: () => mockClient,
+  })),
+  isLarkClientServiceInitialized: vi.fn(() => true),
+}));
+
 // Mock logger
 vi.mock('../utils/logger.js', () => ({
   createLogger: vi.fn(() => ({

--- a/src/mcp/feishu-mcp-server.test.ts
+++ b/src/mcp/feishu-mcp-server.test.ts
@@ -45,6 +45,14 @@ vi.mock('../config/index.js', () => ({
   },
 }));
 
+// Mock LarkClientService (Issue #1030)
+vi.mock('../services/index.js', () => ({
+  getLarkClientService: vi.fn(() => ({
+    getClient: () => mockClient,
+  })),
+  isLarkClientServiceInitialized: vi.fn(() => true),
+}));
+
 // Mock logger
 vi.mock('../utils/logger.js', () => ({
   createLogger: vi.fn(() => ({

--- a/src/mcp/tools/interactive-message.test.ts
+++ b/src/mcp/tools/interactive-message.test.ts
@@ -21,12 +21,12 @@ vi.mock('@larksuiteoapi/node-sdk', () => ({
   },
 }));
 
-// Mock config
-vi.mock('../../config/index.js', () => ({
-  Config: {
-    FEISHU_APP_ID: 'test-app-id',
-    FEISHU_APP_SECRET: 'test-app-secret',
-  },
+// Mock LarkClientService (Issue #1030)
+vi.mock('../../services/index.js', () => ({
+  getLarkClientService: vi.fn(() => ({
+    getClient: () => mockClient,
+  })),
+  isLarkClientServiceInitialized: vi.fn(() => true),
 }));
 
 // Mock logger

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -7,10 +7,8 @@
  * @module mcp/tools/interactive-message
  */
 
-import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
-import { Config } from '../../config/index.js';
-import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import { getMessageSentCallback } from './send-message.js';
@@ -216,18 +214,15 @@ export async function send_interactive_message(params: {
       };
     }
 
-    // Get Feishu credentials
-    const appId = Config.FEISHU_APP_ID;
-    const appSecret = Config.FEISHU_APP_SECRET;
-
-    if (!appId || !appSecret) {
-      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+    // Issue #1030: Use unified LarkClientService instead of creating own client
+    if (!isLarkClientServiceInitialized()) {
+      const errorMsg = 'LarkClientService not initialized. Cannot send interactive message.';
       logger.error({ chatId }, errorMsg);
       return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
     }
 
     // Send the message
-    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const client = getLarkClientService().getClient();
     const result = await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(card), parentMessageId);
 
     // Register action prompts if message was sent successfully

--- a/src/mcp/tools/send-file.ts
+++ b/src/mcp/tools/send-file.ts
@@ -6,10 +6,9 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
 import { Config } from '../../config/index.js';
-import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 import type { SendFileResult } from './types.js';
 
 const logger = createLogger('SendFile');
@@ -23,15 +22,14 @@ export async function send_file(params: {
   try {
     if (!chatId) { throw new Error('chatId is required'); }
 
-    const appId = Config.FEISHU_APP_ID;
-    const appSecret = Config.FEISHU_APP_SECRET;
-
-    if (!appId || !appSecret) {
-      logger.warn({ filePath, chatId }, 'File send skipped (platform not configured)');
+    // Issue #1030: Use unified LarkClientService instead of creating own client
+    if (!isLarkClientServiceInitialized()) {
+      const errorMsg = 'LarkClientService not initialized. Cannot send file.';
+      logger.warn({ filePath, chatId }, errorMsg);
       return {
         success: false,
-        error: 'Platform credentials not configured',
-        message: '⚠️ File cannot be sent: Platform is not configured.',
+        error: errorMsg,
+        message: `⚠️ ${errorMsg}`,
       };
     }
 
@@ -44,7 +42,7 @@ export async function send_file(params: {
     if (!stats.isFile()) { throw new Error(`Path is not a file: ${filePath}`); }
 
     const { uploadAndSendFile } = await import('../../file-transfer/outbound/feishu-uploader.js');
-    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const client = getLarkClientService().getClient();
     const fileSize = await uploadAndSendFile(client, resolvedPath, chatId);
 
     const sizeMB = (fileSize / 1024 / 1024).toFixed(2);

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -4,10 +4,8 @@
  * @module mcp/tools/send-message
  */
 
-import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../../utils/logger.js';
-import { Config } from '../../config/index.js';
-import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 import { sendMessageToFeishu } from '../utils/feishu-api.js';
 import { isValidFeishuCard, getCardValidationError } from '../utils/card-validator.js';
 import type { SendMessageResult, MessageSentCallback } from './types.js';
@@ -54,16 +52,14 @@ export async function send_message(params: {
     if (!format) { throw new Error('format is required (must be "text" or "card")'); }
     if (!chatId) { throw new Error('chatId is required'); }
 
-    const appId = Config.FEISHU_APP_ID;
-    const appSecret = Config.FEISHU_APP_SECRET;
-
-    if (!appId || !appSecret) {
-      const errorMsg = 'Feishu credentials not configured. Please set FEISHU_APP_ID and FEISHU_APP_SECRET in disclaude.config.yaml';
+    // Issue #1030: Use unified LarkClientService instead of creating own client
+    if (!isLarkClientServiceInitialized()) {
+      const errorMsg = 'LarkClientService not initialized. Cannot send message.';
       logger.error({ chatId, format }, errorMsg);
       return { success: false, error: errorMsg, message: `❌ ${errorMsg}` };
     }
 
-    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const client = getLarkClientService().getClient();
 
     if (format === 'text') {
       const textContent = typeof content === 'string' ? content : JSON.stringify(content);


### PR DESCRIPTION
## Summary

Phase 1 of Issue #1030: Unify Lark SDK Client management in MCP tools.

This PR refactors the MCP tools (`send-message`, `send-file`, `interactive-message`) to use the unified `LarkClientService` instead of creating their own Lark Client instances.

## Changes

### MCP Tools Refactored
| File | Change |
|------|--------|
| `src/mcp/tools/send-message.ts` | Use `getLarkClientService().getClient()` instead of `createFeishuClient()` |
| `src/mcp/tools/send-file.ts` | Use unified LarkClientService |
| `src/mcp/tools/interactive-message.ts` | Use unified LarkClientService |

### Test Updates
| File | Change |
|------|--------|
| `src/mcp/feishu-context-mcp.test.ts` | Add mock for LarkClientService |
| `src/mcp/feishu-mcp-server.test.ts` | Add mock for LarkClientService |
| `src/mcp/tools/interactive-message.test.ts` | Add mock for LarkClientService, remove unused Config mock |

## Benefits

- ✅ **Single client instance** per process
- ✅ **Consistent configuration** (timeout, retry settings)
- ✅ **Centralized logging** and monitoring
- ✅ **Foundation for Phase 2**: IPC-based routing for cross-process communication

## Test Results

- All **1730 tests pass**

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)