### PR TITLE
feat(mcp): add generate_mindmap tool for NotebookLM M3 (Issue #950)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -17,6 +17,7 @@ import {
   generate_flashcards,
   generate_quiz,
   create_study_guide,
+  generate_mindmap,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 
@@ -877,6 +878,83 @@ Part of NotebookLM features - generates comprehensive study materials including:
         return Promise.resolve(toolSuccess(output));
       } catch (error) {
         return Promise.resolve(toolSuccess(`⚠️ Study guide creation failed: ${error instanceof Error ? error.message : String(error)}`));
+      }
+    },
+  },
+  // NotebookLM Mind Map Tool (Issue #950 M3)
+  {
+    name: 'generate_mindmap',
+    description: `Generate a mind map from content.
+
+Part of NotebookLM features - creates visual mind maps to organize information.
+
+## Parameters
+- **content**: The text content to generate mind map from
+- **format**: Output format - "mermaid", "markmap", or "both" (default: "mermaid")
+- **title**: Title for the mind map root (optional)
+- **maxDepth**: Maximum depth of the mind map (default: 3)
+- **maxNodesPerLevel**: Maximum nodes per level (default: 6)
+
+## Output Formats
+
+### Mermaid (for rendering in Markdown)
+\`\`\`mermaid
+mindmap
+  root((Central Idea))
+    Branch1
+      Sub-topic 1
+      Sub-topic 2
+    Branch2
+      Sub-topic 1
+\`\`\`
+
+### Markmap (for interactive Markdown mind maps)
+\`\`\`markdown
+# Central Idea
+## Branch1
+### Sub-topic 1
+### Sub-topic 2
+## Branch2
+### Sub-topic 1
+\`\`\`
+
+## Example
+\`\`\`json
+{
+  "content": "# Project Overview\\n## Feature A\\n## Feature B\\n### Sub-feature B1",
+  "format": "mermaid",
+  "title": "My Project",
+  "maxDepth": 3
+}
+\`\`\`
+
+## Tips
+- Use markdown headings (# ## ###) in content for best structure extraction
+- Keep titles short and descriptive
+- The tool extracts structure from headings and lists`,
+    parameters: z.object({
+      content: z.string(),
+      format: z.enum(['mermaid', 'markmap', 'both']).optional(),
+      title: z.string().optional(),
+      maxDepth: z.number().optional(),
+      maxNodesPerLevel: z.number().optional(),
+    }),
+    handler: (options) => {
+      try {
+        const result = generate_mindmap(options);
+        if (!result.success) {
+          return Promise.resolve(toolSuccess(`⚠️ ${result.error}`));
+        }
+        let output = `Mind Map generated successfully!\n\n`;
+        if (result.mermaid) {
+          output += `### Mermaid Format\n\`\`\`mermaid\n${result.mermaid}\`\`\`\n\n`;
+        }
+        if (result.markmap) {
+          output += `### Markmap Format (Markdown)\n${result.markmap}\n`;
+        }
+        return Promise.resolve(toolSuccess(output));
+      } catch (error) {
+        return Promise.resolve(toolSuccess(`⚠️ Mind map generation failed: ${error instanceof Error ? error.message : String(error)}`));
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -51,3 +51,15 @@ export type {
   StudyGuideOptions,
   StudyGuideResult,
 } from './study-guide-generator.js';
+
+// Mind Map Generator (NotebookLM M3)
+export {
+  generate_mindmap,
+  generate_mindmap_prompt,
+} from './mindmap-generator.js';
+
+export type {
+  MindmapNode,
+  MindmapGeneratorOptions,
+  MindmapGeneratorResult,
+} from './mindmap-generator.js';

--- a/src/mcp/tools/mindmap-generator.test.ts
+++ b/src/mcp/tools/mindmap-generator.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for Mind Map Generator Tool.
+ *
+ * @module mcp/tools/mindmap-generator.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generate_mindmap,
+  generate_mindmap_prompt,
+  type MindmapGeneratorOptions,
+} from './mindmap-generator.js';
+
+const sampleContent = `
+# Project Overview
+
+This document describes the main features of our project.
+
+## Feature A
+
+Feature A provides core functionality for the application.
+
+### Sub-feature A1
+Description of sub-feature A1.
+
+### Sub-feature A2
+Description of sub-feature A2.
+
+## Feature B
+
+Feature B handles user authentication and authorization.
+
+### Authentication
+- OAuth 2.0 support
+- JWT tokens
+- Session management
+
+### Authorization
+- Role-based access control
+- Permission management
+
+## Feature C
+
+Feature C manages data processing and storage.
+
+- Data ingestion
+- Data transformation
+- Data export
+`;
+
+const simpleContent = `
+# Main Topic
+
+## Branch 1
+- Item 1.1
+- Item 1.2
+
+## Branch 2
+- Item 2.1
+- Item 2.2
+
+## Branch 3
+- Item 3.1
+`;
+
+describe('generate_mindmap', () => {
+  describe('basic functionality', () => {
+    it('should generate a mermaid mindmap with default options', () => {
+      const result = generate_mindmap({ content: sampleContent });
+
+      expect(result.success).toBe(true);
+      expect(result.mermaid).toBeDefined();
+      expect(result.mermaid).toContain('mindmap');
+      expect(result.mermaid).toContain('root');
+      expect(result.nodes).toBeDefined();
+    });
+
+    it('should generate a markmap mindmap when format is markmap', () => {
+      const options: MindmapGeneratorOptions = {
+        content: sampleContent,
+        format: 'markmap',
+      };
+      const result = generate_mindmap(options);
+
+      expect(result.success).toBe(true);
+      expect(result.markmap).toBeDefined();
+      expect(result.markmap).toContain('#');
+      expect(result.mermaid).toBeUndefined();
+    });
+
+    it('should generate both formats when format is both', () => {
+      const options: MindmapGeneratorOptions = {
+        content: sampleContent,
+        format: 'both',
+      };
+      const result = generate_mindmap(options);
+
+      expect(result.success).toBe(true);
+      expect(result.mermaid).toBeDefined();
+      expect(result.markmap).toBeDefined();
+    });
+  });
+
+  describe('title customization', () => {
+    it('should use custom title for root node', () => {
+      const options: MindmapGeneratorOptions = {
+        content: simpleContent,
+        title: 'Custom Title',
+      };
+      const result = generate_mindmap(options);
+
+      expect(result.success).toBe(true);
+      expect(result.mermaid).toContain('Custom Title');
+      expect(result.nodes?.text).toBe('Custom Title');
+    });
+  });
+
+  describe('depth control', () => {
+    it('should respect maxDepth parameter', () => {
+      const options: MindmapGeneratorOptions = {
+        content: sampleContent,
+        maxDepth: 2,
+      };
+      const result = generate_mindmap(options);
+
+      expect(result.success).toBe(true);
+      expect(result.nodes).toBeDefined();
+    });
+
+    it('should respect maxNodesPerLevel parameter', () => {
+      const options: MindmapGeneratorOptions = {
+        content: sampleContent,
+        maxNodesPerLevel: 3,
+      };
+      const result = generate_mindmap(options);
+
+      expect(result.success).toBe(true);
+      expect(result.nodes).toBeDefined();
+    });
+  });
+
+  describe('structure extraction', () => {
+    it('should extract structure from markdown headings', () => {
+      const result = generate_mindmap({ content: sampleContent });
+
+      expect(result.success).toBe(true);
+      expect(result.nodes?.children).toBeDefined();
+      expect(result.nodes?.children?.length).toBeGreaterThan(0);
+    });
+
+    it('should handle content without headings', () => {
+      const plainContent = 'This is plain text without any structure. It has multiple sentences. Each sentence should become a node.';
+      const result = generate_mindmap({ content: plainContent });
+
+      expect(result.success).toBe(true);
+      expect(result.nodes?.children).toBeDefined();
+      expect(result.nodes?.children?.length).toBeGreaterThan(0);
+    });
+
+    it('should extract list items as children', () => {
+      const listContent = `
+# Main
+## Section
+- Item 1
+- Item 2
+- Item 3
+`;
+      const result = generate_mindmap({ content: listContent });
+
+      expect(result.success).toBe(true);
+      // Structure: root -> Main -> Section -> [Item 1, Item 2, Item 3]
+      const mainNode = result.nodes?.children?.[0];
+      const sectionNode = mainNode?.children?.[0];
+      expect(sectionNode?.children?.length).toBe(3);
+      expect(sectionNode?.children?.map(c => c.text)).toEqual(['Item 1', 'Item 2', 'Item 3']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should fail with empty content', () => {
+      const result = generate_mindmap({ content: '' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('required');
+    });
+
+    it('should fail with whitespace-only content', () => {
+      const result = generate_mindmap({ content: '   \n\t  ' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('required');
+    });
+  });
+
+  describe('output format validation', () => {
+    it('should generate valid mermaid syntax', () => {
+      const result = generate_mindmap({ content: sampleContent });
+
+      expect(result.success).toBe(true);
+      expect(result.mermaid).toMatch(/^mindmap\n/);
+      expect(result.mermaid).toMatch(/root\(\(.*\)\)/);
+    });
+
+    it('should generate valid markdown headings for markmap', () => {
+      const result = generate_mindmap({ content: sampleContent, format: 'markmap' });
+
+      expect(result.success).toBe(true);
+      expect(result.markmap).toMatch(/^# .+\n/);
+    });
+  });
+});
+
+describe('generate_mindmap_prompt', () => {
+  it('should generate a prompt template', () => {
+    const prompt = generate_mindmap_prompt(sampleContent);
+
+    expect(prompt).toContain('Mind Map Generation Request');
+    expect(prompt).toContain(sampleContent.slice(0, 50));
+    expect(prompt).toContain('mermaid');
+    expect(prompt).toContain('mindmap');
+  });
+
+  it('should include title if provided', () => {
+    const prompt = generate_mindmap_prompt(sampleContent, 'My Project');
+
+    expect(prompt).toContain('My Project');
+    expect(prompt).toContain('Title');
+  });
+
+  it('should not include title section if not provided', () => {
+    const prompt = generate_mindmap_prompt(sampleContent);
+
+    expect(prompt).not.toContain('**Title**');
+  });
+});

--- a/src/mcp/tools/mindmap-generator.ts
+++ b/src/mcp/tools/mindmap-generator.ts
@@ -1,0 +1,351 @@
+/**
+ * Mind Map Generator Tool for NotebookLM features (Issue #950 M3).
+ *
+ * Generates mind maps from content in Mermaid and Markmap formats.
+ *
+ * @module mcp/tools/mindmap-generator
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+export interface MindmapNode {
+  /** Node text content */
+  text: string;
+  /** Child nodes */
+  children?: MindmapNode[];
+  /** Node icon (optional, for visual enhancement) */
+  icon?: string;
+}
+
+export interface MindmapGeneratorOptions {
+  /** The content to generate mind map from */
+  content: string;
+  /** Output format: 'mermaid' | 'markmap' | 'both' */
+  format?: 'mermaid' | 'markmap' | 'both';
+  /** Title for the mind map root */
+  title?: string;
+  /** Maximum depth of the mind map */
+  maxDepth?: number;
+  /** Maximum number of nodes per level */
+  maxNodesPerLevel?: number;
+}
+
+export interface MindmapGeneratorResult {
+  success: boolean;
+  /** Mermaid format mind map */
+  mermaid?: string;
+  /** Markmap format mind map (Markdown) */
+  markmap?: string;
+  /** Parsed node structure */
+  nodes?: MindmapNode;
+  /** Error message if failed */
+  error?: string;
+}
+
+// ============================================================================
+// Mermaid Mindmap Generator
+// ============================================================================
+
+/**
+ * Convert a MindmapNode tree to Mermaid mindmap syntax.
+ *
+ * Mermaid mindmap syntax example:
+ * ```mermaid
+ * mindmap
+ *   root((Project))
+ *     Branch1
+ *       Leaf1
+ *       Leaf2
+ *     Branch2
+ *       Leaf3
+ * ```
+ */
+function nodeToMermaid(node: MindmapNode, indent: number = 0): string {
+  const spaces = '  '.repeat(indent);
+  let result = '';
+
+  // Escape special characters for Mermaid
+  const escapeText = (text: string): string => {
+    // Replace special characters that might break Mermaid syntax
+    return text
+      .replace(/[(){}[\]]/g, '')
+      .replace(/\n/g, ' ')
+      .trim();
+  };
+
+  const escapedText = escapeText(node.text);
+
+  if (indent === 0) {
+    // Root node uses circle syntax
+    result += `${spaces}root((${escapedText}))\n`;
+  } else {
+    result += `${spaces}${escapedText}\n`;
+  }
+
+  // Add children
+  if (node.children && node.children.length > 0) {
+    for (const child of node.children) {
+      result += nodeToMermaid(child, indent + 1);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Generate a Mermaid mindmap from a node structure.
+ */
+function generateMermaidMindmap(root: MindmapNode): string {
+  return `mindmap\n${nodeToMermaid(root, 0)}`;
+}
+
+// ============================================================================
+// Markmap Generator
+// ============================================================================
+
+/**
+ * Convert a MindmapNode tree to Markmap (Markdown) syntax.
+ *
+ * Markmap uses standard Markdown headings with indentation:
+ * ```markdown
+ * # Project
+ * ## Branch1
+ * ### Leaf1
+ * ### Leaf2
+ * ## Branch2
+ * ### Leaf3
+ * ```
+ */
+function nodeToMarkmap(node: MindmapNode, level: number = 1): string {
+  const prefix = '#'.repeat(Math.min(level, 6));
+  let result = `${prefix} ${node.text}\n`;
+
+  // Add children
+  if (node.children && node.children.length > 0) {
+    for (const child of node.children) {
+      result += nodeToMarkmap(child, level + 1);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Generate a Markmap-compatible markdown from a node structure.
+ */
+function generateMarkmapMindmap(root: MindmapNode): string {
+  return nodeToMarkmap(root, 1);
+}
+
+// ============================================================================
+// Content Analysis
+// ============================================================================
+
+/**
+ * Extract structure from content to create a mind map.
+ * This function analyzes the content and extracts headings, lists, and key concepts.
+ */
+function extractStructureFromContent(
+  content: string,
+  maxDepth: number = 3,
+  maxNodesPerLevel: number = 6
+): MindmapNode {
+  const lines = content.split('\n').filter(line => line.trim());
+
+  // Try to extract structure from markdown headings
+  const headingPattern = /^(#{1,6})\s+(.+)$/;
+  const listPattern = /^[-*+]\s+(.+)$/;
+
+  const root: MindmapNode = { text: 'Main Topic', children: [] };
+  const stack: { node: MindmapNode; level: number }[] = [{ node: root, level: 0 }];
+
+  let currentNodeCount = 0;
+
+  for (const line of lines) {
+    const headingMatch = line.match(headingPattern);
+    const listMatch = line.match(listPattern);
+
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+
+      // Skip if we've exceeded max depth or max nodes
+      if (level > maxDepth || currentNodeCount >= maxNodesPerLevel * maxDepth) {
+        continue;
+      }
+
+      const newNode: MindmapNode = { text, children: [] };
+
+      // Find the appropriate parent based on level
+      while (stack.length > 1 && stack[stack.length - 1].level >= level) {
+        stack.pop();
+      }
+
+      const parent = stack[stack.length - 1].node;
+      if (parent.children) {
+        parent.children.push(newNode);
+      } else {
+        parent.children = [newNode];
+      }
+
+      stack.push({ node: newNode, level });
+      currentNodeCount++;
+    } else if (listMatch && stack.length > 1) {
+      // Add list items as children of the current heading
+      const text = listMatch[1].trim();
+      const currentLevel = stack[stack.length - 1].level;
+
+      // Skip if we've exceeded max depth
+      if (currentLevel + 1 > maxDepth) {
+        continue;
+      }
+
+      const newNode: MindmapNode = { text };
+
+      const parent = stack[stack.length - 1].node;
+      if (parent.children) {
+        // Limit children per node
+        if (parent.children.length < maxNodesPerLevel) {
+          parent.children.push(newNode);
+        }
+      } else {
+        parent.children = [newNode];
+      }
+      currentNodeCount++;
+    }
+  }
+
+  // If no structure was found, create a simple structure from key sentences
+  if (!root.children || root.children.length === 0) {
+    const sentences = content
+      .split(/[.!?。！？\n]+/)
+      .map(s => s.trim())
+      .filter(s => s.length > 10 && s.length < 100)
+      .slice(0, maxNodesPerLevel);
+
+    root.children = sentences.map(sentence => ({ text: sentence }));
+  }
+
+  return root;
+}
+
+// ============================================================================
+// Main Generator Function
+// ============================================================================
+
+/**
+ * Generate a mind map from content.
+ *
+ * This function analyzes the content structure and generates a mind map
+ * in the specified format(s).
+ *
+ * @example
+ * ```typescript
+ * const result = generate_mindmap({
+ *   content: '# Project\n## Feature A\n## Feature B',
+ *   format: 'mermaid',
+ *   title: 'My Project'
+ * });
+ * ```
+ */
+export function generate_mindmap(options: MindmapGeneratorOptions): MindmapGeneratorResult {
+  const {
+    content,
+    format = 'mermaid',
+    title = 'Mind Map',
+    maxDepth = 3,
+    maxNodesPerLevel = 6,
+  } = options;
+
+  if (!content || content.trim().length === 0) {
+    return {
+      success: false,
+      error: 'Content is required for mind map generation',
+    };
+  }
+
+  try {
+    // Extract structure from content
+    const nodeStructure = extractStructureFromContent(content, maxDepth, maxNodesPerLevel);
+
+    // Override root title if provided
+    if (title && title !== 'Main Topic') {
+      nodeStructure.text = title;
+    }
+
+    const result: MindmapGeneratorResult = {
+      success: true,
+      nodes: nodeStructure,
+    };
+
+    // Generate in requested format(s)
+    if (format === 'mermaid' || format === 'both') {
+      result.mermaid = generateMermaidMindmap(nodeStructure);
+    }
+
+    if (format === 'markmap' || format === 'both') {
+      result.markmap = generateMarkmapMindmap(nodeStructure);
+    }
+
+    return result;
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to generate mind map: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+// ============================================================================
+// Prompt Template Generator
+// ============================================================================
+
+/**
+ * Generate a prompt template for LLM-based mind map generation.
+ * This provides guidance for the LLM to create a well-structured mind map.
+ */
+export function generate_mindmap_prompt(content: string, title?: string): string {
+  const titleSection = title ? `**Title**: ${title}` : '';
+
+  return `## Mind Map Generation Request
+
+${titleSection}
+
+### Content
+\`\`\`
+${content}
+\`\`\`
+
+---
+
+**Instructions**: Generate a mind map based on the content above.
+
+**Analysis Steps**:
+1. Identify the main topic/central idea
+2. Extract 3-7 primary branches (main concepts)
+3. For each branch, identify 2-5 sub-topics
+4. Keep node labels concise (1-5 words)
+
+**Output Format** (Mermaid):
+\`\`\`mermaid
+mindmap
+  root((Central Idea))
+    Branch1
+      Sub-topic 1
+      Sub-topic 2
+    Branch2
+      Sub-topic 1
+      Sub-topic 2
+    Branch3
+      Sub-topic 1
+\`\`\`
+
+**Guidelines**:
+- Use clear, descriptive labels
+- Maintain logical hierarchy
+- Balance the tree (avoid too many or too few branches)
+- Focus on key concepts, not details
+`;
+}


### PR DESCRIPTION
## Summary

Implements the Mind Map generation feature (M3) for NotebookLM-style document understanding and knowledge management.

## Changes

| File | Change |
|------|--------|
| `src/mcp/tools/mindmap-generator.ts` | New file - Mind map generation logic |
| `src/mcp/tools/mindmap-generator.test.ts` | New file - 16 unit tests |
| `src/mcp/tools/index.ts` | Export mindmap-generator types and functions |
| `src/mcp/feishu-context-mcp.ts` | Register `generate_mindmap` MCP tool |

## Features

### New MCP Tool: `generate_mindmap`

Generates visual mind maps from content in multiple formats:

```json
{
  "content": "# Project\n## Feature A\n## Feature B",
  "format": "mermaid",
  "title": "My Project",
  "maxDepth": 3,
  "maxNodesPerLevel": 6
}
```

### Output Formats

**Mermaid** (for Markdown rendering):
```mermaid
mindmap
  root((My Project))
    Feature A
    Feature B
```

**Markmap** (for interactive Markdown mind maps):
```markdown
# My Project
## Feature A
## Feature B
```

### Content Analysis

- Extracts structure from markdown headings (# ## ###)
- Parses list items as child nodes
- Falls back to sentence extraction for plain text
- Configurable depth and node limits

## Test Results

- ✅ 16 unit tests passing
- ✅ 37 feishu-context-mcp tests passing
- ✅ TypeScript type check passing

Closes #950 (M3 milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)