### PR TITLE
fix(lint): resolve ESLint errors in ipc.test.ts for PR #1006

### DIFF
--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -230,7 +230,7 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     resetIpcClient();
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     resetIpcClient();
     if (existsSync(socketPath)) {
       try {
@@ -253,7 +253,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should return available when server is running', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},
@@ -294,7 +293,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should return true when connected', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},
@@ -333,7 +331,6 @@ describe('UnixSocketIpcClient - Graceful Fallback (Issue #1079)', () => {
     });
 
     it('should connect on retry if server becomes available', async () => {
-      const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
       const handler = createInteractiveMessageHandler({
         getActionPrompts: () => undefined,
         registerActionPrompts: () => {},


### PR DESCRIPTION
## Summary

This PR fixes the 4 ESLint errors in PR #1006 that are blocking CI:

| File | Error Type | Count |
|------|------------|-------|
| ipc.test.ts | require-await | 1 |
| ipc.test.ts | @typescript-eslint/no-unused-vars | 3 |

## Changes

### 1. Remove unnecessary `async` keyword (line 233)
```diff
- afterEach(async () => {
+ afterEach(() => {
```
The `afterEach` callback doesn't use any `await` expressions.

### 2. Remove unused `mockContexts` variables (lines 256, 297, 336)
```diff
- const mockContexts = new Map<string, { chatId: string; actionPrompts: Record<string, string> }>();
  const handler = createInteractiveMessageHandler({
```
These variables were declared but never used.

## Test Results

```
✅ Lint: 0 errors, 96 warnings (pre-existing)
✅ Tests: 23 passed (ipc.test.ts)
```

## Related

- Fixes CI errors in PR #1006
- Issue #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)