### PR TITLE
fix(test): resolve ESLint errors in chat_record test file (PR #1124)

### DIFF
--- a/src/channels/feishu/message-handler-chat-record.test.ts
+++ b/src/channels/feishu/message-handler-chat-record.test.ts
@@ -10,10 +10,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock dependencies before importing
-vi.mock('@larksuiteoapi/node-sdk', () => ({
-  Client: vi.fn(() => ({})),
-}));
-
 vi.mock('../../utils/logger.js', () => ({
   createLogger: vi.fn(() => ({
     debug: vi.fn(),
@@ -187,7 +183,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should indicate this is a forwarded conversation
       expect(emittedMessage.content).toContain('转发了一段聊天记录');
@@ -228,7 +224,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should include sender ID
       expect(emittedMessage.content).toContain('specific_user_id');
@@ -266,7 +262,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should include a formatted date (the exact format depends on locale)
       expect(emittedMessage.content).toContain('2023');
@@ -305,7 +301,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       expect(emittedMessage.content).toContain('Rich text content');
     });
@@ -341,7 +337,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should show default "未知用户" for missing sender
       expect(emittedMessage.content).toContain('未知用户');
@@ -378,7 +374,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should still include the message
       expect(emittedMessage.content).toContain('Message without timestamp');
@@ -479,7 +475,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Should include text and post content
       expect(emittedMessage.content).toContain('Text message');
@@ -526,7 +522,7 @@ describe('MessageHandler - Issue #1123: chat_record message type', () => {
       });
 
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
-      const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
 
       // Messages should be separated by divider
       expect(emittedMessage.content).toContain('---');


### PR DESCRIPTION
## Summary

- Fix ESLint errors blocking PR #1124 CI
- Remove forbidden `vi.mock('@larksuiteoapi/node-sdk')` - not needed for these tests
- Use array destructuring (`[[emittedMessage]]`) to satisfy `prefer-destructuring` rule

## Problem

PR #1124's CI was failing with 9 ESLint errors:
- 1 error: `no-restricted-syntax` - forbidden vi.mock for @larksuiteoapi/node-sdk
- 8 errors: `prefer-destructuring` - array access instead of destructuring

## Solution

1. **Removed the forbidden mock**: The `vi.mock('@larksuiteoapi/node-sdk')` was not actually needed because:
   - The tests mock all dependencies manually
   - No actual lark SDK calls are made in these tests

2. **Fixed array destructuring**: Changed from:
   ```typescript
   const emittedMessage = mockCallbacks.emitMessage.mock.calls[0][0];
   ```
   to:
   ```typescript
   const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
   ```

## Test Results

- ✅ All 10 tests pass
- ✅ Lint passes (0 errors)

## Related

- Fixes lint errors in PR #1124
- Issue #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)