### PR TITLE
fix: 持久化聊天记录优化：只保存实际发送的消息内容 (Issue #1231)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -705,9 +705,14 @@ export class MessageHandler {
       return;
     }
 
+    // Issue #1231: Save original text for persistence (without packed history)
+    const originalText = text;
+
     // Issue #846: If packed chat history was detected, prepend it to the message
+    // This enhanced text is for Agent processing only, NOT for persistence
+    let enhancedText = text;
     if (packedChatHistory) {
-      text = `${packedChatHistory}\n\n---\n\n用户消息: ${text}`;
+      enhancedText = `${packedChatHistory}\n\n---\n\n用户消息: ${text}`;
       logger.info(
         { messageId: message_id, chatId: chat_id, hasPackedHistory: true },
         'Message with packed chat history received'
@@ -716,12 +721,12 @@ export class MessageHandler {
       logger.info({ messageId: message_id, chatId: chat_id }, 'Message received');
     }
 
-    // Log message
+    // Issue #1231: Log original message content only (without packed history)
     await messageLogger.logIncomingMessage(
       message_id,
       this.extractOpenId(sender) || 'unknown',
       chat_id,
-      text,
+      originalText,
       message_type,
       create_time
     );
@@ -733,7 +738,8 @@ export class MessageHandler {
     const commandRegistry = getCommandRegistry();
 
     // Strip leading mentions to detect commands in messages like "@bot /help"
-    const textWithoutMentions = stripLeadingMentions(text, mentions);
+    // Use originalText for command detection (commands are in user's message, not packed history)
+    const textWithoutMentions = stripLeadingMentions(originalText, mentions);
 
     // Group chat passive mode
     const isPassiveCommand = textWithoutMentions.startsWith('/passive');
@@ -743,7 +749,8 @@ export class MessageHandler {
         { messageId: message_id, chatId: chat_id, chat_type },
         'Skipped group chat message without @mention (passive mode)'
       );
-      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
+      // Issue #1231: Use originalText for filtered message forwarding
+      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, originalText, this.extractOpenId(sender), { chat_type });
       return;
     }
 
@@ -851,11 +858,12 @@ export class MessageHandler {
     }
 
     // Emit as incoming message
+    // Issue #1231: Use enhancedText for Agent processing (includes packed history if present)
     await this.callbacks.emitMessage({
       messageId: message_id,
       chatId: chat_id,
       userId: this.extractOpenId(sender),
-      content: text,
+      content: enhancedText,
       messageType: message_type,
       timestamp: create_time,
       threadId,

--- a/src/platforms/feishu/feishu-message-sender.ts
+++ b/src/platforms/feishu/feishu-message-sender.ts
@@ -139,9 +139,11 @@ export class FeishuMessageSender implements IMessageSender {
 
       const botMessageId = response?.data?.message_id;
       if (botMessageId) {
+        // Issue #1231: Only log user-visible content, not full JSON structure
+        // If description is provided, use it; otherwise extract text from card
         const cardContent = description
-          ? `[Card] ${description}\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
-          : `[Interactive Card]\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
+          ? `[Card] ${description}`
+          : this.extractCardTextContent(card);
         await messageLogger.logOutgoingMessage(botMessageId, chatId, cardContent);
       }
 
@@ -187,6 +189,76 @@ export class FeishuMessageSender implements IMessageSender {
     } catch (error) {
       this.logger.error({ err: error, filePath, chatId, threadId }, 'Failed to send file to user');
     }
+  }
+
+  /**
+   * Extract user-visible text content from a Feishu Card structure.
+   * Issue #1231: Only persist what the user actually sees, not the full JSON.
+   *
+   * @param card - Feishu card object
+   * @returns Extracted text content for logging
+   */
+  private extractCardTextContent(card: Record<string, unknown>): string {
+    const textParts: string[] = [];
+
+    // Extract header title if present
+    const header = card.header as { title?: { content?: string } } | undefined;
+    if (header?.title?.content) {
+      textParts.push(`[${header.title.content}]`);
+    }
+
+    // Recursively extract text from elements
+    const extractFromElements = (elements: unknown[]): void => {
+      for (const element of elements) {
+        if (!element || typeof element !== 'object') continue;
+
+        const el = element as Record<string, unknown>;
+
+        // Extract from markdown content
+        if (el.tag === 'markdown' && typeof el.content === 'string') {
+          // Only take first line or first 100 chars for brevity
+          const content = el.content.split('\n')[0]?.slice(0, 100) || '';
+          if (content.trim()) {
+            textParts.push(content.trim());
+          }
+        }
+
+        // Extract from plain text
+        if (el.tag === 'div' && typeof el.text === 'string') {
+          textParts.push(el.text.trim());
+        }
+
+        // Extract from button text
+        if (el.tag === 'button' && el.text) {
+          const text = (el.text as { content?: string })?.content;
+          if (text) {
+            textParts.push(`[${text}]`);
+          }
+        }
+
+        // Recursively process nested elements
+        if (Array.isArray(el.elements)) {
+          extractFromElements(el.elements);
+        }
+
+        // Process actions array
+        if (Array.isArray(el.actions)) {
+          extractFromElements(el.actions);
+        }
+      }
+    };
+
+    // Start extraction from card elements
+    const elements = card.elements as unknown[] | undefined;
+    if (Array.isArray(elements)) {
+      extractFromElements(elements);
+    }
+
+    // If we found text content, return it; otherwise return a generic description
+    if (textParts.length > 0) {
+      return `[Interactive Card] ${textParts.slice(0, 3).join(' | ')}`;
+    }
+    return '[Interactive Card]';
   }
 
   async addReaction(messageId: string, emoji: string): Promise<boolean> {

--- a/src/services/lark-client-service.ts
+++ b/src/services/lark-client-service.ts
@@ -204,9 +204,10 @@ export class LarkClientService {
 
       const botMessageId = response?.data?.message_id;
       if (botMessageId) {
+        // Issue #1231: Only log user-visible content, not full JSON structure
         const cardContent = options?.description
-          ? `[Card] ${options.description}\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
-          : `[Interactive Card]\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
+          ? `[Card] ${options.description}`
+          : this.extractCardTextContent(card);
         await messageLogger.logOutgoingMessage(botMessageId, chatId, cardContent);
       }
 
@@ -378,5 +379,75 @@ export class LarkClientService {
       logger.error({ err: error }, 'Failed to get bot info');
       throw error;
     }
+  }
+
+  /**
+   * Extract user-visible text content from a Feishu Card structure.
+   * Issue #1231: Only persist what the user actually sees, not the full JSON.
+   *
+   * @param card - Feishu card object
+   * @returns Extracted text content for logging
+   */
+  private extractCardTextContent(card: Record<string, unknown>): string {
+    const textParts: string[] = [];
+
+    // Extract header title if present
+    const header = card.header as { title?: { content?: string } } | undefined;
+    if (header?.title?.content) {
+      textParts.push(`[${header.title.content}]`);
+    }
+
+    // Recursively extract text from elements
+    const extractFromElements = (elements: unknown[]): void => {
+      for (const element of elements) {
+        if (!element || typeof element !== 'object') continue;
+
+        const el = element as Record<string, unknown>;
+
+        // Extract from markdown content
+        if (el.tag === 'markdown' && typeof el.content === 'string') {
+          // Only take first line or first 100 chars for brevity
+          const content = el.content.split('\n')[0]?.slice(0, 100) || '';
+          if (content.trim()) {
+            textParts.push(content.trim());
+          }
+        }
+
+        // Extract from plain text
+        if (el.tag === 'div' && typeof el.text === 'string') {
+          textParts.push(el.text.trim());
+        }
+
+        // Extract from button text
+        if (el.tag === 'button' && el.text) {
+          const text = (el.text as { content?: string })?.content;
+          if (text) {
+            textParts.push(`[${text}]`);
+          }
+        }
+
+        // Recursively process nested elements
+        if (Array.isArray(el.elements)) {
+          extractFromElements(el.elements);
+        }
+
+        // Process actions array
+        if (Array.isArray(el.actions)) {
+          extractFromElements(el.actions);
+        }
+      }
+    };
+
+    // Start extraction from card elements
+    const elements = card.elements as unknown[] | undefined;
+    if (Array.isArray(elements)) {
+      extractFromElements(elements);
+    }
+
+    // If we found text content, return it; otherwise return a generic description
+    if (textParts.length > 0) {
+      return `[Interactive Card] ${textParts.slice(0, 3).join(' | ')}`;
+    }
+    return '[Interactive Card]';
   }
 }


### PR DESCRIPTION
## Summary

- Fixes #1231: 优化持久化聊天记录，只保存实际发送/接收的消息内容
- 分离原始文本和增强文本（包含打包历史）用于正确的持久化
- Card 消息现在保存用户可见的内容，而不是完整的 JSON 结构

## Problem

当前持久化实现保存了一些不应该保存的内容：
1. 打包的聊天历史（来自转发消息）被保存到日志中
2. Card 消息保存了完整的 JSON 结构，而不是用户可见的内容

## Solution

### 1. message-handler.ts
- 保存原始用户文本用于持久化
- 增强文本（包含打包历史）仅用于 Agent 处理
- 命令检测使用原始文本

### 2. feishu-message-sender.ts 和 lark-client-service.ts
- 添加了 `extractCardTextContent()` 方法来提取用户可见的文本
- Card 消息现在保存：`[Card] description` 或提取的文本内容
- 不再保存完整的 JSON 结构

## Changes

| File | Change |
|------|--------|
| `src/channels/feishu/message-handler.ts` | 分离 originalText 和 enhancedText |
| `src/platforms/feishu/feishu-message-sender.ts` | 添加卡片文本提取 |
| `src/services/lark-client-service.ts` | 添加卡片文本提取 |

## Test Results

✅ All message-handler tests passed (9 tests)
✅ All feishu-message-sender tests passed (14 tests)
✅ All lark-client-service tests passed (23 tests)
✅ Build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)