### PR TITLE
feat(mcp): implement discussion focus maintenance (Issue #1228)

### DIFF
--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -47,6 +47,7 @@ import { MessageBuilder } from './message-builder.js';
 import type { PilotCallbacks, PilotConfig, MessageData } from './types.js';
 import { TaskComplexityAgent } from '../task-complexity-agent.js';
 import { taskProgressService } from '../task-progress-service.js';
+import { getGroupService } from '../../platforms/feishu/group-service.js';
 
 // Re-export types for backward compatibility
 export type { PilotCallbacks, PilotConfig, MessageData } from './types.js';
@@ -425,11 +426,19 @@ export class Pilot extends BaseAgent implements ChatAgent {
     // Get capabilities for message building
     const capabilities = this.callbacks.getCapabilities?.(chatId);
 
+    // Get discussion topic for focus maintenance (Issue #1228)
+    const groupInfo = getGroupService().getGroup(chatId);
+    const discussionTopic = groupInfo?.discussionTopic;
+    const discussionContext = groupInfo?.discussionContext;
+
     // Build the user message using MessageBuilder (Issue #697)
     // Issue #955: Include persisted history context for session restoration
+    // Issue #1228: Include discussion topic for focus maintenance
     const enhancedContent = this.messageBuilder.buildEnhancedContent({
       text, messageId, senderOpenId, attachments, chatHistoryContext,
       persistedHistoryContext: this.persistedHistoryContext,
+      discussionTopic,
+      discussionContext,
     }, chatId, capabilities);
 
     const userMessage: StreamingUserMessage = {

--- a/src/agents/pilot/message-builder.test.ts
+++ b/src/agents/pilot/message-builder.test.ts
@@ -4,6 +4,7 @@
  * Issue #809: Tests for image analyzer MCP hint in buildAttachmentsInfo.
  * Issue #955: Tests for persisted history context in session restoration.
  * Issue #962: Tests for output format guidance to prevent raw JSON in responses.
+ * Issue #1228: Tests for discussion focus maintenance.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -215,6 +216,75 @@ describe('MessageBuilder', () => {
 
       expect(result).toContain('Convert JSON objects to readable text');
       expect(result).toContain('Markdown tables instead of raw JSON');
+    });
+  });
+
+  describe('buildEnhancedContent with discussionTopic (Issue #1228)', () => {
+    it('should include discussion focus section when discussionTopic is provided', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'What do you think about this?',
+        messageId: 'msg-123',
+        discussionTopic: 'Should we migrate to TypeScript?',
+      }, 'chat-123');
+
+      expect(result).toContain('Discussion Focus');
+      expect(result).toContain('Should we migrate to TypeScript?');
+      expect(result).toContain('Stay on Topic');
+      expect(result).toContain('Detect Drifting');
+    });
+
+    it('should include discussion context when provided', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'What do you think?',
+        messageId: 'msg-123',
+        discussionTopic: 'API Design',
+        discussionContext: 'We are designing a new REST API for our microservices architecture.',
+      }, 'chat-123');
+
+      expect(result).toContain('Discussion Focus');
+      expect(result).toContain('API Design');
+      expect(result).toContain('We are designing a new REST API');
+    });
+
+    it('should not include discussion focus section when no discussionTopic', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+      }, 'chat-123');
+
+      expect(result).not.toContain('Discussion Focus');
+    });
+
+    it('should not include discussion focus section for skill commands', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: '/reset',
+        messageId: 'msg-123',
+        discussionTopic: 'Some topic',
+      }, 'chat-123');
+
+      expect(result).not.toContain('Discussion Focus');
+    });
+
+    it('should include drift guidance with original topic', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'Hello',
+        messageId: 'msg-123',
+        discussionTopic: 'Database Migration',
+      }, 'chat-123');
+
+      expect(result).toContain('Let\'s get back to our main topic: Database Migration');
+    });
+
+    it('should include discussion focus with senderOpenId', () => {
+      const result = messageBuilder.buildEnhancedContent({
+        text: 'I think we should go with PostgreSQL',
+        messageId: 'msg-123',
+        senderOpenId: 'user-456',
+        discussionTopic: 'Database Selection',
+      }, 'chat-123');
+
+      expect(result).toContain('Discussion Focus');
+      expect(result).toContain('Database Selection');
     });
   });
 });

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -74,6 +74,33 @@ ${msg.persistedHistoryContext}
 `
       : '';
 
+    // Build discussion focus section for focus maintenance (Issue #1228)
+    const discussionFocusSection = msg.discussionTopic
+      ? `
+
+---
+
+## 🎯 Discussion Focus
+
+You are in a **group discussion** with the following focus:
+
+**Topic:** ${msg.discussionTopic}
+${msg.discussionContext ? `\n**Context:** ${msg.discussionContext}` : ''}
+
+### Guidelines
+
+1. **Stay on Topic** - Keep the discussion focused on the original topic above
+2. **Detect Drifting** - If the conversation starts to drift away from the main topic, gently guide it back
+3. **Summarize Progress** - Occasionally summarize what has been discussed in relation to the original topic
+4. **Conclude Properly** - When the discussion reaches a conclusion, clearly state the outcome
+
+If you notice the discussion has drifted, you can say:
+> "Let's get back to our main topic: ${msg.discussionTopic}"
+
+---
+`
+      : '';
+
     if (isSkillCommand) {
       // For skill commands: command first, then minimal context for skill to use
       const contextInfo = msg.senderOpenId
@@ -126,7 +153,7 @@ To notify the user in your FINAL response, use:
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
 **Sender Open ID:** ${msg.senderOpenId}
-${persistedHistorySection}${chatHistorySection}${mentionSection}
+${discussionFocusSection}${persistedHistorySection}${chatHistorySection}${mentionSection}
 
 ---
 
@@ -144,7 +171,7 @@ ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
 
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
-${persistedHistorySection}${chatHistorySection}
+${discussionFocusSection}${persistedHistorySection}${chatHistorySection}
 ## Tools
 ${toolsSection}
 ${nextStepGuidance}

--- a/src/agents/pilot/types.ts
+++ b/src/agents/pilot/types.ts
@@ -93,4 +93,8 @@ export interface MessageData {
   chatHistoryContext?: string;
   /** Persisted history context for session restoration (Issue #955) */
   persistedHistoryContext?: string;
+  /** Discussion topic for focus maintenance (Issue #1228) */
+  discussionTopic?: string;
+  /** Discussion context for focus maintenance (Issue #1228) */
+  discussionContext?: string;
 }

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -287,13 +287,15 @@ This tool initiates an async discussion. The conclusions will be returned when p
         // Create the discussion group
         const chatId = await createDiscussionChat(client, { topic, members });
 
-        // Register the group for tracking
+        // Register the group for tracking with discussion topic for focus maintenance (Issue #1228)
         const groupService = getGroupService();
         groupService.registerGroup({
           chatId,
           name: topic,
           createdAt: Date.now(),
           initialMembers: members || [],
+          discussionTopic: topic,
+          discussionContext: context,
         });
 
         // Send the initial topic message

--- a/src/platforms/feishu/group-service.ts
+++ b/src/platforms/feishu/group-service.ts
@@ -37,6 +37,19 @@ export interface GroupInfo {
    * @see Issue #721 - 话题群基础设施
    */
   isTopicGroup?: boolean;
+  /**
+   * Discussion topic - the initial question/goal for this group discussion.
+   * Used by ChatAgent to maintain focus on the original discussion target.
+   *
+   * @see Issue #1228 - 讨论焦点保持
+   */
+  discussionTopic?: string;
+  /**
+   * Discussion context - background information for the discussion.
+   *
+   * @see Issue #1228 - 讨论焦点保持
+   */
+  discussionContext?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Issue #1228: 讨论焦点保持 - 让 ChatAgent 始终回归初始问题

This PR adds a mechanism to keep ChatAgent focused on the original discussion topic in group discussions started by `start_group_discussion` tool.

## Problem

When ChatAgent facilitates discussions in group chats created by `start_group_discussion`, the conversation can drift away from the original topic:

```
用户发起讨论: "是否应该自动化代码格式化？"
    ↓
