### PR TITLE
feat(config): add Ruliu platform configuration support (Issue #725)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -63,6 +63,45 @@ feishu:
     maxAgeMs: 60000
 
 # -----------------------------------------------------------------------------
+# Ruliu (如流) Platform Configuration
+# -----------------------------------------------------------------------------
+# Ruliu is Baidu's enterprise instant messaging platform.
+# Enable this section to integrate with Ruliu bots.
+ruliu:
+  # Enable/disable Ruliu integration
+  # Default: false
+  enabled: false
+
+  # API host (usually no need to change)
+  apiHost: "https://apiin.im.baidu.com"
+
+  # Verification token from Ruliu bot settings
+  checkToken: "your_ruliu_check_token_here"
+
+  # Message encryption key (Base64 encoded, 43 characters)
+  encodingAESKey: "your_ruliu_encoding_aes_key_here"
+
+  # Application credentials from Ruliu bot settings
+  appKey: "your_ruliu_app_key_here"
+  appSecret: "your_ruliu_app_secret_here"
+
+  # Robot name for @mention detection
+  robotName: "MyBot"
+
+  # Reply mode
+  # Options: ignore, record, mention-only, mention-and-watch, proactive
+  # Default: mention-and-watch
+  replyMode: "mention-and-watch"
+
+  # Follow-up mode settings
+  followUp: true
+  followUpWindow: 300  # seconds
+
+  # Webhook path for receiving messages
+  # Default: /webhook/ruliu
+  webhookPath: "/webhook/ruliu"
+
+# -----------------------------------------------------------------------------
 # GLM (Zhipu AI) API Configuration
 # -----------------------------------------------------------------------------
 glm:

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -81,6 +81,49 @@ export interface GlmConfig {
 }
 
 /**
+ * Ruliu reply mode.
+ * Controls how the bot responds to messages.
+ */
+export type RuliuReplyMode =
+  | 'ignore'           // Discard messages
+  | 'record'           // Only record, no reply
+  | 'mention-only'     // Reply only when @mentioned
+  | 'mention-and-watch' // @ + watch list + follow-up window (default)
+  | 'proactive';       // Proactive participation
+
+/**
+ * Ruliu (如流) platform configuration section.
+ * Baidu's enterprise instant messaging platform integration.
+ * @see Issue #725
+ */
+export interface RuliuConfig {
+  /** Enable/disable Ruliu integration */
+  enabled?: boolean;
+  /** API host (e.g., https://apiin.im.baidu.com) */
+  apiHost?: string;
+  /** Verification token from Ruliu bot settings */
+  checkToken?: string;
+  /** Message encryption key (Base64 encoded, 43 characters) */
+  encodingAESKey?: string;
+  /** Application key from Ruliu bot settings */
+  appKey?: string;
+  /** Application secret from Ruliu bot settings */
+  appSecret?: string;
+  /** Robot name for @mention detection */
+  robotName?: string;
+  /** Reply mode (default: mention-and-watch) */
+  replyMode?: RuliuReplyMode;
+  /** Enable follow-up mode */
+  followUp?: boolean;
+  /** Follow-up window in seconds */
+  followUpWindow?: number;
+  /** Users to watch for mentions */
+  watchMentions?: string[];
+  /** Webhook path for receiving messages */
+  webhookPath?: string;
+}
+
+/**
  * Logging configuration section.
  */
 export interface LoggingConfig {
@@ -279,6 +322,8 @@ export interface DisclaudeConfig {
   agent?: AgentConfig;
   /** Feishu platform settings */
   feishu?: FeishuConfig;
+  /** Ruliu (如流) platform settings */
+  ruliu?: RuliuConfig;
   /** GLM API settings */
   glm?: GlmConfig;
   /** Logging settings */


### PR DESCRIPTION
## Summary

Add configuration support for Ruliu (如流) platform integration, completing Phase 1 of Issue #725.

### Changes

1. **src/config/types.ts**
   - Add `RuliuReplyMode` type for bot reply modes
   - Add `RuliuConfig` interface with all required configuration fields
   - Update `DisclaudeConfig` to include `ruliu` configuration section

2. **disclaude.config.example.yaml**
   - Add complete Ruliu configuration section with documentation
   - Include all configuration options: API credentials, encryption, reply modes, webhook settings

### Configuration Options

```yaml
ruliu:
  enabled: false
  apiHost: "https://apiin.im.baidu.com"
  checkToken: "your_ruliu_check_token_here"
  encodingAESKey: "your_ruliu_encoding_aes_key_here"
  appKey: "your_ruliu_app_key_here"
  appSecret: "your_ruliu_app_secret_here"
  robotName: "MyBot"
  replyMode: "mention-and-watch"
  followUp: true
  followUpWindow: 300
  webhookPath: "/webhook/ruliu"
```

### Related

- Issue #725: feat: 如流(Ruliu)平台适配器集成
- Existing implementation: `src/platforms/ruliu/`

## Test Plan

- [x] TypeScript type check passes (`npm run type-check`)
- [x] All 1755 tests pass (`npm test`)
- [x] Configuration follows existing pattern (similar to `feishu` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)