### PR TITLE
fix(lint): resolve TypeScript errors in task-progress-service (PR #1136)

### DIFF
--- a/src/agents/task-progress-service.test.ts
+++ b/src/agents/task-progress-service.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for TaskProgressService.
+ *
+ * Issue #857: Complex Task Auto-Start Task Agent
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { TaskProgressService } from './task-progress-service.js';
+import type { TaskComplexityResult } from './task-complexity-agent.js';
+
+describe('TaskProgressService', () => {
+  let service: TaskProgressService;
+  let mockSendCard: Mock<(card: Record<string, unknown>) => Promise<void>>;
+
+  const mockComplexity: TaskComplexityResult = {
+    complexityScore: 8,
+    complexityLevel: 'high',
+    estimatedSteps: 5,
+    estimatedSeconds: 300,
+    confidence: 0.75,
+    reasoning: {
+      taskType: 'refactoring',
+      scope: 'multiple_files',
+      uncertainty: 'medium',
+      dependencies: ['file_system', 'testing'],
+      keyFactors: ['Factor 1', 'Factor 2', 'Factor 3'],
+    },
+    recommendation: {
+      shouldStartTaskAgent: true,
+      reportingInterval: 60,
+      message: '检测到复杂任务，已启动后台执行模式',
+    },
+  };
+
+  beforeEach(() => {
+    service = new TaskProgressService();
+    mockSendCard = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    // Clean up any active tracking
+    vi.clearAllMocks();
+  });
+
+  describe('startTracking', () => {
+    it('should start tracking and send initial progress card', async () => {
+    const taskId = await service.startTracking({
+      chatId: 'test-chat-id',
+      messageId: 'test-message-id',
+      userMessage: 'Refactor the authentication module',
+      complexity: mockComplexity,
+      sendCard: mockSendCard,
+      });
+
+      expect(taskId).toBeDefined();
+      expect(taskId).toMatch(/^task-test-chat-id-\d+$/);
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+
+      // Verify card structure
+      const [[cardArg]] = mockSendCard.mock.calls;
+      expect(cardArg).toHaveProperty('config');
+      expect(cardArg).toHaveProperty('header');
+      expect(cardArg).toHaveProperty('elements');
+    });
+
+    it('should track active task after starting', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      expect(service.hasActiveTask(chatId)).toBe(true);
+      expect(service.getActiveTask(chatId)).toBeDefined();
+    });
+  });
+
+  describe('completeTask', () => {
+    it('should complete task successfully', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      // Reset mock for completion card
+      mockSendCard.mockClear();
+
+      await service.completeTask(chatId, true, 'Task completed successfully');
+
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+      expect(service.hasActiveTask(chatId)).toBe(false);
+    });
+
+    it('should complete task with failure', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      mockSendCard.mockClear();
+
+      await service.completeTask(chatId, false, 'Task failed');
+
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+      expect(service.hasActiveTask(chatId)).toBe(false);
+    });
+
+    it('should handle completion for non-existent task', async () => {
+      // Should not throw
+      await expect(
+        service.completeTask('non-existent-chat', true, 'Done')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('hasActiveTask', () => {
+    it('should return false when no active task', () => {
+      expect(service.hasActiveTask('non-existent-chat')).toBe(false);
+    });
+
+    it('should return true when task is active', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      expect(service.hasActiveTask(chatId)).toBe(true);
+    });
+  });
+
+  describe('getActiveTask', () => {
+    it('should return undefined when no active task', () => {
+      expect(service.getActiveTask('non-existent-chat')).toBeUndefined();
+    });
+
+    it('should return task info when task is active', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      const taskInfo = service.getActiveTask(chatId);
+      expect(taskInfo).toBeDefined();
+      expect(taskInfo?.taskId).toMatch(/^task-/);
+      expect(taskInfo?.percent).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('buildProgressCard', () => {
+    it('should build card with correct structure', async () => {
+      await service.startTracking({
+        chatId: 'test-chat-id',
+        messageId: 'test-message-id',
+        userMessage: 'Task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      const [[cardArg]] = mockSendCard.mock.calls;
+
+      // Check structure
+      expect(cardArg.config).toEqual({ wide_screen_mode: true });
+      expect(cardArg.header).toHaveProperty('title');
+      expect(cardArg.header).toHaveProperty('template');
+      expect(Array.isArray(cardArg.elements)).toBe(true);
+    });
+
+    it('should include task ID in card', async () => {
+      await service.startTracking({
+        chatId: 'test-chat-id',
+        messageId: 'test-message-id',
+        userMessage: 'Task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      const [[cardArg]] = mockSendCard.mock.calls as [[Record<string, unknown>]];
+      const [firstElement] = cardArg.elements as Record<string, unknown>[];
+      expect(firstElement.content).toContain('任务ID');
+    });
+  });
+});

--- a/src/agents/task-progress-service.ts
+++ b/src/agents/task-progress-service.ts
@@ -1,0 +1,350 @@
+/**
+ * Task Progress Service - Manages progress tracking for complex tasks.
+ *
+ * Issue #857: Complex Task Auto-Start Task Agent
+ *
+ * This service provides:
+ * - Progress card management with ETA updates
+ * - Task execution recording to history
+ * - Progress updates at appropriate intervals
+ *
+ * @module agents/task-progress-service
+ */
+
+import { createLogger } from '../utils/logger.js';
+import { taskHistoryStorage, type TaskRecord } from './task-history.js';
+import type { TaskComplexityResult } from './task-complexity-agent.js';
+
+const logger = createLogger('TaskProgressService');
+
+/**
+ * Progress card configuration.
+ */
+export interface ProgressCardConfig {
+  chatId: string;
+  messageId: string;
+  userMessage: string;
+  complexity: TaskComplexityResult;
+  sendCard: (card: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Active progress tracking state.
+ */
+interface ActiveProgress {
+  taskId: string;
+  chatId: string;
+  messageId: string;
+  userMessage: string;
+  complexity: TaskComplexityResult;
+  startTime: number;
+  lastUpdateTime: number;
+  currentPercent: number;
+  currentStep: string;
+  cardMessageId?: string;
+  updateInterval: ReturnType<typeof setInterval>;
+  sendCard: (card: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Task Progress Service.
+ *
+ * Manages progress cards and task execution recording.
+ */
+export class TaskProgressService {
+  private activeProgress: Map<string, ActiveProgress> = new Map();
+
+  /** Minimum interval between progress updates (30 seconds) */
+  private readonly MIN_UPDATE_INTERVAL = 30000;
+
+  /** Maximum progress before completion (capped at 90%) */
+  private readonly MAX_PROGRESS_BEFORE_COMPLETE = 90;
+
+  /**
+   * Start tracking a complex task.
+   *
+   * @param config - Progress card configuration
+   * @returns Task ID for tracking
+   */
+  async startTracking(config: ProgressCardConfig): Promise<string> {
+    const { chatId, messageId, userMessage, complexity, sendCard } = config;
+
+    // Generate unique task ID
+    const taskId = `task-${chatId}-${Date.now()}`;
+
+    logger.info({
+      taskId,
+      chatId,
+      messageId,
+      complexityScore: complexity.complexityScore,
+      estimatedSeconds: complexity.estimatedSeconds,
+    }, 'Starting progress tracking for complex task');
+
+    // Send initial progress card
+    const card = this.buildProgressCard({
+      taskId,
+      status: 'running',
+      percent: 0,
+      message: complexity.recommendation.message || '任务已启动',
+      eta: complexity.estimatedSeconds,
+      currentStep: '正在分析任务...',
+    });
+
+    await sendCard(card);
+
+    // Create progress tracking state
+    const startTime = Date.now();
+    const progress: ActiveProgress = {
+      taskId,
+      chatId,
+      messageId,
+      userMessage,
+      complexity,
+      startTime,
+      lastUpdateTime: startTime,
+      currentPercent: 0,
+      currentStep: '正在分析任务...',
+      sendCard,
+      updateInterval: setInterval(
+        () => this.updateProgress(taskId),
+        Math.max(this.MIN_UPDATE_INTERVAL, complexity.recommendation.reportingInterval * 1000)
+      ),
+    };
+
+    this.activeProgress.set(chatId, progress);
+
+    return taskId;
+  }
+
+  /**
+   * Update progress for an active task.
+   *
+   * @param taskId - Task ID to update
+   */
+  private async updateProgress(taskId: string): Promise<void> {
+    const progress = this.activeProgress.get(taskId);
+    if (!progress) {
+      logger.warn({ taskId }, 'No active progress found for update');
+      return;
+    }
+
+    const elapsed = (Date.now() - progress.startTime) / 1000;
+    const estimated = progress.complexity.estimatedSeconds;
+
+    // Calculate progress percentage (capped at 90% until completion)
+    const rawPercent = Math.min(
+      this.MAX_PROGRESS_BEFORE_COMPLETE,
+      Math.floor((elapsed / estimated) * 100)
+    );
+
+    // Only update if progress increased by at least 5%
+    if (rawPercent <= progress.currentPercent + 5) {
+      return;
+    }
+
+    progress.currentPercent = rawPercent;
+    progress.lastUpdateTime = Date.now();
+
+    // Determine current step based on progress
+    const stepIndex = Math.floor(
+      (rawPercent / 100) * progress.complexity.estimatedSteps
+    );
+    progress.currentStep = this.getStepDescription(stepIndex, progress.complexity);
+
+    logger.debug({
+      taskId,
+      percent: rawPercent,
+      elapsed,
+      estimated,
+    }, 'Updating progress');
+
+    // Send updated progress card
+    const card = this.buildProgressCard({
+      taskId,
+      status: 'running',
+      percent: rawPercent,
+      message: '任务执行中',
+      eta: Math.max(0, estimated - elapsed),
+      currentStep: progress.currentStep,
+    });
+
+    await progress.sendCard(card);
+  }
+
+  /**
+   * Complete a tracked task.
+   *
+   * @param chatId - Chat ID to complete task for
+   * @param success - Whether task completed successfully
+   * @param summary - Optional task summary
+   */
+  async completeTask(chatId: string, success: boolean, summary?: string): Promise<void> {
+    const progress = this.activeProgress.get(chatId);
+    if (!progress) {
+      logger.debug({ chatId }, 'No active progress to complete');
+      return;
+    }
+
+    // Clear update interval
+    clearInterval(progress.updateInterval);
+
+    const elapsed = (Date.now() - progress.startTime) / 1000;
+
+    // Send completion card
+    const card = this.buildProgressCard({
+      taskId: progress.taskId,
+      status: success ? 'completed' : 'failed',
+      percent: 100,
+      message: success ? '任务完成' : '任务失败',
+      eta: 0,
+      currentStep: summary || (success ? '所有步骤已完成' : '任务执行失败'),
+    });
+
+    await progress.sendCard(card);
+
+    // Record to history
+    const record: TaskRecord = {
+      taskId: progress.taskId,
+      chatId: progress.chatId,
+      userMessage: progress.userMessage,
+      taskType: progress.complexity.reasoning.taskType,
+      complexityScore: progress.complexity.complexityScore,
+      estimatedSeconds: progress.complexity.estimatedSeconds,
+      actualSeconds: elapsed,
+      success,
+      startedAt: progress.startTime,
+      completedAt: Date.now(),
+      keyFactors: progress.complexity.reasoning.keyFactors,
+    };
+
+    await taskHistoryStorage.recordTask(record);
+
+    logger.info({
+      taskId: progress.taskId,
+      success,
+      elapsed,
+      estimated: progress.complexity.estimatedSeconds,
+    }, 'Task completed and recorded');
+
+    // Remove from active tracking
+    this.activeProgress.delete(chatId);
+  }
+
+  /**
+   * Check if there's an active task for a chat.
+   */
+  hasActiveTask(chatId: string): boolean {
+    return this.activeProgress.has(chatId);
+  }
+
+  /**
+   * Get active task info for a chat.
+   */
+  getActiveTask(chatId: string): { taskId: string; percent: number } | undefined {
+    const progress = this.activeProgress.get(chatId);
+    if (!progress) {
+      return undefined;
+    }
+    return {
+      taskId: progress.taskId,
+      percent: progress.currentPercent,
+    };
+  }
+
+  /**
+   * Build a progress card for Feishu.
+   */
+  private buildProgressCard(params: {
+    taskId: string;
+    status: 'running' | 'completed' | 'failed';
+    percent: number;
+    message: string;
+    eta: number;
+    currentStep: string;
+  }): Record<string, unknown> {
+    const { taskId, status, percent, message, eta, currentStep } = params;
+
+    const statusEmoji = {
+      running: '🔄',
+      completed: '✅',
+      failed: '❌',
+    }[status];
+
+    const headerColor = {
+      running: 'blue',
+      completed: 'green',
+      failed: 'red',
+    }[status];
+
+    const progressBar = this.buildProgressBar(percent);
+
+    const elements: Array<Record<string, unknown>> = [
+      { tag: 'markdown', content: `**任务ID**: \`${taskId.slice(-8)}\`` },
+      { tag: 'markdown', content: `**状态**: ${statusEmoji} ${message}` },
+      { tag: 'markdown', content: `**进度**: ${progressBar} ${percent}%` },
+    ];
+
+    if (status === 'running' && eta > 0) {
+      elements.push({
+        tag: 'markdown',
+        content: `**预计剩余时间**: ${this.formatTime(eta)}`,
+      });
+    }
+
+    elements.push({
+      tag: 'markdown',
+      content: `**当前步骤**: ${currentStep}`,
+    });
+
+    return {
+      config: { wide_screen_mode: true },
+      header: {
+        title: { tag: 'plain_text', content: `${statusEmoji} 任务执行中` },
+        template: headerColor,
+      },
+      elements,
+    };
+  }
+
+  /**
+   * Build a text progress bar.
+   */
+  private buildProgressBar(percent: number): string {
+    const filled = Math.floor(percent / 5);
+    const empty = 20 - filled;
+    return '█'.repeat(filled) + '░'.repeat(empty);
+  }
+
+  /**
+   * Format time in human-readable format.
+   */
+  private formatTime(seconds: number): string {
+    if (seconds < 60) {
+      return `${Math.round(seconds)}秒`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.round(seconds % 60);
+    if (minutes < 60) {
+      return secs > 0 ? `${minutes}分${secs}秒` : `${minutes}分钟`;
+    }
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return mins > 0 ? `${hours}小时${mins}分钟` : `${hours}小时`;
+  }
+
+  /**
+   * Get step description based on progress.
+   */
+  private getStepDescription(stepIndex: number, complexity: TaskComplexityResult): string {
+    const factors = complexity.reasoning.keyFactors;
+    if (factors.length === 0) {
+      return `步骤 ${stepIndex + 1}/${complexity.estimatedSteps}`;
+    }
+    return factors[stepIndex % factors.length] || `步骤 ${stepIndex + 1}/${complexity.estimatedSteps}`;
+  }
+}
+
+/**
+ * Global task progress service instance.
+ */
+export const taskProgressService = new TaskProgressService();


### PR DESCRIPTION
## Summary

This PR fixes the TypeScript errors in PR #1136 that are blocking CI.

### Changes

**src/agents/task-progress-service.test.ts**
- Fix TS2344: Changed `ReturnType<typeof TaskProgressService>` to `Mock<(card: Record<string, unknown>) => Promise<void>>`
- Fix TS2488: Added type assertions for mock.calls destructuring

### Problem

PR #1136 (fix lint errors in task-progress-service) has 1 TypeScript error:

| File | Error Type | Location |
|------|------------|----------|
| task-progress-service.test.ts | TS2344 | 13:32 |

### Solution

1. Import `Mock` type from vitest
2. Use proper mock function type: `Mock<(card: Record<string, unknown>) => Promise<void>>`
3. Add type assertions for destructuring mock calls

## Test Results

```
✅ TypeScript type-check: 0 errors
✅ ESLint: 0 errors (only warnings)
✅ Unit tests: 11 passed
```

## Related

- Fixes TypeScript errors in PR #1136
- Issue #857 (Complex Task Auto-Start Task Agent)
- PR #1069 (original TaskProgressService implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)