### PR TITLE
fix: remove obsolete update_card from next-step skill allowed-tools

### DIFF
--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-step
 description: Analyze completed task and recommend follow-up actions
-allowed-tools: [send_user_feedback, update_card, wait_for_interaction]
+allowed-tools: [send_user_feedback, wait_for_interaction]
 ---
 
 # Next Step Recommender


### PR DESCRIPTION
## Summary

- Remove `update_card` from `skills/next-step/SKILL.md` allowed-tools list
- The tool was removed in a previous refactoring but this reference was overlooked

## Changes

- `skills/next-step/SKILL.md`: Removed `update_card` from `allowed-tools` array

## Verification

- ✅ Global search confirms no other `update_card` references remain (except CHANGELOG.md which is historical)
- ✅ File syntax remains valid YAML

## Test plan

- [ ] Verify skill file syntax is valid
- [ ] Confirm next-step skill can be loaded without errors

Closes #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)