### PR TITLE
refactor(core,worker-node): add Worker Node type definitions (Issue #1041)

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -52,3 +52,8 @@ export type {
 } from './primary-node.js';
 
 export { getNodeCapabilities } from './primary-node.js';
+
+// Worker Node types (Issue #1041)
+export type { WorkerNodeConfig } from './worker-node.js';
+
+export { getWorkerNodeCapabilities } from './worker-node.js';

--- a/packages/core/src/types/worker-node.ts
+++ b/packages/core/src/types/worker-node.ts
@@ -1,0 +1,34 @@
+/**
+ * Worker Node type definitions.
+ *
+ * This module defines the types used by Worker Node.
+ *
+ * @see Issue #1041 - Separate Worker Node code to @disclaude/worker-node
+ */
+
+import type { BaseNodeConfig, NodeCapabilities } from './primary-node.js';
+
+/**
+ * Configuration for Worker Node.
+ * Worker Node has only execution (exec) capability and connects to Primary Node.
+ */
+export interface WorkerNodeConfig extends BaseNodeConfig {
+  type: 'worker';
+
+  /** Primary Node WebSocket URL to connect to */
+  primaryUrl: string;
+  /** Reconnection interval in milliseconds (default: 3000) */
+  reconnectInterval?: number;
+  /**
+   * Timeout for Feishu API requests in milliseconds (default: 30000).
+   * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
+   */
+  feishuApiRequestTimeout?: number;
+}
+
+/**
+ * Get capabilities for Worker Node type.
+ */
+export function getWorkerNodeCapabilities(): NodeCapabilities {
+  return { communication: false, execution: true };
+}

--- a/packages/worker-node/package.json
+++ b/packages/worker-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@disclaude/worker-node",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Worker Node process for disclaude - handles agent execution and scheduled tasks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/worker-node/src/index.ts
+++ b/packages/worker-node/src/index.ts
@@ -3,14 +3,19 @@
  *
  * Worker Node process for disclaude.
  *
- * This package will contain:
- * - Agent execution
- * - WebSocket client
- * - Scheduler
- * - File transfer client
+ * This package contains:
+ * - WorkerNodeConfig type definition
+ * - (Future) Agent execution code
+ * - (Future) WebSocket client
+ * - (Future) Scheduler
+ * - (Future) File transfer client
  *
- * Code will be migrated from src/ in subsequent PRs.
+ * @see Issue #1041 - Separate Worker Node code to @disclaude/worker-node
  */
 
-// Placeholder - code will be migrated from src/ in subsequent issues
-export const WORKER_NODE_VERSION = '0.0.1';
+// Re-export types from @disclaude/core
+export type { WorkerNodeConfig } from '@disclaude/core';
+export { getWorkerNodeCapabilities } from '@disclaude/core';
+
+// Package version
+export const WORKER_NODE_VERSION = '0.0.2';


### PR DESCRIPTION
## Summary

- Add `WorkerNodeConfig` type definition to `@disclaude/core`
- Export `WorkerNodeConfig` and `getWorkerNodeCapabilities` from `@disclaude/core`
- Update `@disclaude/worker-node` to re-export types from `@disclaude/core`
- Bump `@disclaude/worker-node` version to 0.0.2

This is Phase 1 of the Worker Node code migration (Issue #1041). The actual code migration from `src/` to `packages/worker-node/` will be done in subsequent PRs.

## Related Issues

- Fixes #1041
- Parent issue: #1037
- Depends on: #1038, #1039, #1040 (already completed)

## Test Plan

- [x] `npm run type-check` passes
- [x] All 1851 tests pass
- [x] `npm run build` in packages/core succeeds
- [x] `npm run build` in packages/worker-node succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)