### PR TITLE
fix(ipc): support dynamic registration of Feishu API handlers

### DIFF
--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -26,7 +26,13 @@ import {
 } from './feishu/index.js';
 // Issue #992: Import IPC server for cross-process interactive contexts
 // Issue #1116: Also import FeishuApiHandlers type
-import { startIpcServer, stopIpcServer } from '../mcp/tools/interactive-message.js';
+// Issue #1120: Import registerFeishuHandlers for dynamic handler registration
+import {
+  startIpcServer,
+  stopIpcServer,
+  registerFeishuHandlers,
+  unregisterFeishuHandlers,
+} from '../mcp/tools/interactive-message.js';
 import type { FeishuApiHandlers } from '../ipc/unix-socket-server.js';
 // Issue #1032: Use LarkClientService for IPC handlers
 import { getLarkClientService, isLarkClientServiceInitialized } from '../services/index.js';
@@ -209,12 +215,15 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
     // Issue #992: Start IPC server for cross-process interactive contexts
     // This must be called during channel startup, not at module load time,
     // to avoid test timeouts (see PR #982)
-    // Issue #1116: Pass feishuHandlers to enable IPC-based Feishu API calls
+    // Issue #1120: Use registerFeishuHandlers for dynamic handler registration
     try {
-      let feishuHandlers: FeishuApiHandlers | undefined;
+      // Start IPC server first (may already be running from feishu-context-mcp.ts)
+      await startIpcServer();
+
+      // Register Feishu API handlers dynamically
       if (isLarkClientServiceInitialized()) {
         const service = getLarkClientService();
-        feishuHandlers = {
+        const feishuHandlers: FeishuApiHandlers = {
           sendMessage: async (chatId, text, threadId) => {
             await service.sendMessage(chatId, text, threadId ? { threadId } : undefined);
           },
@@ -228,12 +237,11 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
             return await service.getBotInfo();
           },
         };
-        logger.debug('Feishu API handlers registered for IPC server');
+        registerFeishuHandlers(feishuHandlers);
+        logger.info('IPC server ready with Feishu API handlers');
       } else {
         logger.warn('LarkClientService not initialized, IPC Feishu API handlers not available');
       }
-      await startIpcServer(feishuHandlers);
-      logger.info('IPC server started for cross-process interactive contexts');
     } catch (error) {
       logger.error({ err: error }, 'Failed to start IPC server, interactive cards may not work across processes');
     }
@@ -250,6 +258,9 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
 
     // Clean up old attachments to prevent memory leaks
     attachmentManager.cleanupOldAttachments();
+
+    // Issue #1120: Unregister Feishu handlers before stopping IPC server
+    unregisterFeishuHandlers();
 
     // Issue #992: Stop IPC server
     stopIpcServer();

