### PR TITLE
fix(feishu): fix MentionDetector bot info fetch and log level configuration

### DIFF
--- a/src/channels/feishu/mention-detector.ts
+++ b/src/channels/feishu/mention-detector.ts
@@ -54,7 +54,9 @@ export class MentionDetector {
         url: '/open-apis/bot/v3/info',
       });
 
-      const bot = response.data?.bot;
+      // Lark SDK returns response directly with bot/code/msg at top level
+      const responseRecord = response as unknown as Record<string, unknown>;
+      const bot = responseRecord.bot as { open_id?: string; app_id?: string } | undefined;
       if (bot?.open_id) {
         this.botInfo = {
           open_id: bot.open_id,
@@ -65,10 +67,21 @@ export class MentionDetector {
           'Bot info fetched for mention detection'
         );
       } else {
-        logger.warn('Failed to fetch bot info, mention detection may be less accurate');
+        logger.warn(
+          {
+            responseCode: responseRecord.code,
+            responseMsg: responseRecord.msg,
+            hasBot: !!bot,
+            botKeys: bot ? Object.keys(bot) : [],
+          },
+          'Failed to fetch bot info: no bot.open_id in response, mention detection may be less accurate'
+        );
       }
     } catch (error) {
-      logger.warn({ err: error }, 'Failed to fetch bot info, mention detection may be less accurate');
+      logger.warn(
+        { err: error, errorMessage: error instanceof Error ? error.message : String(error) },
+        'Failed to fetch bot info, mention detection may be less accurate'
+      );
     }
   }
 

--- a/src/cli-entry.ts
+++ b/src/cli-entry.ts
@@ -37,6 +37,7 @@ type ConfigType = typeof import('./config/index.js').Config;
 type InitLoggerFn = typeof import('./utils/logger.js').initLogger;
 type FlushLoggerFn = typeof import('./utils/logger.js').flushLogger;
 type GetRootLoggerFn = typeof import('./utils/logger.js').getRootLogger;
+type SetLogLevelFn = typeof import('./utils/logger.js').setLogLevel;
 type HandleErrorFn = typeof import('./utils/error-handler.js').handleError;
 type ErrorCategoryType = typeof import('./utils/error-handler.js').ErrorCategory;
 type SetupSkillsFn = typeof import('./utils/skills-setup.js').setupSkillsInWorkspace;
@@ -47,6 +48,7 @@ let Config: ConfigType;
 let initLogger: InitLoggerFn;
 let flushLogger: FlushLoggerFn;
 let getRootLogger: GetRootLoggerFn;
+let setLogLevel: SetLogLevelFn;
 let handleError: HandleErrorFn;
 let ErrorCategory: ErrorCategoryType;
 let setupSkillsInWorkspace: SetupSkillsFn;
@@ -61,7 +63,7 @@ async function loadDependencies(): Promise<void> {
   ({ Config } = configModule);
 
   const loggerModule = await import('./utils/logger.js');
-  ({ initLogger, flushLogger, getRootLogger } = loggerModule);
+  ({ initLogger, flushLogger, getRootLogger, setLogLevel } = loggerModule);
 
   const errorHandlerModule = await import('./utils/error-handler.js');
   ({ handleError, ErrorCategory } = errorHandlerModule);
@@ -148,13 +150,19 @@ async function main(): Promise<void> {
   // Load all dependencies after config is set
   await loadDependencies();
 
+  // Get logging config from file and apply log level
+  const loggingConfig = Config.getLoggingConfig();
+  // Set log level first (rootLogger may already be initialized by module imports)
+  setLogLevel(loggingConfig.level as import('./utils/logger.js').LogLevel);
   const logger = await initLogger({
+    level: loggingConfig.level as import('./utils/logger.js').LogLevel,
     metadata: {
       version: packageJson.version,
       nodeVersion: process.version,
       platform: process.platform
     }
   });
+  logger.debug({ loggingConfig }, 'Logging configuration applied');
 
   const globalArgs = parseGlobalArgs();
   const { mode } = globalArgs;


### PR DESCRIPTION
## Summary

- Fix MentionDetector to correctly parse Lark SDK response for bot info API
- Fix log level configuration not being applied from config file

## Problem

Group chat messages with `@bot` mentions were being silently ignored. Investigation revealed two bugs:

1. **MentionDetector**: The `/open-apis/bot/v3/info` API response was being parsed incorrectly. Code accessed `response.data.bot` but the actual response has `bot` at the top level, causing bot info fetch to fail.

2. **Log Level**: The `logging.level` config was not being applied because `rootLogger` was initialized at module load time before config was read.

## Changes

### `src/channels/feishu/mention-detector.ts`
- Fix response parsing: access `response.bot` directly instead of `response.data.bot`
- Add detailed warning logs for debugging

### `src/cli-entry.ts`
- Import and call `setLogLevel()` to update log level after config is loaded
- This ensures debug/trace logs are visible when configured

## Test Plan

- [x] Deploy to production environment
- [x] Verify bot info is fetched correctly: `Bot info fetched for mention detection` with `botOpenId`
- [x] Send `@bot hello world` in group chat and verify bot responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)