### PR TITLE
fix: resolve TypeScript type errors blocking CI

### DIFF
--- a/src/ipc/unix-socket-client.ts
+++ b/src/ipc/unix-socket-client.ts
@@ -39,6 +39,11 @@ export type IpcAvailabilityStatus =
   | { available: false; reason: 'socket_not_found' | 'connection_failed' | 'timeout' | 'error'; error?: Error };
 
 /**
+ * Extract the reason type from IpcAvailabilityStatus (only available when available is false)
+ */
+export type IpcUnavailableReason = Extract<IpcAvailabilityStatus, { available: false }>['reason'];
+
+/**
  * Unix Socket IPC Client.
  */
 export class UnixSocketIpcClient {
@@ -244,7 +249,7 @@ export class UnixSocketIpcClient {
       return this.availabilityCache;
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      let reason: IpcAvailabilityStatus['reason'] = 'connection_failed';
+      let reason: IpcUnavailableReason = 'connection_failed';
 
       if (err.message.includes('timeout')) {
         reason = 'timeout';

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -265,12 +265,12 @@ export async function send_interactive_message(params: {
           message: '❌ Failed to send interactive message via IPC.',
         };
       }
-      messageId = result.messageId;
+      ({ messageId } = result);
     } else {
       // Fallback: Create client directly
       const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
       const result = await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(card), parentMessageId);
-      messageId = result.messageId;
+      ({ messageId } = result);
     }
 
     // Register action prompts if message was sent successfully

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -412,7 +412,7 @@ export class WorkerNode {
 
     this.ws.on('message', async (data) => {
       try {
-        const message = JSON.parse(data.toString()) as PromptMessage | CommandMessage | CardActionMessage;
+        const message = JSON.parse(data.toString()) as PromptMessage | CommandMessage | CardActionMessage | FeishuApiResponseMessage;
 
         // Handle command messages
         if (message.type === 'command') {


### PR DESCRIPTION
## Summary

This PR fixes TypeScript type errors that were blocking all PRs from passing CI on the main branch.

### Changes

1. **src/ipc/unix-socket-client.ts**: Fix `IpcAvailabilityStatus['reason']` type error
   - Added `IpcUnavailableReason` type using `Extract` to properly type the reason field
   - The original type was a union where `available: true` had no `reason` property

2. **src/nodes/worker-node.ts**: Fix `message.type` error on `never` type
   - Added `FeishuApiResponseMessage` to the message type union
   - The type narrowing caused TypeScript to infer `never` after handling other message types

3. **src/mcp/tools/interactive-message.ts**: Fix `prefer-destructuring` lint errors
   - Changed `messageId = result.messageId` to `({ messageId } = result)`

## Root Cause

The main branch had two TypeScript type errors:
```
src/ipc/unix-socket-client.ts(247,41): error TS2339: Property 'reason' does not exist on type 'IpcAvailabilityStatus'.
src/nodes/worker-node.ts(539,21): error TS2339: Property 'type' does not exist on type 'never'.
```

These errors were blocking all PRs (including #1093, #1096, #1091) from passing CI.

## Test Plan

- [x] `npm run type-check` - TypeScript type check passes
- [x] `npm run lint` - No lint errors (0 errors, 97 warnings)
- [x] `npm test` - All 1755 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)