### PR TITLE
fix(lint): resolve ESLint errors in Issue #631 implementation

### DIFF
--- a/src/mcp/tools/interactive-message.ts
+++ b/src/mcp/tools/interactive-message.ts
@@ -293,7 +293,9 @@ export async function startIpcServer(): Promise<void> {
     // Issue #631: 离线消息相关
     getOfflineContext: (messageId: string) => {
       const context = getOfflineContext(messageId);
-      if (!context) return undefined;
+      if (!context) {
+        return undefined;
+      }
       return {
         id: context.id,
         messageId: context.messageId,
@@ -309,7 +311,9 @@ export async function startIpcServer(): Promise<void> {
       formData?: Record<string, unknown>
     ) => {
       const context = getOfflineContext(messageId);
-      if (!context) return undefined;
+      if (!context) {
+        return undefined;
+      }
       return generateFollowUpPrompt(context, actionValue, actionText, formData);
     },
     unregisterOfflineContext,

--- a/src/mcp/tools/leave-message.ts
+++ b/src/mcp/tools/leave-message.ts
@@ -319,7 +319,7 @@ export async function leave_message(params: {
 
       return {
         success: true,
-        message: `✅ 离线留言已发送。用户回复后将触发新任务。`,
+        message: '✅ 离线留言已发送。用户回复后将触发新任务。',
         messageId: result.messageId,
         offlineId: context.id,
       };


### PR DESCRIPTION
## Summary

This PR fixes ESLint errors in PR #1070 (Issue #631) that are blocking CI:

- **2 files changed**, 7 insertions(+), 3 deletions(-)
- **3 ESLint errors fixed** (0 errors remaining, only warnings)

## Problem

PR #1070 (feat: add leave_message tool for non-blocking offline interaction) introduced 3 ESLint errors that are blocking CI:

| File | Error Type | Line |
|------|------------|------|
| interactive-message.ts | curly | 296 |
| interactive-message.ts | curly | 312 |
| leave-message.ts | quotes | 322 |

## Solution

### 1. interactive-message.ts
- Added curly braces to single-line `if` statements (curly rule)
  - `if (!context) return undefined;` → `if (!context) { return undefined; }`

### 2. leave-message.ts
- Changed template literal to single quotes (quotes rule)
  - `` `✅ 离线留言已发送。用户回复后将触发新任务。` `` → `'✅ 离线留言已发送。用户回复后将触发新任务。'`

## Test Results

```
✓ npm run lint: 0 errors, 96 warnings
✓ npm test: 1730 tests passed
```

## Related

- Fixes lint errors in PR #1070
- Issue #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)