--- a/src/ipc/unix-socket-server.ts
+++ b/src/ipc/unix-socket-server.ts
@@ -67,11 +67,20 @@ export interface FeishuApiHandlers {
 }
 
 /**
+ * Mutable container for Feishu API handlers.
+ * Issue #1120: Allows dynamic registration of handlers after IPC server starts.
+ */
+export interface FeishuHandlersContainer {
+  handlers: FeishuApiHandlers | undefined;
+}
+
+/**
  * Create an IPC request handler from interactive message handlers.
+ * Issue #1120: Uses FeishuHandlersContainer for dynamic handler registration.
  */
 export function createInteractiveMessageHandler(
   handlers: InteractiveMessageHandlers,
-  feishuHandlers?: FeishuApiHandlers
+  feishuHandlersContainer?: FeishuHandlersContainer
 ): IpcRequestHandler {
   // eslint-disable-next-line require-await
   return async (request: IpcRequest): Promise<IpcResponse> => {
@@ -126,7 +135,9 @@ export function createInteractiveMessageHandler(
         }
 
         // Feishu API operations (Issue #1035)
+        // Issue #1120: Use container for dynamic handler registration
         case 'feishuSendMessage': {
+          const feishuHandlers = feishuHandlersContainer?.handlers;
           if (!feishuHandlers) {
             return {
               id: request.id,
@@ -146,6 +157,7 @@ export function createInteractiveMessageHandler(
         }
 
         case 'feishuSendCard': {
+          const feishuHandlers = feishuHandlersContainer?.handlers;
           if (!feishuHandlers) {
             return {
               id: request.id,
@@ -165,6 +177,7 @@ export function createInteractiveMessageHandler(
         }
 
         case 'feishuUploadFile': {
+          const feishuHandlers = feishuHandlersContainer?.handlers;
           if (!feishuHandlers) {
             return {
               id: request.id,
@@ -184,6 +197,7 @@ export function createInteractiveMessageHandler(
         }
 
         case 'feishuGetBotInfo': {
+          const feishuHandlers = feishuHandlersContainer?.handlers;
           if (!feishuHandlers) {
             return {
               id: request.id,

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -32,6 +32,8 @@ export {
   startIpcServer,
   stopIpcServer,
   isIpcServerRunning,
+  registerFeishuHandlers,
+  unregisterFeishuHandlers,
 } from './tools/interactive-message.js';
 export { ask_user } from './tools/ask-user.js';
 

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -19,6 +19,7 @@ import {
   UnixSocketIpcServer,
   createInteractiveMessageHandler,
   type FeishuApiHandlers,
+  type FeishuHandlersContainer,
 } from '../../ipc/unix-socket-server.js';
 import { getIpcClient } from '../../ipc/unix-socket-client.js';
 import { DEFAULT_IPC_CONFIG } from '../../ipc/protocol.js';
@@ -333,12 +334,41 @@ export async function send_interactive_message(params: {
 let ipcServer: UnixSocketIpcServer | null = null;
 
 /**
+ * Issue #1120: Mutable container for Feishu API handlers.
+ * Allows dynamic registration of handlers after IPC server starts.
+ */
+const feishuHandlersContainer: FeishuHandlersContainer = {
+  handlers: undefined,
+};
+
+/**
+ * Register Feishu API handlers for IPC-based operations.
+ * Issue #1120: Allows FeishuChannel to register handlers after IPC server starts.
+ *
+ * @param handlers - The Feishu API handlers to register.
+ */
+export function registerFeishuHandlers(handlers: FeishuApiHandlers): void {
+  feishuHandlersContainer.handlers = handlers;
+  logger.info('Feishu API handlers registered for IPC server');
+}
+
+/**
+ * Unregister Feishu API handlers.
+ * Issue #1120: Cleanup function for when FeishuChannel stops.
+ */
+export function unregisterFeishuHandlers(): void {
+  feishuHandlersContainer.handlers = undefined;
+  logger.debug('Feishu API handlers unregistered from IPC server');
+}
+
+/**
  * Start the IPC server for cross-process communication.
  * This allows other processes (e.g., the main bot process) to query
  * the interactive contexts stored in this process.
  *
  * Issue #1116: Accept feishuHandlers to enable IPC-based Feishu API calls
  * in Primary Node standalone mode.
+ * Issue #1120: Use FeishuHandlersContainer for dynamic handler registration.
  *
  * @param feishuHandlers - Optional handlers for Feishu API operations.
  *                         When provided, IPC clients can send messages/cards
@@ -347,7 +377,16 @@ let ipcServer: UnixSocketIpcServer | null = null;
 export async function startIpcServer(feishuHandlers?: FeishuApiHandlers): Promise<void> {
   if (ipcServer) {
     logger.debug('IPC server already running');
+    // Issue #1120: Still try to register handlers if provided
+    if (feishuHandlers) {
+      registerFeishuHandlers(feishuHandlers);
+    }
     return;
+  }
+
+  // Issue #1120: Register initial handlers if provided
+  if (feishuHandlers) {
+    feishuHandlersContainer.handlers = feishuHandlers;
   }
 
   const handler = createInteractiveMessageHandler({
@@ -356,7 +395,7 @@ export async function startIpcServer(feishuHandlers?: FeishuApiHandlers): Promis
     unregisterActionPrompts,
     generateInteractionPrompt,
     cleanupExpiredContexts,
-  }, feishuHandlers);
+  }, feishuHandlersContainer);
 
   ipcServer = new UnixSocketIpcServer(handler);
 


### PR DESCRIPTION
## Summary

- Fixes #1120: IPC server initialization order causes Feishu API handlers not available
- Implements dynamic handler registration to allow Feishu handlers to be registered after IPC server starts

## Problem

The IPC server was started by `feishu-context-mcp.ts` at module load time without Feishu handlers. When `FeishuChannel.doStart()` later tried to register handlers, the server was already running and the handlers were never registered, causing "Feishu API handlers not available" errors.

## Solution

Implemented **Option B: Dynamic handler registration** from the issue:

1. Added `FeishuHandlersContainer` interface to hold handlers mutably
2. Added `registerFeishuHandlers()` function for dynamic registration
3. Added `unregisterFeishuHandlers()` function for cleanup
4. Updated `FeishuChannel` to use dynamic registration after server starts

## Changes

| File | Changes |
|------|---------|
| `src/ipc/unix-socket-server.ts` | Add `FeishuHandlersContainer`, update `createInteractiveMessageHandler` to use container |
| `src/mcp/tools/interactive-message.ts` | Add `registerFeishuHandlers`, `unregisterFeishuHandlers`, update `startIpcServer` to accept handlers after server starts |
| `src/channels/feishu-channel.ts` | Use `registerFeishuHandlers` instead of passing handlers to `startIpcServer` |
| `src/mcp/feishu-context-mcp.ts` | Export new functions |

## Test Plan

- [x] All IPC tests pass (23/23)
- [x] All interactive-message tests pass (16/16)
- [x] Build succeeds
- [x] Manual verification of the fix logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)