### PR TITLE
fix(lint): resolve TypeScript and ESLint errors in PR #1188 (Issue #631)

### DIFF
--- a/src/agents/subagent-manager.ts
+++ b/src/agents/subagent-manager.ts
@@ -535,14 +535,14 @@ ${options.prompt}
     // Create agent using factory
     const agent = AgentFactory.createChatAgent('pilot', options.chatId, options.callbacks);
 
-    this.inMemoryAgents.set(subagentId, handle);
+    this.inMemoryAgents.set(subagentId, agent);
     handle.status = 'running';
 
     logger.info({ subagentId, name: options.name, chatId: options.chatId }, 'Chat subagent started for discussion');
     this.notifyStatusChange(handle);
 
     // Execute discussion
-    let discussionResult: DiscussionResult = {
+    const discussionResult: DiscussionResult = {
       subagentId,
       chatId: options.chatId,
       topic: options.prompt,

--- a/src/mcp/tools/discussion.ts
+++ b/src/mcp/tools/discussion.ts
@@ -65,19 +65,25 @@ export interface StartDiscussionResult {
  * @param client - Feishu client for API calls
  * @returns PilotCallbacks implementation
  */
-function buildDiscussionCallbacks(client: lark.Client): PilotCallbacks {
+function buildDiscussionCallbacks(_client: lark.Client): PilotCallbacks {
   return {
-    sendMessage: async (chatId: string, text: string, parentMessageId?: string) => {
+    sendMessage: (chatId: string, _text: string, parentMessageId?: string) => {
       // Use IPC or direct API to send message
       logger.debug({ chatId, parentMessageId }, 'Discussion agent sending message');
       // For now, we'll use the Feishu API directly
       // In production, this should go through IPC
+      // TODO: Implement actual message sending via IPC or Feishu API
+      return Promise.resolve();
     },
-    sendCard: async (chatId: string, card: Record<string, unknown>, description?: string, parentMessageId?: string) => {
+    sendCard: (chatId: string, _card: Record<string, unknown>, _description?: string, parentMessageId?: string) => {
       logger.debug({ chatId, parentMessageId }, 'Discussion agent sending card');
+      // TODO: Implement actual card sending via IPC or Feishu API
+      return Promise.resolve();
     },
-    sendFile: async (chatId: string, filePath: string) => {
-      logger.debug({ chatId, filePath }, 'Discussion agent sending file');
+    sendFile: (chatId: string, _filePath: string) => {
+      logger.debug({ chatId }, 'Discussion agent sending file');
+      // TODO: Implement actual file sending via IPC or Feishu API
+      return Promise.resolve();
     },
   };
 }
@@ -164,7 +170,7 @@ export async function start_discussion(params: {
         members,
         creatorId,
       });
-      chatId = group.chatId;
+      ({ chatId } = group);
       logger.info({ chatId, groupName: group.name }, 'Created new discussion group');
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the TypeScript and ESLint errors in PR #1188 that are blocking CI.

### Changes

**src/mcp/tools/discussion.ts**
- Remove unnecessary `async` keywords from callback functions (require-await)
- Add `_` prefix to unused parameters (`text`, `card`, `description`, `filePath`, `client`)
- Return `Promise.resolve()` to satisfy PilotCallbacks interface
- Use object destructuring for chatId assignment (prefer-destructuring)

**src/agents/subagent-manager.ts**
- Fix type error: Store `agent` (ChatAgent) instead of `handle` (SubagentHandle) in inMemoryAgents
- Use `const` instead of `let` for discussionResult (prefer-const)

## Problem

PR #1188 (feat: add chat subagent type for offline discussions) has TypeScript and ESLint errors blocking CI:

| File | Error Type | Count |
|------|------------|-------|
| discussion.ts | TS2322 (void vs Promise<void>) | 3 |
| discussion.ts | TS6133 (unused variables) | 4 |
| discussion.ts | prefer-destructuring | 1 |
| subagent-manager.ts | TS2345 (type mismatch) | 1 |
| subagent-manager.ts | prefer-const | 1 |

## Solution

1. Remove `async` keyword and return `Promise.resolve()` explicitly
2. Prefix unused parameters with `_`
3. Use object destructuring pattern `({ chatId } = group)`
4. Store `agent` instead of `handle` in the correct type map
5. Use `const` for never-reassigned variables

## Test Results

```
✅ TypeScript type-check: 0 errors
✅ ESLint: 0 errors (only warnings)
✅ All 1851 unit tests pass
```

## Related

- Fixes CI failure in PR #1188
- Issue #631: feat: 离线提问 - Agent 不阻塞工作的留言机制

🤖 Generated with [Claude Code](https://claude.com/claude-code)