### PR TITLE
fix(mcp): pass Feishu API handlers to IPC server for Primary standalone mode

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -25,7 +25,11 @@ import {
   type MessageCallbacks,
 } from './feishu/index.js';
 // Issue #992: Import IPC server for cross-process interactive contexts
+// Issue #1116: Also import FeishuApiHandlers type
 import { startIpcServer, stopIpcServer } from '../mcp/tools/interactive-message.js';
+import type { FeishuApiHandlers } from '../ipc/unix-socket-server.js';
+// Issue #1032: Use LarkClientService for IPC handlers
+import { getLarkClientService, isLarkClientServiceInitialized } from '../services/index.js';
 import type {
   FeishuEventData,
   FeishuCardActionEventData,
@@ -205,8 +209,30 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #992: Start IPC server for cross-process interactive contexts
     // This must be called during channel startup, not at module load time,
     // to avoid test timeouts (see PR #982)
+    // Issue #1116: Pass feishuHandlers to enable IPC-based Feishu API calls
     try {
-      await startIpcServer();
+      let feishuHandlers: FeishuApiHandlers | undefined;
+      if (isLarkClientServiceInitialized()) {
+        const service = getLarkClientService();
+        feishuHandlers = {
+          sendMessage: async (chatId, text, threadId) => {
+            await service.sendMessage(chatId, text, threadId ? { threadId } : undefined);
+          },
+          sendCard: async (chatId, card, threadId, description) => {
+            await service.sendCard(chatId, card, description ? { description, threadId } : { threadId });
+          },
+          uploadFile: async (chatId, filePath, threadId) => {
+            return await service.uploadFile(chatId, filePath, threadId ? { threadId } : undefined);
+          },
+          getBotInfo: async () => {
+            return await service.getBotInfo();
+          },
+        };
+        logger.debug('Feishu API handlers registered for IPC server');
+      } else {
+        logger.warn('LarkClientService not initialized, IPC Feishu API handlers not available');
+      }
+      await startIpcServer(feishuHandlers);
       logger.info('IPC server started for cross-process interactive contexts');
     } catch (error) {
       logger.error({ err: error }, 'Failed to start IPC server, interactive cards may not work across processes');

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -18,6 +18,7 @@ import { getMessageSentCallback } from './send-message.js';
 import {
   UnixSocketIpcServer,
   createInteractiveMessageHandler,
+  type FeishuApiHandlers,
 } from '../../ipc/unix-socket-server.js';
 import { getIpcClient } from '../../ipc/unix-socket-client.js';
 import { DEFAULT_IPC_CONFIG } from '../../ipc/protocol.js';
@@ -335,8 +336,15 @@ let ipcServer: UnixSocketIpcServer | null = null;
  * Start the IPC server for cross-process communication.
  * This allows other processes (e.g., the main bot process) to query
  * the interactive contexts stored in this process.
+ *
+ * Issue #1116: Accept feishuHandlers to enable IPC-based Feishu API calls
+ * in Primary Node standalone mode.
+ *
+ * @param feishuHandlers - Optional handlers for Feishu API operations.
+ *                         When provided, IPC clients can send messages/cards
+ *                         through the Primary Node's LarkClientService.
  */
-export async function startIpcServer(): Promise<void> {
+export async function startIpcServer(feishuHandlers?: FeishuApiHandlers): Promise<void> {
   if (ipcServer) {
     logger.debug('IPC server already running');
     return;
@@ -348,7 +356,7 @@ export async function startIpcServer(): Promise<void> {
     unregisterActionPrompts,
     generateInteractionPrompt,
     cleanupExpiredContexts,
-  });
+  }, feishuHandlers);
 
   ipcServer = new UnixSocketIpcServer(handler);
 


### PR DESCRIPTION
## Summary

Fixes #1116

In Primary Node standalone mode (without Worker Node), when Agent calls `send_message` or `send_interactive_message` tools via IPC, it fails with:
```
IPC_REQUEST_FAILED: Feishu API handlers not available
```

## Problem

`startIpcServer()` only registered `InteractiveMessageHandlers` but not `FeishuApiHandlers`, so IPC server cannot handle Feishu API requests.

## Solution

Pass `feishuHandlers` from `LarkClientService` to `startIpcServer()` in `FeishuChannel.doStart()`. This enables IPC clients to send messages/cards through the Primary Node's unified LarkClientService.

### Changes

| File | Changes |
|------|---------|
| `src/mcp/tools/interactive-message.ts` | Accept optional `feishuHandlers` parameter in `startIpcServer()` |
| `src/channels/feishu-channel.ts` | Create `feishuHandlers` from `LarkClientService` and pass to `startIpcServer()` |

## Why This Is The Right Fix

1. Primary Node owns `LarkClientService`, should expose it via IPC
2. Avoids duplicate Feishu client creation in MCP tools
3. Follows #1085 architecture: Primary handles all external API calls
4. **NOT a fallback approach** (rejected in PR #1090, #1093) - this fixes the root cause

## Test Results

- ✅ Type check: passed
- ✅ IPC tests: 23 passed
- ✅ Interactive message tests: 16 passed
- ✅ LarkClientService tests: 23 passed
- ✅ Lint: 0 errors (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)