### PR TITLE
feat(feishu): add user-visible confirmation for interactive component clicks

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -1009,6 +1009,22 @@ export class MessageHandler {
       logger.error({ err: error, messageId: message_id, chatId: chat_id }, 'Failed to emit card action message');
     }
 
+    // Issue #1223: Send user-visible confirmation when clicking interactive component
+    const confirmationText = action.text ?? action.value;
+    const userConfirmation = `✅ 您选择了「${confirmationText}」`;
+
+    // Send confirmation message to user
+    try {
+      await this.callbacks.sendMessage({
+        chatId: chat_id,
+        type: 'text',
+        text: userConfirmation,
+      });
+      logger.debug({ messageId: message_id, chatId: chat_id, confirmation: userConfirmation }, 'User confirmation sent');
+    } catch (confirmError) {
+      logger.warn({ err: confirmError, messageId: message_id }, 'Failed to send user confirmation');
+      }
+
     try {
       // Try to handle via InteractionManager
       // Build a compatible FeishuCardActionEvent for InteractionManager


### PR DESCRIPTION
## Summary
Issue #1223: Send confirmation message when users click interactive components.

## Changes
- Add confirmation message sending after card action is processed
- Display button text or value in confirmation message  
- Handle confirmation send errors gracefully

## Technical Details
- Location: `src/channels/feishu/message-handler.ts`
- Added after card action message emission
- Uses existing `callbacks.sendMessage` method
- Confirmation text format: `✅ 您选择了「{text}」`

## User Experience
- Immediate visual feedback when clicking buttons
- Clear indication of what was selected
- Consistent with other confirmation patterns in the codebase

## Test Plan
- [ ] Manual testing with interactive cards
- [ ] Verify confirmation message appears in chat
- [ ] Verify agent still receives the action prompt

Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)