### PR TITLE
fix: resolve ESLint errors in PR #1110

### DIFF
--- a/src/mcp/tools/thread-operations.ts
+++ b/src/mcp/tools/thread-operations.ts
@@ -125,7 +125,7 @@ export async function reply_in_thread(params: {
           success: true,
           messageId: result.messageId,
           threadId: result.threadId,
-          message: `✅ Reply sent in thread`,
+          message: '✅ Reply sent in thread',
         };
       }
       return {
@@ -159,7 +159,7 @@ export async function reply_in_thread(params: {
       success: true,
       messageId: newMessageId,
       threadId,
-      message: `✅ Reply sent in thread`,
+      message: '✅ Reply sent in thread',
     };
 
   } catch (error) {
@@ -434,7 +434,7 @@ export async function get_thread_messages(params: {
  * Helper function for API responses.
  */
 function extractMessageContent(body: unknown): string {
-  if (!body) return '';
+  if (!body) {return '';}
 
   try {
     const bodyObj = body as Record<string, unknown>;
@@ -442,7 +442,7 @@ function extractMessageContent(body: unknown): string {
       // Try to parse JSON content
       try {
         const parsed = JSON.parse(bodyObj.content as string);
-        if (parsed.text) return parsed.text;
+        if (parsed.text) {return parsed.text;}
         return bodyObj.content as string;
       } catch {
         return bodyObj.content as string;

--- a/src/services/lark-client-service.ts
+++ b/src/services/lark-client-service.ts
@@ -646,7 +646,7 @@ export class LarkClientService {
    * Helper method for Thread API operations.
    */
   private extractMessageContent(body: unknown): string {
-    if (!body) return '';
+    if (!body) {return '';}
 
     try {
       const bodyObj = body as Record<string, unknown>;
@@ -654,7 +654,7 @@ export class LarkClientService {
         // Try to parse JSON content
         try {
           const parsed = JSON.parse(bodyObj.content as string);
-          if (parsed.text) return parsed.text;
+          if (parsed.text) {return parsed.text;}
           return bodyObj.content as string;
         } catch {
           return bodyObj.content as string;


### PR DESCRIPTION
## Summary

This PR fixes the ESLint errors that caused CI failure in PR #1110.

## Changes

- Replace template literals with single quotes where appropriate (quotes rule)
- Add curly braces to single-line if statements (curly rule)

## Files Changed

| File | Change |
|------|--------|
| `src/mcp/tools/thread-operations.ts` | Fixed 4 ESLint errors |
| `src/services/lark-client-service.ts` | Fixed 2 ESLint errors |

## Test Plan

- [x] `npm run lint` passes with 0 errors

## Related

- Target: PR #1110 (feat: add Thread API tools for topic group discussions)
- Issue: #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)