### PR TITLE
fix: 持久化聊天记录优化：只保存实际发送的消息内容 (Issue #1231)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -705,9 +705,14 @@ export class MessageHandler {
       return;
     }
 
+    // Issue #1231: Save original text for persistence (without packed history)
+    const originalText = text;
+
     // Issue #846: If packed chat history was detected, prepend it to the message
+    // This enhanced text is for Agent processing only, NOT for persistence
+    let enhancedText = text;
     if (packedChatHistory) {
-      text = `${packedChatHistory}\n\n---\n\n用户消息: ${text}`;
+      enhancedText = `${packedChatHistory}\n\n---\n\n用户消息: ${text}`;
       logger.info(
         { messageId: message_id, chatId: chat_id, hasPackedHistory: true },
         'Message with packed chat history received'
@@ -716,12 +721,12 @@ export class MessageHandler {
       logger.info({ messageId: message_id, chatId: chat_id }, 'Message received');
     }
 
-    // Log message
+    // Issue #1231: Log original message content only (without packed history)
     await messageLogger.logIncomingMessage(
       message_id,
       this.extractOpenId(sender) || 'unknown',
       chat_id,
-      text,
+      originalText,
       message_type,
       create_time
     );
@@ -733,7 +738,8 @@ export class MessageHandler {
     const commandRegistry = getCommandRegistry();
 
     // Strip leading mentions to detect commands in messages like "@bot /help"
-    const textWithoutMentions = stripLeadingMentions(text, mentions);
+    // Issue #1231: Use originalText for command detection (commands are in user's message, not packed history)
+    const textWithoutMentions = stripLeadingMentions(originalText, mentions);
 
     // Group chat passive mode
     const isPassiveCommand = textWithoutMentions.startsWith('/passive');
@@ -743,7 +749,8 @@ export class MessageHandler {
         { messageId: message_id, chatId: chat_id, chat_type },
         'Skipped group chat message without @mention (passive mode)'
       );
-      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, text, this.extractOpenId(sender), { chat_type });
+      // Issue #1231: Use originalText for filtered message forwarding
+      await this.forwardFilteredMessage('passive_mode', message_id, chat_id, originalText, this.extractOpenId(sender), { chat_type });
       return;
     }
 
@@ -852,11 +859,12 @@ export class MessageHandler {
     }
 
     // Emit as incoming message
+    // Issue #1231: Use enhancedText for Agent processing (includes packed history if present)
     await this.callbacks.emitMessage({
       messageId: message_id,
       chatId: chat_id,
       userId: this.extractOpenId(sender),
-      content: text,
+      content: enhancedText,
       messageType: message_type,
       timestamp: create_time,
       threadId,

--- a/src/platforms/feishu/card-builders/card-text-extractor.test.ts
+++ b/src/platforms/feishu/card-builders/card-text-extractor.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { extractCardTextContent } from './card-text-extractor.js';
+
+describe('extractCardTextContent', () => {
+  it('should extract header title', () => {
+    const card = {
+      header: {
+        title: { content: '任务执行中' }
+      },
+      elements: []
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('[任务执行中]');
+  });
+
+  it('should extract markdown content', () => {
+    const card = {
+      elements: [
+        { tag: 'markdown', content: '正在处理您的请求...' }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('正在处理您的请求...');
+    expect(result).toContain('[Interactive Card]');
+  });
+
+  it('should extract div text', () => {
+    const card = {
+      elements: [
+        { tag: 'div', text: '这是一条文本消息' }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('这是一条文本消息');
+  });
+
+  it('should extract button text', () => {
+    const card = {
+      elements: [
+        {
+          tag: 'action',
+          actions: [
+            { tag: 'button', text: { content: '确认' } }
+          ]
+        }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('[确认]');
+  });
+
+  it('should extract note content', () => {
+    const card = {
+      elements: [
+        { tag: 'note', content: '这是一条备注信息' }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('这是一条备注信息');
+  });
+
+  it('should handle nested elements', () => {
+    const card = {
+      elements: [
+        {
+          tag: 'column_set',
+          columns: [
+            {
+              elements: [
+                { tag: 'markdown', content: '列1内容' }
+              ]
+            },
+            {
+              elements: [
+                { tag: 'markdown', content: '列2内容' }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('列1内容');
+    expect(result).toContain('列2内容');
+  });
+
+  it('should limit output to first 3 text parts', () => {
+    const card = {
+      elements: [
+        { tag: 'markdown', content: '第一行' },
+        { tag: 'markdown', content: '第二行' },
+        { tag: 'markdown', content: '第三行' },
+        { tag: 'markdown', content: '第四行（不应出现）' }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('第一行');
+    expect(result).toContain('第二行');
+    expect(result).toContain('第三行');
+    expect(result).not.toContain('第四行');
+  });
+
+  it('should truncate long markdown content to first line and 100 chars', () => {
+    const longContent = '这是一个很长很长的内容，'.repeat(20);
+    const card = {
+      elements: [
+        { tag: 'markdown', content: longContent }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result.length).toBeLessThan(200); // Reasonable limit
+  });
+
+  it('should return generic description for empty card', () => {
+    const card = {
+      elements: []
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toBe('[Interactive Card]');
+  });
+
+  it('should return generic description for card with no recognizable content', () => {
+    const card = {
+      elements: [
+        { tag: 'unknown', data: 'something' }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toBe('[Interactive Card]');
+  });
+
+  it('should handle complex real-world card', () => {
+    const card = {
+      header: {
+        title: { content: '接下来您可以...' }
+      },
+      elements: [
+        { tag: 'markdown', content: '✅ 任务已完成' },
+        {
+          tag: 'action',
+          actions: [
+            { tag: 'button', text: { content: '选项1' } },
+            { tag: 'button', text: { content: '选项2' } }
+          ]
+        }
+      ]
+    };
+    const result = extractCardTextContent(card);
+    expect(result).toContain('[接下来您可以...]');
+    expect(result).toContain('✅ 任务已完成');
+  });
+});

--- a/src/platforms/feishu/card-builders/card-text-extractor.ts
+++ b/src/platforms/feishu/card-builders/card-text-extractor.ts
@@ -1,0 +1,97 @@
+/**
+ * Card Text Extractor.
+ *
+ * Extracts user-visible text content from a Feishu Card structure.
+ * Issue #1231: Only persist what the user actually sees, not the full JSON.
+ */
+
+/**
+ * Extract user-visible text content from a Feishu Card structure.
+ *
+ * @param card - Feishu card object
+ * @returns Extracted text content for logging
+ */
+export function extractCardTextContent(card: Record<string, unknown>): string {
+  const textParts: string[] = [];
+
+  // Extract header title if present
+  const header = card.header as { title?: { content?: string } } | undefined;
+  if (header?.title?.content) {
+    textParts.push(`[${header.title.content}]`);
+  }
+
+  // Recursively extract text from elements
+  const extractFromElements = (elements: unknown[]): void => {
+    for (const element of elements) {
+      if (!element || typeof element !== 'object') continue;
+
+      const el = element as Record<string, unknown>;
+
+      // Extract from markdown content
+      if (el.tag === 'markdown' && typeof el.content === 'string') {
+        // Only take first line or first 100 chars for brevity
+        const content = el.content.split('\n')[0]?.slice(0, 100) || '';
+        if (content.trim()) {
+          textParts.push(content.trim());
+        }
+      }
+
+      // Extract from plain text
+      if (el.tag === 'div' && typeof el.text === 'string') {
+        textParts.push(el.text.trim());
+      }
+
+      // Extract from note
+      if (el.tag === 'note' && typeof el.content === 'string') {
+        const content = el.content.split('\n')[0]?.slice(0, 100) || '';
+        if (content.trim()) {
+          textParts.push(content.trim());
+        }
+      }
+
+      // Extract from button text
+      if (el.tag === 'button' && el.text) {
+        const text = (el.text as { content?: string })?.content;
+        if (text) {
+          textParts.push(`[${text}]`);
+        }
+      }
+
+      // Recursively process nested elements
+      if (Array.isArray(el.elements)) {
+        extractFromElements(el.elements);
+      }
+
+      // Process actions array
+      if (Array.isArray(el.actions)) {
+        extractFromElements(el.actions);
+      }
+
+      // Process columns (for column_set layout)
+      if (Array.isArray(el.columns)) {
+        for (const column of el.columns) {
+          if (column && typeof column === 'object') {
+            const col = column as Record<string, unknown>;
+            if (Array.isArray(col.elements)) {
+              extractFromElements(col.elements);
+            }
+          }
+        }
+      }
+    }
+  };
+
+  // Start extraction from card elements
+  const elements = card.elements as unknown[] | undefined;
+  if (Array.isArray(elements)) {
+    extractFromElements(elements);
+  }
+
+  // If we found text content, return it; otherwise return a generic description
+  if (textParts.length > 0) {
+    // Limit to first 3 items to keep log concise
+    const parts = textParts.slice(0, 3);
+    return `[Interactive Card] ${parts.join(' | ')}`;
+  }
+  return '[Interactive Card]';
+}

--- a/src/platforms/feishu/feishu-message-sender.ts
+++ b/src/platforms/feishu/feishu-message-sender.ts
@@ -11,6 +11,7 @@ import type { Logger } from 'pino';
 import type { IMessageSender } from '../../channels/adapters/types.js';
 import { handleError, ErrorCategory } from '../../utils/error-handler.js';
 import { buildTextContent } from './card-builders/content-builder.js';
+import { extractCardTextContent } from './card-builders/card-text-extractor.js';
 import { messageLogger } from '../../feishu/message-logger.js';
 import { retry } from '../../utils/retry.js';
 
@@ -139,9 +140,11 @@ export class FeishuMessageSender implements IMessageSender {
 
       const botMessageId = response?.data?.message_id;
       if (botMessageId) {
+        // Issue #1231: Only log user-visible content, not full JSON structure
+        // If description is provided, use it; otherwise extract text from card
         const cardContent = description
-          ? `[Card] ${description}\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
-          : `[Interactive Card]\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
+          ? `[Card] ${description}`
+          : extractCardTextContent(card);
         await messageLogger.logOutgoingMessage(botMessageId, chatId, cardContent);
       }
 

--- a/src/services/lark-client-service.ts
+++ b/src/services/lark-client-service.ts
@@ -11,6 +11,7 @@ import * as lark from '@larksuiteoapi/node-sdk';
 import { createLogger } from '../utils/logger.js';
 import { createFeishuClient, CreateFeishuClientOptions } from '../platforms/feishu/create-feishu-client.js';
 import { buildTextContent } from '../platforms/feishu/card-builders/content-builder.js';
+import { extractCardTextContent } from '../platforms/feishu/card-builders/card-text-extractor.js';
 import { messageLogger } from '../feishu/message-logger.js';
 import { retry } from '../utils/retry.js';
 import { handleError, ErrorCategory } from '../utils/error-handler.js';
@@ -204,9 +205,11 @@ export class LarkClientService {
 
       const botMessageId = response?.data?.message_id;
       if (botMessageId) {
+        // Issue #1231: Only log user-visible content, not full JSON structure
+        // If description is provided, use it; otherwise extract text from card
         const cardContent = options?.description
-          ? `[Card] ${options.description}\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
-          : `[Interactive Card]\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``;
+          ? `[Card] ${options.description}`
+          : extractCardTextContent(card);
         await messageLogger.logOutgoingMessage(botMessageId, chatId, cardContent);
       }
 


### PR DESCRIPTION
## Summary

- 在 `message-handler.ts` 中区分原始消息和增强消息
  - 日志记录只保存原始用户消息（不含 packed history）
  - Agent 处理使用增强消息（包含 packed history）
- 在 `feishu-message-sender.ts` 和 `lark-client-service.ts` 中优化卡片消息日志
  - 新增 `extractCardTextContent` 工具函数从卡片结构提取用户可见的文本内容
  - 卡片消息日志不再保存完整 JSON 结构

## 问题背景

Issue #1231 要求持久化聊天记录中只保存实际发送给用户的消息内容，而不是完整的内部处理数据。

### 之前的问题
1. **传入消息**: 当有 packed chat history 时，日志保存了包含完整历史记录的增强消息
2. **卡片消息**: 日志保存了完整的 JSON 结构，而不是用户实际看到的文本

### 修复后
1. **传入消息**: 只保存原始用户消息，增强后的消息仅用于 Agent 处理
2. **卡片消息**: 从卡片结构中提取用户可见的文本内容保存

## Changes

| File | Change |
|------|--------|
| `src/platforms/feishu/card-builders/card-text-extractor.ts` | New file: extract user-visible text from card |
| `src/platforms/feishu/card-builders/card-text-extractor.test.ts` | New test file (11 tests) |
| `src/channels/feishu/message-handler.ts` | Distinguish originalText vs enhancedText |
| `src/platforms/feishu/feishu-message-sender.ts` | Use extractCardTextContent |
| `src/services/lark-client-service.ts` | Use extractCardTextContent |

## Test Plan

- [x] 单元测试：`npx vitest run src/platforms/feishu/card-builders/card-text-extractor.test.ts` ✅ (11 tests passed)
- [x] 单元测试：`npx vitest run src/feishu/message-logger.test.ts` ✅ (23 tests passed)

Fixes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)