### PR TITLE
feat(multimodal): enhance image analyzer MCP prompt for better scheduling (Issue #656)

### DIFF
--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -97,9 +97,11 @@ describe('MessageBuilder', () => {
 
       const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
 
-      expect(result).toContain('Image attachment(s) detected');
-      expect(result).toContain('analyze_image');
-      expect(result).toContain('image analyzer MCP');
+      // Issue #656: Enhanced image analysis prompt
+      expect(result).toContain('Image Analysis Required');
+      expect(result).toContain('mcp__4_5v_mcp__analyze_image');
+      expect(result).toContain('MUST analyze the image content');
+      expect(result).toContain('Analysis Workflow');
     });
 
     it('should not include image analyzer hint when no image analyzer MCP is configured', async () => {
@@ -116,8 +118,9 @@ describe('MessageBuilder', () => {
 
       const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
 
-      expect(result).not.toContain('Image attachment(s) detected');
-      expect(result).not.toContain('analyze_image');
+      // Should not contain enhanced image analysis prompt
+      expect(result).not.toContain('Image Analysis Required');
+      expect(result).not.toContain('mcp__4_5v_mcp__analyze_image');
     });
 
     it('should not include image analyzer hint for non-image attachments', async () => {
@@ -167,7 +170,8 @@ describe('MessageBuilder', () => {
         }];
 
         const result = getAttachmentsInfo(new MessageBuilder(), imageAttachment);
-        expect(result).toContain('analyze_image');
+        // Issue #656: Enhanced prompt includes image analysis workflow
+        expect(result).toContain('Image Analysis Required');
       }
     });
   });

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -222,13 +222,37 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
       .join('\n');
 
     // Issue #809: Check if there are image attachments and image analyzer MCP is configured
+    // Issue #656: Enhanced prompt for better image analyzer MCP scheduling
     const hasImageAttachment = attachments.some(att =>
       att.mimeType?.startsWith('image/')
     );
     const imageAnalyzerHint = hasImageAttachment && this.hasImageAnalyzerMcp()
       ? `
 
-**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the \`analyze_image\` tool from the image analyzer MCP server for better results. You can also use the Read tool to view images if the model supports native multimodal input.`
+## 🖼️ Image Analysis Required
+
+The user has attached image(s). **You MUST analyze the image content before responding** to provide accurate assistance.
+
+### How to Analyze Images
+
+Use the \`mcp__4_5v_mcp__analyze_image\` tool (or \`analyze_image\` if available):
+
+\`\`\`
+mcp__4_5v_mcp__analyze_image(
+  imageSource: "local file path from attachment",
+  prompt: "Describe what you see in this image in detail"
+)
+\`\`\`
+
+### Analysis Workflow
+
+1. **First**: Call the image analysis tool with the image's local path
+2. **Then**: Based on the analysis result, respond to the user's request
+3. **Important**: Do NOT guess or make assumptions about image content without analysis
+
+### Alternative: Native Multimodal
+
+If your model supports native multimodal input, you can also use the Read tool to view images directly. However, for non-native multimodal models, the MCP tool provides better image understanding.`
       : '';
 
     return `


### PR DESCRIPTION
## Summary

Enhanced the image attachment prompt in MessageBuilder to provide clearer guidance for agents on how to analyze images using the image analyzer MCP tool.

Fixes #656

### Changes

- Replaced conditional hint (`If you need to analyze...`) with mandatory analysis instruction (`You MUST analyze...`)
- Added detailed workflow: first analyze, then respond
- Provided explicit tool usage example with `mcp__4_5v_mcp__analyze_image`
- Added guidance for native multimodal vs MCP-based analysis
- Updated tests to reflect new enhanced prompt

### Before

```
**Note:** Image attachment(s) detected. If you need to analyze the image content, prefer using the `analyze_image` tool...
```

### After

```
## 🖼️ Image Analysis Required

The user has attached image(s). **You MUST analyze the image content before responding** to provide accurate assistance.

### How to Analyze Images
Use the `mcp__4_5v_mcp__analyze_image` tool...

### Analysis Workflow
1. **First**: Call the image analysis tool with the image's local path
2. **Then**: Based on the analysis result, respond to the user's request
3. **Important**: Do NOT guess or make assumptions about image content without analysis
```

### Why This Matters

Per issue #656 discussion, non-native multimodal models (like GLM-5) need better guidance to use the image analyzer MCP effectively. The previous conditional hint was often ignored by agents. The new mandatory instruction with clear workflow ensures:

1. Agents always analyze images before responding
2. Clear tool usage examples reduce confusion
3. Non-native multimodal models get the same user experience as native ones

## Test Plan

- [x] All 14 tests in `message-builder.test.ts` pass
- [x] No new lint errors introduced
- [x] Manual verification of enhanced prompt content

🤖 Generated with [Claude Code](https://claude.com/claude-code)