### PR TITLE
fix(feishu): resolve TypeScript errors in card action handling

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -746,7 +746,7 @@ export class MessageHandler {
     const rawData = data as Record<string, unknown>;
     const context = rawData.context as { open_message_id?: string; open_chat_id?: string } | undefined;
     const operator = rawData.operator as { open_id?: string; user_id?: string; union_id?: string } | undefined;
-    const actionData = rawData.action as { value?: string; tag?: string; type?: string } | undefined;
+    const actionData = rawData.action as { value?: string; tag?: string; type?: string; text?: string } | undefined;
 
     // Extract fields from actual structure
     const message_id = context?.open_message_id;
@@ -755,6 +755,7 @@ export class MessageHandler {
       type: actionData.tag ?? actionData.type ?? '',
       value: actionData.value ?? '',
       trigger: 'button' as const,
+      text: actionData.text,
     } : undefined;
     const user = operator ? {
       sender_id: {
@@ -875,7 +876,7 @@ export class MessageHandler {
         action,
         message_id,
         chat_id,
-        user,
+        user: user ?? { sender_id: { open_id: '' } },
         tenant_key: (rawData.tenant_key as string) || '',
       };
       const handled = await this.interactionManager.handleAction(compatEvent, async (defaultEvent) => {


### PR DESCRIPTION
## Summary

修复 main 分支上的 TypeScript 类型错误，这些错误阻塞了所有 PR 的 CI 检查。

## Changes

- 在 `actionData` 类型定义中添加 `text` 属性
- 创建 `action` 对象时包含 `text` 字段
- 当 `user` 为 undefined 时提供默认值

## Problem

main 分支上存在以下 TypeScript 错误：
- `Property 'text' does not exist on type '{ type: string; value: string; trigger: "button"; }'`
- `Type 'undefined' is not assignable to type '{ sender_id: { open_id: string; ... }; }'`

这些错误导致了 PR #1132 (Issue #1044) 的 CI 检查失败。

## Verification

| Check | Status |
|-------|--------|
| TypeScript type-check | ✅ Passed |
| ESLint | ✅ No errors (warnings only) |
| Unit Tests (1776) | ✅ All passed |

## Test Plan

- [x] Run `npm run type-check` - no errors
- [x] Run `npm run lint` - no errors
- [x] Run `npm test` - all 1776 tests pass

Fixes TypeScript errors blocking CI on main branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)