### PR TITLE
refactor(worker-node): migrate WebSocket types to @disclaude/core (Issue #1041)

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -38,6 +38,9 @@ export type {
   FeedbackMessage,
   CardActionMessage,
   CardContextMessage,
+  FeishuApiAction,
+  FeishuApiRequestMessage,
+  FeishuApiResponseMessage,
 } from './websocket-messages.js';
 
 // Primary Node types (Issue #1040)

--- a/packages/core/src/types/websocket-messages.ts
+++ b/packages/core/src/types/websocket-messages.ts
@@ -134,3 +134,49 @@ export interface CardContextMessage {
   /** Node ID that sent the card (for routing callbacks) */
   nodeId: string;
 }
+
+/**
+ * Feishu API action types supported by the WS routing.
+ * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
+ */
+export type FeishuApiAction = 'sendMessage' | 'sendCard' | 'uploadFile' | 'getBotInfo';
+
+/**
+ * Message sent from Worker Node to Primary Node for Feishu API requests.
+ * Enables Worker Node to make Feishu API calls via Primary Node's LarkClientService.
+ *
+ * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
+ */
+export interface FeishuApiRequestMessage {
+  type: 'feishu-api-request';
+  /** Unique request ID for response matching */
+  requestId: string;
+  /** Action to perform */
+  action: FeishuApiAction;
+  /** Action parameters */
+  params: {
+    chatId?: string;
+    text?: string;
+    card?: Record<string, unknown>;
+    filePath?: string;
+    threadId?: string;
+    description?: string;
+  };
+}
+
+/**
+ * Message sent from Primary Node to Worker Node for Feishu API responses.
+ *
+ * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
+ */
+export interface FeishuApiResponseMessage {
+  type: 'feishu-api-response';
+  /** Request ID matching the original request */
+  requestId: string;
+  /** Whether the request was successful */
+  success: boolean;
+  /** Response data (on success) */
+  data?: unknown;
+  /** Error message (on failure) */
+  error?: string;
+}

--- a/packages/worker-node/package.json
+++ b/packages/worker-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@disclaude/worker-node",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Worker Node process for disclaude - handles agent execution and scheduled tasks",
   "type": "module",
   "main": "./dist/index.js",
@@ -16,9 +16,11 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@disclaude/core": "*"
+    "@disclaude/core": "*",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/ws": "^8.18.1",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/worker-node/src/index.ts
+++ b/packages/worker-node/src/index.ts
@@ -10,6 +10,9 @@
  * - (Future) Scheduler
  * - (Future) File transfer client
  *
+ * Note: The actual WorkerNode implementation is currently in src/nodes/worker-node.ts
+ * and will be migrated in a subsequent phase as part of Issue #1041.
+ *
  * @see Issue #1041 - Separate Worker Node code to @disclaude/worker-node
  */
 
@@ -18,4 +21,4 @@ export type { WorkerNodeConfig } from '@disclaude/core';
 export { getWorkerNodeCapabilities } from '@disclaude/core';
 
 // Package version
-export const WORKER_NODE_VERSION = '0.0.2';
+export const WORKER_NODE_VERSION = '0.0.3';

--- a/src/nodes/worker-node.ts
+++ b/src/nodes/worker-node.ts
@@ -19,13 +19,15 @@
  *  特点：无通信能力，必须连接主节点                              │
  * └─────────────────────────────────────────────────────────────┘
  * ```
+ *
+ * @see Issue #1041 - Separate Worker Node code to @disclaude/worker-node
  */
 
 import * as path from 'path';
 import WebSocket from 'ws';
 import { Config } from '../config/index.js';
 import { AgentFactory, AgentPool } from '../agents/index.js';
-import { createLogger } from '../utils/logger.js';
+import { createLogger } from '@disclaude/core';
 import {
   ScheduleManager,
   Scheduler,

--- a/src/types/websocket-messages.ts
+++ b/src/types/websocket-messages.ts
@@ -1,182 +1,21 @@
 /**
  * WebSocket message types for Communication Node and Execution Node communication.
  *
- * These types define the message format exchanged between the two nodes:
- * - Communication Node sends: PromptMessage, CommandMessage
- * - Execution Node sends: FeedbackMessage
- */
-
-import type { FileRef } from '../file-transfer/types.js';
-
-/**
- * Message sent from Communication Node to Execution Node when a user sends a prompt.
- */
-export interface PromptMessage {
-  type: 'prompt';
-  chatId: string;
-  prompt: string;
-  messageId: string;
-  senderOpenId?: string;
-  /** Thread root message ID for thread replies */
-  threadId?: string;
-  /** File attachments (if any) */
-  attachments?: FileRef[];
-  /** Chat history context for passive mode (Issue #517) */
-  chatHistoryContext?: string;
-}
-
-/**
- * Message sent from Communication Node to Execution Node for control commands.
- */
-export interface CommandMessage {
-  type: 'command';
-  command: 'reset' | 'restart' | 'list-nodes' | 'switch-node';
-  chatId: string;
-  /** Target exec node ID for switch-node command */
-  targetNodeId?: string;
-}
-
-/**
- * Message sent from Execution Node to Communication Node for registration.
- */
-export interface RegisterMessage {
-  type: 'register';
-  /** Unique identifier for this exec node */
-  nodeId: string;
-  /** Human-readable name for this exec node */
-  name?: string;
-}
-
-/**
- * Information about a connected execution node.
- */
-export interface ExecNodeInfo {
-  /** Unique identifier */
-  nodeId: string;
-  /** Human-readable name */
-  name: string;
-  /** Connection status */
-  status: 'connected' | 'disconnected';
-  /** Number of active chats assigned */
-  activeChats: number;
-  /** Connection time */
-  connectedAt: Date;
-}
-
-/**
- * Message sent from Execution Node to Communication Node for feedback.
- */
-export interface FeedbackMessage {
-  type: 'text' | 'card' | 'file' | 'done' | 'error';
-  chatId: string;
-  text?: string;
-  card?: Record<string, unknown>;
-  error?: string;
-  /** Thread root message ID for thread replies */
-  threadId?: string;
-
-  // ===== File transfer fields =====
-
-  /** File reference */
-  fileRef?: FileRef;
-
-  /** File name (redundant field for convenience) */
-  fileName?: string;
-
-  /** File size (bytes) */
-  fileSize?: number;
-
-  /** MIME type */
-  mimeType?: string;
-}
-
-/**
- * Message sent from Communication Node to Execution Node when a card action occurs.
- * This enables Worker Node to receive card interaction callbacks from Primary Node.
+ * These types are now defined in @disclaude/core and re-exported here for backward compatibility.
  *
- * Issue #935: WebSocket bidirectional communication for card actions.
+ * @see packages/core/src/types/websocket-messages.ts
  */
-export interface CardActionMessage {
-  type: 'card_action';
-  /** Chat ID where the card was displayed */
-  chatId: string;
-  /** The card message ID in Feishu */
-  cardMessageId: string;
-  /** Action type (button, select_static, etc.) */
-  actionType: string;
-  /** Action value from the button/menu */
-  actionValue: string;
-  /** Display text of the action (optional) */
-  actionText?: string;
-  /** User who triggered the action */
-  userId?: string;
-  /** Full action data for complex interactions */
-  action?: {
-    type: string;
-    value: string;
-    text?: string;
-    trigger?: string;
-  };
-}
 
-/**
- * Message sent from Communication Node to Execution Node for card context registration.
- * After a card is sent successfully, Primary Node notifies Worker Node of the message ID.
- *
- * Issue #935: WebSocket bidirectional communication for card actions.
- */
-export interface CardContextMessage {
-  type: 'card_context';
-  /** Chat ID where the card was sent */
-  chatId: string;
-  /** The card message ID returned by Feishu */
-  cardMessageId: string;
-  /** Node ID that sent the card (for routing callbacks) */
-  nodeId: string;
-}
-
-/**
- * Feishu API action types supported by the WS routing.
- * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
- */
-export type FeishuApiAction = 'sendMessage' | 'sendCard' | 'uploadFile' | 'getBotInfo';
-
-/**
- * Message sent from Worker Node to Primary Node for Feishu API requests.
- * Enables Worker Node to make Feishu API calls via Primary Node's LarkClientService.
- *
- * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
- */
-export interface FeishuApiRequestMessage {
-  type: 'feishu-api-request';
-  /** Unique request ID for response matching */
-  requestId: string;
-  /** Action to perform */
-  action: FeishuApiAction;
-  /** Action parameters */
-  params: {
-    chatId?: string;
-    text?: string;
-    card?: Record<string, unknown>;
-    filePath?: string;
-    threadId?: string;
-    description?: string;
-  };
-}
-
-/**
- * Message sent from Primary Node to Worker Node for Feishu API responses.
- *
- * Issue #1036: WebSocket request routing (WorkerNode → PrimaryNode)
- */
-export interface FeishuApiResponseMessage {
-  type: 'feishu-api-response';
-  /** Request ID matching the original request */
-  requestId: string;
-  /** Whether the request was successful */
-  success: boolean;
-  /** Response data (on success) */
-  data?: unknown;
-  /** Error message (on failure) */
-  error?: string;
-}
+// Re-export all types from @disclaude/core
+export type {
+  PromptMessage,
+  CommandMessage,
+  RegisterMessage,
+  ExecNodeInfo,
+  FeedbackMessage,
+  CardActionMessage,
+  CardContextMessage,
+  FeishuApiAction,
+  FeishuApiRequestMessage,
+  FeishuApiResponseMessage,
+} from '@disclaude/core';


### PR DESCRIPTION
## Summary

This PR migrates WebSocket message types to `@disclaude/core` as the first phase of Issue #1041 (Separate Worker Node code to @disclaude/worker-node).

### Changes

#### @disclaude/core
- Add `FeishuApiAction`, `FeishuApiRequestMessage`, `FeishuApiResponseMessage` types
- Export new types from core package

#### @disclaude/worker-node
- Update package version to 0.0.3
- Add `ws` and `@types/ws` dependencies (preparation for future migration)
- Update package description

#### src/types/websocket-messages.ts
- Re-export all WebSocket message types from `@disclaude/core` for backward compatibility

#### src/nodes/worker-node.ts
- Update imports to use `@disclaude/core` for `createLogger`

### Verification

- ✅ All packages build successfully
- ✅ Type check passes
- ✅ WorkerNode tests pass (5/5)

### Notes

The full migration of `WorkerNode` implementation to `@disclaude/worker-node` requires additional work to:
1. Move dependent modules (agents, schedule, file-transfer, etc.) to separate packages
2. Or refactor WorkerNode to accept dependencies via dependency injection

This PR establishes the foundation by:
- Centralizing shared types in `@disclaude/core`
- Maintaining backward compatibility through re-exports
- Preparing the worker-node package structure

## Test plan

- [x] Build passes (`npm run build:packages`)
- [x] Type check passes (`npm run type-check`)
- [x] WorkerNode tests pass
- [x] Backward compatibility maintained (existing code continues to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)