### PR TITLE
feat(config): add enableAgentTeams option for Agent Teams mode

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -41,6 +41,13 @@ agent:
   # Default: 1
   maxConcurrentTasks: 1
 
+  # Enable Claude Code Agent Teams mode
+  # When enabled, the agent can spawn and coordinate multiple teammate sessions
+  # for parallel work on complex tasks.
+  # @see https://code.claude.com/docs/en/agent-teams
+  # Default: false
+  # enableAgentTeams: true
+
 # -----------------------------------------------------------------------------
 # Feishu/Lark Platform Configuration
 # -----------------------------------------------------------------------------

--- a/src/agents/base-agent.test.ts
+++ b/src/agents/base-agent.test.ts
@@ -37,6 +37,7 @@ vi.mock('../config/index.js', () => ({
       rotate: false,
       sdkDebug: true,
     })),
+    isAgentTeamsEnabled: vi.fn(() => false),
   },
 }));
 

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -161,10 +161,15 @@ export abstract class BaseAgent implements Disposable {
 
     // Set environment
     const loggingConfig = Config.getLoggingConfig();
+    // Build global env with agent teams support
+    const globalEnv = { ...Config.getGlobalEnv() };
+    if (Config.isAgentTeamsEnabled()) {
+      globalEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
+    }
     options.env = buildSdkEnv(
       this.apiKey,
       this.apiBaseUrl,
-      Config.getGlobalEnv(),
+      globalEnv,
       loggingConfig.sdkDebug
     );
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -356,4 +356,15 @@ export class Config {
   static getRestChannelConfig(): import('./types.js').RestChannelConfig {
     return fileConfigOnly.channels?.rest || {};
   }
+
+  /**
+   * Check if Agent Teams mode is enabled.
+   * When enabled, sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 for SDK subprocess.
+   * @see Issue #1208
+   *
+   * @returns true if agent teams mode is enabled
+   */
+  static isAgentTeamsEnabled(): boolean {
+    return fileConfigOnly.agent?.enableAgentTeams ?? false;
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -44,6 +44,13 @@ export interface AgentConfig {
   maxConcurrentTasks?: number;
   /** Model identifier for Anthropic/Claude (only used when provider is 'anthropic') */
   model?: string;
+  /**
+   * Enable Claude Code Agent Teams mode.
+   * When enabled, sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 for SDK subprocess.
+   * This allows the agent to spawn and coordinate multiple teammate sessions.
+   * @see https://code.claude.com/docs/en/agent-teams
+   */
+  enableAgentTeams?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add `enableAgentTeams` configuration option to allow enabling Claude Code Agent Teams mode.

## Changes

- **`src/config/types.ts`**: Add `enableAgentTeams?: boolean` to `AgentConfig` interface
- **`src/config/index.ts`**: Add `Config.isAgentTeamsEnabled()` method
- **`src/agents/base-agent.ts`**: Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` env var when enabled
- **`disclaude.config.example.yaml`**: Add documentation for new config option

## Usage

Users can enable Agent Teams mode in their `disclaude.config.yaml`:

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] Configuration correctly passed to SDK subprocess

Fixes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>