### PR TITLE
fix(mcp): remove wait_for_interaction tool references (Issue #1086)

### DIFF
--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-step
 description: Analyze completed task and recommend follow-up actions
-allowed-tools: [send_user_feedback, wait_for_interaction]
+allowed-tools: [send_user_feedback]
 ---
 
 # Next Step Recommender
@@ -120,8 +120,6 @@ Send an interactive card using `send_user_feedback`:
 When user clicks a button, the system will send a message to the agent:
 - The agent will receive: `User clicked '📋 提交 GitHub Issue'`
 - The agent should then process the request accordingly
-
-**DO NOT** use `wait_for_interaction` to block - let the system handle clicks asynchronously.
 
 ## Chat ID
 

--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -459,7 +459,7 @@ export class Pilot extends BaseAgent implements ChatAgent {
     const supportedMcpTools = capabilities?.supportedMcpTools;
 
     // Determine if we should include Context MCP server
-    const contextTools = ['send_message', 'send_file', 'wait_for_interaction'];
+    const contextTools = ['send_message', 'send_file'];
     const shouldIncludeContextMcp = supportedMcpTools === undefined ||
       contextTools.some(tool => supportedMcpTools.includes(tool));
 

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -167,9 +167,6 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
         if (toolName === 'send_file') {
           return capabilities?.supportsFile !== false;
         }
-        if (toolName === 'wait_for_interaction') {
-          return capabilities?.supportsCard !== false;
-        }
         return true; // send_message is always available
       }
       return supportedTools.includes(toolName);
@@ -181,14 +178,9 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 - Chat ID: \`${chatId}\`
 - parentMessageId: \`${messageId}\` (for thread replies)`);
 
-      // Include card support note if supported
-      if (hasTool('wait_for_interaction')) {
-        parts.push(`
+      // Include card support note
+      parts.push(`
 - For rich content, use format: "card" with a valid Feishu card structure`);
-      } else {
-        parts.push(`
-- Note: This channel does not support interactive cards. Use text format only.`);
-      }
     }
 
     // send_file tool
@@ -198,12 +190,6 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     } else if (supportedTools !== undefined) {
       parts.push(`
 - Note: send_file is NOT supported on this channel. Files will not be sent.`);
-    }
-
-    // wait_for_interaction tool
-    if (hasTool('wait_for_interaction')) {
-      parts.push(`
-- wait_for_interaction is available for waiting for user card interactions`);
     }
 
     // Include thread support note

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -279,8 +279,6 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       supportedMcpTools: [
         'send_message',
         'send_file',
-        
-        'wait_for_interaction',
       ],
     };
   }

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -15,7 +15,6 @@ import { FeishuMessageSender } from '../../platforms/feishu/feishu-message-sende
 import { InteractionManager } from '../../platforms/feishu/interaction-manager.js';
 import { getLarkClientService, isLarkClientServiceInitialized } from '../../services/index.js';
 import { getCommandRegistry } from '../../nodes/commands/command-registry.js';
-import { resolvePendingInteraction } from '../../mcp/feishu-context-mcp.js';
 import { generateInteractionPrompt } from '../../mcp/tools/interactive-message.js';
 import { getIpcClient } from '../../ipc/unix-socket-client.js';
 import { filteredMessageForwarder } from '../../feishu/filtered-message-forwarder.js';
@@ -606,18 +605,6 @@ export class MessageHandler {
       }
     }
 
-    // First, try to resolve any pending wait_for_interaction calls
-    const resolved = resolvePendingInteraction(
-      message_id,
-      action.value,
-      action.type,
-      user?.sender_id?.open_id || 'unknown'
-    );
-
-    if (resolved) {
-      logger.debug({ messageId: message_id }, 'Card action resolved pending interaction');
-    }
-
     // Always emit card action as a message to the agent
     try {
       // Try to get a pre-defined prompt template via IPC first (cross-process),
@@ -664,7 +651,6 @@ export class MessageHandler {
         metadata: {
           cardAction: action,
           cardMessageId: message_id,
-          wasPendingInteraction: resolved,
           usedPromptTemplate: !!promptFromTemplate,
         },
       });
@@ -675,11 +661,6 @@ export class MessageHandler {
       );
     } catch (error) {
       logger.error({ err: error, messageId: message_id, chatId: chat_id }, 'Failed to emit card action message');
-    }
-
-    // Return early if resolved
-    if (resolved) {
-      return;
     }
 
     try {


### PR DESCRIPTION
## Summary

This PR fixes the TypeScript errors in PR #1096 and #1101 by properly removing all `wait_for_interaction` references.

## Changes

| File | Change |
|------|--------|
| `src/channels/feishu/message-handler.ts` | Remove `resolvePendingInteraction` import and usage |
| `src/channels/feishu/message-handler.ts` | Remove `wasPendingInteraction` metadata field |
| `src/channels/feishu/message-handler.ts` | Remove early return logic based on `resolved` variable |
| `src/agents/pilot/index.ts` | Remove `wait_for_interaction` from context tools list |
| `src/agents/pilot/message-builder.ts` | Remove `wait_for_interaction` capability checks |
| `src/channels/feishu-channel.ts` | Remove `wait_for_interaction` from supportedMcpTools |
| `skills/next-step/SKILL.md` | Remove `wait_for_interaction` references |

## Test Results

- ✅ TypeScript compilation passes (0 errors)
- ✅ ESLint passes (0 errors, 2 warnings unrelated to this change)

## Related

- Fixes #1086
- Supersedes #1096, #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)