### PR TITLE
fix(lint): resolve ESLint errors in PR #1001 (Issue #997)

### DIFF
--- a/src/agents/subagent-manager.test.ts
+++ b/src/agents/subagent-manager.test.ts
@@ -300,7 +300,7 @@ describe('SubagentManager', () => {
 
       await manager.dispose();
 
-      const list = manager.list();
+      const _list = manager.list();
       // dispose calls terminateAll which terminates running agents
       // completed agents are still in the list
     });

--- a/src/agents/subagent-manager.ts
+++ b/src/agents/subagent-manager.ts
@@ -45,7 +45,7 @@ import { Config } from '../config/index.js';
 import { createLogger } from '../utils/logger.js';
 import { findSkill } from '../skills/index.js';
 import { AgentFactory } from './factory.js';
-import type { ChatAgent, BaseAgentConfig, AgentProvider } from './types.js';
+import type { ChatAgent, AgentProvider } from './types.js';
 import type { PilotCallbacks } from './pilot/index.js';
 
 const logger = createLogger('SubagentManager');
@@ -577,9 +577,7 @@ export class SubagentManager {
   async terminateAll(): Promise<void> {
     const runningHandles = this.listRunning();
 
-    for (const handle of runningHandles) {
-      this.terminate(handle.id);
-    }
+    await Promise.all(runningHandles.map(handle => this.terminate(handle.id)));
 
     logger.info({ count: runningHandles.length }, 'All subagents terminated');
   }


### PR DESCRIPTION
## Summary

This PR fixes ESLint errors in PR #1001 (Issue #997) that are blocking CI:

- **2 files changed**, 3 insertions(+), 5 deletions(-)
- **3 ESLint errors fixed** (0 errors remaining, only warnings)

## Problem

PR #1001 (feat: add SubagentManager for unified subagent spawning) introduced 3 ESLint errors that are blocking CI:

| File | Error Type | Line |
|------|------------|------|
| subagent-manager.ts | no-unused-vars | 48 |
| subagent-manager.ts | require-await | 577 |
| subagent-manager.test.ts | no-unused-vars | 303 |

## Solution

### 1. subagent-manager.ts (line 48)
- Removed unused import `BaseAgentConfig`
- `import type { ChatAgent, AgentProvider } from './types.js';`

### 2. subagent-manager.ts (line 577)
- Added `await` to `terminateAll()` by using `Promise.all()`
- Changed from `for...of` loop without await to `await Promise.all()`

### 3. subagent-manager.test.ts (line 303)
- Prefixed unused variable `list` with underscore: `_list`

## Test Results

```
✓ npm run lint: 0 errors, 106 warnings
✓ npm test: 22 tests passed (subagent-manager)
```

## Related

- Fixes lint errors in PR #1001
- Issue #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)