### PR TITLE
feat(mcp): add request_review tools for streamlined review experience (Issue #946)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -11,6 +11,9 @@ import {
   send_file,
   send_interactive_message,
   setMessageSentCallback,
+  request_review,
+  quick_review,
+  batch_review,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 import { getGroupService } from '../platforms/feishu/group-service.js';
@@ -312,6 +315,153 @@ This tool initiates an async discussion. The conclusions will be returned when p
         return toolSuccess(`✅ 群聊讨论已启动\n- 群聊ID: ${chatId}\n- 话题: ${topic}\n- 成员数: ${members?.length || 0}\n- 超时: ${timeout || 30} 分钟\n\n请在群聊中进行讨论。讨论完成后，系统将收集结论并解散群聊。`);
       } catch (error) {
         return toolSuccess(`⚠️ Failed to start group discussion: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  // ============================================================================
+  // Issue #946: 御书房批奏折体验 - Request Review Tools
+  // ============================================================================
+  {
+    name: 'request_review',
+    description: `Request user review with the "御书房批奏折" (Imperial Study Review) experience.
+
+Sends a beautifully formatted interactive card for user approval/rejection, providing a streamlined experience for quick decision making.
+
+---
+
+## 🎯 Themes
+
+| Theme | Style | Approve | Reject | Request Changes |
+|-------|-------|---------|--------|-----------------|
+| \`imperial\` | 🏛️ 御书房 | 👑 准奏 | ❌ 驳回 | 📝 再议 |
+| \`modern\` | 📋 审批中心 | ✅ 批准 | ❌ 拒绝 | 🔄 需要修改 |
+| \`minimal\` | 简洁 | 同意 | 拒绝 | 修改 |
+
+---
+
+## Parameters
+
+- **title** (required): Review title
+- **summary** (required): Summary/description of the review request
+- **chatId** (required): Target chat ID
+- **theme**: Theme style (default: "modern")
+- **changes**: List of file changes with type, additions, deletions
+- **details**: Additional context or details
+- **context**: Context for action prompts (e.g., "PR #123")
+- **parentMessageId**: For thread reply
+
+---
+
+## Example
+
+\`\`\`json
+{
+  "title": "代码变更请求",
+  "summary": "修复了用户认证的 bug",
+  "theme": "imperial",
+  "changes": [
+    { "path": "src/auth.ts", "type": "modified", "additions": 10, "deletions": 5 },
+    { "path": "tests/auth.test.ts", "type": "added", "additions": 30 }
+  ],
+  "chatId": "oc_xxx"
+}
+\`\`\``,
+    parameters: z.object({
+      title: z.string().describe('Review title'),
+      summary: z.string().describe('Summary/description of the review request'),
+      chatId: z.string().describe('Target chat ID'),
+      theme: z.enum(['imperial', 'modern', 'minimal']).optional().describe('Theme style (default: modern)'),
+      changes: z.array(z.object({
+        path: z.string(),
+        type: z.enum(['added', 'modified', 'deleted', 'renamed']),
+        description: z.string().optional(),
+        additions: z.number().optional(),
+        deletions: z.number().optional(),
+      })).optional().describe('List of changes'),
+      details: z.string().optional().describe('Additional context or details'),
+      context: z.string().optional().describe('Context for action prompts'),
+      parentMessageId: z.string().optional().describe('Parent message ID for thread reply'),
+    }),
+    handler: async ({ title, summary, chatId, theme, changes, details, context, parentMessageId }) => {
+      try {
+        const result = await request_review({ title, summary, chatId, theme, changes, details, context, parentMessageId });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Review request failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'quick_review',
+    description: `Request a quick review with approve/reject buttons only.
+
+Use for simple decisions that don't need detailed change information.
+
+---
+
+## Example
+
+\`\`\`json
+{
+  "title": "确认操作",
+  "message": "是否继续执行删除操作？",
+  "theme": "imperial",
+  "chatId": "oc_xxx"
+}
+\`\`\``,
+    parameters: z.object({
+      title: z.string().describe('Review title'),
+      message: z.string().describe('Review message/question'),
+      chatId: z.string().describe('Target chat ID'),
+      theme: z.enum(['imperial', 'modern', 'minimal']).optional().describe('Theme style'),
+      parentMessageId: z.string().optional().describe('Parent message ID for thread reply'),
+    }),
+    handler: async ({ title, message, chatId, theme, parentMessageId }) => {
+      try {
+        const result = await quick_review({ title, message, chatId, theme, parentMessageId });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Quick review request failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'batch_review',
+    description: `Request batch approval for multiple items.
+
+Use when you need user to approve/reject multiple items at once.
+
+---
+
+## Example
+
+\`\`\`json
+{
+  "title": "批量文件审批",
+  "items": [
+    { "name": "file1.ts", "description": "新增功能" },
+    { "name": "file2.ts", "description": "修复bug" }
+  ],
+  "theme": "modern",
+  "chatId": "oc_xxx"
+}
+\`\`\``,
+    parameters: z.object({
+      title: z.string().describe('Review title'),
+      items: z.array(z.object({
+        name: z.string(),
+        description: z.string().optional(),
+      })).describe('Items to review'),
+      chatId: z.string().describe('Target chat ID'),
+      theme: z.enum(['imperial', 'modern', 'minimal']).optional().describe('Theme style'),
+      parentMessageId: z.string().optional().describe('Parent message ID for thread reply'),
+    }),
+    handler: async ({ title, items, chatId, theme, parentMessageId }) => {
+      try {
+        const result = await batch_review({ title, items, chatId, theme, parentMessageId });
+        return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
+      } catch (error) {
+        return toolSuccess(`⚠️ Batch review request failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -65,3 +65,14 @@ export type {
   StudyGuideOptions,
   StudyGuideResult,
 } from './study-guide-generator.js';
+
+// Request Review Tools (Issue #946: 御书房批奏折体验)
+export { request_review, quick_review, batch_review } from './request-review.js';
+export type {
+  RequestReviewParams,
+  QuickReviewParams,
+  BatchReviewParams,
+  RequestReviewResult,
+  ReviewTheme,
+  ReviewChange,
+} from './request-review.js';

--- a/src/mcp/tools/request-review.test.ts
+++ b/src/mcp/tools/request-review.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for Request Review MCP Tool.
+ *
+ * This module tests the request_review tool functionality for the
+ * "御书房批奏折" review experience (Issue #946).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { request_review, quick_review, batch_review } from './request-review.js';
+import * as interactiveMessage from './interactive-message.js';
+
+// Mock the send_interactive_message function
+vi.mock('./interactive-message.js', () => ({
+  send_interactive_message: vi.fn(),
+}));
+
+describe('Request Review Tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('request_review', () => {
+    it('should send review request with default modern theme', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await request_review({
+        title: 'Code Review',
+        summary: 'Please review this change',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('审批请求已发送');
+      expect(result.messageId).toBe('msg_123');
+      expect(interactiveMessage.send_interactive_message).toHaveBeenCalledTimes(1);
+    });
+
+    it('should send review request with imperial theme', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await request_review({
+        title: '代码变更请求',
+        summary: '修复了用户认证的 bug',
+        theme: 'imperial',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('御书房');
+    });
+
+    it('should send review request with changes list', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await request_review({
+        title: 'Code Review',
+        summary: 'Multiple changes',
+        changes: [
+          { path: 'src/auth.ts', type: 'modified', additions: 10, deletions: 5 },
+          { path: 'tests/auth.test.ts', type: 'added', additions: 30 },
+        ],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(interactiveMessage.send_interactive_message).toHaveBeenCalledTimes(1);
+
+      // Verify the call included proper card structure
+      const callArgs = vi.mocked(interactiveMessage.send_interactive_message).mock.calls[0][0];
+      expect(callArgs.card).toBeDefined();
+      expect(callArgs.actionPrompts).toBeDefined();
+    });
+
+    it('should send review request with details', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await request_review({
+        title: 'Code Review',
+        summary: 'Please review',
+        details: 'Additional context here',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should send review request with parentMessageId for thread reply', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_123',
+      });
+
+      const result = await request_review({
+        title: 'Thread Review',
+        summary: 'Reply in thread',
+        chatId: 'oc_test',
+        parentMessageId: 'parent_msg_456',
+      });
+
+      expect(result.success).toBe(true);
+      const callArgs = vi.mocked(interactiveMessage.send_interactive_message).mock.calls[0][0];
+      expect(callArgs.parentMessageId).toBe('parent_msg_456');
+    });
+
+    it('should handle API failure', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: false,
+        message: 'API error',
+      });
+
+      const result = await request_review({
+        title: 'Code Review',
+        summary: 'Please review',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('失败');
+    });
+
+    it('should handle exceptions', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockRejectedValue(new Error('Network error'));
+
+      const result = await request_review({
+        title: 'Code Review',
+        summary: 'Please review',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('出错');
+    });
+  });
+
+  describe('quick_review', () => {
+    it('should send quick review request', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_456',
+      });
+
+      const result = await quick_review({
+        title: 'Quick Decision',
+        message: 'Should we proceed?',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('快速审批请求已发送');
+      expect(result.messageId).toBe('msg_456');
+    });
+
+    it('should send quick review with imperial theme', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_456',
+      });
+
+      const result = await quick_review({
+        title: '确认操作',
+        message: '是否继续执行？',
+        theme: 'imperial',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should handle API failure', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: false,
+        message: 'Failed to send',
+      });
+
+      const result = await quick_review({
+        title: 'Quick Review',
+        message: 'Test',
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('batch_review', () => {
+    it('should send batch review request', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_789',
+      });
+
+      const result = await batch_review({
+        title: 'Batch Approval',
+        items: [
+          { name: 'file1.ts', description: 'New feature' },
+          { name: 'file2.ts', description: 'Bug fix' },
+        ],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('批量审批请求已发送');
+      expect(result.message).toContain('项目数: 2');
+    });
+
+    it('should send batch review with many items', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: true,
+        message: 'Message sent',
+        messageId: 'msg_789',
+      });
+
+      const items = Array.from({ length: 15 }, (_, i) => ({
+        name: `file${i}.ts`,
+        description: `Change ${i}`,
+      }));
+
+      const result = await batch_review({
+        title: 'Large Batch',
+        items,
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('项目数: 15');
+    });
+
+    it('should handle API failure', async () => {
+      vi.mocked(interactiveMessage.send_interactive_message).mockResolvedValue({
+        success: false,
+        message: 'Failed',
+      });
+
+      const result = await batch_review({
+        title: 'Batch Review',
+        items: [{ name: 'file.ts' }],
+        chatId: 'oc_test',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/mcp/tools/request-review.ts
+++ b/src/mcp/tools/request-review.ts
@@ -1,0 +1,300 @@
+/**
+ * Request Review MCP Tool.
+ *
+ * Provides "御书房批奏折" (Imperial Study Review) experience for AI to request
+ * user reviews with beautifully formatted Feishu cards.
+ *
+ * @module mcp/tools/request-review
+ */
+
+import { createLogger } from '../../utils/logger.js';
+import { send_interactive_message } from './interactive-message.js';
+import {
+  buildReviewCard,
+  buildQuickReviewCard,
+  buildBatchReviewCard,
+  buildReviewActionPrompts,
+  type ReviewCardConfig,
+  type ChangeItem,
+} from '../../platforms/feishu/card-builders/review-card-builder.js';
+import type { SendInteractiveResult } from './types.js';
+
+const logger = createLogger('RequestReview');
+
+/**
+ * Review theme options.
+ */
+export type ReviewTheme = 'imperial' | 'modern' | 'minimal';
+
+/**
+ * Change type for review.
+ */
+export interface ReviewChange {
+  /** File path or item name */
+  path: string;
+  /** Change type */
+  type: 'added' | 'modified' | 'deleted' | 'renamed';
+  /** Optional description */
+  description?: string;
+  /** Lines added */
+  additions?: number;
+  /** Lines deleted */
+  deletions?: number;
+}
+
+/**
+ * Parameters for request_review tool.
+ */
+export interface RequestReviewParams {
+  /** Review title */
+  title: string;
+  /** Summary/description of the review request */
+  summary: string;
+  /** Target chat ID */
+  chatId: string;
+  /** Theme: 'imperial' (御书房), 'modern' (审批中心), 'minimal' (简洁) */
+  theme?: ReviewTheme;
+  /** List of changes to display */
+  changes?: ReviewChange[];
+  /** Additional context or details */
+  details?: string;
+  /** Context for action prompts (e.g., "PR #123") */
+  context?: string;
+  /** Parent message ID for thread reply */
+  parentMessageId?: string;
+}
+
+/**
+ * Parameters for quick_review tool.
+ */
+export interface QuickReviewParams {
+  /** Review title */
+  title: string;
+  /** Review message/question */
+  message: string;
+  /** Target chat ID */
+  chatId: string;
+  /** Theme */
+  theme?: ReviewTheme;
+  /** Parent message ID for thread reply */
+  parentMessageId?: string;
+}
+
+/**
+ * Parameters for batch_review tool.
+ */
+export interface BatchReviewParams {
+  /** Review title */
+  title: string;
+  /** Items to review */
+  items: Array<{ name: string; description?: string }>;
+  /** Target chat ID */
+  chatId: string;
+  /** Theme */
+  theme?: ReviewTheme;
+  /** Parent message ID for thread reply */
+  parentMessageId?: string;
+}
+
+/**
+ * Result of review request.
+ */
+export interface RequestReviewResult {
+  success: boolean;
+  message: string;
+  messageId?: string;
+}
+
+/**
+ * Request a full review with the "御书房批奏折" experience.
+ *
+ * @param params - Review parameters
+ * @returns Result of the review request
+ */
+export async function request_review(params: RequestReviewParams): Promise<RequestReviewResult> {
+  const { title, summary, chatId, theme = 'modern', changes, details, context, parentMessageId } = params;
+
+  logger.debug({ title, chatId, theme }, 'Requesting review');
+
+  try {
+    // Build the review card
+    const changeItems: ChangeItem[] = (changes || []).map((c) => ({
+      path: c.path,
+      type: c.type,
+      description: c.description,
+      additions: c.additions,
+      deletions: c.deletions,
+    }));
+
+    const cardConfig: ReviewCardConfig = {
+      title,
+      summary,
+      theme,
+      changes: changeItems,
+      details,
+      approveAction: 'approve',
+      rejectAction: 'reject',
+      requestChangesAction: 'request_changes',
+      showViewDetails: !!details,
+      viewDetailsAction: details ? 'view_details' : undefined,
+    };
+
+    const card = buildReviewCard(cardConfig);
+
+    // Generate action prompts
+    const actionPrompts = buildReviewActionPrompts(context || title, theme);
+
+    // Send the interactive card
+    const result: SendInteractiveResult = await send_interactive_message({
+      card: card as unknown as Record<string, unknown>,
+      actionPrompts,
+      chatId,
+      parentMessageId,
+    });
+
+    if (result.success) {
+      logger.info({ title, chatId, messageId: result.messageId }, 'Review request sent successfully');
+      return {
+        success: true,
+        message: `✅ 审批请求已发送\n标题: ${title}\n主题: ${getThemeName(theme)}`,
+        messageId: result.messageId,
+      };
+    }
+
+    logger.warn({ title, chatId, error: result.message }, 'Failed to send review request');
+    return {
+      success: false,
+      message: `⚠️ 发送审批请求失败: ${result.message}`,
+    };
+  } catch (error) {
+    logger.error({ error, title, chatId }, 'Error sending review request');
+    return {
+      success: false,
+      message: `❌ 发送审批请求出错: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Request a quick review (approve/reject only).
+ *
+ * @param params - Quick review parameters
+ * @returns Result of the review request
+ */
+export async function quick_review(params: QuickReviewParams): Promise<RequestReviewResult> {
+  const { title, message, chatId, theme = 'modern', parentMessageId } = params;
+
+  logger.debug({ title, chatId, theme }, 'Requesting quick review');
+
+  try {
+    // Build the quick review card
+    const card = buildQuickReviewCard(title, message, 'approve', 'reject', theme);
+
+    // Generate action prompts
+    const actionPrompts = buildReviewActionPrompts(title, theme);
+    // Quick review only needs approve and reject
+    const quickPrompts = {
+      approve: actionPrompts.approve,
+      reject: actionPrompts.reject,
+    };
+
+    // Send the interactive card
+    const result: SendInteractiveResult = await send_interactive_message({
+      card: card as unknown as Record<string, unknown>,
+      actionPrompts: quickPrompts,
+      chatId,
+      parentMessageId,
+    });
+
+    if (result.success) {
+      logger.info({ title, chatId, messageId: result.messageId }, 'Quick review request sent successfully');
+      return {
+        success: true,
+        message: `✅ 快速审批请求已发送\n标题: ${title}`,
+        messageId: result.messageId,
+      };
+    }
+
+    logger.warn({ title, chatId, error: result.message }, 'Failed to send quick review request');
+    return {
+      success: false,
+      message: `⚠️ 发送快速审批请求失败: ${result.message}`,
+    };
+  } catch (error) {
+    logger.error({ error, title, chatId }, 'Error sending quick review request');
+    return {
+      success: false,
+      message: `❌ 发送快速审批请求出错: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Request a batch review for multiple items.
+ *
+ * @param params - Batch review parameters
+ * @returns Result of the review request
+ */
+export async function batch_review(params: BatchReviewParams): Promise<RequestReviewResult> {
+  const { title, items, chatId, theme = 'modern', parentMessageId } = params;
+
+  logger.debug({ title, chatId, theme, itemCount: items.length }, 'Requesting batch review');
+
+  try {
+    // Build the batch review card
+    const card = buildBatchReviewCard(title, items, 'approve_all', 'reject_all', theme);
+
+    // Generate action prompts
+    const actionPrompts = buildReviewActionPrompts(title, theme);
+    // Batch review only needs approve_all and reject_all
+    const batchPrompts = {
+      approve_all: actionPrompts.approve_all,
+      reject_all: actionPrompts.reject_all,
+    };
+
+    // Send the interactive card
+    const result: SendInteractiveResult = await send_interactive_message({
+      card: card as unknown as Record<string, unknown>,
+      actionPrompts: batchPrompts,
+      chatId,
+      parentMessageId,
+    });
+
+    if (result.success) {
+      logger.info({ title, chatId, messageId: result.messageId, itemCount: items.length }, 'Batch review request sent successfully');
+      return {
+        success: true,
+        message: `✅ 批量审批请求已发送\n标题: ${title}\n项目数: ${items.length}`,
+        messageId: result.messageId,
+      };
+    }
+
+    logger.warn({ title, chatId, error: result.message }, 'Failed to send batch review request');
+    return {
+      success: false,
+      message: `⚠️ 发送批量审批请求失败: ${result.message}`,
+    };
+  } catch (error) {
+    logger.error({ error, title, chatId }, 'Error sending batch review request');
+    return {
+      success: false,
+      message: `❌ 发送批量审批请求出错: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Get theme display name.
+ */
+function getThemeName(theme: ReviewTheme): string {
+  switch (theme) {
+    case 'imperial':
+      return '🏛️ 御书房';
+    case 'modern':
+      return '📋 审批中心';
+    case 'minimal':
+      return '简洁';
+    default:
+      return theme;
+  }
+}


### PR DESCRIPTION
## Summary

Add three new MCP tools to provide "御书房批奏折" (Imperial Study Review) experience:

- `request_review`: Full-featured review with changes, diff, and themes
- `quick_review`: Simple approve/reject for quick decisions
- `batch_review`: Batch approval for multiple items

## Features

### Themes

| Theme | Style | Approve | Reject | Request Changes |
|-------|-------|---------|--------|-----------------|
| `imperial` | 🏛️ 御书房 | 👑 准奏 | ❌ 驳回 | 📝 再议 |
| `modern` | 📋 审批中心 | ✅ 批准 | ❌ 拒绝 | 🔄 需要修改 |
| `minimal` | 简洁 | 同意 | 拒绝 | 修改 |

### Integration

- Uses existing `review-card-builder` module
- Pre-configured action prompts for user interactions
- Support for file changes with additions/deletions stats

## Files Changed

| File | Change |
|------|--------|
| `src/mcp/tools/request-review.ts` | New file - Tool implementation |
| `src/mcp/tools/request-review.test.ts` | New file - 13 tests |
| `src/mcp/tools/index.ts` | Export new tools |
| `src/mcp/feishu-context-mcp.ts` | Register MCP tool definitions |

## Test Results

```
✓ src/mcp/tools/request-review.test.ts (13 tests)
✓ src/platforms/feishu/card-builders/review-card-builder.test.ts (11 tests)
✓ src/mcp/feishu-context-mcp.test.ts (30 tests)

Test Files  3 passed (3)
     Tests  54 passed (54)
```

## Example Usage

```json
{
  "title": "代码变更请求",
  "summary": "修复了用户认证的 bug",
  "theme": "imperial",
  "changes": [
    { "path": "src/auth.ts", "type": "modified", "additions": 10, "deletions": 5 },
    { "path": "tests/auth.test.ts", "type": "added", "additions": 30 }
  ],
  "chatId": "oc_xxx"
}
```

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)