### PR TITLE
feat(agents): add task control methods to TaskProgressService (Issue #857 Phase 5)

### DIFF
--- a/src/agents/task-progress-service.test.ts
+++ b/src/agents/task-progress-service.test.ts
@@ -199,4 +199,158 @@ describe('TaskProgressService', () => {
       expect(firstElement.content).toContain('任务ID');
     });
   });
+
+  describe('pauseTask', () => {
+    it('should pause a running task', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      mockSendCard.mockClear();
+
+      const result = await service.pauseTask(chatId);
+
+      expect(result).toBe(true);
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+
+      const taskInfo = service.getActiveTask(chatId);
+      expect(taskInfo?.status).toBe('paused');
+    });
+
+    it('should return false when no task to pause', async () => {
+      const result = await service.pauseTask('non-existent-chat');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when task is already paused', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      await service.pauseTask(chatId);
+      mockSendCard.mockClear();
+
+      const result = await service.pauseTask(chatId);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('resumeTask', () => {
+    it('should resume a paused task', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      await service.pauseTask(chatId);
+      mockSendCard.mockClear();
+
+      const result = await service.resumeTask(chatId);
+
+      expect(result).toBe(true);
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+
+      const taskInfo = service.getActiveTask(chatId);
+      expect(taskInfo?.status).toBe('running');
+    });
+
+    it('should return false when no task to resume', async () => {
+      const result = await service.resumeTask('non-existent-chat');
+      expect(result).toBe(false);
+    });
+
+    it('should return false when task is running (not paused)', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      mockSendCard.mockClear();
+
+      const result = await service.resumeTask(chatId);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('cancelTask', () => {
+    it('should cancel a running task', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      mockSendCard.mockClear();
+
+      const result = await service.cancelTask(chatId);
+
+      expect(result).toBe(true);
+      expect(mockSendCard).toHaveBeenCalledTimes(1);
+      expect(service.hasActiveTask(chatId)).toBe(false);
+    });
+
+    it('should cancel a paused task', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      await service.pauseTask(chatId);
+      mockSendCard.mockClear();
+
+      const result = await service.cancelTask(chatId);
+
+      expect(result).toBe(true);
+      expect(service.hasActiveTask(chatId)).toBe(false);
+    });
+
+    it('should return false when no task to cancel', async () => {
+      const result = await service.cancelTask('non-existent-chat');
+      expect(result).toBe(false);
+    });
+
+    it('should send cancelled card with correct status', async () => {
+      const chatId = 'test-chat-id';
+      await service.startTracking({
+        chatId,
+        messageId: 'test-message-id',
+        userMessage: 'Complex task',
+        complexity: mockComplexity,
+        sendCard: mockSendCard,
+      });
+
+      mockSendCard.mockClear();
+
+      await service.cancelTask(chatId);
+
+      const cardArg = mockSendCard.mock.calls[0][0] as Record<string, unknown>;
+      const header = cardArg.header as Record<string, unknown>;
+      expect(header.template).toBe('grey');
+    });
+  });
 });

--- a/src/agents/task-progress-service.ts
+++ b/src/agents/task-progress-service.ts
@@ -29,6 +29,11 @@ export interface ProgressCardConfig {
 }
 
 /**
+ * Task status for progress tracking.
+ */
+type TaskStatus = 'running' | 'paused' | 'completed' | 'failed' | 'cancelled';
+
+/**
  * Active progress tracking state.
  */
 interface ActiveProgress {
@@ -41,8 +46,9 @@ interface ActiveProgress {
   lastUpdateTime: number;
   currentPercent: number;
   currentStep: string;
+  status: TaskStatus;
   cardMessageId?: string;
-  updateInterval: ReturnType<typeof setInterval>;
+  updateInterval: ReturnType<typeof setInterval> | null;
   sendCard: (card: Record<string, unknown>) => Promise<void>;
 }
 
@@ -104,6 +110,7 @@ export class TaskProgressService {
       lastUpdateTime: startTime,
       currentPercent: 0,
       currentStep: '正在分析任务...',
+      status: 'running',
       sendCard,
       updateInterval: setInterval(
         () => this.updateProgress(taskId),
@@ -125,6 +132,17 @@ export class TaskProgressService {
     const progress = this.activeProgress.get(taskId);
     if (!progress) {
       logger.warn({ taskId }, 'No active progress found for update');
+      return;
+    }
+
+    // Skip update if task is paused
+    if (progress.status === 'paused') {
+      logger.debug({ taskId }, 'Task is paused, skipping update');
+      return;
+    }
+
+    // Skip if task is no longer running
+    if (progress.status !== 'running') {
       return;
     }
 
@@ -186,7 +204,9 @@ export class TaskProgressService {
     }
 
     // Clear update interval
-    clearInterval(progress.updateInterval);
+    if (progress.updateInterval) {
+      clearInterval(progress.updateInterval);
+    }
 
     const elapsed = (Date.now() - progress.startTime) / 1000;
 
@@ -240,7 +260,7 @@ export class TaskProgressService {
   /**
    * Get active task info for a chat.
    */
-  getActiveTask(chatId: string): { taskId: string; percent: number } | undefined {
+  getActiveTask(chatId: string): { taskId: string; percent: number; status: TaskStatus } | undefined {
     const progress = this.activeProgress.get(chatId);
     if (!progress) {
       return undefined;
@@ -248,7 +268,157 @@ export class TaskProgressService {
     return {
       taskId: progress.taskId,
       percent: progress.currentPercent,
+      status: progress.status,
     };
+  }
+
+  /**
+   * Pause a tracked task.
+   *
+   * Issue #857 Phase 5: Support task pause/resume
+   *
+   * @param chatId - Chat ID to pause task for
+   * @returns true if task was paused, false if no task to pause
+   */
+  async pauseTask(chatId: string): Promise<boolean> {
+    const progress = this.activeProgress.get(chatId);
+    if (!progress) {
+      logger.debug({ chatId }, 'No active progress to pause');
+      return false;
+    }
+
+    if (progress.status !== 'running') {
+      logger.warn({ chatId, status: progress.status }, 'Task is not running, cannot pause');
+      return false;
+    }
+
+    // Update status
+    progress.status = 'paused';
+    progress.lastUpdateTime = Date.now();
+
+    // Send paused card
+    const elapsed = (Date.now() - progress.startTime) / 1000;
+    const card = this.buildProgressCard({
+      taskId: progress.taskId,
+      status: 'paused',
+      percent: progress.currentPercent,
+      message: '任务已暂停',
+      eta: Math.max(0, progress.complexity.estimatedSeconds - elapsed),
+      currentStep: progress.currentStep,
+    });
+
+    await progress.sendCard(card);
+
+    logger.info({ chatId, taskId: progress.taskId }, 'Task paused');
+    return true;
+  }
+
+  /**
+   * Resume a paused task.
+   *
+   * Issue #857 Phase 5: Support task pause/resume
+   *
+   * @param chatId - Chat ID to resume task for
+   * @returns true if task was resumed, false if no task to resume
+   */
+  async resumeTask(chatId: string): Promise<boolean> {
+    const progress = this.activeProgress.get(chatId);
+    if (!progress) {
+      logger.debug({ chatId }, 'No active progress to resume');
+      return false;
+    }
+
+    if (progress.status !== 'paused') {
+      logger.warn({ chatId, status: progress.status }, 'Task is not paused, cannot resume');
+      return false;
+    }
+
+    // Update status
+    progress.status = 'running';
+    progress.lastUpdateTime = Date.now();
+
+    // Send resumed card
+    const elapsed = (Date.now() - progress.startTime) / 1000;
+    const card = this.buildProgressCard({
+      taskId: progress.taskId,
+      status: 'running',
+      percent: progress.currentPercent,
+      message: '任务已恢复',
+      eta: Math.max(0, progress.complexity.estimatedSeconds - elapsed),
+      currentStep: progress.currentStep,
+    });
+
+    await progress.sendCard(card);
+
+    logger.info({ chatId, taskId: progress.taskId }, 'Task resumed');
+    return true;
+  }
+
+  /**
+   * Cancel a tracked task.
+   *
+   * Issue #857 Phase 5: Support task cancellation
+   *
+   * @param chatId - Chat ID to cancel task for
+   * @returns true if task was cancelled, false if no task to cancel
+   */
+  async cancelTask(chatId: string): Promise<boolean> {
+    const progress = this.activeProgress.get(chatId);
+    if (!progress) {
+      logger.debug({ chatId }, 'No active progress to cancel');
+      return false;
+    }
+
+    if (!['running', 'paused'].includes(progress.status)) {
+      logger.warn({ chatId, status: progress.status }, 'Task is not running or paused, cannot cancel');
+      return false;
+    }
+
+    // Clear update interval
+    if (progress.updateInterval) {
+      clearInterval(progress.updateInterval);
+    }
+
+    const elapsed = (Date.now() - progress.startTime) / 1000;
+
+    // Send cancelled card
+    const card = this.buildProgressCard({
+      taskId: progress.taskId,
+      status: 'cancelled',
+      percent: progress.currentPercent,
+      message: '任务已取消',
+      eta: 0,
+      currentStep: '用户取消了任务',
+    });
+
+    await progress.sendCard(card);
+
+    // Record to history as cancelled (success = false)
+    const record: TaskRecord = {
+      taskId: progress.taskId,
+      chatId: progress.chatId,
+      userMessage: progress.userMessage,
+      taskType: progress.complexity.reasoning.taskType,
+      complexityScore: progress.complexity.complexityScore,
+      estimatedSeconds: progress.complexity.estimatedSeconds,
+      actualSeconds: elapsed,
+      success: false,
+      startedAt: progress.startTime,
+      completedAt: Date.now(),
+      keyFactors: [...progress.complexity.reasoning.keyFactors, 'Cancelled by user'],
+    };
+
+    await taskHistoryStorage.recordTask(record);
+
+    logger.info({
+      taskId: progress.taskId,
+      elapsed,
+    }, 'Task cancelled by user');
+
+    // Remove from active tracking
+    this.activeProgress.delete(chatId);
+
+    return true;
   }
 
   /**
@@ -256,7 +426,7 @@ export class TaskProgressService {
    */
   private buildProgressCard(params: {
     taskId: string;
-    status: 'running' | 'completed' | 'failed';
+    status: TaskStatus;
     percent: number;
     message: string;
     eta: number;
@@ -266,14 +436,18 @@ export class TaskProgressService {
 
     const statusEmoji = {
       running: '🔄',
+      paused: '⏸️',
       completed: '✅',
       failed: '❌',
+      cancelled: '🚫',
     }[status];
 
     const headerColor = {
       running: 'blue',
+      paused: 'orange',
       completed: 'green',
       failed: 'red',
+      cancelled: 'grey',
     }[status];
 
     const progressBar = this.buildProgressBar(percent);


### PR DESCRIPTION
## Summary

Implements **Phase 5** of Issue #857: User Experience Optimization

This PR adds pause, resume, and cancel functionality to TaskProgressService, allowing users to control complex tasks during execution.

### New Methods

| Method | Description |
|--------|-------------|
| `pauseTask(chatId)` | Pause a running task and send paused card |
| `resumeTask(chatId)` | Resume a paused task and send resumed card |
| `cancelTask(chatId)` | Cancel a task and send cancelled card |

### Changes

**src/agents/task-progress-service.ts**
- Add `TaskStatus` type for progress tracking status
- Add `status` field to `ActiveProgress` interface
- Update `updateInterval` to be nullable for paused/cancelled states
- Update `buildProgressCard` to support 'paused' and 'cancelled' statuses
- Add proper null checks for clearInterval calls
- Implement `pauseTask()`, `resumeTask()`, `cancelTask()` methods

**src/agents/task-progress-service.test.ts**
- Add 10 new tests for pause/resume/cancel functionality

### Progress Card Examples

**Paused Task:**
```
┌────────────────────────────────┐
│ ⏸️ 任务执行中                 │
│                              │
│ 任务ID: 4a7b8c9d              │
│ 状态: ⏸️ 任务已暂停          │
│ 进度: ████░░░░░░░░░░░░ 20%   │
│ 当前步骤: 正在分析代码...     │
└────────────────────────────────┘
```

**Cancelled Task:**
```
┌────────────────────────────────┐
│ 🚫 任务执行中                 │
│                              │
│ 任务ID: 4a7b8c9d              │
│ 状态: 🚫 任务已取消          │
│ 进度: ██████████████████ 100%│
│ 当前步骤: 用户取消了任务      │
└────────────────────────────────┘
```

## Test Results

| Check | Status |
|-------|--------|
| Unit tests (21) | ✅ Passed |
| TypeScript | ✅ Passed |
| ESLint | ✅ Passed |

## Design Decisions

1. **Boolean return values**: All control methods return `boolean` to indicate success/failure
2. **History recording**: Cancelled tasks are recorded to history for learning (with "Cancelled by user" key factor)
3. **Status indicators**: Each status has appropriate emoji and card color:
   - Running: 🔄 Blue
   - Paused: ⏸️ Orange
   - Cancelled: 🚫 Grey

## Next Steps

Future work could integrate these methods with:
- MCP tools for task control (`task_pause`, `task_resume`, `task_cancel`)
- Interactive card buttons for quick task control
- Integration with existing `/task` command

## Related

- Issue: #857
- Phase 1-4 PR: #1179 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)