ChatAgent 与用户讨论
    ↓
讨论偏离: "你们用的什么编辑器？" → "VS Code 插件推荐" → ...
    ↓
❌ 忘记了原始问题
```

## Solution

Using **方案 A: Prompt 注入** (the simplest and most effective approach):

1. **Store Discussion Topic**: When `start_group_discussion` creates a group, save `discussionTopic` and `discussionContext` to `GroupInfo`
2. **Inject Focus Prompt**: When ChatAgent processes messages in that chatId, inject a "Discussion Focus" section into the prompt with:
   - The original topic
   - Background context (if any)
   - Guidelines for staying on topic
   - Drift detection and guidance back

## Changes

| File | Change |
|------|--------|
| `group-service.ts` | Add `discussionTopic` and `discussionContext` fields to `GroupInfo` |
| `feishu-context-mcp.ts` | Save topic/context when registering discussion group |
| `types.ts` | Add `discussionTopic` and `discussionContext` to `MessageData` |
| `message-builder.ts` | Add `buildDiscussionFocusSection` for focus guidance prompt |
| `index.ts (Pilot)` | Fetch discussion topic from GroupService and pass to MessageBuilder |
| `message-builder.test.ts` | Add 6 tests for discussion focus feature |

## Test Results

```
✓ src/agents/pilot/message-builder.test.ts (20 tests) 4ms
✓ src/platforms/feishu/group-service.test.ts (29 tests) 18ms
```

## Example Prompt Injection

When a message is processed in a discussion group with topic "Should we migrate to TypeScript?", the agent receives:

```
---

## 🎯 Discussion Focus

You are in a **group discussion** with the following focus:

**Topic:** Should we migrate to TypeScript?

### Guidelines

1. **Stay on Topic** - Keep the discussion focused on the original topic above
2. **Detect Drifting** - If the conversation starts to drift away from the main topic, gently guide it back
3. **Summarize Progress** - Occasionally summarize what has been discussed in relation to the original topic
4. **Conclude Properly** - When the discussion reaches a conclusion, clearly state the outcome

If you notice the discussion has drifted, you can say:
> "Let's get back to our main topic: Should we migrate to TypeScript?"

---
```

## Acceptance Criteria

- [x] ChatAgent 能识别初始讨论目标
- [x] 讨论偏离时能提示或引导回归
- [x] 不影响正常的多轮讨论

Fixes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)