### PR TITLE
fix(feishu): add typing reaction uniformly for all valid messages

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -563,6 +563,10 @@ export class MessageHandler {
       }
     }
 
+    // Issue #1232: Add typing reaction uniformly for all valid messages
+    // This ensures control commands, regular messages, and file messages all receive feedback
+    await this.addTypingReaction(message_id);
+
     // Handle file/image messages
     if (message_type === 'image' || message_type === 'file' || message_type === 'media') {
       logger.info(
@@ -639,9 +643,6 @@ export class MessageHandler {
         message_type,
         create_time
       );
-
-      // Add typing reaction
-      await this.addTypingReaction(message_id);
 
       // Emit as incoming message
       await this.callbacks.emitMessage({
@@ -813,9 +814,6 @@ export class MessageHandler {
     if (botMentioned && textWithoutMentions.startsWith('/')) {
       logger.debug({ messageId: message_id, chatId: chat_id, command: textWithoutMentions }, 'Bot mentioned with non-control command, passing to agent');
     }
-
-    // Add typing reaction only for messages that will be processed
-    await this.addTypingReaction(message_id);
 
     // Issue #846: Get quoted/replied message context if this is a reply
     let quotedMessageContext: string | undefined;


### PR DESCRIPTION
## Summary
- 将 typing reaction 添加统一移至消息验证通过后（去重、bot 检查、消息年龄检查之后）
- 移除 chat_record 和普通消息处理中的重复 reaction 调用
- 确保所有消息类型（控制命令、文件、chat_record、普通消息）都能收到 typing 反馈

## 问题描述
当用户发送系统指令（如 `/help`、`/status`、`/reset` 等）时，系统不会给原消息添加 reaction 反馈，导致用户无法直观地知道系统正在处理请求。

## 解决方案
之前的 PR #1233 被拒绝，原因是"应该统一处理 reaction，而不是在各类不同消息下分别增加 reaction"。

本 PR 采用正确的方式：在消息处理的入口处（通过基本验证后）统一添加 typing reaction，而不是在各个分支中单独添加。

## 修改内容
- 在 `handleMessageReceive` 方法中，消息年龄检查后统一添加 `addTypingReaction`
- 移除 chat_record 消息处理中的单独 reaction 调用
- 移除普通消息处理末尾的 reaction 调用

## 测试结果
- 代码审查确认修改正确
- typing reaction 现在只在第 568 行有一处调用
- 所有消息类型都会在通过基本验证后收到 reaction

Fixes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)