### PR TITLE
fix(lint): resolve ESLint errors in feishu-context-mcp.ts for PR #1176

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -10,12 +10,7 @@ import {
   send_message,
   send_file,
   send_interactive_message,
-  ask_user,
   setMessageSentCallback,
-  generate_summary,
-  generate_qa_pairs,
-  generate_flashcards,
-  generate_quiz,
   create_study_guide,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
@@ -259,7 +254,9 @@ Generates: summary, Q&A pairs, flashcards, and quiz questions.
           return Promise.resolve(toolSuccess(`⚠️ ${result.error}`));
         }
         let output = 'Study Guide created!\n';
-        if (result.outputPath) output += `Saved: ${result.outputPath}\n\n`;
+        if (result.outputPath) {
+          output += `Saved: ${result.outputPath}\n\n`;
+        }
         output += result.studyGuide;
         return Promise.resolve(toolSuccess(output));
       } catch (error) {


### PR DESCRIPTION
## Summary

修复 PR #1176 中的 ESLint 错误，使 CI 检查通过。

## 修改内容

- 移除未使用的导入：`ask_user`, `generate_summary`, `generate_qa_pairs`, `generate_flashcards`, `generate_quiz`
- 修复 `curly` 规则：为 if 语句添加大括号

## 测试结果

- ✅ `npm run lint` 通过（0 errors, 100 warnings）
- ✅ 之前有 6 个 error，现在全部修复

## 关联

- 修复 PR #1176 的 lint 错误
- 关联 Issue #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)