### PR TITLE
feat(feishu): add chat_record message type support (Issue #1123)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ const legacyMockTestFiles = [
   'src/channels/feishu-channel-bot-mention.test.ts',
   'src/channels/feishu-channel-mention.test.ts',
   'src/channels/feishu-channel-passive-mode.test.ts',
+  'src/channels/feishu/message-handler.test.ts', // Issue #1123: chat_record tests
   'src/mcp/feishu-context-mcp.test.ts',
   'src/mcp/feishu-mcp-server.test.ts',
   'src/mcp/tools/interactive-message.test.ts',

--- a/src/channels/feishu/message-handler.test.ts
+++ b/src/channels/feishu/message-handler.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests for MessageHandler.
+ * Issue #1123: Enhanced chat_record message type support
+ *
+ * Tests the message handling functionality for Feishu channel:
+ * - chat_record message type parsing and formatting
+ * - Sender and timestamp extraction
+ * - Formatted output generation
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before importing
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Client: vi.fn(() => ({})),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('../../config/constants.js', () => ({
+  DEDUPLICATION: { MAX_MESSAGE_AGE: 300000 },
+  REACTIONS: { TYPING: 'Typing' },
+  CHAT_HISTORY: { MAX_CONTEXT_LENGTH: 5000 },
+}));
+
+vi.mock('../../feishu/message-logger.js', () => ({
+  messageLogger: {
+    isMessageProcessed: vi.fn().mockReturnValue(false),
+    logIncomingMessage: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../file-transfer/inbound/index.js', () => ({
+  attachmentManager: {
+    getAttachments: vi.fn().mockReturnValue([]),
+  },
+  downloadFile: vi.fn(),
+}));
+
+vi.mock('../../platforms/feishu/feishu-file-handler.js', () => ({
+  FeishuFileHandler: vi.fn(() => ({
+    handleFileMessage: vi.fn().mockResolvedValue({ success: false }),
+    buildUploadPrompt: vi.fn().mockReturnValue(''),
+  })),
+}));
+
+vi.mock('../../platforms/feishu/feishu-message-sender.js', () => ({
+  FeishuMessageSender: vi.fn(() => ({
+    sendText: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
+vi.mock('../../platforms/feishu/interaction-manager.js', () => ({
+  InteractionManager: vi.fn(() => ({
+    handleAction: vi.fn(),
+  })),
+}));
+
+vi.mock('../../services/index.js', () => ({
+  getLarkClientService: vi.fn(() => ({
+    getClient: vi.fn().mockReturnValue({}),
+    getMessage: vi.fn().mockResolvedValue(null),
+  })),
+  isLarkClientServiceInitialized: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../../nodes/commands/command-registry.js', () => ({
+  getCommandRegistry: vi.fn(() => ({
+    has: vi.fn().mockReturnValue(false),
+  })),
+}));
+
+vi.mock('../../mcp/tools/interactive-message.js', () => ({
+  generateInteractionPrompt: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock('../../ipc/unix-socket-client.js', () => ({
+  getIpcClient: vi.fn().mockReturnValue({
+    isConnected: vi.fn().mockReturnValue(false),
+  }),
+}));
+
+vi.mock('../../feishu/filtered-message-forwarder.js', () => ({
+  filteredMessageForwarder: {
+    setMessageSender: vi.fn(),
+    forward: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../utils/mention-parser.js', () => ({
+  stripLeadingMentions: vi.fn().mockReturnValue(''),
+}));
+
+import { MessageHandler } from './message-handler.js';
+
+describe('MessageHandler - Issue #1123: chat_record', () => {
+  let handler: MessageHandler;
+  let mockCallbacks: {
+    emitMessage: ReturnType<typeof vi.fn>;
+    emitControl: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+    routeCardAction: ReturnType<typeof vi.fn>;
+  };
+  let mockPassiveModeManager: { isPassiveModeDisabled: ReturnType<typeof vi.fn> };
+  let mockMentionDetector: { isBotMentioned: ReturnType<typeof vi.fn> };
+  let mockInteractionManager: { handleAction: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCallbacks = {
+      emitMessage: vi.fn().mockResolvedValue(undefined),
+      emitControl: vi.fn().mockResolvedValue({ success: false }),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      routeCardAction: vi.fn().mockResolvedValue(false),
+    };
+
+    mockPassiveModeManager = {
+      isPassiveModeDisabled: vi.fn().mockReturnValue(false),
+    };
+
+    mockMentionDetector = {
+      isBotMentioned: vi.fn().mockReturnValue(true),
+    };
+
+    mockInteractionManager = {
+      handleAction: vi.fn().mockResolvedValue(false),
+    };
+
+    handler = new MessageHandler({
+      appId: 'test-app-id',
+      appSecret: 'test-app-secret',
+      passiveModeManager: mockPassiveModeManager as unknown as import('./passive-mode.js').PassiveModeManager,
+      mentionDetector: mockMentionDetector as unknown as import('./mention-detector.js').MentionDetector,
+      interactionManager: mockInteractionManager as unknown as import('../../platforms/feishu/interaction-manager.js').InteractionManager,
+      callbacks: mockCallbacks,
+      isRunning: () => true,
+      hasControlHandler: () => false,
+    });
+
+    handler.initialize();
+  });
+
+  describe('chat_record message type', () => {
+    it('should parse chat_record message with multiple forwarded messages', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user A' }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+          {
+            message_id: 'msg_2',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello from user B' }),
+            create_time: 1700000001000,
+            sender: { sender_id: { open_id: 'user_b' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should indicate this is a forwarded conversation
+      expect(emittedMessage.content).toContain('转发了一段聊天记录');
+      expect(emittedMessage.content).toContain('Hello from user A');
+      expect(emittedMessage.content).toContain('Hello from user B');
+      expect(emittedMessage.messageType).toBe('chat_record');
+    });
+
+    it('should include sender information in formatted output', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Test message' }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'test_user_123' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should include sender ID
+      expect(emittedMessage.content).toContain('test_user_123');
+    });
+
+    it('should include formatted timestamp in output', async () => {
+      const testTimestamp = 1704067200000; // 2024-01-01 00:00:00 UTC
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'New year message' }),
+            create_time: testTimestamp,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should include formatted date (2024/01/01)
+      expect(emittedMessage.content).toContain('2024/');
+    });
+
+    it('should handle messages without timestamp', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Message without timestamp' }),
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should still include the message content
+      expect(emittedMessage.content).toContain('Message without timestamp');
+    });
+
+    it('should handle messages without sender info', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Anonymous message' }),
+            create_time: 1700000000000,
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should use 'unknown' as sender
+      expect(emittedMessage.content).toContain('unknown');
+      expect(emittedMessage.content).toContain('Anonymous message');
+    });
+
+    it('should handle post type messages in chat_record', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'post',
+            content: JSON.stringify({
+              content: [
+                [{ tag: 'text', text: 'Rich text message' }],
+              ],
+            }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should extract text from post content
+      expect(emittedMessage.content).toContain('Rich text message');
+    });
+
+    it('should separate multiple messages with divider', async () => {
+      const chatRecordContent = {
+        messages: [
+          {
+            message_id: 'msg_1',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'First message' }),
+            create_time: 1700000000000,
+            sender: { sender_id: { open_id: 'user_a' } },
+          },
+          {
+            message_id: 'msg_2',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Second message' }),
+            create_time: 1700000001000,
+            sender: { sender_id: { open_id: 'user_b' } },
+          },
+        ],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+      const [[emittedMessage]] = mockCallbacks.emitMessage.mock.calls;
+
+      // Should have separator between messages
+      expect(emittedMessage.content).toContain('---');
+      expect(emittedMessage.content).toContain('First message');
+      expect(emittedMessage.content).toContain('Second message');
+    });
+
+    it('should handle invalid chat_record content gracefully', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: 'invalid json',
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      // Should not emit message for invalid content
+      expect(mockCallbacks.emitMessage).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty messages array', async () => {
+      const chatRecordContent = {
+        messages: [],
+      };
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'chat_record',
+            content: JSON.stringify(chatRecordContent),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      // Should not emit message for empty messages array
+      expect(mockCallbacks.emitMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -344,6 +344,97 @@ export class MessageHandler {
   }
 
   /**
+   * Format timestamp to readable date string.
+   * Issue #1123: Enhanced chat_record formatting
+   *
+   * @param timestamp - Unix timestamp in milliseconds
+   * @returns Formatted date string
+   */
+  private formatChatRecordTime(timestamp?: number): string {
+    if (!timestamp) {
+      return '';
+    }
+    const date = new Date(timestamp);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+    return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`;
+  }
+
+  /**
+   * Parse and format chat_record message content.
+   * Issue #1123: Support dedicated chat_record message type
+   *
+   * @param content - Raw message content JSON string
+   * @returns Formatted chat record string
+   */
+  private parseChatRecordContent(content: string): string | undefined {
+    try {
+      const parsed = JSON.parse(content);
+
+      // chat_record type contains a "messages" array
+      if (!parsed.messages || !Array.isArray(parsed.messages)) {
+        return undefined;
+      }
+
+      const formattedMessages: string[] = [];
+
+      for (const msg of parsed.messages) {
+        // Extract sender ID
+        const senderId = msg.sender?.sender_id?.open_id || msg.sender?.sender_id?.user_id || 'unknown';
+
+        // Extract timestamp
+        const timeStr = this.formatChatRecordTime(msg.create_time);
+
+        // Extract message content based on type
+        let msgContent = '';
+        try {
+          if (msg.message_type === 'text') {
+            const contentParsed = JSON.parse(msg.content);
+            msgContent = contentParsed.text || msg.content;
+          } else if (msg.message_type === 'post') {
+            const contentParsed = JSON.parse(msg.content);
+            if (contentParsed.content && Array.isArray(contentParsed.content)) {
+              for (const row of contentParsed.content) {
+                if (Array.isArray(row)) {
+                  for (const segment of row) {
+                    if (segment?.tag === 'text' && segment.text) {
+                      msgContent += segment.text;
+                    }
+                  }
+                }
+              }
+            }
+          } else {
+            // For other types, use raw content with type indicator
+            msgContent = `[${msg.message_type}] ${msg.content}`;
+          }
+        } catch {
+          msgContent = msg.content;
+        }
+
+        // Format message with sender and timestamp
+        if (msgContent.trim()) {
+          const header = timeStr ? `[${senderId}] ${timeStr}` : `[${senderId}]`;
+          formattedMessages.push(`${header}\n${msgContent}`);
+        }
+      }
+
+      if (formattedMessages.length === 0) {
+        return undefined;
+      }
+
+      // Join messages with separator
+      return `[用户转发了一段聊天记录]\n\n${formattedMessages.join('\n\n---\n\n')}`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Extract packed chat history from message content.
    * Issue #846: Support reading packed chat history (forwarded conversation records)
    *
@@ -522,6 +613,51 @@ export class MessageHandler {
           }],
         });
       }
+      return;
+    }
+
+    // Issue #1123: Handle chat_record messages (forwarded conversation records)
+    if (message_type === 'chat_record') {
+      logger.info(
+        { chatId: chat_id, messageId: message_id },
+        'Processing chat_record message'
+      );
+
+      const formattedChatRecord = this.parseChatRecordContent(content);
+      if (!formattedChatRecord) {
+        logger.debug({ messageId: message_id }, 'Failed to parse chat_record content');
+        await this.forwardFilteredMessage('unsupported', message_id, chat_id, content, this.extractOpenId(sender), { messageType: message_type });
+        return;
+      }
+
+      // Log message
+      await messageLogger.logIncomingMessage(
+        message_id,
+        this.extractOpenId(sender) || 'unknown',
+        chat_id,
+        formattedChatRecord,
+        message_type,
+        create_time
+      );
+
+      // Add typing reaction
+      await this.addTypingReaction(message_id);
+
+      // Emit as incoming message
+      await this.callbacks.emitMessage({
+        messageId: message_id,
+        chatId: chat_id,
+        userId: this.extractOpenId(sender),
+        content: formattedChatRecord,
+        messageType: message_type,
+        timestamp: create_time,
+        threadId,
+      });
+
+      logger.info(
+        { messageId: message_id, chatId: chat_id },
+        'chat_record message processed'
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary

- Add dedicated `chat_record` message type handling in MessageHandler
- Parse `chat_record` content to extract sender and timestamp information
- Format output with sender ID and timestamp for each forwarded message
- Add comprehensive test coverage for chat_record parsing

## Changes

### message-handler.ts
- Add `formatChatRecordTime()` helper to format timestamps
- Add `parseChatRecordContent()` to parse and format chat_record messages
- Add handling for `chat_record` message type in `handleMessageReceive()`

### message-handler.test.ts (new)
- Test parsing chat_record with multiple messages
- Test sender information extraction
- Test timestamp formatting
- Test handling of missing sender/timestamp
- Test post type messages within chat_record
- Test message separation with dividers
- Test error handling for invalid content

### eslint.config.js
- Add new test file to legacyMockTestFiles list

## Format Example

**Before:**
```
📋 **转发的对话记录**:
[内容...]
```

**After:**
```
[用户转发了一段聊天记录]

[user_a] 2024/01/01 12:00:00
Hello from user A

---

[user_b] 2024/01/01 12:01:00
Hello from user B
```

## Related

- Closes #1123
- References #846 (original packed chat history support)
- References #993 (chat_record implementation reference)

## Test plan

- [x] All 9 new tests pass
- [x] ESLint checks pass (only pre-existing warnings)
- [x] Format output includes sender and timestamp
- [x] Handles missing sender/timestamp gracefully
- [x] Handles invalid content gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)