### PR TITLE
fix: resolve merge conflicts for PR #1182 (Issue #631)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -10,6 +10,7 @@ import {
   send_message,
   send_file,
   send_interactive_message,
+  start_discussion,
   setMessageSentCallback,
   create_study_guide,
   reply_in_thread,
@@ -34,6 +35,18 @@ export {
   unregisterFeishuHandlers,
 } from './tools/interactive-message.js';
 export { ask_user } from './tools/ask-user.js';
+export {
+  start_discussion,
+  registerDiscussionCallback,
+  getDiscussionCallback,
+  unregisterDiscussionCallback,
+  cleanupExpiredDiscussionCallbacks,
+} from './tools/start-discussion.js';
+export type {
+  StartDiscussionOptions,
+  StartDiscussionResult,
+  DiscussionResponseCallback,
+} from './tools/start-discussion.js';
 
 // Start IPC server on module load for cross-process communication
 // This allows the main process to query interactive contexts
@@ -473,6 +486,104 @@ Returns an array of messages, each containing:
         return toolSuccess(output);
       } catch (error) {
         return toolSuccess(`⚠️ Get thread messages failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  // Start Discussion tool (Issue #631: 离线提问)
+  {
+    name: 'start_discussion',
+    description: `Start a non-blocking offline discussion (Issue #631).
+
+This tool allows you to initiate a discussion without blocking your work:
+1. Creates a new discussion group (if chatId not provided)
+2. Sends an initial message
+3. Continues working without waiting for response
+
+---
+
+## 🎯 使用场景
+
+### 1. 每日回顾讨论
+\`\`\`json
+{
+  "topic": "每日聊天回顾 - 重复问题讨论",
+  "message": "今天的聊天回顾发现了一些重复问题，想和大家讨论一下...",
+  "members": ["ou_user1", "ou_user2"],
+  "followUpContext": "daily-review-2024-01-15"
+}
+\`\`\`
+
+### 2. 代码风格讨论
+\`\`\`json
+{
+  "topic": "代码风格统一讨论",
+  "message": "最近发现代码风格有些不一致，建议制定统一的规范...",
+  "members": ["ou_dev1", "ou_dev2"],
+  "isTopicGroup": true
+}
+\`\`\`
+
+### 3. 在现有群发起讨论
+\`\`\`json
+{
+  "topic": "紧急问题讨论",
+  "message": "发现了一个紧急问题需要大家关注...",
+  "chatId": "oc_xxx"
+}
+\`\`\`
+
+---
+
+## Parameters
+
+- **topic**: Discussion topic/title (used as group name for new groups)
+- **message**: Initial message to send (non-blocking)
+- **chatId**: Existing chat ID (optional - creates new group if not provided)
+- **members**: User open_ids to add to new group (optional)
+- **creatorId**: Creator open_id for tracking (optional)
+- **followUpContext**: Context for follow-up actions when users respond (optional)
+- **isTopicGroup**: Whether this is a topic group/BBS mode (optional, default: false)
+
+---
+
+## 非阻塞特性
+
+与 \`ask_user\` 不同，这个工具是**非阻塞**的：
+- \`ask_user\`: 发送问题后等待用户响应，阻塞当前任务
+- \`start_discussion\`: 发起讨论后立即返回，继续工作
+
+当用户回复时，系统可以根据 \`followUpContext\` 触发后续动作。
+
+---
+
+## Best Practices
+
+1. **明确主题**: topic 应该清晰描述讨论内容
+2. **提供上下文**: message 应包含足够的背景信息
+3. **选择合适的人**: members 应该包含相关人员
+4. **标记话题群**: 如果是长期讨论，设置 isTopicGroup: true`,
+    parameters: z.object({
+      topic: z.string(),
+      message: z.string(),
+      chatId: z.string().optional(),
+      members: z.array(z.string()).optional(),
+      creatorId: z.string().optional(),
+      followUpContext: z.string().optional(),
+      isTopicGroup: z.boolean().optional(),
+    }),
+    handler: async ({ topic, message, chatId, members, creatorId, followUpContext, isTopicGroup }) => {
+      try {
+        const result = await start_discussion({ topic, message, chatId, members, creatorId, followUpContext, isTopicGroup });
+        if (result.success) {
+          let output = result.message;
+          if (result.chatId) {
+            output += ` (chatId: ${result.chatId})`;
+          }
+          return toolSuccess(output);
+        }
+        return toolSuccess(`⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Start discussion failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -41,6 +41,20 @@ export type {
   GetThreadMessagesToolResult,
 } from './thread-tools.js';
 
+// Start Discussion tool (Issue #631: 离线提问)
+export {
+  start_discussion,
+  registerDiscussionCallback,
+  getDiscussionCallback,
+  unregisterDiscussionCallback,
+  cleanupExpiredDiscussionCallbacks,
+} from './start-discussion.js';
+export type {
+  StartDiscussionOptions,
+  StartDiscussionResult,
+  DiscussionResponseCallback,
+} from './start-discussion.js';
+
 // Study Guide Generator (NotebookLM M4)
 export {
   generate_summary,

--- a/src/mcp/tools/start-discussion.test.ts
+++ b/src/mcp/tools/start-discussion.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for start_discussion tool.
+ *
+ * Issue #631: 离线提问 - Agent 不阻塞工作的留言机制
+ *
+ * @module mcp/tools/start-discussion.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  start_discussion,
+  registerDiscussionCallback,
+  getDiscussionCallback,
+  unregisterDiscussionCallback,
+  cleanupExpiredDiscussionCallbacks,
+} from './start-discussion.js';
+import * as chatOps from '../../platforms/feishu/chat-ops.js';
+import * as sendMessageModule from './send-message.js';
+
+// Mock dependencies
+vi.mock('../../platforms/feishu/create-feishu-client.js', () => ({
+  createFeishuClient: vi.fn(() => ({})),
+}));
+
+vi.mock('../../config/index.js', () => ({
+  Config: {
+    FEISHU_APP_ID: 'test_app_id',
+    FEISHU_APP_SECRET: 'test_app_secret',
+  },
+}));
+
+vi.mock('../../platforms/feishu/chat-ops.js', () => ({
+  createDiscussionChat: vi.fn(),
+}));
+
+vi.mock('./send-message.js', () => ({
+  send_message: vi.fn(),
+  getMessageSentCallback: vi.fn(() => null),
+}));
+
+describe('start_discussion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('parameter validation', () => {
+    it('should fail without topic', async () => {
+      const result = await start_discussion({
+        topic: '',
+        message: 'Test message',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('topic is required');
+    });
+
+    it('should fail without message', async () => {
+      const result = await start_discussion({
+        topic: 'Test topic',
+        message: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('message is required');
+    });
+  });
+
+  describe('with existing chatId', () => {
+    it('should send message to existing chat', async () => {
+      vi.mocked(sendMessageModule.send_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+      });
+
+      const result = await start_discussion({
+        topic: 'Test discussion',
+        message: 'Hello everyone!',
+        chatId: 'oc_test_chat',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.chatId).toBe('oc_test_chat');
+      expect(result.isNewGroup).toBeFalsy();
+      expect(result.message).toContain('现有群中发起');
+    });
+
+    it('should handle message send failure', async () => {
+      vi.mocked(sendMessageModule.send_message).mockResolvedValue({
+        success: false,
+        message: 'Send failed',
+        error: 'Network error',
+      });
+
+      const result = await start_discussion({
+        topic: 'Test discussion',
+        message: 'Hello everyone!',
+        chatId: 'oc_test_chat',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+  });
+
+  describe('creating new group', () => {
+    it('should create new group and send message', async () => {
+      vi.mocked(chatOps.createDiscussionChat).mockResolvedValue('oc_new_chat');
+      vi.mocked(sendMessageModule.send_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+      });
+
+      const result = await start_discussion({
+        topic: 'New Discussion',
+        message: 'Let us discuss this topic',
+        members: ['ou_user1', 'ou_user2'],
+        creatorId: 'ou_creator',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.chatId).toBe('oc_new_chat');
+      expect(result.isNewGroup).toBe(true);
+      expect(result.groupInfo).toBeDefined();
+      expect(result.groupInfo?.name).toBe('New Discussion');
+      expect(result.message).toContain('已创建');
+
+      // Verify createDiscussionChat was called with correct params
+      expect(chatOps.createDiscussionChat).toHaveBeenCalledWith(
+        expect.anything(),
+        { topic: 'New Discussion', members: ['ou_user1', 'ou_user2'] },
+        'ou_creator'
+      );
+    });
+
+    it('should handle group creation failure', async () => {
+      vi.mocked(chatOps.createDiscussionChat).mockRejectedValue(new Error('API error'));
+
+      const result = await start_discussion({
+        topic: 'Failed Discussion',
+        message: 'This will fail',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API error');
+    });
+
+    it('should register group as topic group when isTopicGroup is true', async () => {
+      vi.mocked(chatOps.createDiscussionChat).mockResolvedValue('oc_topic_chat');
+      vi.mocked(sendMessageModule.send_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+      });
+
+      const result = await start_discussion({
+        topic: 'Topic Group',
+        message: 'Topic group message',
+        isTopicGroup: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.groupInfo?.isTopicGroup).toBe(true);
+    });
+  });
+});
+
+describe('Discussion callback management', () => {
+  beforeEach(() => {
+    // Clear all callbacks before each test
+    cleanupExpiredDiscussionCallbacks();
+  });
+
+  describe('registerDiscussionCallback', () => {
+    it('should register callback for chat', () => {
+      const callback = vi.fn();
+      registerDiscussionCallback('oc_test', callback, 'test-context');
+
+      const registered = getDiscussionCallback('oc_test');
+      expect(registered).toBeDefined();
+      expect(registered?.callback).toBe(callback);
+      expect(registered?.context).toBe('test-context');
+    });
+
+    it('should overwrite existing callback', () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      registerDiscussionCallback('oc_test', callback1);
+      registerDiscussionCallback('oc_test', callback2, 'new-context');
+
+      const registered = getDiscussionCallback('oc_test');
+      expect(registered?.callback).toBe(callback2);
+      expect(registered?.context).toBe('new-context');
+    });
+  });
+
+  describe('getDiscussionCallback', () => {
+    it('should return undefined for unregistered chat', () => {
+      const result = getDiscussionCallback('oc_nonexistent');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return callback for registered chat', () => {
+      const callback = vi.fn();
+      registerDiscussionCallback('oc_test', callback);
+
+      const result = getDiscussionCallback('oc_test');
+      expect(result?.callback).toBe(callback);
+    });
+  });
+
+  describe('unregisterDiscussionCallback', () => {
+    it('should remove registered callback', () => {
+      const callback = vi.fn();
+      registerDiscussionCallback('oc_test', callback);
+
+      const removed = unregisterDiscussionCallback('oc_test');
+      expect(removed).toBe(true);
+
+      const result = getDiscussionCallback('oc_test');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return false for non-existent callback', () => {
+      const removed = unregisterDiscussionCallback('oc_nonexistent');
+      expect(removed).toBe(false);
+    });
+  });
+
+  describe('cleanupExpiredDiscussionCallbacks', () => {
+    it('should not remove recent callbacks', () => {
+      const callback = vi.fn();
+      registerDiscussionCallback('oc_test', callback);
+
+      const cleaned = cleanupExpiredDiscussionCallbacks();
+      expect(cleaned).toBe(0);
+
+      const result = getDiscussionCallback('oc_test');
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/mcp/tools/start-discussion.ts
+++ b/src/mcp/tools/start-discussion.ts
@@ -1,0 +1,360 @@
+/**
+ * Start Discussion tool implementation.
+ *
+ * This tool provides non-blocking offline discussion capability for agents.
+ * Agent can start a discussion in a new or existing chat, and continue working
+ * without waiting for responses. When users respond, a callback can trigger
+ * follow-up actions.
+ *
+ * Issue #631: 离线提问 - Agent 不阻塞工作的留言机制
+ *
+ * @module mcp/tools/start-discussion
+ */
+
+import * as lark from '@larksuiteoapi/node-sdk';
+import { createLogger } from '../../utils/logger.js';
+import { Config } from '../../config/index.js';
+import { createFeishuClient } from '../../platforms/feishu/create-feishu-client.js';
+import { getGroupService, type GroupInfo } from '../../platforms/feishu/group-service.js';
+import { createDiscussionChat } from '../../platforms/feishu/chat-ops.js';
+import { send_message, getMessageSentCallback } from './send-message.js';
+
+const logger = createLogger('StartDiscussion');
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Options for starting a discussion.
+ */
+export interface StartDiscussionOptions {
+  /** Topic/title for the discussion */
+  topic: string;
+  /** Initial message to send (non-blocking) */
+  message: string;
+  /** Chat ID to use (optional - if not provided, creates new group) */
+  chatId?: string;
+  /** Member open_ids to add (for new groups) */
+  members?: string[];
+  /** Creator open_id (for tracking) */
+  creatorId?: string;
+  /** Context for follow-up actions when user responds */
+  followUpContext?: string;
+  /** Whether this is a topic group (BBS mode) */
+  isTopicGroup?: boolean;
+}
+
+/**
+ * Result from start_discussion tool.
+ */
+export interface StartDiscussionResult {
+  success: boolean;
+  message: string;
+  /** Chat ID where discussion was started */
+  chatId?: string;
+  /** Whether a new group was created */
+  isNewGroup?: boolean;
+  /** Group info if new group was created */
+  groupInfo?: GroupInfo;
+  /** Error details if failed */
+  error?: string;
+}
+
+/**
+ * Callback type for handling user responses to discussions.
+ */
+export type DiscussionResponseCallback = (
+  chatId: string,
+  userId: string,
+  message: string,
+  context?: string
+) => Promise<void> | void;
+
+// ============================================================================
+// Discussion Response Handling
+// ============================================================================
+
+/**
+ * Registry for discussion response callbacks.
+ * Maps chatId to callback and context.
+ */
+const discussionCallbacks = new Map<string, {
+  callback: DiscussionResponseCallback;
+  context?: string;
+  createdAt: number;
+}>();
+
+/**
+ * Register a callback for a discussion.
+ *
+ * @param chatId - Chat ID where discussion is happening
+ * @param callback - Function to call when user responds
+ * @param context - Optional context for follow-up actions
+ */
+export function registerDiscussionCallback(
+  chatId: string,
+  callback: DiscussionResponseCallback,
+  context?: string
+): void {
+  discussionCallbacks.set(chatId, {
+    callback,
+    context,
+    createdAt: Date.now(),
+  });
+  logger.debug({ chatId, hasContext: !!context }, 'Discussion callback registered');
+}
+
+/**
+ * Get discussion callback for a chat.
+ *
+ * @param chatId - Chat ID to look up
+ * @returns Callback info or undefined
+ */
+export function getDiscussionCallback(chatId: string): {
+  callback: DiscussionResponseCallback;
+  context?: string;
+} | undefined {
+  return discussionCallbacks.get(chatId);
+}
+
+/**
+ * Unregister a discussion callback.
+ *
+ * @param chatId - Chat ID to unregister
+ */
+export function unregisterDiscussionCallback(chatId: string): boolean {
+  const removed = discussionCallbacks.delete(chatId);
+  if (removed) {
+    logger.debug({ chatId }, 'Discussion callback unregistered');
+  }
+  return removed;
+}
+
+/**
+ * Cleanup expired discussion callbacks (older than 7 days).
+ */
+export function cleanupExpiredDiscussionCallbacks(): number {
+  const maxAge = 7 * 24 * 60 * 60 * 1000; // 7 days
+  const now = Date.now();
+  let cleaned = 0;
+
+  for (const [chatId, info] of discussionCallbacks) {
+    if (now - info.createdAt > maxAge) {
+      discussionCallbacks.delete(chatId);
+      cleaned++;
+    }
+  }
+
+  if (cleaned > 0) {
+    logger.debug({ count: cleaned }, 'Cleaned up expired discussion callbacks');
+  }
+
+  return cleaned;
+}
+
+// ============================================================================
+// Start Discussion Implementation
+// ============================================================================
+
+/**
+ * Start a non-blocking discussion.
+ *
+ * This tool allows an agent to:
+ * 1. Create a new discussion group (if chatId not provided)
+ * 2. Send an initial message (non-blocking)
+ * 3. Continue working without waiting for response
+ *
+ * When users respond, the registered callback (if any) will be triggered
+ * to handle follow-up actions.
+ *
+ * @example
+ * ```typescript
+ * // Start a new discussion
+ * const result = await start_discussion({
+ *   topic: '关于代码风格的讨论',
+ *   message: '我发现最近的代码风格有些不一致，想和大家讨论一下...',
+ *   members: ['ou_user1', 'ou_user2'],
+ *   followUpContext: 'code-style-discussion',
+ * });
+ *
+ * // Start discussion in existing chat
+ * const result = await start_discussion({
+ *   topic: '每日回顾',
+ *   message: '今天的聊天回顾发现了一些重复问题...',
+ *   chatId: 'oc_xxx',
+ * });
+ * ```
+ */
+export async function start_discussion(params: StartDiscussionOptions): Promise<StartDiscussionResult> {
+  const { topic, message, chatId, members, creatorId, followUpContext: _followUpContext, isTopicGroup } = params;
+
+  logger.info({
+    topic,
+    hasChatId: !!chatId,
+    memberCount: members?.length ?? 0,
+    isTopicGroup,
+  }, 'start_discussion called');
+
+  try {
+    // Validate required parameters
+    if (!topic) {
+      return {
+        success: false,
+        message: '❌ topic 是必需的',
+        error: 'topic is required',
+      };
+    }
+
+    if (!message) {
+      return {
+        success: false,
+        message: '❌ message 是必需的',
+        error: 'message is required',
+      };
+    }
+
+    // Get Feishu credentials
+    const appId = Config.FEISHU_APP_ID;
+    const appSecret = Config.FEISHU_APP_SECRET;
+
+    if (!appId || !appSecret) {
+      const errorMsg = 'Feishu credentials not configured';
+      logger.error(errorMsg);
+      return {
+        success: false,
+        message: '❌ Feishu 凭证未配置',
+        error: errorMsg,
+      };
+    }
+
+    // Create Feishu client
+    const client = createFeishuClient(appId, appSecret, { domain: lark.Domain.Feishu });
+    const groupService = getGroupService();
+
+    let targetChatId: string;
+    let isNewGroup = false;
+    let groupInfo: GroupInfo | undefined;
+
+    // Use existing chat or create new group
+    if (chatId) {
+      targetChatId = chatId;
+      logger.debug({ chatId: targetChatId }, 'Using existing chat');
+    } else {
+      // Create new discussion group
+      try {
+        logger.info({ topic, memberCount: members?.length ?? 0 }, 'Creating new discussion group');
+
+        const newChatId = await createDiscussionChat(
+          client,
+          { topic, members },
+          creatorId
+        );
+
+        targetChatId = newChatId;
+        isNewGroup = true;
+
+        // Register the group
+        const actualMembers = members && members.length > 0
+          ? members
+          : (creatorId ? [creatorId] : []);
+
+        groupInfo = {
+          chatId: targetChatId,
+          name: topic,
+          createdAt: Date.now(),
+          createdBy: creatorId,
+          initialMembers: actualMembers,
+          isTopicGroup: isTopicGroup ?? false,
+        };
+
+        groupService.registerGroup(groupInfo);
+
+        logger.info({
+          chatId: targetChatId,
+          topic,
+          isNewGroup,
+          isTopicGroup,
+        }, 'Discussion group created');
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.error({ err: error, topic }, 'Failed to create discussion group');
+        return {
+          success: false,
+          message: `❌ 创建讨论群失败: ${errorMsg}`,
+          error: errorMsg,
+        };
+      }
+    }
+
+    // Send initial message (non-blocking)
+    const sendResult = await send_message({
+      content: message,
+      format: 'text',
+      chatId: targetChatId,
+    });
+
+    if (!sendResult.success) {
+      logger.error({
+        chatId: targetChatId,
+        error: sendResult.error,
+      }, 'Failed to send initial message');
+
+      // If we created a new group but failed to send message, still return success
+      // but indicate the message issue
+      if (isNewGroup) {
+        return {
+          success: true,
+          message: `⚠️ 讨论群已创建，但初始消息发送失败: ${sendResult.message}`,
+          chatId: targetChatId,
+          isNewGroup,
+          groupInfo,
+        };
+      }
+
+      return {
+        success: false,
+        message: `❌ 发送消息失败: ${sendResult.message}`,
+        chatId: targetChatId,
+        error: sendResult.error,
+      };
+    }
+
+    // Invoke message sent callback
+    const msgCallback = getMessageSentCallback();
+    if (msgCallback) {
+      try {
+        msgCallback(targetChatId);
+      } catch (error) {
+        logger.error({ err: error }, 'Failed to invoke message sent callback');
+      }
+    }
+
+    const successMessage = isNewGroup
+      ? `✅ 讨论群「${topic}」已创建并发起讨论`
+      : '✅ 讨论已在现有群中发起';
+
+    logger.info({
+      chatId: targetChatId,
+      topic,
+      isNewGroup,
+    }, 'Discussion started successfully');
+
+    return {
+      success: true,
+      message: successMessage,
+      chatId: targetChatId,
+      isNewGroup,
+      groupInfo,
+    };
+
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    logger.error({ err: error }, 'start_discussion failed');
+    return {
+      success: false,
+      message: `❌ 发起讨论失败: ${errorMsg}`,
+      error: errorMsg,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

This PR resolves the merge conflicts between PR #1182 (Issue #631) and main branch, enabling the offline discussion feature to be merged.

## Conflict Analysis

Both branches modified the same files:
- `src/mcp/tools/index.ts`: Added different tool exports
- `src/mcp/feishu-context-mcp.ts`: Added different tool definitions

### Root Cause
- PR #1182 added `start_discussion` tool for Issue #631
- Main branch added `thread-tools` for Issue #873 and consolidated tools for Issue #1155
- Both modified the same export and tool definition locations

## Solution

1. **tools/index.ts**: Combined exports from both branches
   - Keep thread-tools exports from main
   - Add start-discussion exports from PR #1182

2. **feishu-context-mcp.ts**: Merged tool definitions
   - Keep main's consolidated tool structure (Issue #1155)
   - Add `start_discussion` tool to `feishuToolDefinitions` array
   - Add necessary imports and re-exports

## Files Changed

| File | Change |
|------|--------|
| `src/mcp/tools/start-discussion.ts` | New file from PR #1182 |
| `src/mcp/tools/start-discussion.test.ts` | New file from PR #1182 |
| `src/mcp/tools/index.ts` | Add start-discussion exports |
| `src/mcp/feishu-context-mcp.ts` | Add start_discussion tool definition |

## Feature: start_discussion Tool (Issue #631)

Non-blocking offline discussion mechanism:
- Creates new discussion groups (or uses existing chats)
- Sends initial messages without blocking current work
- Continues working while waiting for user responses
- Supports follow-up actions via callback registration

## Verification

- [x] TypeScript type-check passes (`npm run type-check`)
- [x] ESLint: 0 errors
- [x] All 14 start-discussion tests pass

## Test Plan

- [x] Run `npm run type-check` - passes with no errors
- [x] Run `npm run lint` - 0 errors (only warnings)
- [x] Run `npx vitest run src/mcp/tools/start-discussion.test.ts` - 14/14 tests pass
- [ ] CI/CD pipeline should pass

## Related

- Closes #631 (feat: 离线提问 - Agent 不阻塞工作的留言机制)
- Original PR: #1182
- Milestone: 0.4.1 离线提问

🤖 Generated with [Claude Code](https://claude.com/claude-code)