### PR TITLE
fix(test): update multimodal tests to match enhanced image analysis prompt

### DIFF
--- a/src/agents/pilot/multimodal.test.ts
+++ b/src/agents/pilot/multimodal.test.ts
@@ -73,8 +73,8 @@ describe('Multimodal Message Handling (Issue #808)', () => {
       expect(result).toContain('image/png');
 
       // Should include image analyzer hint
-      expect(result).toContain('Image attachment(s) detected');
-      expect(result).toContain('analyze_image');
+      expect(result).toContain('## 🖼️ Image Analysis Required');
+      expect(result).toContain('mcp__4_5v_mcp__analyze_image');
     });
 
     it('should handle JPEG image', () => {
@@ -148,7 +148,7 @@ describe('Multimodal Message Handling (Issue #808)', () => {
       expect(result).toContain('2 file(s)');
 
       // Should include image analyzer hint
-      expect(result).toContain('Image attachment(s) detected');
+      expect(result).toContain('## 🖼️ Image Analysis Required');
     });
 
     it('should handle multiple images with different formats', () => {
@@ -311,7 +311,7 @@ console.log(data.value);
           attachments: [attachment],
         }, 'chat-789');
 
-        expect(result).toContain('Image attachment(s) detected');
+        expect(result).toContain('## 🖼️ Image Analysis Required');
         expect(result).toContain(mimeType);
       }
     });
@@ -338,7 +338,7 @@ console.log(data.value);
         attachments: [pdfAttachment],
       }, 'chat-789');
 
-      expect(result).not.toContain('Image attachment(s) detected');
+      expect(result).not.toContain('## 🖼️ Image Analysis Required');
       expect(result).toContain('document.pdf');
     });
   });


### PR DESCRIPTION
## Summary

The image analysis prompt in `message-builder.ts` was enhanced in PR #1174 (Issue #656) to provide clearer guidance for agents on how to analyze images. However, the multimodal tests were not updated to match the new prompt format, causing CI failures on main branch.

## Problem

Tests in `src/agents/pilot/multimodal.test.ts` expected:
- `"Image attachment(s) detected"` (old text)
- `"analyze_image"` (old tool name)

But the code now uses:
- `"## 🖼️ Image Analysis Required"` (enhanced prompt)
- `"mcp__4_5v_mcp__analyze_image"` (MCP tool name)

## Changes

| File | Change |
|------|--------|
| `src/agents/pilot/multimodal.test.ts` | Updated 4 assertions to match enhanced prompt |

**Updated assertions:**
1. Line 76-77: `"Image attachment(s) detected"` → `"## 🖼️ Image Analysis Required"`
2. Line 77: `"analyze_image"` → `"mcp__4_5v_mcp__analyze_image"`
3. Line 151: `"Image attachment(s) detected"` → `"## 🖼️ Image Analysis Required"`
4. Line 314: `"Image attachment(s) detected"` → `"## 🖼️ Image Analysis Required"`
5. Line 341: Negative assertion also updated

## Test Results

| Check | Status |
|-------|--------|
| Unit Tests (1876) | ✅ All passed |
| ESLint | ✅ 0 errors (only warnings) |

## Related

- Fixes CI failure on main branch
- Related: #656 (enhanced image analyzer prompt)
- Related: #808 (multimodal tests)
- Related: PR #1174 (introduced the prompt change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>