### PR TITLE
fix(test): resolve ESLint errors in expert-tools files (PR #1094)

### DIFF
--- a/src/mcp/tools/expert-tools.test.ts
+++ b/src/mcp/tools/expert-tools.test.ts
@@ -4,7 +4,7 @@
  * @see Issue #536 - 专家查询与匹配
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock the expert-service module before any imports
 const mockSearchBySkill = vi.fn();

--- a/src/mcp/tools/expert-tools.ts
+++ b/src/mcp/tools/expert-tools.ts
@@ -6,7 +6,7 @@
  * @see Issue #536 - 专家查询与匹配
  */
 
-import { getExpertService, type ExpertProfile, type SkillLevel } from '../../experts/index.js';
+import { getExpertService, type SkillLevel } from '../../experts/index.js';
 import { createLogger } from '../../utils/logger.js';
 
 const logger = createLogger('expert-tools');

--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -265,12 +265,12 @@ export async function send_interactive_message(params: {
           message: '❌ Failed to send interactive message via IPC.',
         };
       }
-      messageId = result.messageId;
+      ({ messageId } = result);
     } else {
       // Fallback: Create client directly
       const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
       const result = await sendMessageToFeishu(client, chatId, 'interactive', JSON.stringify(card), parentMessageId);
-      messageId = result.messageId;
+      ({ messageId } = result);
     }
 
     // Register action prompts if message was sent successfully


### PR DESCRIPTION
## Summary

- Fixes ESLint errors blocking PR #1094 from passing CI
- Resolves 4 lint errors (0 errors after fix)

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `src/mcp/tools/expert-tools.test.ts` | `afterEach` imported but never used | Remove unused import |
| `src/mcp/tools/expert-tools.ts` | `ExpertProfile` imported but never used | Remove unused import |
| `src/mcp/tools/interactive-message.ts` | Lines 268, 273: Use object destructuring | Change `messageId = result.messageId` to `({ messageId } = result)` |

## Test Results

- ✅ Lint: 0 errors, 97 warnings (same as main branch)
- ✅ All 1768 tests pass

## Related

- Fixes lint errors in PR #1094 (feat: add find_experts and list_experts tools for Issue #536)

🤖 Generated with [Claude Code](https://claude.com/claude-code)