### PR TITLE
refactor(docker): optimize Worker Node image with Alpine Linux (Issue #1219)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -56,34 +56,36 @@ COPY . .
 RUN npm run build
 
 # -----------------------------------------------------------------------------
-# Stage 3: Production Image (Python-based for data analysis)
+# Stage 3: Production Image (Python-first Alpine for data analysis)
 # -----------------------------------------------------------------------------
-FROM docker.m.daocloud.io/library/python:3.11-slim AS production
+FROM docker.m.daocloud.io/library/python:3.12-alpine AS production
 WORKDIR /app
 
-# Install Node.js 20 from NodeSource
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install Node.js 20 and runtime dependencies via apk
+# Note: Alpine uses musl libc instead of glibc
+RUN apk add --no-cache \
+    nodejs \
+    npm \
     curl \
-    ca-certificates && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     procps \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install GitHub CLI (gh)
-RUN apt-get update && apt-get install -y --no-install-recommends gnupg && \
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y gh && \
-    rm -rf /var/lib/apt/lists/*
+    github-cli \
+    # Build dependencies for Python packages with native extensions
+    build-base \
+    libffi-dev \
+    openssl-dev \
+    python3-dev \
+    # Dependencies for matplotlib
+    freetype-dev \
+    libpng-dev \
+    # Dependencies for scipy/numpy
+    openblas-dev \
+    gfortran
 
 # Install Python data analysis libraries
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir \
+# Use --break-system-packages for Alpine's externally managed environment
+RUN pip install --no-cache-dir --break-system-packages --upgrade pip && \
+    pip install --no-cache-dir --break-system-packages \
     pandas \
     numpy \
     scipy \
@@ -100,9 +102,9 @@ RUN pip install --no-cache-dir --upgrade pip && \
 RUN npm config set registry https://registry.npmmirror.com && \
     npm install -g pm2@latest
 
-# Create non-root user for running the application
-RUN groupadd -g 1001 disclaude && \
-    useradd -r -u 1001 -g disclaude -d /app -s /usr/sbin/nologin -c "Disclaude user" disclaude
+# Create non-root user for running the application (Alpine style)
+RUN addgroup -g 1001 disclaude && \
+    adduser -D -u 1001 -G disclaude -h /app -s /sbin/nologin disclaude
 
 # Create directories for runtime with proper permissions
 RUN mkdir -p /app/workspace /app/logs /app/.claude /app/.claude/backups /app/.claude/debug /app/.pm2 && \


### PR DESCRIPTION
## Summary

Switch Worker Node Dockerfile from Debian-based `python:3.11-slim` to Alpine-based `python:3.12-alpine` for smaller image size and better Python environment support.

## Changes

| Before | After |
|--------|-------|
| `python:3.11-slim` (Debian) | `python:3.12-alpine` (Alpine) |
| `apt-get` package manager | `apk` package manager |
| Node.js via NodeSource | Node.js via apk (`nodejs` package) |
| GitHub CLI via apt repository | GitHub CLI via apk (`github-cli` package) |
| `groupadd`/`useradd` | `addgroup`/`adduser` (Alpine style) |
| `pip install` | `pip install --break-system-packages` |

## Benefits

- **Smaller image size**: Alpine images are ~40% smaller than Debian-based images
- **Consistent base**: Both Primary and Worker nodes now use Alpine Linux
- **Python-first environment**: Better compatibility with ML/data analysis tasks
- **Python 3.12**: Upgraded from Python 3.11 to latest stable version

## Implementation Details

The production stage now uses Alpine packages:
- `nodejs`, `npm` - Node.js runtime
- `github-cli` - GitHub CLI for repository operations
- `build-base`, `libffi-dev`, `openssl-dev`, `python3-dev` - Build dependencies for Python packages
- `freetype-dev`, `libpng-dev` - Dependencies for matplotlib
- `openblas-dev`, `gfortran` - Dependencies for scipy/numpy

## Test Plan

- [x] Build: `npm run build` ✅
- [ ] Docker build: `docker build -f Dockerfile.worker -t disclaude:worker .` (requires Docker)
- [ ] Runtime verification: Worker node starts successfully with new image

Fixes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)