### PR TITLE
feat(auth): implement Device Code Flow (RFC 8628) for OAuth

### DIFF
--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -15,7 +15,9 @@ import { z } from 'zod';
 import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
 import { createLogger } from '../utils/logger.js';
 import { getOAuthManager, OAuthManager } from './oauth-manager.js';
-import type { OAuthProviderConfig } from './types.js';
+import { getDeviceCodeFlowManager } from './device-code-flow.js';
+import { getProviderTemplate, createProviderConfig } from './provider-templates.js';
+import type { OAuthProviderConfig, DeviceCodeProviderConfig } from './types.js';
 
 const logger = createLogger('AuthMCP');
 
@@ -67,6 +69,46 @@ export function createAuthCard(authUrl: string, provider: string): Record<string
       {
         tag: 'markdown',
         content: '_💡 授权信息将加密存储，AI 无法直接查看您的凭证_',
+      },
+    ],
+  };
+}
+
+/**
+ * Create Device Code Flow authorization card for Feishu.
+ * This card displays the user code and verification URL for Device Code Flow.
+ */
+export function createDeviceCodeCard(
+  userCode: string,
+  verificationUri: string,
+  provider: string,
+  expiresInMinutes: number = 15
+): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: `🔐 ${provider} 授权` },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: `请在浏览器中完成授权：\n\n**1.** 访问: ${verificationUri}\n**2.** 输入设备码: \`${userCode}\`\n\n⏳ 授权有效期: ${expiresInMinutes} 分钟`,
+      },
+      {
+        tag: 'action',
+        actions: [
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: '打开授权页面' },
+            url: verificationUri,
+            type: 'primary',
+          },
+        ],
+      },
+      {
+        tag: 'markdown',
+        content: '_💡 完成授权后，系统将自动获取令牌，无需手动确认_',
       },
     ],
   };
