### PR TITLE
fix(test): resolve ESLint errors in request-review files (PR #1092)

### DIFF
--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -265,12 +265,12 @@ export async function send_interactive_message(params: {
           message: '❌ Failed to send interactive message via IPC.',
         };
       }
-      messageId = result.messageId;
+      ({ messageId } = result);
     } else {
       // Fallback: Create client directly
       const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
       const result = await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(card), parentMessageId);
-      messageId = result.messageId;
+      ({ messageId } = result);
     }
 
     // Register action prompts if message was sent successfully

--- a/src/mcp/tools/request-review.test.ts
+++ b/src/mcp/tools/request-review.test.ts
@@ -72,7 +72,7 @@ describe('request_review', () => {
     expect(result.messageId).toBe('msg_123');
     expect(interactiveMessage.send_interactive_message).toHaveBeenCalledTimes(1);
 
-    const callArgs = vi.mocked(interactiveMessage.send_interactive_message).mock.calls[0][0];
+    const [[callArgs]] = vi.mocked(interactiveMessage.send_interactive_message).mock.calls;
     expect(callArgs.chatId).toBe('oc_test');
     expect(callArgs.card).toBeDefined();
     expect(callArgs.actionPrompts).toBeDefined();
@@ -97,7 +97,7 @@ describe('request_review', () => {
 
     expect(result.success).toBe(true);
 
-    const callArgs = vi.mocked(interactiveMessage.send_interactive_message).mock.calls[0][0];
+    const [[callArgs]] = vi.mocked(interactiveMessage.send_interactive_message).mock.calls;
     expect(callArgs.actionPrompts.approve).toContain('准奏');
     expect(callArgs.actionPrompts.reject).toContain('驳回');
   });

--- a/src/mcp/tools/request-review.ts
+++ b/src/mcp/tools/request-review.ts
@@ -222,7 +222,7 @@ export async function request_quick_review(params: {
 
     return {
       success: true,
-      message: `✅ Quick review request sent`,
+      message: '✅ Quick review request sent',
       messageId: result.messageId,
     };
 


### PR DESCRIPTION
## Summary

This PR fixes ESLint errors in the request-review files that are causing CI to fail in PR #1092.

## Changes

- **interactive-message.ts**: Use object destructuring instead of property assignment (lines 268, 273)
- **request-review.test.ts**: Use array destructuring instead of index access (lines 75, 100)
- **request-review.ts**: Use single quotes instead of template literal for simple string (line 225)

## Test Results

- ✅ All 12 tests in request-review.test.ts pass
- ✅ Lint passes with 0 errors (97 warnings remain, pre-existing)

## Related

- Fixes lint errors blocking PR #1092
- Original Issue: #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)