### PR TITLE
feat(mcp): implement discussion conclusion mechanism (Issue #1229)

### DIFF
--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -296,6 +296,9 @@ This tool initiates an async discussion. The conclusions will be returned when p
           initialMembers: members || [],
         });
 
+        // Start the discussion tracking (Issue #1229)
+        groupService.startDiscussion(chatId, topic, context);
+
         // Send the initial topic message
         let initialMessage = `## 🎯 讨论话题\n\n**${topic}**\n\n`;
         if (context) {
@@ -312,6 +315,173 @@ This tool initiates an async discussion. The conclusions will be returned when p
         return toolSuccess(`✅ 群聊讨论已启动\n- 群聊ID: ${chatId}\n- 话题: ${topic}\n- 成员数: ${members?.length || 0}\n- 超时: ${timeout || 30} 分钟\n\n请在群聊中进行讨论。讨论完成后，系统将收集结论并解散群聊。`);
       } catch (error) {
         return toolSuccess(`⚠️ Failed to start group discussion: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  // ============================================================================
+  // Issue #1229: Discussion Status Management
+  // ============================================================================
+  {
+    name: 'check_discussion_status',
+    description: `Check the status of a discussion in a group chat.
+
+Use this tool to:
+1. Check if a discussion is still active or has concluded
+2. Get the discussion topic and context
+3. See how long the discussion has been running
+
+---
+
+## Parameters
+
+- **chatId**: The group chat ID to check
+
+---
+
+## Returns
+
+- Discussion status (active/concluded/abandoned)
+- Topic and context
+- Duration since start
+- Conclusion (if concluded)
+
+---
+
+## Use Cases
+
+1. Before sending a message to a discussion group, check if it's still active
+2. Monitor discussion progress
+3. Decide whether to prompt for conclusion
+
+---
+
+*Issue #1229: 智能会话结束*`,
+    parameters: z.object({
+      chatId: z.string().describe('The group chat ID to check'),
+    }),
+    handler: async ({ chatId }) => {
+      try {
+        const groupService = getGroupService();
+        const group = groupService.getGroup(chatId);
+
+        if (!group) {
+          return toolSuccess(`⚠️ 群组未找到: ${chatId}`);
+        }
+
+        if (!group.discussion) {
+          return toolSuccess(`ℹ️ 该群组没有进行中的讨论\n- 群组名称: ${group.name}`);
+        }
+
+        const discussion = group.discussion;
+        const duration = Math.floor((Date.now() - discussion.startedAt) / 60000); // minutes
+        const statusEmoji = {
+          active: '🟢',
+          concluded: '✅',
+          abandoned: '❌',
+        }[discussion.status];
+
+        let result = `📋 讨论状态\n\n`;
+        result += `- **状态**: ${statusEmoji} ${discussion.status}\n`;
+        result += `- **话题**: ${discussion.topic}\n`;
+        if (discussion.context) {
+          result += `- **背景**: ${discussion.context}\n`;
+        }
+        result += `- **已进行**: ${duration} 分钟\n`;
+
+        if (discussion.status === 'concluded' && discussion.conclusion) {
+          result += `- **结论**: ${discussion.conclusion}\n`;
+        }
+
+        if (discussion.followUpActions && discussion.followUpActions.length > 0) {
+          result += `- **后续动作**: ${discussion.followUpActions.join(', ')}\n`;
+        }
+
+        return toolSuccess(result);
+      } catch (error) {
+        return toolSuccess(`⚠️ Failed to check discussion status: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'conclude_discussion',
+    description: `Conclude a discussion in a group chat.
+
+Use this tool when:
+1. The discussion has reached a natural conclusion
+2. Users have confirmed they're satisfied with the outcome
+3. You want to formally close the discussion
+
+---
+
+## Parameters
+
+- **chatId**: The group chat ID
+- **conclusion**: The conclusion/summary of the discussion
+- **followUpActions**: Optional array of follow-up actions to take
+
+---
+
+## Workflow
+
+1. First, use \`ask_user\` to confirm with participants that the discussion is complete
+2. Summarize the key points and conclusions
+3. Call this tool to formally conclude the discussion
+4. Execute any follow-up actions as needed
+
+---
+
+## Example
+
+\`\`\`json
+{
+  "chatId": "oc_xxx",
+  "conclusion": "团队决定采用 TypeScript 进行新项目开发，并在一个月内完成迁移。",
+  "followUpActions": ["创建迁移计划文档", "安排技术分享会"]
+}
+\`\`\`
+
+---
+
+*Issue #1229: 智能会话结束*`,
+    parameters: z.object({
+      chatId: z.string().describe('The group chat ID'),
+      conclusion: z.string().describe('The conclusion/summary of the discussion'),
+      followUpActions: z.array(z.string()).optional().describe('Optional follow-up actions to take'),
+    }),
+    handler: async ({ chatId, conclusion, followUpActions }) => {
+      try {
+        const groupService = getGroupService();
+        const group = groupService.getGroup(chatId);
+
+        if (!group) {
+          return toolSuccess(`⚠️ 群组未找到: ${chatId}`);
+        }
+
+        if (!group.discussion) {
+          return toolSuccess(`⚠️ 该群组没有进行中的讨论`);
+        }
+
+        if (group.discussion.status !== 'active') {
+          return toolSuccess(`⚠️ 讨论已经${group.discussion.status === 'concluded' ? '结束' : '放弃'}，无法再次结束`);
+        }
+
+        const success = groupService.concludeDiscussion(chatId, conclusion, followUpActions);
+
+        if (success) {
+          let result = `✅ 讨论已结束\n\n`;
+          result += `**结论**: ${conclusion}\n`;
+          if (followUpActions && followUpActions.length > 0) {
+            result += `\n**后续动作**:\n`;
+            followUpActions.forEach((action: string, i: number) => {
+              result += `${i + 1}. ${action}\n`;
+            });
+          }
+          return toolSuccess(result);
+        } else {
+          return toolSuccess(`⚠️ 结束讨论失败`);
+        }
+      } catch (error) {
+        return toolSuccess(`⚠️ Failed to conclude discussion: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/platforms/feishu/group-service.test.ts
+++ b/src/platforms/feishu/group-service.test.ts
@@ -438,4 +438,285 @@ describe('GroupService', () => {
       expect(topicGroups.map(g => g.chatId).sort()).toEqual(['oc_topic1', 'oc_topic2']);
     });
   });
+
+  // Issue #1229: Discussion status tests
+  describe('startDiscussion', () => {
+    it('should start a discussion in a group', () => {
+      const info: GroupInfo = {
+        chatId: 'oc_discussion_test',
+        name: 'Discussion Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      };
+
+      service.registerGroup(info);
+      const result = service.startDiscussion('oc_discussion_test', 'Test Topic', 'Test Context');
+
+      expect(result).toBe(true);
+      const discussion = service.getDiscussion('oc_discussion_test');
+      expect(discussion).toBeDefined();
+      expect(discussion?.topic).toBe('Test Topic');
+      expect(discussion?.context).toBe('Test Context');
+      expect(discussion?.status).toBe('active');
+      expect(discussion?.startedAt).toBeDefined();
+    });
+
+    it('should return false for non-existent group', () => {
+      const result = service.startDiscussion('oc_nonexistent', 'Topic');
+      expect(result).toBe(false);
+    });
+
+    it('should work without context', () => {
+      service.registerGroup({
+        chatId: 'oc_no_context',
+        name: 'No Context Group',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const result = service.startDiscussion('oc_no_context', 'Topic Only');
+      expect(result).toBe(true);
+
+      const discussion = service.getDiscussion('oc_no_context');
+      expect(discussion?.context).toBeUndefined();
+    });
+  });
+
+  describe('getDiscussion', () => {
+    it('should return undefined for group without discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_no_discussion',
+        name: 'No Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      expect(service.getDiscussion('oc_no_discussion')).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent group', () => {
+      expect(service.getDiscussion('oc_nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('hasActiveDiscussion', () => {
+    it('should return true for active discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_active',
+        name: 'Active Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_active', 'Active Topic');
+
+      expect(service.hasActiveDiscussion('oc_active')).toBe(true);
+    });
+
+    it('should return false for concluded discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_concluded',
+        name: 'Concluded Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_concluded', 'Topic');
+      service.concludeDiscussion('oc_concluded', 'Done');
+
+      expect(service.hasActiveDiscussion('oc_concluded')).toBe(false);
+    });
+
+    it('should return false for group without discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_no_disc',
+        name: 'No Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      expect(service.hasActiveDiscussion('oc_no_disc')).toBe(false);
+    });
+  });
+
+  describe('concludeDiscussion', () => {
+    it('should conclude an active discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_conclude',
+        name: 'To Conclude',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_conclude', 'Topic');
+
+      const result = service.concludeDiscussion('oc_conclude', 'Final conclusion');
+
+      expect(result).toBe(true);
+      const discussion = service.getDiscussion('oc_conclude');
+      expect(discussion?.status).toBe('concluded');
+      expect(discussion?.conclusion).toBe('Final conclusion');
+      expect(discussion?.concludedAt).toBeDefined();
+    });
+
+    it('should include follow-up actions', () => {
+      service.registerGroup({
+        chatId: 'oc_followup',
+        name: 'With Follow-up',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_followup', 'Topic');
+
+      const result = service.concludeDiscussion(
+        'oc_followup',
+        'Done',
+        ['Action 1', 'Action 2']
+      );
+
+      expect(result).toBe(true);
+      const discussion = service.getDiscussion('oc_followup');
+      expect(discussion?.followUpActions).toEqual(['Action 1', 'Action 2']);
+    });
+
+    it('should return false for group without discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_no_disc',
+        name: 'No Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const result = service.concludeDiscussion('oc_no_disc', 'Conclusion');
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent group', () => {
+      const result = service.concludeDiscussion('oc_nonexistent', 'Conclusion');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('abandonDiscussion', () => {
+    it('should abandon an active discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_abandon',
+        name: 'To Abandon',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_abandon', 'Topic');
+
+      const result = service.abandonDiscussion('oc_abandon', 'No longer needed');
+
+      expect(result).toBe(true);
+      const discussion = service.getDiscussion('oc_abandon');
+      expect(discussion?.status).toBe('abandoned');
+      expect(discussion?.conclusion).toBe('已放弃: No longer needed');
+    });
+
+    it('should work without reason', () => {
+      service.registerGroup({
+        chatId: 'oc_abandon_no_reason',
+        name: 'Abandon No Reason',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_abandon_no_reason', 'Topic');
+
+      const result = service.abandonDiscussion('oc_abandon_no_reason');
+
+      expect(result).toBe(true);
+      const discussion = service.getDiscussion('oc_abandon_no_reason');
+      expect(discussion?.status).toBe('abandoned');
+      expect(discussion?.conclusion).toBeUndefined();
+    });
+
+    it('should return false for group without discussion', () => {
+      service.registerGroup({
+        chatId: 'oc_no_disc_abandon',
+        name: 'No Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const result = service.abandonDiscussion('oc_no_disc_abandon');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('listActiveDiscussions', () => {
+    it('should return only groups with active discussions', () => {
+      // Register groups with different discussion states
+      service.registerGroup({
+        chatId: 'oc_active1',
+        name: 'Active 1',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_active1', 'Topic 1');
+
+      service.registerGroup({
+        chatId: 'oc_concluded1',
+        name: 'Concluded 1',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_concluded1', 'Topic 2');
+      service.concludeDiscussion('oc_concluded1', 'Done');
+
+      service.registerGroup({
+        chatId: 'oc_active2',
+        name: 'Active 2',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_active2', 'Topic 3');
+
+      service.registerGroup({
+        chatId: 'oc_no_disc',
+        name: 'No Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+
+      const activeDiscussions = service.listActiveDiscussions();
+      expect(activeDiscussions.length).toBe(2);
+      expect(activeDiscussions.map(g => g.chatId).sort()).toEqual(['oc_active1', 'oc_active2']);
+    });
+
+    it('should return empty array when no active discussions', () => {
+      service.registerGroup({
+        chatId: 'oc_only_concluded',
+        name: 'Only Concluded',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_only_concluded', 'Topic');
+      service.concludeDiscussion('oc_only_concluded', 'Done');
+
+      expect(service.listActiveDiscussions()).toEqual([]);
+    });
+  });
+
+  describe('discussion persistence', () => {
+    it('should persist discussion status', () => {
+      service.registerGroup({
+        chatId: 'oc_persist_disc',
+        name: 'Persist Discussion',
+        createdAt: Date.now(),
+        initialMembers: [],
+      });
+      service.startDiscussion('oc_persist_disc', 'Persistent Topic', 'Context');
+      service.concludeDiscussion('oc_persist_disc', 'Final Conclusion', ['Action 1']);
+
+      // Create a new service instance to verify persistence
+      const newService = new GroupService({ filePath: testFilePath });
+      const discussion = newService.getDiscussion('oc_persist_disc');
+
+      expect(discussion).toBeDefined();
+      expect(discussion?.topic).toBe('Persistent Topic');
+      expect(discussion?.context).toBe('Context');
+      expect(discussion?.status).toBe('concluded');
+      expect(discussion?.conclusion).toBe('Final Conclusion');
+      expect(discussion?.followUpActions).toEqual(['Action 1']);
+    });
+  });
 });

--- a/src/platforms/feishu/group-service.ts
+++ b/src/platforms/feishu/group-service.ts
@@ -17,6 +17,35 @@ import { createDiscussionChat } from './chat-ops.js';
 const logger = createLogger('GroupService');
 
 /**
+ * Discussion status for a group.
+ *
+ * @see Issue #1229 - 智能会话结束
+ */
+export type DiscussionStatus = 'active' | 'concluded' | 'abandoned';
+
+/**
+ * Discussion metadata for a group.
+ *
+ * @see Issue #1229 - 智能会话结束
+ */
+export interface DiscussionInfo {
+  /** The discussion topic */
+  topic: string;
+  /** Background context for the discussion */
+  context?: string;
+  /** Current status of the discussion */
+  status: DiscussionStatus;
+  /** When the discussion was started */
+  startedAt: number;
+  /** When the discussion was concluded (if applicable) */
+  concludedAt?: number;
+  /** Conclusion/summary of the discussion (if applicable) */
+  conclusion?: string;
+  /** Actions to take after discussion concludes */
+  followUpActions?: string[];
+}
+
+/**
  * Group metadata.
  */
 export interface GroupInfo {
@@ -37,6 +66,12 @@ export interface GroupInfo {
    * @see Issue #721 - 话题群基础设施
    */
   isTopicGroup?: boolean;
+  /**
+   * Discussion metadata for discussion groups.
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  discussion?: DiscussionInfo;
 }
 
 /**
@@ -228,6 +263,131 @@ export class GroupService {
    */
   listTopicGroups(): GroupInfo[] {
     return Object.values(this.registry.groups).filter(g => g.isTopicGroup === true);
+  }
+
+  // ============================================================================
+  // Discussion Status Management (Issue #1229)
+  // ============================================================================
+
+  /**
+   * Start a discussion in a group.
+   *
+   * @param chatId - Group chat ID
+   * @param topic - Discussion topic
+   * @param context - Optional background context
+   * @returns Whether the operation succeeded
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  startDiscussion(chatId: string, topic: string, context?: string): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group) {
+      logger.warn({ chatId }, 'Cannot start discussion: group not found');
+      return false;
+    }
+
+    group.discussion = {
+      topic,
+      context,
+      status: 'active',
+      startedAt: Date.now(),
+    };
+    this.save();
+
+    logger.info({ chatId, topic }, 'Discussion started');
+    return true;
+  }
+
+  /**
+   * Get discussion info for a group.
+   *
+   * @param chatId - Group chat ID
+   * @returns Discussion info or undefined
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  getDiscussion(chatId: string): DiscussionInfo | undefined {
+    return this.registry.groups[chatId]?.discussion;
+  }
+
+  /**
+   * Check if a group has an active discussion.
+   *
+   * @param chatId - Group chat ID
+   * @returns Whether the group has an active discussion
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  hasActiveDiscussion(chatId: string): boolean {
+    const discussion = this.getDiscussion(chatId);
+    return discussion?.status === 'active';
+  }
+
+  /**
+   * Conclude a discussion.
+   *
+   * @param chatId - Group chat ID
+   * @param conclusion - The conclusion/summary of the discussion
+   * @param followUpActions - Optional follow-up actions to take
+   * @returns Whether the operation succeeded
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  concludeDiscussion(chatId: string, conclusion: string, followUpActions?: string[]): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group || !group.discussion) {
+      logger.warn({ chatId }, 'Cannot conclude discussion: no active discussion found');
+      return false;
+    }
+
+    group.discussion.status = 'concluded';
+    group.discussion.concludedAt = Date.now();
+    group.discussion.conclusion = conclusion;
+    if (followUpActions && followUpActions.length > 0) {
+      group.discussion.followUpActions = followUpActions;
+    }
+    this.save();
+
+    logger.info({ chatId, conclusion }, 'Discussion concluded');
+    return true;
+  }
+
+  /**
+   * Abandon a discussion.
+   *
+   * @param chatId - Group chat ID
+   * @param reason - Optional reason for abandoning
+   * @returns Whether the operation succeeded
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  abandonDiscussion(chatId: string, reason?: string): boolean {
+    const group = this.registry.groups[chatId];
+    if (!group || !group.discussion) {
+      logger.warn({ chatId }, 'Cannot abandon discussion: no discussion found');
+      return false;
+    }
+
+    group.discussion.status = 'abandoned';
+    group.discussion.concludedAt = Date.now();
+    if (reason) {
+      group.discussion.conclusion = `已放弃: ${reason}`;
+    }
+    this.save();
+
+    logger.info({ chatId, reason }, 'Discussion abandoned');
+    return true;
+  }
+
+  /**
+   * List all groups with active discussions.
+   *
+   * @returns Array of group info with active discussions
+   *
+   * @see Issue #1229 - 智能会话结束
+   */
+  listActiveDiscussions(): GroupInfo[] {
+    return Object.values(this.registry.groups).filter(g => g.discussion?.status === 'active');
   }
 
   /**


### PR DESCRIPTION
## Summary

Implements Issue #1229: 智能会话结束 - 判断讨论何时可以关闭

Adds a mechanism to track discussion status and allow agents to formally conclude discussions in group chats created by `start_group_discussion`.

## Changes

| File | Change |
|------|--------|
| `group-service.ts` | Add `DiscussionInfo` interface and discussion status management methods |
| `feishu-context-mcp.ts` | Add `check_discussion_status` and `conclude_discussion` MCP tools |
| `group-service.test.ts` | Add 18 tests for discussion status management |

## New Features

### 1. DiscussionInfo Interface

```typescript
interface DiscussionInfo {
  topic: string;
  context?: string;
  status: 'active' | 'concluded' | 'abandoned';
  startedAt: number;
  concludedAt?: number;
  conclusion?: string;
  followUpActions?: string[];
}
```

### 2. GroupService Methods

- `startDiscussion(chatId, topic, context?)` - Start tracking a discussion
- `getDiscussion(chatId)` - Get discussion info
- `hasActiveDiscussion(chatId)` - Check if discussion is active
- `concludeDiscussion(chatId, conclusion, followUpActions?)` - Conclude a discussion
- `abandonDiscussion(chatId, reason?)` - Abandon a discussion
- `listActiveDiscussions()` - List all groups with active discussions

### 3. New MCP Tools

- `check_discussion_status` - Check discussion status in a group
- `conclude_discussion` - Formally conclude a discussion with conclusion and follow-up actions

## Workflow

1. `start_group_discussion` now automatically calls `startDiscussion()` to track the discussion
2. Agent can use `check_discussion_status` to monitor discussion progress
3. When discussion reaches conclusion, agent uses `ask_user` to confirm with participants
4. Agent calls `conclude_discussion` to formally close the discussion
5. Follow-up actions can be specified for post-discussion execution

## Test Results

```
✓ src/platforms/feishu/group-service.test.ts (47 tests) 25ms
```

## Acceptance Criteria

- [x] 能判断讨论是否达成目标 (`check_discussion_status` + `hasActiveDiscussion`)
- [x] 用户确认后能正式关闭会话 (`conclude_discussion`)
- [x] 不影响未完成讨论的继续 (状态持久化，不会自动关闭)

Fixes #1229

## Test plan

- [x] Unit tests: 47 tests passed
- [x] TypeScript compilation: No errors in modified files
- [ ] Integration test with actual Feishu group discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)