@@ -235,6 +277,142 @@ export const authToolDefinitions: InlineToolDefinition[] = [
         }
       } catch (error) {
         return toolError(`Failed to revoke authorization: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'auth_start_device_flow',
+    description: 'Start a Device Code Flow for OAuth authorization. Use this when the user cannot access a local callback URL (e.g., server deployment, chat scenario). Returns a user code and verification URL. Send these to the user so they can authorize in their browser.',
+    parameters: z.object({
+      providerName: z.string().describe('Provider name (e.g., "github", "google"). Use a known provider for automatic endpoint configuration.'),
+      clientId: z.string().describe('OAuth client ID'),
+      clientSecret: z.string().describe('OAuth client secret'),
+      scopes: z.string().optional().describe('Space-separated OAuth scopes to request (optional, uses defaults if not provided)'),
+      chatId: z.string().describe('Chat ID from the task context'),
+    }),
+    handler: async ({ providerName, clientId, clientSecret, scopes, chatId }) => {
+      try {
+        // Try to get provider template for endpoint URLs
+        const template = getProviderTemplate(providerName);
+
+        if (!template) {
+          return toolError(
+            `Unknown provider: ${providerName}. Known providers: ${Object.keys(getProviderTemplate).join(', ')}. ` +
+            'For custom providers, use auth_generate_url with explicit endpoints.'
+          );
+        }
+
+        if (!template.supportsDeviceCode) {
+          return toolError(
+            `Provider ${providerName} does not support Device Code Flow. ` +
+            'Use auth_generate_url for standard OAuth flow instead.'
+          );
+        }
+
+        // Create provider config
+        const config = createProviderConfig(providerName, {
+          clientId,
+          clientSecret,
+          scopes: scopes ? scopes.split(' ').filter(Boolean) : template.scopes,
+        }) as DeviceCodeProviderConfig;
+
+        if (!config || !config.deviceCodeUrl) {
+          return toolError(`Failed to create provider config for ${providerName}`);
+        }
+
+        // Start device code flow
+        const manager = getDeviceCodeFlowManager();
+        const state = await manager.startFlow(config, chatId);
+
+        const expiresInMinutes = Math.round((state.expiresAt - Date.now()) / 60000);
+
+        logger.info(
+          {
+            chatId,
+            provider: providerName,
+            flowId: state.id,
+            userCode: state.userCode,
+          },
+          'Device code flow started'
+        );
+
+        return toolSuccess(
+          'Device Code Flow started:\n\n' +
+          `**Provider:** ${providerName}\n` +
+          `**Verification URL:** ${state.verificationUri}\n` +
+          `**User Code:** \`${state.userCode}\`\n` +
+          `**Expires in:** ${expiresInMinutes} minutes\n\n` +
+          '**Flow ID:** `' + state.id + '`\n\n' +
+          'Send the verification URL and user code to the user. ' +
+          'After the user authorizes, call `auth_complete_device_flow` with the flow ID to complete the authorization.'
+        );
+      } catch (error) {
+        return toolError(`Failed to start device code flow: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'auth_complete_device_flow',
+    description: 'Complete a Device Code Flow by polling for the authorization token. Call this after the user has had time to complete authorization. This will block until authorization is complete or times out.',
+    parameters: z.object({
+      flowId: z.string().describe('The flow ID returned from auth_start_device_flow'),
+      timeout: z.number().optional().describe('Maximum time to wait in seconds (default: 300, max: 900)'),
+    }),
+    handler: async ({ flowId, timeout = 300 }) => {
+      try {
+        const manager = getDeviceCodeFlowManager();
+        const state = manager.getFlowState(flowId);
+
+        if (!state) {
+          return toolError('Invalid or expired flow ID. Please start a new device code flow.');
+        }
+
+        // Calculate remaining time
+        const remainingMs = state.expiresAt - Date.now();
+        if (remainingMs <= 0) {
+          return toolError('Device code has expired. Please start a new device code flow.');
+        }
+
+        const maxWaitMs = Math.min(timeout * 1000, 900000, remainingMs); // Max 15 minutes
+
+        logger.info(
+          { flowId, provider: state.provider, maxWaitMs },
+          'Starting to poll for device code completion'
+        );
+
+        // Poll with timeout
+        const startTime = Date.now();
+
+        const result = await manager.completeFlow(flowId, (status) => {
+          logger.debug({ flowId, status }, 'Device code flow status update');
+        });
+
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+
+        logger.info(
+          { flowId, chatId: result.chatId, provider: result.provider, elapsed },
+          'Device code flow completed successfully'
+        );
+
+        return toolSuccess(
+          `✅ Authorization successful!\n\n` +
+          `**Provider:** ${result.provider}\n` +
+          `**Chat ID:** ${result.chatId}\n` +
+          `**Time elapsed:** ${elapsed} seconds\n\n` +
+          'You can now use `auth_request` to make authenticated API calls.'
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        if (errorMessage.includes('expired')) {
+          return toolError('Device code has expired. Please start a new device code flow.');
+        }
+
+        if (errorMessage.includes('denied')) {
+          return toolError('Authorization was denied by the user.');
+        }
+
+        return toolError(`Failed to complete device code flow: ${errorMessage}`);
       }
     },
   },

--- a/src/auth/device-code-flow.test.ts
+++ b/src/auth/device-code-flow.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for Device Code Flow implementation (RFC 8628).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  initiateDeviceCode,
+  pollForToken,
+  DeviceCodeFlowManager,
+  getDeviceCodeFlowManager,
+} from './device-code-flow.js';
+import type { DeviceCodeProviderConfig, DeviceCodeResponse } from './types.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Mock token store
+vi.mock('./token-store.js', () => ({
+  getTokenStore: vi.fn(() => ({
+    setToken: vi.fn().mockResolvedValue(undefined),
+    getToken: vi.fn().mockResolvedValue(null),
+    getAccessToken: vi.fn().mockResolvedValue(null),
+    deleteToken: vi.fn().mockResolvedValue(true),
+    listProviders: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+describe('Device Code Flow', () => {
+  const mockProviderConfig: DeviceCodeProviderConfig = {
+    name: 'github',
+    authUrl: 'https://github.com/login/oauth/authorize',
+    tokenUrl: 'https://github.com/login/oauth/access_token',
+    deviceCodeUrl: 'https://github.com/login/device/code',
+    deviceTokenUrl: 'https://github.com/login/oauth/access_token',
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    scopes: ['repo', 'user'],
+    callbackUrl: 'http://localhost:3000/auth/callback',
+    supportsDeviceCode: true,
+  };
+
+  const mockDeviceCodeResponse: DeviceCodeResponse = {
+    device_code: 'test-device-code-12345',
+    user_code: 'ABCD-1234',
+    verification_uri: 'https://github.com/login/device',
+    expires_in: 900,
+    interval: 5,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('initiateDeviceCode', () => {
+    it('should request device code from provider', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDeviceCodeResponse,
+      });
+
+      const result = await initiateDeviceCode(mockProviderConfig);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://github.com/login/device/code',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        })
+      );
+
+      expect(result).toEqual(mockDeviceCodeResponse);
+    });
+
+    it('should throw error when device code URL is not configured', async () => {
+      const configWithoutDeviceUrl: DeviceCodeProviderConfig = {
+        ...mockProviderConfig,
+        deviceCodeUrl: undefined,
+      };
+
+      await expect(initiateDeviceCode(configWithoutDeviceUrl)).rejects.toThrow(
+        'does not have a device code URL configured'
+      );
+    });
+
+    it('should throw error on failed request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad Request',
+      });
+
+      await expect(initiateDeviceCode(mockProviderConfig)).rejects.toThrow(
+        'Failed to request device code: 400'
+      );
+    });
+  });
+
+  describe('pollForToken', () => {
+    it('should poll until authorization is complete', async () => {
+      // First poll: pending
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ error: 'authorization_pending' }),
+      });
+
+      // Second poll: success
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          scope: 'repo user',
+          expires_in: 3600,
+        }),
+      });
+
+      const result = await pollForToken(
+        mockProviderConfig,
+        'test-device-code',
+        0 // No delay for testing
+      );
+
+      expect(result.accessToken).toBe('test-access-token');
+      expect(result.tokenType).toBe('Bearer');
+      expect(result.scope).toBe('repo user');
+    });
+
+    it('should handle slow_down error by increasing interval', async () => {
+      const statusUpdates: string[] = [];
+
+      // First poll: slow_down
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ error: 'slow_down' }),
+      });
+
+      // Second poll: success
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+        }),
+      });
+
+      const result = await pollForToken(
+        mockProviderConfig,
+        'test-device-code',
+        0,
+        (status) => statusUpdates.push(status)
+      );
+
+      expect(result.accessToken).toBe('test-access-token');
+      expect(statusUpdates).toContainEqual(expect.stringContaining('slow_down'));
+    });
+
+    it('should throw error on expired token', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ error: 'expired_token' }),
+      });
+
+      await expect(
+        pollForToken(mockProviderConfig, 'test-device-code', 0)
+      ).rejects.toThrow('Device code has expired');
+    });
+
+    it('should throw error on access denied', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ error: 'access_denied' }),
+      });
+
+      await expect(
+        pollForToken(mockProviderConfig, 'test-device-code', 0)
+      ).rejects.toThrow('Authorization was denied');
+    });
+  });
+
+  describe('DeviceCodeFlowManager', () => {
+    it('should start a device code flow', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDeviceCodeResponse,
+      });
+
+      const manager = new DeviceCodeFlowManager();
+      const state = await manager.startFlow(mockProviderConfig, 'test-chat-id');
+
+      expect(state.chatId).toBe('test-chat-id');
+      expect(state.provider).toBe('github');
+      expect(state.userCode).toBe('ABCD-1234');
+      expect(state.deviceCode).toBe('test-device-code-12345');
+      expect(state.verificationUri).toBe('https://github.com/login/device');
+    });
+
+    it('should complete a device code flow', async () => {
+      // Start flow
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDeviceCodeResponse,
+      });
+
+      const manager = new DeviceCodeFlowManager();
+      const state = await manager.startFlow(mockProviderConfig, 'test-chat-id');
+
+      // Complete flow with success
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        }),
+      });
+
+      const result = await manager.completeFlow(state.id);
+
+      expect(result.chatId).toBe('test-chat-id');
+      expect(result.provider).toBe('github');
+    });
+
+    it('should cancel a pending flow', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockDeviceCodeResponse,
+      });
+
+      const manager = new DeviceCodeFlowManager();
+      const state = await manager.startFlow(mockProviderConfig, 'test-chat-id');
+
+      manager.cancelFlow(state.id);
+
+      const retrievedState = manager.getFlowState(state.id);
+      expect(retrievedState).toBeUndefined();
+    });
+
+    it('should throw error for invalid flow ID', async () => {
+      const manager = new DeviceCodeFlowManager();
+
+      await expect(manager.completeFlow('invalid-id')).rejects.toThrow(
+        'Invalid or expired device code flow'
+      );
+    });
+  });
+
+  describe('getDeviceCodeFlowManager', () => {
+    it('should return singleton instance', () => {
+      const instance1 = getDeviceCodeFlowManager();
+      const instance2 = getDeviceCodeFlowManager();
+
+      expect(instance1).toBe(instance2);
+    });
+  });
+});

--- a/src/auth/device-code-flow.ts
+++ b/src/auth/device-code-flow.ts
@@ -1,0 +1,422 @@
+/**
+ * Device Code Flow implementation (RFC 8628).
+ *
+ * Provides OAuth 2.0 Device Authorization Grant for scenarios
+ * where a local callback server is not available or practical:
+ * - Server deployments without public IP
+ * - Chat/IM scenarios
+ * - Containerized deployments
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8628
+ */
+
+import { createLogger } from '../utils/logger.js';
+import { getTokenStore, TokenStore } from './token-store.js';
+import type {
+  DeviceCodeProviderConfig,
+  DeviceCodeResponse,
+  DeviceCodeState,
+  OAuthToken,
+} from './types.js';
+
+const logger = createLogger('DeviceCodeFlow');
+
+/**
+ * In-memory store for pending Device Code states.
+ * States are short-lived (default 15 minutes) so memory storage is acceptable.
+ */
+const pendingDeviceCodes = new Map<string, DeviceCodeState>();
+
+/**
+ * Active polling intervals for cleanup on cancellation.
+ */
+const activePollers = new Map<string, NodeJS.Timeout>();
+
+/**
+ * Generate a unique ID for device code flow.
+ */
+function generateFlowId(): string {
+  return `dc_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+}
+
+/**
+ * Clean up expired device code states.
+ */
+function cleanupExpiredStates(): void {
+  const now = Date.now();
+
+  for (const [id, state] of pendingDeviceCodes.entries()) {
+    if (now > state.expiresAt) {
+      pendingDeviceCodes.delete(id);
+      // Also stop any active polling
+      const poller = activePollers.get(id);
+      if (poller) {
+        clearInterval(poller);
+        activePollers.delete(id);
+      }
+      logger.debug({ id, provider: state.provider }, 'Expired device code state removed');
+    }
+  }
+}
+
+/**
+ * Request a device code from the OAuth provider.
+ *
+ * @param config - Provider configuration with device code endpoint
+ * @returns Device code response with user_code and verification_uri
+ */
+export async function initiateDeviceCode(
+  config: DeviceCodeProviderConfig
+): Promise<DeviceCodeResponse> {
+  if (!config.deviceCodeUrl) {
+    throw new Error(`Provider ${config.name} does not have a device code URL configured`);
+  }
+
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    scope: config.scopes.join(' '),
+  });
+
+  logger.info({ provider: config.name }, 'Requesting device code');
+
+  const response = await fetch(config.deviceCodeUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to request device code: ${response.status} - ${text}`);
+  }
+
+  const data = (await response.json()) as DeviceCodeResponse;
+
+  logger.info(
+    {
+      provider: config.name,
+      userCode: data.user_code,
+      expiresIn: data.expires_in,
+    },
+    'Device code received'
+  );
+
+  return data;
+}
+
+/**
+ * Poll for token after user authorization.
+ *
+ * @param config - Provider configuration
+ * @param deviceCode - The device code from initiation
+ * @param interval - Polling interval in seconds
+ * @param onStatus - Optional callback for status updates
+ * @returns OAuth token when authorization is complete
+ */
+export async function pollForToken(
+  config: DeviceCodeProviderConfig,
+  deviceCode: string,
+  interval: number = 5,
+  onStatus?: (status: string) => void
+): Promise<OAuthToken> {
+  const tokenUrl = config.deviceTokenUrl || config.tokenUrl;
+
+  if (!tokenUrl) {
+    throw new Error(`Provider ${config.name} does not have a token URL configured`);
+  }
+
+  const maxAttempts = 180; // 15 minutes at 5 second intervals
+  let attempts = 0;
+  let currentInterval = interval;
+
+  while (attempts < maxAttempts) {
+    attempts++;
+
+    // Wait before polling (except first attempt)
+    if (attempts > 1) {
+      await new Promise(resolve => setTimeout(resolve, currentInterval * 1000));
+    }
+
+    const params = new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      client_id: config.clientId,
+      device_code: deviceCode,
+    });
+
+    // Include client secret if available (required by some providers)
+    if (config.clientSecret) {
+      params.append('client_secret', config.clientSecret);
+    }
+
+    try {
+      const response = await fetch(tokenUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: params.toString(),
+      });
+
+      const data = (await response.json()) as Record<string, unknown>;
+
+      // Check for errors
+      if (data.error) {
+        const error = data.error as string;
+
+        if (error === 'authorization_pending') {
+          onStatus?.('waiting');
+          logger.debug({ provider: config.name }, 'Authorization pending, continuing to poll');
+          continue;
+        }
+
+        if (error === 'slow_down') {
+          currentInterval = Math.min(currentInterval + 5, 60); // Max 60 seconds
+          onStatus?.(`slow_down:${currentInterval}`);
+          logger.info(
+            { provider: config.name, newInterval: currentInterval },
+            'Slowing down polling'
+          );
+          continue;
+        }
+
+        if (error === 'expired_token') {
+          throw new Error('Device code has expired. Please start a new authorization flow.');
+        }
+
+        if (error === 'access_denied') {
+          throw new Error('Authorization was denied by the user.');
+        }
+
+        throw new Error(`Token polling error: ${error} - ${data.error_description || 'Unknown error'}`);
+      }
+
+      // Success! We have a token
+      const expiresIn = typeof data.expires_in === 'number' ? data.expires_in : 3600;
+      const expiresAt = Date.now() + expiresIn * 1000;
+
+      const token: OAuthToken = {
+        accessToken: String(data.access_token),
+        refreshToken: data.refresh_token ? String(data.refresh_token) : undefined,
+        tokenType: String(data.token_type || 'Bearer'),
+        expiresAt,
+        scope: typeof data.scope === 'string' ? data.scope : undefined,
+        createdAt: Date.now(),
+      };
+
+      logger.info({ provider: config.name }, 'Device code authorization successful');
+      onStatus?.('success');
+
+      return token;
+    } catch (error) {
+      if (error instanceof Error && (
+        error.message.includes('expired') ||
+        error.message.includes('denied')
+      )) {
+        throw error;
+      }
+
+      logger.warn(
+        { err: error, provider: config.name, attempt: attempts },
+        'Token polling attempt failed, retrying'
+      );
+    }
+  }
+
+  throw new Error('Device code authorization timed out after maximum attempts');
+}
+
+/**
+ * Device Code Flow Manager.
+ *
+ * Manages the complete Device Code Flow lifecycle:
+ * 1. Initiate: Request device code from provider
+ * 2. Display: Show user code and verification URL
+ * 3. Poll: Wait for user to complete authorization
+ * 4. Store: Save token when authorization completes
+ */
+export class DeviceCodeFlowManager {
+  private readonly tokenStore: TokenStore;
+
+  constructor(tokenStore?: TokenStore) {
+    this.tokenStore = tokenStore || getTokenStore();
+  }
+
+  /**
+   * Start a Device Code Flow.
+   *
+   * @param config - Provider configuration
+   * @param chatId - Chat ID initiating the flow
+   * @returns Device code state with user_code and verification_uri
+   */
+  async startFlow(
+    config: DeviceCodeProviderConfig,
+    chatId: string
+  ): Promise<DeviceCodeState> {
+    // Clean up old states
+    cleanupExpiredStates();
+
+    // Request device code
+    const response = await initiateDeviceCode(config);
+
+    // Create state
+    const state: DeviceCodeState = {
+      id: generateFlowId(),
+      chatId,
+      provider: config.name,
+      deviceCode: response.device_code,
+      userCode: response.user_code,
+      verificationUri: response.verification_uri_complete || response.verification_uri,
+      interval: response.interval,
+      expiresAt: Date.now() + response.expires_in * 1000,
+      createdAt: Date.now(),
+      providerConfig: config,
+    };
+
+    // Store state
+    pendingDeviceCodes.set(state.id, state);
+
+    logger.info(
+      {
+        id: state.id,
+        chatId,
+        provider: config.name,
+        userCode: state.userCode,
+      },
+      'Device code flow started'
+    );
+
+    return state;
+  }
+
+  /**
+   * Complete a Device Code Flow by polling for the token.
+   *
+   * @param flowId - The flow ID returned from startFlow
+   * @param onStatus - Optional callback for status updates
+   * @returns The chat ID and provider when complete
+   */
+  async completeFlow(
+    flowId: string,
+    onStatus?: (status: string) => void
+  ): Promise<{ chatId: string; provider: string }> {
+    const state = pendingDeviceCodes.get(flowId);
+
+    if (!state) {
+      throw new Error('Invalid or expired device code flow');
+    }
+
+    if (Date.now() > state.expiresAt) {
+      pendingDeviceCodes.delete(flowId);
+      throw new Error('Device code has expired. Please start a new authorization flow.');
+    }
+
+    try {
+      // Poll for token
+      const token = await pollForToken(
+        state.providerConfig,
+        state.deviceCode,
+        state.interval,
+        onStatus
+      );
+
+      // Store token
+      await this.tokenStore.setToken(state.chatId, state.provider, token);
+
+      // Clean up state
+      pendingDeviceCodes.delete(flowId);
+
+      logger.info(
+        { flowId, chatId: state.chatId, provider: state.provider },
+        'Device code flow completed successfully'
+      );
+
+      return {
+        chatId: state.chatId,
+        provider: state.provider,
+      };
+    } catch (error) {
+      // Clean up on failure
+      pendingDeviceCodes.delete(flowId);
+      throw error;
+    }
+  }
+
+  /**
+   * Cancel a pending Device Code Flow.
+   *
+   * @param flowId - The flow ID to cancel
+   */
+  cancelFlow(flowId: string): void {
+    const poller = activePollers.get(flowId);
+    if (poller) {
+      clearInterval(poller);
+      activePollers.delete(flowId);
+    }
+    pendingDeviceCodes.delete(flowId);
+    logger.info({ flowId }, 'Device code flow cancelled');
+  }
+
+  /**
+   * Get a pending flow state.
+   *
+   * @param flowId - The flow ID
+   * @returns The flow state or undefined
+   */
+  getFlowState(flowId: string): DeviceCodeState | undefined {
+    return pendingDeviceCodes.get(flowId);
+  }
+
+  /**
+   * Start polling in the background and resolve when complete.
+   *
+   * @param flowId - The flow ID
+   * @param onStatus - Status callback
+   * @returns Promise that resolves when authorization completes
+   */
+  async pollInBackground(
+    flowId: string,
+    onStatus?: (status: string) => void
+  ): Promise<{ chatId: string; provider: string }> {
+    return new Promise((resolve, reject) => {
+      const state = pendingDeviceCodes.get(flowId);
+
+      if (!state) {
+        reject(new Error('Invalid or expired device code flow'));
+        return;
+      }
+
+      const poll = async () => {
+        try {
+          const result = await this.completeFlow(flowId, onStatus);
+          activePollers.delete(flowId);
+          resolve(result);
+        } catch (error) {
+          activePollers.delete(flowId);
+          reject(error);
+        }
+      };
+
+      // Start polling
+      poll();
+    });
+  }
+}
+
+/**
+ * Singleton instance.
+ */
+let deviceCodeFlowInstance: DeviceCodeFlowManager | null = null;
+
+/**
+ * Get the global Device Code Flow manager instance.
+ */
+export function getDeviceCodeFlowManager(): DeviceCodeFlowManager {
+  if (!deviceCodeFlowInstance) {
+    deviceCodeFlowInstance = new DeviceCodeFlowManager();
+  }
+  return deviceCodeFlowInstance;
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -3,6 +3,7 @@
  *
  * This module provides:
  * - OAuth 2.0 PKCE flow management
+ * - Device Code Flow (RFC 8628) for server/chat scenarios
  * - Encrypted token storage
  * - MCP tools for agent integration
  *
@@ -21,6 +22,10 @@ export type {
   ApiRequestConfig,
   ApiResponse,
   AuthConfig,
+  DeviceCodeResponse,
+  DeviceTokenResponse,
+  DeviceCodeProviderConfig,
+  DeviceCodeState,
 } from './types.js';
 
 // Crypto utilities
@@ -38,5 +43,27 @@ export { TokenStore, getTokenStore } from './token-store.js';
 // OAuth manager
 export { OAuthManager, getOAuthManager } from './oauth-manager.js';
 
+// Device Code Flow
+export {
+  DeviceCodeFlowManager,
+  getDeviceCodeFlowManager,
+  initiateDeviceCode,
+  pollForToken,
+} from './device-code-flow.js';
+
+// Provider templates
+export {
+  OAUTH_PROVIDER_TEMPLATES,
+  getProviderTemplate,
+  supportsDeviceCode,
+  createProviderConfig,
+} from './provider-templates.js';
+
 // MCP tools
-export { authSdkTools, createAuthSdkMcpServer, createAuthCard } from './auth-mcp.js';
+export {
+  authSdkTools,
+  createAuthSdkMcpServer,
+  createAuthCard,
+  createDeviceCodeCard,
+  authToolDefinitions,
+} from './auth-mcp.js';

--- a/src/auth/provider-templates.ts
+++ b/src/auth/provider-templates.ts
@@ -1,0 +1,118 @@
+/**
+ * OAuth Provider Templates with Device Code Flow support.
+ *
+ * Pre-configured templates for common OAuth providers.
+ * These templates include Device Code Flow endpoints where supported.
+ */
+
+import type { DeviceCodeProviderConfig } from './types.js';
+
+/**
+ * OAuth Provider Templates.
+ *
+ * Each template includes:
+ * - Standard OAuth 2.0 endpoints
+ * - Device Code Flow endpoints (where supported)
+ * - Recommended scopes
+ */
+export const OAUTH_PROVIDER_TEMPLATES: Record<string, Partial<DeviceCodeProviderConfig>> = {
+  github: {
+    name: 'github',
+    authUrl: 'https://github.com/login/oauth/authorize',
+    tokenUrl: 'https://github.com/login/oauth/access_token',
+    deviceCodeUrl: 'https://github.com/login/device/code',
+    deviceTokenUrl: 'https://github.com/login/oauth/access_token',
+    supportsDeviceCode: true,
+    scopes: ['repo', 'user', 'read:org'],
+  },
+
+  google: {
+    name: 'google',
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    deviceCodeUrl: 'https://oauth2.googleapis.com/device/code',
+    deviceTokenUrl: 'https://oauth2.googleapis.com/token',
+    supportsDeviceCode: true,
+    scopes: ['openid', 'email', 'profile'],
+  },
+
+  gitlab: {
+    name: 'gitlab',
+    authUrl: 'https://gitlab.com/oauth/authorize',
+    tokenUrl: 'https://gitlab.com/oauth/token',
+    deviceCodeUrl: 'https://gitlab.com/oauth/authorize_device',
+    deviceTokenUrl: 'https://gitlab.com/oauth/token',
+    supportsDeviceCode: true,
+    scopes: ['api', 'read_user'],
+  },
+
+  microsoft: {
+    name: 'microsoft',
+    authUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+    tokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    deviceCodeUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode',
+    deviceTokenUrl: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    supportsDeviceCode: true,
+    scopes: ['openid', 'email', 'profile', 'User.Read'],
+  },
+
+  notion: {
+    name: 'notion',
+    authUrl: 'https://api.notion.com/v1/oauth/authorize',
+    tokenUrl: 'https://api.notion.com/v1/oauth/token',
+    supportsDeviceCode: false, // Notion does not support Device Code Flow
+    scopes: [],
+  },
+
+  slack: {
+    name: 'slack',
+    authUrl: 'https://slack.com/oauth/v2/authorize',
+    tokenUrl: 'https://slack.com/api/oauth.v2.access',
+    supportsDeviceCode: false, // Slack does not support Device Code Flow
+    scopes: ['chat:write', 'channels:read'],
+  },
+};
+
+/**
+ * Get a provider template by name.
+ *
+ * @param name - Provider name (e.g., 'github', 'google')
+ * @returns Provider template or undefined if not found
+ */
+export function getProviderTemplate(name: string): Partial<DeviceCodeProviderConfig> | undefined {
+  return OAUTH_PROVIDER_TEMPLATES[name.toLowerCase()];
+}
+
+/**
+ * Check if a provider supports Device Code Flow.
+ *
+ * @param name - Provider name
+ * @returns true if Device Code Flow is supported
+ */
+export function supportsDeviceCode(name: string): boolean {
+  const template = getProviderTemplate(name);
+  return template?.supportsDeviceCode === true;
+}
+
+/**
+ * Create a complete provider config from template and overrides.
+ *
+ * @param name - Provider name
+ * @param overrides - Fields to override (clientId, clientSecret, callbackUrl, etc.)
+ * @returns Complete provider configuration
+ */
+export function createProviderConfig(
+  name: string,
+  overrides: Partial<DeviceCodeProviderConfig>
+): DeviceCodeProviderConfig | undefined {
+  const template = getProviderTemplate(name);
+  if (!template) {
+    return undefined;
+  }
+
+  return {
+    ...template,
+    ...overrides,
+    name: name.toLowerCase(),
+  } as DeviceCodeProviderConfig;
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -149,3 +149,82 @@ export interface AuthConfig {
   /** Callback URL base */
   callbackUrl?: string;
 }
+
+/**
+ * Device Code Flow response from OAuth provider.
+ * RFC 8628 Section 3.2
+ */
+export interface DeviceCodeResponse {
+  /** The device verification code */
+  device_code: string;
+  /** The user verification code (displayed to user) */
+  user_code: string;
+  /** The verification URI where user enters the code */
+  verification_uri: string;
+  /** The verification URI with user code pre-filled (optional) */
+  verification_uri_complete?: string;
+  /** Lifetime of device code in seconds */
+  expires_in: number;
+  /** Minimum polling interval in seconds */
+  interval: number;
+}
+
+/**
+ * Device Token response when polling for token.
+ * RFC 8628 Section 3.5
+ */
+export interface DeviceTokenResponse {
+  /** Access token (on success) */
+  access_token?: string;
+  /** Token type (usually 'Bearer') */
+  token_type?: string;
+  /** Granted scopes */
+  scope?: string;
+  /** Refresh token (optional) */
+  refresh_token?: string;
+  /** Token expiration in seconds */
+  expires_in?: number;
+  /** Error code (on failure) */
+  error?: 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied';
+  /** Human-readable error description */
+  error_description?: string;
+}
+
+/**
+ * OAuth Provider with Device Code Flow support.
+ * Extends base OAuthProviderConfig with Device Code specific fields.
+ */
+export interface DeviceCodeProviderConfig extends OAuthProviderConfig {
+  /** Whether this provider supports Device Code Flow */
+  supportsDeviceCode: boolean;
+  /** Device code endpoint URL */
+  deviceCodeUrl?: string;
+  /** Device token endpoint URL (usually same as tokenUrl) */
+  deviceTokenUrl?: string;
+}
+
+/**
+ * Device Code Flow state for tracking pending authorizations.
+ */
+export interface DeviceCodeState {
+  /** Unique identifier for this flow */
+  id: string;
+  /** Chat ID that initiated the flow */
+  chatId: string;
+  /** Provider name */
+  provider: string;
+  /** Device code for polling */
+  deviceCode: string;
+  /** User code displayed to user */
+  userCode: string;
+  /** Verification URI */
+  verificationUri: string;
+  /** Polling interval in seconds */
+  interval: number;
+  /** Expiration timestamp */
+  expiresAt: number;
+  /** When this state was created */
+  createdAt: number;
+  /** Provider configuration */
+  providerConfig: DeviceCodeProviderConfig;
+}


### PR DESCRIPTION
## Summary

Implements OAuth 2.0 Device Authorization Grant (RFC 8628) for scenarios where a local callback server is not available:
- Server deployments without public IP
- Chat/IM scenarios
- Containerized deployments

Closes #1215

## Changes

| File | Change |
|------|--------|
| `src/auth/types.ts` | Add DeviceCodeResponse, DeviceCodeState, DeviceCodeProviderConfig types |
| `src/auth/device-code-flow.ts` | **New file** - Device Code Flow core implementation |
| `src/auth/provider-templates.ts` | **New file** - Pre-configured OAuth provider templates |
| `src/auth/auth-mcp.ts` | Add new MCP tools and Feishu card helper |
| `src/auth/device-code-flow.test.ts` | **New file** - Unit tests |
| `src/auth/index.ts` | Export new modules |

## New Features

### 1. Device Code Flow Core (`device-code-flow.ts`)

- `initiateDeviceCode()`: Request device code from OAuth provider
- `pollForToken()`: Poll for authorization completion with proper error handling
- `DeviceCodeFlowManager`: Manage complete flow lifecycle

### 2. OAuth Provider Templates (`provider-templates.ts`)

Pre-configured templates for common OAuth providers:

| Provider | Device Code Support |
|----------|---------------------|
| GitHub | ✅ |
| Google | ✅ |
| GitLab | ✅ |
| Microsoft | ✅ |
| Notion | ❌ (not supported) |
| Slack | ❌ (not supported) |

### 3. New MCP Tools

- `auth_start_device_flow`: Start Device Code Flow, returns user_code and verification URL
- `auth_complete_device_flow`: Complete flow by polling for token

### 4. Feishu Card Helper

`createDeviceCodeCard()`: Generate Feishu card for Device Code authorization UI

## Usage

```typescript
// Start Device Code Flow
const state = await manager.startFlow(providerConfig, chatId);

// Send card to user
const card = createDeviceCodeCard(
  state.userCode,
  state.verificationUri,
  state.provider,
  expiresInMinutes
);

// Poll for completion
const result = await manager.completeFlow(state.id);
```

## Test Results

| Check | Status |
|-------|--------|
| TypeScript | ✅ 0 errors |
| Unit Tests | ✅ 12 passed |
| All Tests | ✅ 1885 passed (3 unrelated failures) |

## Verification Checklist

- [x] Support GitHub Device Code Flow
- [x] Support Google Device Code Flow
- [x] Token encrypted storage (reuses existing token-store)
- [x] Timeout handling (default 15 minutes)
- [x] User cancellation handling
- [x] `slow_down` error handling
- [x] `expired_token` error handling
- [x] `access_denied` error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)