### PR TITLE
feat(feishu): add user-visible confirmation on card action (Issue #1223)

### DIFF
--- a/src/channels/feishu/message-handler.test.ts
+++ b/src/channels/feishu/message-handler.test.ts
@@ -480,4 +480,81 @@ describe('MessageHandler - Issue #1123: chat_record', () => {
       expect(mockCallbacks.emitMessage).not.toHaveBeenCalled();
     });
   });
+
+  describe('Issue #1223: User confirmation on card action', () => {
+    it('should send user confirmation when card action is triggered', async () => {
+      await handler.handleCardAction({
+        context: {
+          open_message_id: 'test-msg-id',
+          open_chat_id: 'test-chat-id',
+        },
+        operator: {
+          open_id: 'user-open-id',
+        },
+        action: {
+          value: 'action_confirm',
+          tag: 'button',
+          text: '确认操作',
+        },
+      });
+
+      // Should send user confirmation message
+      expect(mockCallbacks.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: 'test-chat-id',
+          type: 'text',
+          text: expect.stringContaining('确认操作'),
+        })
+      );
+    });
+
+    it('should use action value when action text is not available', async () => {
+      await handler.handleCardAction({
+        context: {
+          open_message_id: 'test-msg-id',
+          open_chat_id: 'test-chat-id',
+        },
+        operator: {
+          open_id: 'user-open-id',
+        },
+        action: {
+          value: 'analyze_issue',
+          tag: 'button',
+        },
+      });
+
+      // Should use action value in confirmation
+      expect(mockCallbacks.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatId: 'test-chat-id',
+          type: 'text',
+          text: expect.stringContaining('analyze_issue'),
+        })
+      );
+    });
+
+    it('should continue processing even if confirmation fails', async () => {
+      // Make sendMessage fail once
+      const mockSend = vi.fn().mockRejectedValueOnce(new Error('Send failed')).mockResolvedValue(undefined);
+      mockCallbacks.sendMessage = mockSend;
+
+      await handler.handleCardAction({
+        context: {
+          open_message_id: 'test-msg-id',
+          open_chat_id: 'test-chat-id',
+        },
+        operator: {
+          open_id: 'user-open-id',
+        },
+        action: {
+          value: 'test_action',
+          tag: 'button',
+          text: '测试',
+        },
+      });
+
+      // Should still emit message to agent even if confirmation failed
+      expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -926,6 +926,24 @@ export class MessageHandler {
       'Card action received'
     );
 
+    // Issue #1223: Send user-visible confirmation message
+    const buttonText = action.text || action.value;
+    if (buttonText) {
+      const confirmationText = `✅ 您选择了「${buttonText}」`;
+      try {
+        await this.callbacks.sendMessage({
+          chatId: chat_id,
+          type: 'text',
+          text: confirmationText,
+          threadId: message_id,
+        });
+        logger.debug({ messageId: message_id, chatId: chat_id, buttonText }, 'User confirmation sent');
+      } catch (error) {
+        // Non-fatal: continue even if confirmation fails
+        logger.warn({ err: error, messageId: message_id, chatId: chat_id }, 'Failed to send user confirmation');
+      }
+    }
+
     // Issue #935: Try to route card action to Worker Node first
     // If the card was sent by a Worker Node, forward the action to that node
     if (this.callbacks.routeCardAction) {


### PR DESCRIPTION
## Summary
- Fixes #1223: Send user-visible confirmation when clicking interactive card components
- Add confirmation message showing the user's selection before processing
- Add tests for the new confirmation behavior

## Problem
When users click interactive card components (buttons, menus, etc.), the `actionPrompts` are only sent to the Agent, with no immediate feedback on the user interface. This causes users to be uncertain whether their click was successful.

## Solution
Add a user-visible confirmation message immediately after card action is received:
- Format: `✅ 您选择了「{button}」`
- Uses `action.text` if available, otherwise `action.value`
- Non-fatal: continues processing even if confirmation fails

## Changes
| File | Change |
|------|--------|
| `src/channels/feishu/message-handler.ts` | Add confirmation message sending in `handleCardAction` method |
| `src/channels/feishu/message-handler.test.ts` | Add 3 tests for confirmation behavior |

## Test Results
- ✅ All 12 tests pass in message-handler.test.ts
- ✅ New tests cover success, fallback, and failure scenarios

## Test Plan
- [x] Unit test: confirmation sent with action text
- [x] Unit test: confirmation sent with action value when text unavailable
- [x] Unit test: continues processing when confirmation fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)