### PR TITLE
fix(test): add missing createdAt property to FileRef in multimodal tests

### DIFF
--- a/src/agents/pilot/multimodal.test.ts
+++ b/src/agents/pilot/multimodal.test.ts
@@ -48,6 +48,7 @@ describe('Multimodal Message Handling (Issue #808)', () => {
     size,
     localPath: `/tmp/workspace/attachments/${fileName}`,
     source: 'user',
+    createdAt: Date.now(),
   });
 
   describe('Scenario 1: Single image with text query', () => {
@@ -328,6 +329,7 @@ console.log(data.value);
         size: 1024000,
         localPath: '/tmp/document.pdf',
         source: 'user',
+        createdAt: Date.now(),
       };
 
       const result = messageBuilder.buildEnhancedContent({


### PR DESCRIPTION
## Summary

Fixes TypeScript errors blocking CI in PR #1146:
- `src/agents/pilot/multimodal.test.ts(44,18)`: error TS2741: Property 'createdAt' is missing in type
- `src/agents/pilot/multimodal.test.ts(324,13)`: error TS2741: Property 'createdAt' is missing in type

The `FileRef` interface requires `createdAt: number` property but the test helper function `createImageAttachment` and the inline `pdfAttachment` object were missing it.

## Changes

- Added `createdAt: Date.now()` to `createImageAttachment` helper function
- Added `createdAt: Date.now()` to inline `pdfAttachment` object

## Test Results

```
✓ npm run type-check: 0 errors
✓ npm run lint: 0 errors, 102 warnings (no new issues)
✓ npm test -- src/agents/pilot/multimodal.test.ts: 15 tests passed
```

## Related

- Fixes CI for PR #1146
- Issue #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)