### PR TITLE
fix(lint): resolve ESLint errors in chat_record test file (PR #1134)

### DIFF
--- a/src/channels/feishu/__tests__/message-handler-chat-record.test.ts
+++ b/src/channels/feishu/__tests__/message-handler-chat-record.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for MessageHandler chat_record parsing.
+ * Issue #1123: Support chat_record message type for forwarded chat history
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MessageHandler } from '../message-handler.js';
+import type { FeishuEventData } from '../../../types/platform.js';
+
+// Mock dependencies
+vi.mock('../../../services/index.js', () => ({
+  getLarkClientService: vi.fn(() => ({
+    getClient: vi.fn(() => ({})),
+    getMessage: vi.fn(),
+  })),
+  isLarkClientServiceInitialized: vi.fn(() => true),
+}));
+
+vi.mock('../../../file-transfer/inbound/index.js', () => ({
+  attachmentManager: {
+    getAttachments: vi.fn(() => []),
+  },
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('../../../feishu/message-logger.js', () => ({
+  messageLogger: {
+    isMessageProcessed: vi.fn(() => false),
+    logIncomingMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../../../feishu/filtered-message-forwarder.js', () => ({
+  filteredMessageForwarder: {
+    setMessageSender: vi.fn(),
+    forward: vi.fn(),
+  },
+}));
+
+vi.mock('../../../platforms/feishu/feishu-file-handler.js', () => ({
+  FeishuFileHandler: vi.fn(() => ({
+    handleFileMessage: vi.fn(),
+    buildUploadPrompt: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../platforms/feishu/feishu-message-sender.js', () => ({
+  FeishuMessageSender: vi.fn(() => ({
+    addReaction: vi.fn(),
+    sendText: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../platforms/feishu/interaction-manager.js', () => ({
+  InteractionManager: vi.fn(() => ({
+    handleAction: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../ipc/unix-socket-client.js', () => ({
+  getIpcClient: vi.fn(() => ({
+    isConnected: vi.fn(() => false),
+  })),
+}));
+
+describe('MessageHandler - chat_record parsing', () => {
+  let handler: MessageHandler;
+  let emitMessageMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    emitMessageMock = vi.fn();
+
+    const passiveModeManager = {
+      isPassiveModeDisabled: vi.fn(() => false),
+    } as unknown as { isPassiveModeDisabled: (chatId: string) => boolean };
+
+    const mentionDetector = {
+      isBotMentioned: vi.fn(() => false),
+    } as unknown as { isBotMentioned: (mentions: unknown) => boolean };
+
+    const interactionManager = {} as unknown as { handleAction: () => Promise<boolean> };
+
+    handler = new MessageHandler({
+      appId: 'test-app-id',
+      appSecret: 'test-app-secret',
+      passiveModeManager,
+      mentionDetector,
+      interactionManager,
+      callbacks: {
+        emitMessage: emitMessageMock,
+        emitControl: vi.fn(),
+        sendMessage: vi.fn(),
+      },
+      isRunning: () => true,
+      hasControlHandler: () => false,
+    });
+
+    handler.initialize();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('chat_record message type', () => {
+    it('should parse chat_record with text messages', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [
+          {
+            message_id: 'msg-1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user A' }),
+            create_time: 1704067200000, // 2024-01-01 00:00:00 UTC
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+          {
+            message_id: 'msg-2',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user B' }),
+            create_time: 1704067260000, // 2024-01-01 00:01:00 UTC
+            sender: { sender_id: { open_id: 'user_b' } },
+          },
+        ],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      expect(emitMessageMock).toHaveBeenCalledTimes(1);
+      const [[callArgs]] = emitMessageMock.mock.calls;
+
+      expect(callArgs.messageType).toBe('chat_record');
+      expect(callArgs.content).toContain('[用户转发了一段聊天记录]');
+      expect(callArgs.content).toContain('user_a');
+      expect(callArgs.content).toContain('Hello from user A');
+      expect(callArgs.content).toContain('user_b');
+      expect(callArgs.content).toContain('Hello from user B');
+      expect(callArgs.metadata.isChatRecord).toBe(true);
+    });
+
+    it('should parse chat_record with post messages', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [
+          {
+            message_id: 'msg-1',
+            message_type: 'post',
+            content: JSON.stringify({
+              content: [[{ tag: 'text', text: 'Rich text message' }]],
+            }),
+            create_time: 1704067200000,
+            sender: { sender_id: { user_id: 'user_x' } },
+          },
+        ],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      expect(emitMessageMock).toHaveBeenCalledTimes(1);
+      const [[callArgs]] = emitMessageMock.mock.calls;
+
+      expect(callArgs.content).toContain('Rich text message');
+    });
+
+    it('should handle empty messages array', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      // Should not emit message for empty chat_record
+      expect(emitMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle invalid JSON content', async () => {
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: 'not valid json',
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      // Should not emit message for invalid content
+      expect(emitMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing messages field', async () => {
+      const chatRecordContent = JSON.stringify({
+        someOtherField: 'value',
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      // Should not emit message for missing messages field
+      expect(emitMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('should use fallback sender ID when open_id is missing', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [
+          {
+            message_id: 'msg-1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Message with user_id only' }),
+            create_time: 1704067200000,
+            sender: { sender_id: { user_id: 'fallback_user' } },
+          },
+        ],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      expect(emitMessageMock).toHaveBeenCalledTimes(1);
+      const [[callArgs]] = emitMessageMock.mock.calls;
+
+      expect(callArgs.content).toContain('fallback_user');
+    });
+
+    it('should show unknown user when sender info is missing', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [
+          {
+            message_id: 'msg-1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Message without sender' }),
+            create_time: 1704067200000,
+          },
+        ],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      expect(emitMessageMock).toHaveBeenCalledTimes(1);
+      const [[callArgs]] = emitMessageMock.mock.calls;
+
+      expect(callArgs.content).toContain('未知用户');
+    });
+
+    it('should format timestamps correctly', async () => {
+      const chatRecordContent = JSON.stringify({
+        messages: [
+          {
+            message_id: 'msg-1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Test message' }),
+            create_time: 1704067200000, // Fixed timestamp
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+        ],
+      });
+
+      const eventData: FeishuEventData = {
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            content: chatRecordContent,
+            message_type: 'chat_record',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender-open-id' },
+          },
+        },
+      };
+
+      await handler.handleMessageReceive(eventData);
+
+      expect(emitMessageMock).toHaveBeenCalledTimes(1);
+      const [[callArgs]] = emitMessageMock.mock.calls;
+
+      // Should contain formatted date (format may vary by locale)
+      expect(callArgs.content).toMatch(/\d{4}/); // Year
+    });
+  });
+});

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -25,6 +25,7 @@ import type {
   FeishuMessageEvent,
   FeishuCardActionEvent,
   FeishuCardActionEventData,
+  FeishuChatRecordContent,
 } from '../../types/platform.js';
 import type { PassiveModeManager } from './passive-mode.js';
 import type { MentionDetector } from './mention-detector.js';
@@ -418,6 +419,78 @@ export class MessageHandler {
   }
 
   /**
+   * Parse chat_record message content to extract forwarded conversation.
+   * Issue #1123: Support chat_record message type for forwarded chat history
+   *
+   * @param content - JSON string content from chat_record message
+   * @returns Formatted text representation of the conversation, or undefined if parsing fails
+   */
+  private parseChatRecordContent(content: string): string | undefined {
+    try {
+      const parsed = JSON.parse(content) as FeishuChatRecordContent;
+
+      if (!parsed.messages || !Array.isArray(parsed.messages)) {
+        logger.debug({ content }, 'chat_record content missing messages array');
+        return undefined;
+      }
+
+      const formattedMessages: string[] = [];
+
+      for (const msg of parsed.messages) {
+        // Try to extract text from each message
+        let msgText = '';
+        try {
+          const msgContent = JSON.parse(msg.content);
+          if (msg.message_type === 'text') {
+            msgText = msgContent.text?.trim() || '';
+          } else if (msg.message_type === 'post') {
+            // Extract text from post content
+            if (msgContent.content && Array.isArray(msgContent.content)) {
+              for (const row of msgContent.content) {
+                if (Array.isArray(row)) {
+                  for (const segment of row) {
+                    if (segment?.tag === 'text' && segment.text) {
+                      msgText += segment.text;
+                    }
+                  }
+                }
+              }
+              msgText = msgText.trim();
+            }
+          }
+        } catch {
+          // If parsing fails, use raw content
+          msgText = msg.content;
+        }
+
+        if (msgText) {
+          const senderId = msg.sender?.sender_id?.open_id || msg.sender?.sender_id?.user_id || '未知用户';
+          const timestamp = msg.create_time
+            ? new Date(msg.create_time).toLocaleString('zh-CN', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+              })
+            : '';
+          formattedMessages.push(`[${senderId}] ${timestamp}\n${msgText}`);
+        }
+      }
+
+      if (formattedMessages.length === 0) {
+        return undefined;
+      }
+
+      return `[用户转发了一段聊天记录]\n\n${formattedMessages.join('\n\n---\n\n')}`;
+    } catch (error) {
+      logger.debug({ err: error }, 'Failed to parse chat_record content');
+      return undefined;
+    }
+  }
+
+  /**
    * Handle incoming message event from WebSocket.
    */
   async handleMessageReceive(data: FeishuEventData): Promise<void> {
@@ -522,6 +595,55 @@ export class MessageHandler {
           }],
         });
       }
+      return;
+    }
+
+    // Handle chat_record (packed/forwarded conversation) messages
+    // Issue #1123: Support chat_record message type for forwarded chat history
+    if (message_type === 'chat_record') {
+      logger.info(
+        { chatId: chat_id, messageType: message_type, messageId: message_id },
+        'Processing chat_record message'
+      );
+
+      const parsedChatRecord = this.parseChatRecordContent(content);
+      if (!parsedChatRecord) {
+        logger.warn({ messageId: message_id }, 'Failed to parse chat_record content');
+        await this.forwardFilteredMessage('unsupported', message_id, chat_id, content, this.extractOpenId(sender), { messageType: message_type });
+        return;
+      }
+
+      await messageLogger.logIncomingMessage(
+        message_id,
+        this.extractOpenId(sender) || 'unknown',
+        chat_id,
+        parsedChatRecord,
+        message_type,
+        create_time
+      );
+
+      // Add typing reaction
+      await this.addTypingReaction(message_id);
+
+      // Emit as incoming message
+      await this.callbacks.emitMessage({
+        messageId: message_id,
+        chatId: chat_id,
+        userId: this.extractOpenId(sender),
+        content: parsedChatRecord,
+        messageType: message_type,
+        timestamp: create_time,
+        threadId,
+        metadata: {
+          isChatRecord: true,
+          messageCount: (parsedChatRecord.match(/---/g) || []).length + 1,
+        },
+      });
+
+      logger.info(
+        { messageId: message_id, chatId: chat_id },
+        'chat_record message processed successfully'
+      );
       return;
     }
 

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -50,6 +50,27 @@ export interface FeishuMessageEvent {
 }
 
 /**
+ * Chat record message structure for forwarded/packed conversations.
+ * Issue #1123: Support chat_record message type for forwarded chat history
+ * @see https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/events/receive_v1
+ */
+export interface FeishuChatRecordContent {
+  /** List of messages in the packed conversation */
+  messages: Array<{
+    message_id: string;
+    content: string;
+    message_type: string;
+    create_time?: number;
+    sender?: {
+      sender_id?: {
+        open_id?: string;
+        user_id?: string;
+      };
+    };
+  }>;
+}
+
+/**
  * Feishu WebSocket event data wrapper.
  */
 export interface FeishuEventData {


### PR DESCRIPTION
## Summary

This PR fixes the ESLint errors in PR #1134 that are blocking CI.

- Replace array index access with destructuring in test assertions
- Change `emitMessageMock.mock.calls[0][0]` to `const [[callArgs]] = emitMessageMock.mock.calls`
- Fixes 5 `prefer-destructuring` errors

## Problem

PR #1134 (feat: add chat_record message type support) has 5 ESLint errors in the test file:

| File | Error Type | Count |
|------|------------|-------|
| message-handler-chat-record.test.ts | prefer-destructuring | 5 |

## Solution

Use array destructuring instead of index access:
```typescript
// Before
const callArgs = emitMessageMock.mock.calls[0][0];

// After
const [[callArgs]] = emitMessageMock.mock.calls;
```

## Test Plan

- [x] All 8 unit tests pass
- [x] ESLint passes with 0 errors (only warnings)
- [x] No TypeScript errors

Fixes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)