### PR TITLE
fix: optimize context attachment logic for agent sessions (Issue #1230)

### DIFF
--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -189,6 +189,14 @@ export interface ChatAgent extends Disposable {
   ): Promise<void>;
 
   /**
+   * Check if the agent has an active session.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   *
+   * @returns true if the agent has an active session
+   */
+  hasActiveSession(): boolean;
+
+  /**
    * Reset the agent session.
    * Clears conversation history and state.
    *

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -78,6 +78,11 @@ export interface FeishuChannelConfig extends ChannelConfig {
       trigger?: string;
     };
   }) => Promise<boolean>;
+  /**
+   * Check if the agent has an active session for the given chatId.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   */
+  hasActiveSession?: (chatId: string) => boolean;
 }
 
 /**
@@ -132,6 +137,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       },
       // Issue #935: Route card action to Worker Node if applicable
       routeCardAction: config.routeCardAction,
+      // Issue #1230: Check if agent session is active for context attachment
+      hasActiveSession: config.hasActiveSession,
     };
 
     this.feishuMessageHandler = new FeishuMessageHandler({

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -70,6 +70,11 @@ export interface MessageCallbacks {
       trigger?: string;
     };
   }) => Promise<boolean>;
+  /**
+   * Check if the agent has an active session for the given chatId.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   */
+  hasActiveSession?: (chatId: string) => boolean;
 }
 
 /**
@@ -829,15 +834,18 @@ export class MessageHandler {
       }
     }
 
-    // Get chat history context for passive mode
+    // Issue #1230: Get chat history context only in two scenarios:
+    // 1. Passive mode: group chat where bot is mentioned
+    // 2. New session: when the agent session is not yet active
     const isPassiveModeTrigger = this.isGroupChat(chat_type) && botMentioned;
+    const isNewSession = this.callbacks.hasActiveSession ? !this.callbacks.hasActiveSession(chat_id) : false;
     let chatHistoryContext: string | undefined;
 
-    if (isPassiveModeTrigger) {
+    if (isPassiveModeTrigger || isNewSession) {
       chatHistoryContext = await this.getChatHistoryContext(chat_id);
       logger.debug(
-        { messageId: message_id, chatId: chat_id, historyLength: chatHistoryContext?.length },
-        'Including chat history context for passive mode trigger'
+        { messageId: message_id, chatId: chat_id, historyLength: chatHistoryContext?.length, isPassiveModeTrigger, isNewSession },
+        'Including chat history context'
       );
     }
 

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -233,6 +233,14 @@ export class PrimaryNode extends EventEmitter {
             action: message.action,
           });
         },
+        // Issue #1230: Check if agent session is active for context attachment
+        hasActiveSession: (chatId: string) => {
+          if (!this.agentPool) {
+            return false;
+          }
+          const agent = this.agentPool.get(chatId);
+          return agent?.hasActiveSession() ?? false;
+        },
       });
 
       // Initialize TaskFlowOrchestrator for Feishu channel


### PR DESCRIPTION
## Summary

- 只在两种情况下附加 chat history context：
  1. 被动模式：群聊中 bot 被 @ 时
  2. 新 session：agent session 尚未活跃时
- 避免在已经活跃的 1:1 对话中重复附加 context

## Changes

- 在 `ChatAgent` 接口中添加 `hasActiveSession()` 方法
- 在 `MessageCallbacks` 中添加 `hasActiveSession` 回调
- 修改 `MessageHandler` 逻辑：检查 session 状态后决定是否附加 context
- 在 `FeishuChannelConfig` 中添加 `hasActiveSession` 回调
- 在 `PrimaryNode` 中实现 `hasActiveSession` 回调（使用 `AgentPool`）

## Test Plan

- [x] 构建：`npm run build` ✅
- [x] 单元测试：`npx vitest run src/channels/feishu/message-handler.test.ts` ✅
- [x] 单元测试：`npx vitest run src/agents/pilot.test.ts` ✅
- [x] 单元测试：`npx vitest run src/nodes/primary-node.test.ts` ✅

Fixes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)