### PR TITLE
feat(commands): add /name command for setting group chat name (Issue #1072)

### DIFF
--- a/src/nodes/command-services.ts
+++ b/src/nodes/command-services.ts
@@ -16,6 +16,7 @@ import {
   removeMembers,
   getMembers,
   getBotChats,
+  updateChatName,
 } from '../platforms/feishu/chat-ops.js';
 import type { GroupService } from '../platforms/feishu/group-service.js';
 import type { TaskStateManager } from '../utils/task-state-manager.js';
@@ -99,6 +100,7 @@ export function buildCommandServices(deps: CommandServicesDeps): CommandServices
     getMembers,
     dissolveChat,
     getBotChats,
+    updateChatName,
 
     // Group management
     registerGroup: (group: ManagedGroupInfo) => groupService.registerGroup(group),

--- a/src/nodes/commands/builtin-commands.ts
+++ b/src/nodes/commands/builtin-commands.ts
@@ -36,6 +36,7 @@ import {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  NameGroupCommand,
   PassiveCommand,
   SetDebugCommand,
   ShowDebugCommand,
@@ -60,6 +61,7 @@ export {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  NameGroupCommand,
   PassiveCommand,
   SetDebugCommand,
   ShowDebugCommand,
@@ -89,6 +91,8 @@ export function registerDefaultCommands(
   registry.register(new ListGroupMembersCommand());
   registry.register(new ListGroupCommand());
   registry.register(new DissolveGroupCommand());
+  // Issue #1072: Name group command for easy identification
+  registry.register(new NameGroupCommand());
   registry.register(new PassiveCommand());
   registry.register(new SetDebugCommand());
   registry.register(new ShowDebugCommand());

--- a/src/nodes/commands/command-registry.test.ts
+++ b/src/nodes/commands/command-registry.test.ts
@@ -28,6 +28,7 @@ function createMockServices(): CommandServices {
     removeMembers: () => Promise.resolve(),
     getMembers: () => Promise.resolve([]),
     dissolveChat: () => Promise.resolve(),
+    updateChatName: () => Promise.resolve(),
     registerGroup: () => {},
     unregisterGroup: () => false,
     listGroups: () => [],

--- a/src/nodes/commands/commands/group-commands.ts
+++ b/src/nodes/commands/commands/group-commands.ts
@@ -256,3 +256,41 @@ export class DissolveGroupCommand implements Command {
     }
   }
 }
+
+/**
+ * Name Group Command - Set or update the current group chat name.
+ *
+ * Issue #1072: Thread Management (建群+自动命名 MVP)
+ * Allows users to quickly rename the current group for easy identification.
+ */
+export class NameGroupCommand implements Command {
+  readonly name = 'name';
+  readonly category = 'group' as const;
+  readonly description = '设置当前群名称';
+  readonly usage = 'name <群名称>';
+
+  async execute(context: CommandContext): Promise<CommandResult> {
+    const { services, args, chatId } = context;
+
+    if (args.length < 1) {
+      return {
+        success: false,
+        error: '用法: `/name <群名称>`\n\n示例: `/name 财报分析`',
+      };
+    }
+
+    const name = args.join(' ');
+
+    try {
+      const client = services.getFeishuClient();
+      await services.updateChatName(client, chatId, name);
+
+      return {
+        success: true,
+        message: `✅ **群名称已更新**\n\n新名称: ${name}`,
+      };
+    } catch (error) {
+      return { success: false, error: `设置群名称失败: ${(error as Error).message}` };
+    }
+  }
+}

--- a/src/nodes/commands/commands/index.ts
+++ b/src/nodes/commands/commands/index.ts
@@ -20,6 +20,7 @@ export {
   ListGroupMembersCommand,
   ListGroupCommand,
   DissolveGroupCommand,
+  NameGroupCommand,
 } from './group-commands.js';
 
 // Passive command

--- a/src/nodes/commands/schedule-command.test.ts
+++ b/src/nodes/commands/schedule-command.test.ts
@@ -50,6 +50,7 @@ describe('ScheduleCommand', () => {
     removeMembers: () => Promise.resolve(),
     getMembers: () => Promise.resolve([]),
     dissolveChat: () => Promise.resolve(),
+    updateChatName: () => Promise.resolve(),
     registerGroup: () => {},
     unregisterGroup: () => false,
     listGroups: () => [],

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -185,6 +185,9 @@ export interface CommandServices {
   /** Dissolve a chat */
   dissolveChat: (client: lark.Client, chatId: string) => Promise<void>;
 
+  /** Update chat name */
+  updateChatName: (client: lark.Client, chatId: string, name: string) => Promise<void>;
+
   /** Register a group */
   registerGroup: (group: ManagedGroupInfo) => void;
 

--- a/src/platforms/feishu/chat-ops.test.ts
+++ b/src/platforms/feishu/chat-ops.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as lark from '@larksuiteoapi/node-sdk';
-import { createDiscussionChat, dissolveChat, addMembers, removeMembers, getMembers, getBotChats } from './chat-ops.js';
+import { createDiscussionChat, dissolveChat, addMembers, removeMembers, getMembers, getBotChats, updateChatName } from './chat-ops.js';
 
 // Mock lark client
 const mockClient = {
@@ -16,6 +16,7 @@ const mockClient = {
       create: vi.fn(),
       delete: vi.fn(),
       list: vi.fn(),
+      update: vi.fn(),
     },
     chatMembers: {
       create: vi.fn(),
@@ -326,6 +327,30 @@ describe('ChatOps', () => {
       mockList.mockRejectedValue(new Error('API error'));
 
       await expect(getBotChats(mockClient)).rejects.toThrow('API error');
+    });
+  });
+
+  describe('updateChatName', () => {
+    it('should update chat name successfully', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      mockUpdate.mockResolvedValue({});
+
+      await updateChatName(mockClient, 'oc_chat_123', 'New Group Name');
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        path: { chat_id: 'oc_chat_123' },
+        params: { user_id_type: 'open_id' },
+        data: { name: 'New Group Name' },
+      });
+    });
+
+    it('should throw on update error', async () => {
+      const mockUpdate = mockClient.im.chat.update as ReturnType<typeof vi.fn>;
+      mockUpdate.mockRejectedValue(new Error('Permission denied'));
+
+      await expect(
+        updateChatName(mockClient, 'oc_chat_123', 'New Name')
+      ).rejects.toThrow('Permission denied');
     });
   });
 });

--- a/src/platforms/feishu/chat-ops.ts
+++ b/src/platforms/feishu/chat-ops.ts
@@ -211,6 +211,33 @@ export interface BotChatInfo {
 }
 
 /**
+ * Update chat name.
+ *
+ * @param client - Feishu API client
+ * @param chatId - Target chat ID
+ * @param name - New chat name
+ *
+ * @see Issue #1072 - Thread Management (建群+自动命名 MVP)
+ */
+export async function updateChatName(
+  client: lark.Client,
+  chatId: string,
+  name: string
+): Promise<void> {
+  try {
+    await client.im.chat.update({
+      path: { chat_id: chatId },
+      params: { user_id_type: 'open_id' },
+      data: { name },
+    });
+    logger.info({ chatId, name }, 'Chat name updated');
+  } catch (error) {
+    logger.error({ err: error, chatId, name }, 'Failed to update chat name');
+    throw error;
+  }
+}
+
+/**
  * Get all chats the bot is in.
  *
  * Uses Feishu API to get all groups where the bot is a member.


### PR DESCRIPTION
## Summary

Implements the simplified MVP approach for Issue #1072 (Thread Management) as suggested by @hs3180:

> user can create a group for a new thread, we can support a command create the group quickly

This PR adds a `/name` command that allows users to quickly rename the current group chat for easy identification.

## Changes

| File | Change |
|------|--------|
| `src/platforms/feishu/chat-ops.ts` | Add `updateChatName` function |
| `src/platforms/feishu/chat-ops.test.ts` | Add tests for `updateChatName` |
| `src/nodes/commands/types.ts` | Add `updateChatName` to `CommandServices` interface |
| `src/nodes/commands/commands/group-commands.ts` | Add `NameGroupCommand` class |
| `src/nodes/commands/commands/index.ts` | Export `NameGroupCommand` |
| `src/nodes/commands/builtin-commands.ts` | Register `NameGroupCommand` |
| `src/nodes/command-services.ts` | Wire up `updateChatName` service |
| `src/nodes/commands/command-registry.test.ts` | Add mock for `updateChatName` |
| `src/nodes/commands/schedule-command.test.ts` | Add mock for `updateChatName` |

## Usage

```
/name 财报分析    # Set current group name to "财报分析"
```

## Background

The original issue proposed a complex ThreadManager system with `/thread save/list/switch/delete/rename` commands (see closed PR #1074). However, the simpler approach suggested by @hs3180 is:

1. Users create a new group for a new conversation thread
2. Use `/name` to quickly set a meaningful name

This provides natural thread isolation without the complexity of managing multiple threads within a single chat.

## Test Results

- ✅ All 1732 tests pass
- ✅ TypeScript compilation succeeds
- ✅ New tests for `updateChatName` added

## Test Plan

- [x] Unit tests for `updateChatName` function
- [x] TypeScript compilation passes
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)