### PR TITLE
fix: resolve lint errors introduced in PR #1080

### DIFF
--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -230,7 +230,7 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     resetIpcClient();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     resetIpcClient();
     if (existsSync(socketPath)) {
       try {
@@ -253,7 +253,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should return available when server is running', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},
@@ -294,7 +293,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should return true when connected', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},
@@ -333,7 +331,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should connect on retry if server becomes available', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},

--- a/src/mcp/tools/send-file.ts
+++ b/src/mcp/tools/send-file.ts
@@ -81,8 +81,8 @@ export async function send_file(params: {
 
     if (useIpc) {
       logger.debug({ chatId, filePath }, 'Using IPC for file upload');
-      const result = await uploadFileViaIpc(chatId, resolvedPath);
-      fileSize = result.fileSize;
+      const { fileSize: ipcFileSize } = await uploadFileViaIpc(chatId, resolvedPath);
+      fileSize = ipcFileSize;
     } else {
       // Fallback: Create client directly
       const { uploadAndSendFile } = await import('../../file-transfer/outbound/feishu-uploader.js');


### PR DESCRIPTION
## Summary

- Remove unused `async` from `afterEach` in `ipc.test.ts`
- Remove unused `mockContexts` variables in `ipc.test.ts`
- Use object destructuring in `send-file.ts` to satisfy `prefer-destructuring` rule

## Problem

PR #1080 introduced lint errors on the main branch, causing all subsequent PRs to fail CI:

```
src/ipc/ipc.test.ts
  233:22  error  Async arrow function has no 'await' expression
  256:13  error  'mockContexts' is assigned a value but never used
  297:13  error  'mockContexts' is assigned a value but never used
  336:13  error  'mockContexts' is assigned a value but never used

src/mcp/tools/send-file.ts
  85:7  error  Use object destructuring
```

## Test Plan

- [x] Run `npm run lint` - passes with 0 errors
- [x] Run `npm test src/ipc/ipc.test.ts` - all 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)