### PR TITLE
fix(feishu): add typing reaction uniformly for processed messages

### DIFF
--- a/src/channels/feishu/message-handler.test.ts
+++ b/src/channels/feishu/message-handler.test.ts
@@ -96,7 +96,7 @@ vi.mock('../../feishu/filtered-message-forwarder.js', () => ({
 }));
 
 vi.mock('../../utils/mention-parser.js', () => ({
-  stripLeadingMentions: vi.fn().mockReturnValue(''),
+  stripLeadingMentions: vi.fn((text: string) => text),
 }));
 
 import { MessageHandler } from './message-handler.js';
@@ -555,6 +555,111 @@ describe('MessageHandler - Issue #1123: chat_record', () => {
 
       // Should still emit message to agent even if confirmation failed
       expect(mockCallbacks.emitMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('Issue #1232: Typing reaction for control commands', () => {
+    it('should add typing reaction for control commands', async () => {
+      // Mock command registry to recognize 'status' as a control command
+      const { getCommandRegistry } = await import('../../nodes/commands/command-registry.js');
+      vi.mocked(getCommandRegistry).mockReturnValue({
+        has: vi.fn().mockReturnValue(true),
+      } as unknown as ReturnType<typeof getCommandRegistry>);
+
+      // Set up handler with control handler enabled
+      handler = new MessageHandler({
+        appId: 'test-app-id',
+        appSecret: 'test-app-secret',
+        passiveModeManager: mockPassiveModeManager as unknown as import('./passive-mode.js').PassiveModeManager,
+        mentionDetector: mockMentionDetector as unknown as import('./mention-detector.js').MentionDetector,
+        interactionManager: mockInteractionManager as unknown as import('../../platforms/feishu/interaction-manager.js').InteractionManager,
+        callbacks: {
+          ...mockCallbacks,
+          emitControl: vi.fn().mockResolvedValue({ success: true, message: 'Status OK' }),
+        },
+        isRunning: () => true,
+        hasControlHandler: () => true,
+      });
+      handler.initialize();
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: '/status' }),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      // Get the mock message sender instance and verify addReaction was called
+      const { FeishuMessageSender } = await import('../../platforms/feishu/feishu-message-sender.js');
+      const MockFeishuMessageSender = vi.mocked(FeishuMessageSender);
+      const mockInstance = MockFeishuMessageSender.mock.results[MockFeishuMessageSender.mock.results.length - 1]?.value;
+
+      expect(mockInstance?.addReaction).toHaveBeenCalledWith('test-msg-id', 'Typing');
+    });
+
+    it('should add typing reaction for regular messages', async () => {
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id-regular',
+            chat_id: 'test-chat-id',
+            chat_type: 'p2p',
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello bot' }),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      // Get the mock message sender instance and verify addReaction was called
+      const { FeishuMessageSender } = await import('../../platforms/feishu/feishu-message-sender.js');
+      const MockFeishuMessageSender = vi.mocked(FeishuMessageSender);
+      const mockInstance = MockFeishuMessageSender.mock.results[MockFeishuMessageSender.mock.results.length - 1]?.value;
+
+      expect(mockInstance?.addReaction).toHaveBeenCalledWith('test-msg-id-regular', 'Typing');
+    });
+
+    it('should NOT add typing reaction for passive mode filtered messages', async () => {
+      // Mock mention detector to return false (bot not mentioned)
+      mockMentionDetector.isBotMentioned = vi.fn().mockReturnValue(false);
+
+      await handler.handleMessageReceive({
+        event: {
+          message: {
+            message_id: 'test-msg-id-passive',
+            chat_id: 'test-chat-id',
+            chat_type: 'group', // Group chat
+            message_type: 'text',
+            content: JSON.stringify({ text: 'Hello everyone' }),
+            create_time: Date.now(),
+          },
+          sender: {
+            sender_type: 'user',
+            sender_id: { open_id: 'sender_open_id' },
+          },
+        },
+      });
+
+      // Get the mock message sender instance and verify addReaction was NOT called
+      const { FeishuMessageSender } = await import('../../platforms/feishu/feishu-message-sender.js');
+      const MockFeishuMessageSender = vi.mocked(FeishuMessageSender);
+      const mockInstance = MockFeishuMessageSender.mock.results[MockFeishuMessageSender.mock.results.length - 1]?.value;
+
+      expect(mockInstance?.addReaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -747,6 +747,10 @@ export class MessageHandler {
       return;
     }
 
+    // Issue #1232: Add typing reaction uniformly for all messages that will be processed
+    // This is placed after passive mode check to avoid adding reaction for filtered messages
+    await this.addTypingReaction(message_id);
+
     if (textWithoutMentions.startsWith('/')) {
       const [command, ...args] = textWithoutMentions.slice(1).split(/\s+/);
       const cmd = command.toLowerCase();
@@ -813,9 +817,6 @@ export class MessageHandler {
     if (botMentioned && textWithoutMentions.startsWith('/')) {
       logger.debug({ messageId: message_id, chatId: chat_id, command: textWithoutMentions }, 'Bot mentioned with non-control command, passing to agent');
     }
-
-    // Add typing reaction only for messages that will be processed
-    await this.addTypingReaction(message_id);
 
     // Issue #846: Get quoted/replied message context if this is a reply
     let quotedMessageContext: string | undefined;


### PR DESCRIPTION
Fixes #1232

## Summary
- Move `addTypingReaction` to a unified position after passive mode check but before control command processing
- This ensures control commands get typing reaction feedback while passive mode filtered messages do not
- Add test cases covering the new behavior

## Problem
When users send system commands (e.g., `/help`, `/status`, `/reset`), the system does not add a "typing" reaction feedback, causing users to be unsure whether the system is processing their request.

## Previous Attempts Analysis
| PR | Approach | Rejection Reason |
|----|----------|------------------|
| #1233 | Added reaction in command handling branch | "应该统一处理 reaction，而不是在各类不同消息下分别增加 reaction" |
| #1238 | Added reaction before passive mode check | "在被动模式下，不会被自动处理的消息不应该加 reaction" |

## Solution
Based on the rejection feedback, the correct approach is:
1. Handle reaction **uniformly** in one place
2. Only add reaction for messages that **will be processed**
3. **Skip** reaction for passive mode filtered messages

The fix moves `addTypingReaction` to line 749 (after passive mode check, before command processing), ensuring:
- ✅ Passive mode filtered messages do NOT get reaction
- ✅ Control commands get reaction
- ✅ Regular messages get reaction
- ✅ Code is unified and clean

## Test Plan
- [x] Control commands get typing reaction
- [x] Regular messages get typing reaction  
- [x] Passive mode filtered messages do NOT get typing reaction
- [x] All existing tests pass (15 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)