### PR TITLE
fix(mcp): improve IPC error handling with detailed error information (Issue #1088)

### DIFF
--- a/src/ipc/unix-socket-client.ts
+++ b/src/ipc/unix-socket-client.ts
@@ -418,34 +418,56 @@ export class UnixSocketIpcClient {
 
   /**
    * Send a text message via IPC.
+   * Issue #1088: Return detailed error information for better troubleshooting.
    */
   async feishuSendMessage(
     chatId: string,
     text: string,
     threadId?: string
-  ): Promise<{ success: boolean; messageId?: string }> {
+  ): Promise<{ success: boolean; messageId?: string; error?: string; errorType?: 'ipc_unavailable' | 'ipc_timeout' | 'ipc_request_failed' }> {
     try {
       return await this.request('feishuSendMessage', { chatId, text, threadId });
     } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       logger.error({ err: error, chatId }, 'feishuSendMessage failed');
-      return { success: false };
+
+      // Determine error type for better error handling
+      let errorType: 'ipc_unavailable' | 'ipc_timeout' | 'ipc_request_failed' = 'ipc_request_failed';
+      if (err.message.startsWith('IPC_NOT_AVAILABLE')) {
+        errorType = 'ipc_unavailable';
+      } else if (err.message.startsWith('IPC_TIMEOUT')) {
+        errorType = 'ipc_timeout';
+      }
+
+      return { success: false, error: err.message, errorType };
     }
   }
 
   /**
    * Send a card message via IPC.
+   * Issue #1088: Return detailed error information for better troubleshooting.
    */
   async feishuSendCard(
     chatId: string,
     card: Record<string, unknown>,
     threadId?: string,
     description?: string
-  ): Promise<{ success: boolean; messageId?: string }> {
+  ): Promise<{ success: boolean; messageId?: string; error?: string; errorType?: 'ipc_unavailable' | 'ipc_timeout' | 'ipc_request_failed' }> {
     try {
       return await this.request('feishuSendCard', { chatId, card, threadId, description });
     } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       logger.error({ err: error, chatId }, 'feishuSendCard failed');
-      return { success: false };
+
+      // Determine error type for better error handling
+      let errorType: 'ipc_unavailable' | 'ipc_timeout' | 'ipc_request_failed' = 'ipc_request_failed';
+      if (err.message.startsWith('IPC_NOT_AVAILABLE')) {
+        errorType = 'ipc_unavailable';
+      } else if (err.message.startsWith('IPC_TIMEOUT')) {
+        errorType = 'ipc_timeout';
+      }
+
+      return { success: false, error: err.message, errorType };
     }
   }
 

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -36,15 +36,33 @@ function isIpcAvailable(): boolean {
 /**
  * Send card message via IPC to PrimaryNode's LarkClientService.
  * Issue #1035: Routes Feishu API calls through unified client.
+ * Issue #1088: Improved error handling with detailed error information.
  */
 async function sendCardViaIpc(
   chatId: string,
   card: Record<string, unknown>,
   threadId?: string,
   description?: string
-): Promise<{ success: boolean; messageId?: string }> {
+): Promise<{ success: boolean; messageId?: string; error?: string; errorType?: string }> {
   const ipcClient = getIpcClient();
   return await ipcClient.feishuSendCard(chatId, card, threadId, description);
+}
+
+/**
+ * Generate user-friendly error message based on IPC error type.
+ * Issue #1088: Provide actionable error messages.
+ */
+function getIpcErrorMessage(errorType?: string, originalError?: string): string {
+  switch (errorType) {
+    case 'ipc_unavailable':
+      return '❌ IPC 服务不可用。请检查 Primary Node 服务是否正在运行。';
+    case 'ipc_timeout':
+      return '❌ IPC 请求超时。服务可能过载，请稍后重试。';
+    case 'ipc_request_failed':
+      return `❌ IPC 请求失败: ${originalError ?? '未知错误'}`;
+    default:
+      return `❌ 交互消息发送失败: ${originalError ?? '未知错误'}`;
+  }
 }
 
 /**
@@ -259,10 +277,12 @@ export async function send_interactive_message(params: {
       logger.debug({ chatId, parentMessageId }, 'Using IPC for interactive message');
       const result = await sendCardViaIpc(chatId, card, parentMessageId);
       if (!result.success) {
+        const errorMsg = getIpcErrorMessage(result.errorType, result.error);
+        logger.error({ chatId, errorType: result.errorType, error: result.error }, 'IPC interactive message failed');
         return {
           success: false,
-          error: 'Failed to send interactive message via IPC',
-          message: '❌ Failed to send interactive message via IPC.',
+          error: result.error ?? 'Failed to send interactive message via IPC',
+          message: errorMsg,
         };
       }
       ({ messageId } = result);

--- a/src/mcp/tools/send-message.ts
+++ b/src/mcp/tools/send-message.ts
@@ -48,12 +48,13 @@ function isIpcAvailable(): boolean {
 /**
  * Send text message via IPC to PrimaryNode's LarkClientService.
  * Issue #1035: Routes Feishu API calls through unified client.
+ * Issue #1088: Improved error handling with detailed error information.
  */
 async function sendMessageViaIpc(
   chatId: string,
   text: string,
   threadId?: string
-): Promise<{ success: boolean; messageId?: string }> {
+): Promise<{ success: boolean; messageId?: string; error?: string; errorType?: string }> {
   const ipcClient = getIpcClient();
   return await ipcClient.feishuSendMessage(chatId, text, threadId);
 }
@@ -61,15 +62,33 @@ async function sendMessageViaIpc(
 /**
  * Send card message via IPC to PrimaryNode's LarkClientService.
  * Issue #1035: Routes Feishu API calls through unified client.
+ * Issue #1088: Improved error handling with detailed error information.
  */
 async function sendCardViaIpc(
   chatId: string,
   card: Record<string, unknown>,
   threadId?: string,
   description?: string
-): Promise<{ success: boolean; messageId?: string }> {
+): Promise<{ success: boolean; messageId?: string; error?: string; errorType?: string }> {
   const ipcClient = getIpcClient();
   return await ipcClient.feishuSendCard(chatId, card, threadId, description);
+}
+
+/**
+ * Generate user-friendly error message based on IPC error type.
+ * Issue #1088: Provide actionable error messages.
+ */
+function getIpcErrorMessage(errorType?: string, originalError?: string): string {
+  switch (errorType) {
+    case 'ipc_unavailable':
+      return '❌ IPC 服务不可用。请检查 Primary Node 服务是否正在运行。';
+    case 'ipc_timeout':
+      return '❌ IPC 请求超时。服务可能过载，请稍后重试。';
+    case 'ipc_request_failed':
+      return `❌ IPC 请求失败: ${originalError ?? '未知错误'}`;
+    default:
+      return `❌ 消息发送失败: ${originalError ?? '未知错误'}`;
+  }
 }
 
 export async function send_message(params: {
@@ -111,10 +130,12 @@ export async function send_message(params: {
         logger.debug({ chatId, parentMessageId }, 'Using IPC for text message');
         const result = await sendMessageViaIpc(chatId, textContent, parentMessageId);
         if (!result.success) {
+          const errorMsg = getIpcErrorMessage(result.errorType, result.error);
+          logger.error({ chatId, errorType: result.errorType, error: result.error }, 'IPC text message failed');
           return {
             success: false,
-            error: 'Failed to send message via IPC',
-            message: '❌ Failed to send message via IPC.',
+            error: result.error ?? 'Failed to send message via IPC',
+            message: errorMsg,
           };
         }
       } else {
@@ -161,10 +182,12 @@ export async function send_message(params: {
         logger.debug({ chatId, parentMessageId }, 'Using IPC for card message');
         const result = await sendCardViaIpc(chatId, cardContent, parentMessageId);
         if (!result.success) {
+          const errorMsg = getIpcErrorMessage(result.errorType, result.error);
+          logger.error({ chatId, errorType: result.errorType, error: result.error }, 'IPC card message failed');
           return {
             success: false,
-            error: 'Failed to send card via IPC',
-            message: '❌ Failed to send card via IPC.',
+            error: result.error ?? 'Failed to send card via IPC',
+            message: errorMsg,
           };
         }
       } else {


### PR DESCRIPTION
## Summary

Fixes #1088

Improves IPC error handling to provide detailed error information instead of generic "Failed to send message via IPC" errors.

## Problem

Users encountered generic errors without understanding the root cause. The error information was lost in the IPC client's catch block, making it impossible to distinguish between:
- IPC service unavailable (Primary Node not running)
- IPC timeout (service overloaded)  
- IPC request failed (server-side error)

## Solution

Instead of using fallback methods (rejected in PR #1090, #1093), this PR improves error visibility:

### 1. Enhanced IPC Client Error Reporting
- `feishuSendMessage()` and `feishuSendCard()` now return detailed error info
- Includes `errorType` field: `'ipc_unavailable' | 'ipc_timeout' | 'ipc_request_failed'`
- Includes original error message for debugging

### 2. User-Friendly Error Messages
| Error Type | Message |
|------------|---------|
| `ipc_unavailable` | IPC 服务不可用。请检查 Primary Node 服务是否正在运行。 |
| `ipc_timeout` | IPC 请求超时。服务可能过载，请稍后重试。 |
| `ipc_request_failed` | IPC 请求失败: {original_error} |

### 3. Better Logging
MCP tools now log the error type and original error for troubleshooting.

## Changes

| File | Changes |
|------|---------|
| `src/ipc/unix-socket-client.ts` | Enhanced `feishuSendMessage()` and `feishuSendCard()` with error details |
| `src/mcp/tools/send-message.ts` | Added `getIpcErrorMessage()` helper, improved error handling |
| `src/mcp/tools/interactive-message.ts` | Added `getIpcErrorMessage()` helper, improved error handling |

## Test Results

```
✓ src/ipc/ipc.test.ts (23 tests)
✓ src/mcp/feishu-context-mcp.test.ts (30 tests)
✓ src/mcp/tools/interactive-message.test.ts (16 tests)
✓ Lint: 0 errors
✓ Type check: passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)