### PR TITLE
fix(architecture): handle interaction processing on Primary Node (Issue #1085)

### DIFF
--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -74,6 +74,9 @@ import { ScheduleManagement } from './schedule-management.js';
 import { buildCommandServices } from './command-services.js';
 // Issue #935: Card action routing to Worker Nodes
 import { CardActionRouter } from './card-action-router.js';
+// Issue #1085: Generate interaction prompt on Primary Node before routing
+import { generateInteractionPrompt } from '../mcp/tools/interactive-message.js';
+import { getIpcClient } from '../ipc/unix-socket-client.js';
 // Issue #455: Skill Agent System
 import { SkillAgentManager, initSkillAgentManager } from '../agents/skill-agent-manager.js';
 // Issue #1032: Unified Lark Client Service
@@ -781,10 +784,54 @@ export class PrimaryNode extends EventEmitter {
    * Route a card action to the appropriate handler.
    * If the card was sent by a Worker Node, forward the action to that node.
    *
+   * Issue #1085: Primary Node generates prompt content before routing to Worker Node.
+   * This ensures all interaction processing happens on Primary Node,
+   * and Worker Node only receives the pre-processed prompt content.
+   *
    * @param message - Card action message to route
    * @returns True if the action was routed to a Worker Node, false otherwise
    */
-  routeCardAction(message: CardActionMessage): Promise<boolean> {
+  async routeCardAction(message: CardActionMessage): Promise<boolean> {
+    // Issue #1085: Generate prompt content on Primary Node before routing
+    // Try IPC first (cross-process), then fall back to local function (same-process)
+    let promptContent: string | undefined;
+
+    try {
+      const ipcClient = getIpcClient();
+      if (ipcClient.isConnected()) {
+        // Cross-process: query via IPC
+        promptContent = await ipcClient.generateInteractionPrompt(
+          message.cardMessageId,
+          message.actionValue,
+          message.actionText,
+          message.actionType
+        ) ?? undefined;
+        if (promptContent) {
+          logger.debug({ cardMessageId: message.cardMessageId }, 'Got prompt template via IPC');
+        }
+      }
+
+      // Fallback to local function (same-process)
+      if (!promptContent) {
+        promptContent = generateInteractionPrompt(
+          message.cardMessageId,
+          message.actionValue,
+          message.actionText,
+          message.actionType
+        );
+        if (promptContent) {
+          logger.debug({ cardMessageId: message.cardMessageId }, 'Got prompt template from local function');
+        }
+      }
+    } catch (error) {
+      logger.warn({ err: error, cardMessageId: message.cardMessageId }, 'Failed to generate interaction prompt');
+    }
+
+    // Add prompt content to message for Worker Node
+    if (promptContent) {
+      message.promptContent = promptContent;
+    }
+
     return this.cardActionRouter.routeCardAction(message);
   }
 

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -475,30 +475,22 @@ export class WorkerNode {
         }
 
         // Issue #935: Handle card action messages from Primary Node
+        // Issue #1085: Primary Node generates prompt content, Worker just uses it
         if (message.type === 'card_action') {
           const cardActionMsg = message as CardActionMessage;
-          const { chatId, cardMessageId, actionType, actionValue, actionText, userId } = cardActionMsg;
+          const { chatId, cardMessageId, actionType, actionValue, actionText, userId, promptContent } = cardActionMsg;
           logger.info(
-            { chatId, cardMessageId, actionType, actionValue, userId },
+            { chatId, cardMessageId, actionType, actionValue, userId, hasPromptContent: !!promptContent },
             'Received card action from Primary Node'
           );
-
-          // Import the necessary functions to handle card actions
-          const { generateInteractionPrompt } = await import('../mcp/tools/interactive-message.js');
 
           // Get the agent for this chatId and process the card action
           const ctx = this.activeFeedbackChannels.get(chatId);
           if (ctx) {
-            // Generate prompt from template if available
-            const promptFromTemplate = generateInteractionPrompt(
-              cardMessageId,
-              actionValue,
-              actionText,
-              actionType
-            );
-
-            // Use the template prompt if available, otherwise use default message
-            const messageContent = promptFromTemplate || (() => {
+            // Issue #1085: Use pre-generated prompt content from Primary Node
+            // Worker Node no longer calls generateInteractionPrompt directly
+            // This ensures all interaction processing happens on Primary Node
+            const messageContent = promptContent || (() => {
               const buttonText = actionText || actionValue;
               return `User clicked '${buttonText}' button`;
             })();

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -95,6 +95,7 @@ export interface FeedbackMessage {
  * This enables Worker Node to receive card interaction callbacks from Primary Node.
  *
  * Issue #935: WebSocket bidirectional communication for card actions.
+ * Issue #1085: Primary Node generates prompt content before routing to Worker Node.
  */
 export interface CardActionMessage {
   type: 'card_action';
@@ -117,6 +118,12 @@ export interface CardActionMessage {
     text?: string;
     trigger?: string;
   };
+  /**
+   * Pre-generated prompt content from Primary Node.
+   * Issue #1085: Primary Node handles interaction processing, Worker just uses this content.
+   * If not provided, Worker should use a default message.
+   */
+  promptContent?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- 所有交互处理现在在 Primary Node 上完成后再路由到 Worker Node
- Worker Node 只接收预处理的 prompt 内容，不再调用 `generateInteractionPrompt`
- 在 `CardActionMessage` 类型中添加了 `promptContent` 字段用于传递生成的提示

## Changes

### `src/types/websocket-messages.ts`
- 在 `CardActionMessage` 接口中添加 `promptContent?: string` 字段

### `src/nodes/primary-node.ts`
- 修改 `routeCardAction()` 方法，在路由前先生成 prompt 内容
- 优先使用 IPC 客户端（跨进程），然后回退到本地函数（同进程）
- 通过消息将预生成的 `promptContent` 传递给 Worker Node

### `src/nodes/worker-node.ts`
- 简化 `card_action` 消息处理
- Worker 现在直接使用来自 Primary Node 的 `promptContent`
- 移除了对 `generateInteractionPrompt` 的直接调用

## Architecture

| 阶段 | 之前 | 之后 |
|------|------|------|
| 卡片动作处理 | Worker 接收 → 调用 generateInteractionPrompt → 处理 | Primary 生成 prompt → 路由到 Worker → Worker 使用预生成的 prompt |

这确保 Worker Node 保持轻量级，职责单一：发送/接收指令。

## Test Plan

- [x] 所有 1785 个单元测试通过
- [x] TypeScript 类型检查通过

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)