### PR TITLE
fix(mcp): add IPC fallback for send_message and send_interactive_message (Issue #1088)

### DIFF
--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -252,22 +252,24 @@ export async function send_interactive_message(params: {
     }
 
     // Issue #1035: Try IPC first if available
+    // Issue #1088: Add fallback when IPC fails (socket exists but connection unavailable)
     const useIpc = isIpcAvailable();
     let messageId: string | undefined;
 
     if (useIpc) {
       logger.debug({ chatId, parentMessageId }, 'Using IPC for interactive message');
       const result = await sendCardViaIpc(chatId, card, parentMessageId);
-      if (!result.success) {
-        return {
-          success: false,
-          error: 'Failed to send interactive message via IPC',
-          message: '❌ Failed to send interactive message via IPC.',
-        };
+      if (result.success) {
+        messageId = result.messageId;
+        logger.debug({ chatId, parentMessageId, messageId }, 'Interactive message sent (via IPC)');
+      } else {
+        // Issue #1088: IPC failed, fallback to direct client
+        logger.warn({ chatId, parentMessageId }, 'IPC failed, falling back to direct client');
       }
-      messageId = result.messageId;
-    } else {
-      // Fallback: Create client directly
+    }
+
+    // Direct client (fallback or IPC not available/successful)
+    if (!messageId) {
       const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
       const result = await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(card), parentMessageId);
       messageId = result.messageId;

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -102,6 +102,7 @@ export async function send_message(params: {
     }
 
     // Issue #1035: Try IPC first if available
+    // Issue #1088: Add fallback when IPC fails (socket exists but connection unavailable)
     const useIpc = isIpcAvailable();
 
     if (format === 'text') {
@@ -110,18 +111,18 @@ export async function send_message(params: {
       if (useIpc) {
         logger.debug({ chatId, parentMessageId }, 'Using IPC for text message');
         const result = await sendMessageViaIpc(chatId, textContent, parentMessageId);
-        if (!result.success) {
-          return {
-            success: false,
-            error: 'Failed to send message via IPC',
-            message: '❌ Failed to send message via IPC.',
-          };
+        if (result.success) {
+          logger.debug({ chatId, parentMessageId }, 'User feedback sent (text via IPC)');
+          invokeMessageSentCallback(chatId);
+          return { success: true, message: '✅ Message sent (format: text)' };
         }
-      } else {
-        // Fallback: Create client directly
-        const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
-        await sendMessageToFeishu(client, chatId, 'text', JSON.stringify({ text: textContent }), parentMessageId);
+        // Issue #1088: IPC failed, fallback to direct client
+        logger.warn({ chatId, parentMessageId }, 'IPC failed, falling back to direct client');
       }
+
+      // Direct client (fallback or IPC not available)
+      const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+      await sendMessageToFeishu(client, chatId, 'text', JSON.stringify({ text: textContent }), parentMessageId);
       logger.debug({ chatId, parentMessageId }, 'User feedback sent (text)');
     } else {
       // Card format
@@ -160,18 +161,18 @@ export async function send_message(params: {
       if (useIpc) {
         logger.debug({ chatId, parentMessageId }, 'Using IPC for card message');
         const result = await sendCardViaIpc(chatId, cardContent, parentMessageId);
-        if (!result.success) {
-          return {
-            success: false,
-            error: 'Failed to send card via IPC',
-            message: '❌ Failed to send card via IPC.',
-          };
+        if (result.success) {
+          logger.debug({ chatId, parentMessageId }, 'User card sent (via IPC)');
+          invokeMessageSentCallback(chatId);
+          return { success: true, message: '✅ Message sent (format: card)' };
         }
-      } else {
-        // Fallback: Create client directly
-        const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
-        await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(cardContent), parentMessageId);
+        // Issue #1088: IPC failed, fallback to direct client
+        logger.warn({ chatId, parentMessageId }, 'IPC failed, falling back to direct client');
       }
+
+      // Direct client (fallback or IPC not available)
+      const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+      await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(cardContent), parentMessageId);
       logger.debug({ chatId, parentMessageId }, 'User card sent');
     }
 


### PR DESCRIPTION
## Summary

Fixes #1088

When the IPC socket file exists but the connection is unavailable (e.g., after service restart), the MCP tools now fall back to creating a direct Feishu client instead of returning an error.

## Problem

Users encountered `Failed to send message via IPC` errors when using `send_message` and `send_interactive_message` MCP tools. This happened when:
1. Socket file exists (indicating IPC might be available)
2. But the actual IPC connection is unavailable (service restarted, connection dropped, etc.)

The previous code would directly return an error without attempting any fallback.

## Solution

- **send_message.ts**: Add fallback when IPC fails for text/card messages
- **interactive-message.ts**: Add fallback when IPC fails for interactive cards
- Add warning logs when falling back to direct client

## Changes

| File | Changes |
|------|---------|
| `src/mcp/tools/send-message.ts` | IPC failure → fallback to direct client for text and card formats |
| `src/mcp/tools/interactive-message.ts` | IPC failure → fallback to direct client for interactive cards |

## Test Plan

- [x] All existing tests pass (`src/mcp/feishu-context-mcp.test.ts`: 37 tests)
- [x] All interactive message tests pass (`src/mcp/tools/interactive-message.test.ts`: 16 tests)
- [x] Code follows existing fallback pattern from PR #1080

## Behavior

**Before:**
```
IPC available? → Try IPC → IPC fails? → Return error ❌
```

**After:**
```
IPC available? → Try IPC → IPC fails? → Fallback to direct client → Success ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)