### PR TITLE
feat(auth): implement Device Code Flow (RFC 8628) for OAuth authentication

### DIFF
--- a/src/auth/auth-mcp.ts
+++ b/src/auth/auth-mcp.ts
@@ -15,7 +15,8 @@ import { z } from 'zod';
 import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
 import { createLogger } from '../utils/logger.js';
 import { getOAuthManager, OAuthManager } from './oauth-manager.js';
-import type { OAuthProviderConfig } from './types.js';
+import type { OAuthProviderConfig, DeviceCodeProviderConfig } from './types.js';
+import { createDeviceCodeCard } from './device-code-flow.js';
 
 const logger = createLogger('AuthMCP');
 
@@ -235,6 +236,98 @@ export const authToolDefinitions: InlineToolDefinition[] = [
         }
       } catch (error) {
         return toolError(`Failed to revoke authorization: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'auth_start_device_flow',
+    description: 'Start Device Code Flow for OAuth authorization. Use this instead of auth_generate_url when running on a server without public callback URL. Returns a user code and verification URL for the user to authorize in their browser.',
+    parameters: z.object({
+      providerName: z.string().describe('Provider name (e.g., "github", "google")'),
+      deviceCodeUrl: z.string().describe('Device code endpoint URL (e.g., "https://github.com/login/device/code" for GitHub)'),
+      tokenUrl: z.string().describe('OAuth token endpoint URL'),
+      clientId: z.string().describe('OAuth client ID'),
+      clientSecret: z.string().describe('OAuth client secret (optional for some providers)'),
+      scopes: z.string().describe('Space-separated OAuth scopes to request'),
+      chatId: z.string().describe('Chat ID from the task context'),
+    }),
+    handler: async ({ providerName, deviceCodeUrl, tokenUrl, clientId, clientSecret, scopes, chatId }) => {
+      try {
+        const provider: DeviceCodeProviderConfig = {
+          name: providerName,
+          authUrl: '', // Not needed for device code flow
+          tokenUrl,
+          clientId,
+          clientSecret,
+          scopes: scopes.split(' ').filter(Boolean),
+          callbackUrl: '', // Not needed for device code flow
+          deviceCodeUrl,
+          supportsDeviceCode: true,
+        };
+
+        const manager = getManager();
+        const result = await manager.initiateDeviceCodeFlow(provider, chatId);
+
+        if (!result.success) {
+          return toolError(`Failed to start Device Code Flow: ${result.error}`);
+        }
+
+        logger.info({ chatId, provider: providerName, stateId: result.stateId }, 'Device Code Flow started');
+
+        // Create card for user
+        const card = createDeviceCodeCard(
+          result.userCode!,
+          result.verificationUri!,
+          providerName
+        );
+
+        return toolSuccess(
+          `Device Code Flow started.\n\n` +
+          `**User Code:** ${result.userCode}\n` +
+          `**Verification URL:** ${result.verificationUri}\n` +
+          `**State ID:** ${result.stateId}\n\n` +
+          `Send a card to the user with this information. Use auth_poll_device_flow to check authorization status.\n\n` +
+          `Card JSON:\n\`\`\`json\n${JSON.stringify(card, null, 2)}\n\`\`\``
+        );
+      } catch (error) {
+        return toolError(`Failed to start Device Code Flow: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'auth_poll_device_flow',
+    description: 'Poll for Device Code Flow authorization status. Returns whether the user has authorized or if still pending.',
+    parameters: z.object({
+      stateId: z.string().describe('State ID from auth_start_device_flow'),
+    }),
+    handler: async ({ stateId }) => {
+      try {
+        const manager = getManager();
+        const result = await manager.pollDeviceCode(stateId);
+
+        if (result.complete) {
+          if (result.success) {
+            return toolSuccess(`✅ Authorization complete! The user has successfully authorized.`);
+          } else {
+            return toolError(`Authorization failed: ${result.error || 'Unknown error'}`);
+          }
+        }
+
+        // Still pending
+        const state = manager.getDeviceCodeState(stateId);
+        if (state) {
+          const remaining = Math.max(0, Math.floor((state.expiresAt - Date.now()) / 1000));
+          return toolSuccess(
+            `⏳ Authorization pending. User needs to:\n` +
+            `1. Visit: ${state.verificationUri}\n` +
+            `2. Enter code: ${state.userCode}\n\n` +
+            `Time remaining: ${Math.floor(remaining / 60)}m ${remaining % 60}s`
+          );
+        }
+
+        return toolError('Device code state not found. It may have expired.');
+      } catch (error) {
+        return toolError(`Failed to poll Device Code Flow: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/auth/device-code-flow.test.ts
+++ b/src/auth/device-code-flow.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Tests for auth/device-code-flow.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { DeviceCodeFlow } from './device-code-flow.js';
+import { TokenStore } from './token-store.js';
+import type { DeviceCodeProviderConfig } from './types.js';
+
+// Mock fetch for device code requests
+const originalFetch = global.fetch;
+
+describe('DeviceCodeFlow', () => {
+  let tempDir: string;
+  let tokenStore: TokenStore;
+  let deviceCodeFlow: DeviceCodeFlow;
+
+  const mockProvider: DeviceCodeProviderConfig = {
+    name: 'test-provider',
+    authUrl: 'https://example.com/oauth/authorize',
+    tokenUrl: 'https://example.com/oauth/token',
+    deviceCodeUrl: 'https://example.com/oauth/device/code',
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    scopes: ['read', 'write'],
+    callbackUrl: '', // Not needed for device code flow
+    supportsDeviceCode: true,
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'device-code-flow-test-'));
+    const storagePath = path.join(tempDir, 'tokens.json');
+    tokenStore = new TokenStore(storagePath);
+    deviceCodeFlow = new DeviceCodeFlow(tokenStore);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    global.fetch = originalFetch;
+    // Clean up any pending intervals
+    vi.clearAllTimers();
+  });
+
+  describe('initiateDeviceCode', () => {
+    it('should return error when provider does not support device code', async () => {
+      const unsupportedProvider: DeviceCodeProviderConfig = {
+        ...mockProvider,
+        supportsDeviceCode: false,
+        deviceCodeUrl: '',
+      };
+
+      const result = await deviceCodeFlow.initiateDeviceCode(unsupportedProvider, 'chat-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('does not support Device Code Flow');
+    });
+
+    it('should initiate device code flow and return user code', async () => {
+      // Mock fetch for device code request
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const result = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+
+      expect(result.success).toBe(true);
+      expect(result.userCode).toBe('ABCD-1234');
+      expect(result.verificationUri).toBe('https://example.com/device');
+      expect(result.stateId).toBeDefined();
+
+      // Verify fetch was called with correct params
+      expect(global.fetch).toHaveBeenCalledWith(
+        mockProvider.deviceCodeUrl,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/x-www-form-urlencoded',
+          }),
+        })
+      );
+    });
+
+    it('should handle device code request failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => 'Invalid client',
+      });
+
+      const result = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to request device code');
+    });
+
+    it('should handle invalid response missing required fields', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          // Missing device_code, user_code, verification_uri
+          expires_in: 900,
+        }),
+      });
+
+      const result = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('missing required fields');
+    });
+  });
+
+  describe('pollForToken', () => {
+    it('should return error for invalid state', async () => {
+      const result = await deviceCodeFlow.pollForToken('invalid-state-id');
+
+      expect(result.complete).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid or expired');
+    });
+
+    it('should return pending when authorization is pending', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Mock polling response - authorization pending
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          error: 'authorization_pending',
+        }),
+      });
+
+      const pollResult = await deviceCodeFlow.pollForToken(initResult.stateId!);
+
+      expect(pollResult.complete).toBe(false);
+      expect(pollResult.errorType).toBe('authorization_pending');
+    });
+
+    it('should complete successfully when authorized', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Mock polling response - success
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          access_token: 'test-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'read write',
+        }),
+      });
+
+      const pollResult = await deviceCodeFlow.pollForToken(initResult.stateId!);
+
+      expect(pollResult.complete).toBe(true);
+      expect(pollResult.success).toBe(true);
+
+      // Verify token was stored
+      const storedToken = await tokenStore.getToken('chat-1', 'test-provider');
+      expect(storedToken).not.toBeNull();
+      expect(storedToken!.accessToken).toBe('test-access-token');
+    });
+
+    it('should handle expired token error', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Mock polling response - expired
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          error: 'expired_token',
+        }),
+      });
+
+      const pollResult = await deviceCodeFlow.pollForToken(initResult.stateId!);
+
+      expect(pollResult.complete).toBe(true);
+      expect(pollResult.success).toBe(false);
+      expect(pollResult.errorType).toBe('expired_token');
+    });
+
+    it('should handle access denied error', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Mock polling response - access denied
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          error: 'access_denied',
+        }),
+      });
+
+      const pollResult = await deviceCodeFlow.pollForToken(initResult.stateId!);
+
+      expect(pollResult.complete).toBe(true);
+      expect(pollResult.success).toBe(false);
+      expect(pollResult.errorType).toBe('access_denied');
+    });
+
+    it('should increase interval on slow_down error', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Mock polling response - slow down
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          error: 'slow_down',
+        }),
+      });
+
+      const pollResult = await deviceCodeFlow.pollForToken(initResult.stateId!);
+
+      expect(pollResult.complete).toBe(false);
+      expect(pollResult.errorType).toBe('slow_down');
+
+      // Verify interval was increased
+      const state = deviceCodeFlow.getState(initResult.stateId!);
+      expect(state?.interval).toBe(10); // 5 * 2
+    });
+  });
+
+  describe('cancelDeviceCode', () => {
+    it('should cancel a pending device code flow', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      // Verify state exists
+      let state = deviceCodeFlow.getState(initResult.stateId!);
+      expect(state).toBeDefined();
+
+      // Cancel
+      deviceCodeFlow.cancelDeviceCode(initResult.stateId!);
+
+      // Verify state is removed
+      state = deviceCodeFlow.getState(initResult.stateId!);
+      expect(state).toBeUndefined();
+    });
+  });
+
+  describe('getState', () => {
+    it('should return undefined for non-existent state', () => {
+      const state = deviceCodeFlow.getState('non-existent-id');
+      expect(state).toBeUndefined();
+    });
+
+    it('should return state for valid state ID', async () => {
+      // First initiate a device code
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => ({
+          device_code: 'test-device-code',
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://example.com/device',
+          expires_in: 900,
+          interval: 5,
+        }),
+      });
+
+      const initResult = await deviceCodeFlow.initiateDeviceCode(mockProvider, 'chat-1');
+      expect(initResult.success).toBe(true);
+
+      const state = deviceCodeFlow.getState(initResult.stateId!);
+      expect(state).toBeDefined();
+      expect(state?.userCode).toBe('ABCD-1234');
+      expect(state?.provider).toBe('test-provider');
+      expect(state?.chatId).toBe('chat-1');
+    });
+  });
+});
+
+describe('createDeviceCodeCard', () => {
+  it('should create a valid Feishu card', async () => {
+    const { createDeviceCodeCard } = await import('./device-code-flow.js');
+
+    const card = createDeviceCodeCard('ABCD-1234', 'https://example.com/device', 'TestProvider');
+
+    expect(card.config.wide_screen_mode).toBe(true);
+    expect(card.header.title.content).toContain('TestProvider');
+    expect(card.elements).toBeDefined();
+    expect(card.elements.length).toBeGreaterThan(0);
+  });
+});

--- a/src/auth/device-code-flow.ts
+++ b/src/auth/device-code-flow.ts
@@ -1,0 +1,475 @@
+/**
+ * Device Code Flow implementation (RFC 8628).
+ *
+ * Provides OAuth authentication for devices without a browser
+ * or when callback URLs are not available (e.g., server deployment).
+ */
+
+import { createLogger } from '../utils/logger.js';
+import { getTokenStore, TokenStore } from './token-store.js';
+import { generateState } from './crypto.js';
+import type {
+  DeviceCodeResponse,
+  DeviceTokenResponse,
+  DeviceCodeState,
+  DeviceCodeProviderConfig,
+  DeviceCodeFlowResult,
+  DeviceCodePollResult,
+  OAuthToken,
+} from './types.js';
+
+const logger = createLogger('DeviceCodeFlow');
+
+/**
+ * In-memory store for pending Device Code states.
+ * States are short-lived (typically 15 minutes) so memory storage is acceptable.
+ */
+const pendingDeviceCodes = new Map<string, DeviceCodeState>();
+
+/**
+ * Active polling intervals for cleanup.
+ */
+const activePollingIntervals = new Map<string, NodeJS.Timeout>();
+
+/**
+ * Clean up expired device code states.
+ */
+function cleanupExpiredStates(): void {
+  const now = Date.now();
+
+  for (const [id, state] of pendingDeviceCodes.entries()) {
+    if (state.expiresAt < now) {
+      pendingDeviceCodes.delete(id);
+      stopPolling(id);
+      logger.debug({ stateId: id }, 'Expired Device Code state removed');
+    }
+  }
+}
+
+/**
+ * Stop polling for a specific state.
+ */
+function stopPolling(stateId: string): void {
+  const interval = activePollingIntervals.get(stateId);
+  if (interval) {
+    clearInterval(interval);
+    activePollingIntervals.delete(stateId);
+    logger.debug({ stateId }, 'Polling stopped');
+  }
+}
+
+/**
+ * Device Code Flow manager.
+ */
+export class DeviceCodeFlow {
+  private readonly tokenStore: TokenStore;
+
+  constructor(tokenStore?: TokenStore) {
+    this.tokenStore = tokenStore || getTokenStore();
+  }
+
+  /**
+   * Initiate Device Code Flow for a provider.
+   *
+   * @param provider - Provider configuration with device code endpoints
+   * @param chatId - Chat ID initiating the flow
+   * @returns Device Code Flow result with user code and verification URL
+   */
+  async initiateDeviceCode(
+    provider: DeviceCodeProviderConfig,
+    chatId: string
+  ): Promise<DeviceCodeFlowResult> {
+    // Clean up old states
+    cleanupExpiredStates();
+
+    if (!provider.supportsDeviceCode || !provider.deviceCodeUrl) {
+      return {
+        success: false,
+        error: `Provider ${provider.name} does not support Device Code Flow`,
+      };
+    }
+
+    try {
+      // Request device code from provider
+      const params = new URLSearchParams({
+        client_id: provider.clientId,
+        scope: provider.scopes.join(' '),
+      });
+
+      // Some providers require client_secret
+      if (provider.clientSecret) {
+        params.append('client_secret', provider.clientSecret);
+      }
+
+      logger.info({ provider: provider.name, chatId }, 'Requesting device code');
+
+      const response = await fetch(provider.deviceCodeUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: params.toString(),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        logger.error({ status: response.status, body: text }, 'Device code request failed');
+        return {
+          success: false,
+          error: `Failed to request device code: ${response.status} - ${text}`,
+        };
+      }
+
+      const data = (await response.json()) as DeviceCodeResponse;
+
+      // Validate required fields
+      if (!data.device_code || !data.user_code || !data.verification_uri) {
+        return {
+          success: false,
+          error: 'Invalid device code response: missing required fields',
+        };
+      }
+
+      // Create state for tracking
+      const stateId = generateState();
+      const now = Date.now();
+      const expiresIn = data.expires_in || 900; // Default 15 minutes
+      const interval = data.interval || 5; // Default 5 seconds
+
+      const state: DeviceCodeState = {
+        id: stateId,
+        chatId,
+        provider: provider.name,
+        deviceCode: data.device_code,
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        createdAt: now,
+        expiresAt: now + expiresIn * 1000,
+        interval,
+        providerConfig: provider,
+        polling: false,
+      };
+
+      pendingDeviceCodes.set(stateId, state);
+
+      logger.info(
+        { stateId, chatId, provider: provider.name, userCode: data.user_code },
+        'Device Code Flow initiated'
+      );
+
+      return {
+        success: true,
+        userCode: data.user_code,
+        verificationUri: data.verification_uri,
+        stateId,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, provider: provider.name }, 'Device code initiation failed');
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Poll for token after user authorizes.
+   *
+   * @param stateId - State ID from initiation
+   * @returns Poll result indicating authorization status
+   */
+  async pollForToken(stateId: string): Promise<DeviceCodePollResult> {
+    const state = pendingDeviceCodes.get(stateId);
+
+    if (!state) {
+      return {
+        complete: true,
+        success: false,
+        error: 'Invalid or expired device code state',
+      };
+    }
+
+    // Check if expired
+    if (state.expiresAt < Date.now()) {
+      pendingDeviceCodes.delete(stateId);
+      stopPolling(stateId);
+      return {
+        complete: true,
+        success: false,
+        error: 'Device code has expired',
+        errorType: 'expired_token',
+      };
+    }
+
+    try {
+      const params = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: state.deviceCode,
+        client_id: state.providerConfig.clientId,
+      });
+
+      // Some providers require client_secret
+      if (state.providerConfig.clientSecret) {
+        params.append('client_secret', state.providerConfig.clientSecret);
+      }
+
+      const response = await fetch(state.providerConfig.tokenUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: params.toString(),
+      });
+
+      const data = (await response.json()) as DeviceTokenResponse;
+
+      // Check for errors
+      if (data.error) {
+        switch (data.error) {
+          case 'authorization_pending':
+            return {
+              complete: false,
+              errorType: 'authorization_pending',
+            };
+          case 'slow_down':
+            // Increase interval
+            state.interval = Math.min(state.interval * 2, 60);
+            return {
+              complete: false,
+              errorType: 'slow_down',
+            };
+          case 'expired_token':
+            pendingDeviceCodes.delete(stateId);
+            stopPolling(stateId);
+            return {
+              complete: true,
+              success: false,
+              error: 'Device code has expired',
+              errorType: 'expired_token',
+            };
+          case 'access_denied':
+            pendingDeviceCodes.delete(stateId);
+            stopPolling(stateId);
+            return {
+              complete: true,
+              success: false,
+              error: 'User denied authorization',
+              errorType: 'access_denied',
+            };
+          default:
+            return {
+              complete: true,
+              success: false,
+              error: data.error_description || data.error,
+            };
+        }
+      }
+
+      // Success - store token
+      if (data.access_token) {
+        const token: OAuthToken = {
+          accessToken: data.access_token,
+          refreshToken: data.refresh_token,
+          tokenType: data.token_type || 'Bearer',
+          expiresAt: data.expires_in ? Date.now() + data.expires_in * 1000 : undefined,
+          scope: data.scope,
+          createdAt: Date.now(),
+        };
+
+        await this.tokenStore.setToken(state.chatId, state.provider, token);
+
+        // Clean up state
+        pendingDeviceCodes.delete(stateId);
+        stopPolling(stateId);
+
+        logger.info(
+          { stateId, chatId: state.chatId, provider: state.provider },
+          'Device Code Flow completed successfully'
+        );
+
+        return {
+          complete: true,
+          success: true,
+        };
+      }
+
+      return {
+        complete: true,
+        success: false,
+        error: 'Invalid token response',
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logger.error({ err: error, stateId }, 'Token polling failed');
+      return {
+        complete: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Start automatic polling for token.
+   * Polls until authorization is complete, expired, or cancelled.
+   *
+   * @param stateId - State ID from initiation
+   * @param onProgress - Callback for progress updates (optional)
+   * @returns Final poll result
+   */
+  async startPolling(
+    stateId: string,
+    onProgress?: (result: DeviceCodePollResult) => void
+  ): Promise<DeviceCodePollResult> {
+    const state = pendingDeviceCodes.get(stateId);
+
+    if (!state) {
+      return {
+        complete: true,
+        success: false,
+        error: 'Invalid or expired device code state',
+      };
+    }
+
+    if (state.polling) {
+      return {
+        complete: false,
+        error: 'Polling already in progress',
+      };
+    }
+
+    state.polling = true;
+
+    return new Promise((resolve) => {
+      const poll = async () => {
+        const result = await this.pollForToken(stateId);
+
+        if (onProgress) {
+          onProgress(result);
+        }
+
+        if (result.complete) {
+          resolve(result);
+          return;
+        }
+
+        // Schedule next poll
+        const interval = activePollingIntervals.get(stateId);
+        if (interval) {
+          // Interval already set, just return
+          return;
+        }
+
+        const newInterval = setInterval(async () => {
+          const pollResult = await this.pollForToken(stateId);
+
+          if (onProgress) {
+            onProgress(pollResult);
+          }
+
+          if (pollResult.complete) {
+            clearInterval(newInterval);
+            activePollingIntervals.delete(stateId);
+            resolve(pollResult);
+          }
+        }, state.interval * 1000);
+
+        activePollingIntervals.set(stateId, newInterval);
+      };
+
+      // Start polling immediately
+      poll();
+    });
+  }
+
+  /**
+   * Cancel a pending Device Code Flow.
+   *
+   * @param stateId - State ID to cancel
+   */
+  cancelDeviceCode(stateId: string): void {
+    const state = pendingDeviceCodes.get(stateId);
+    if (state) {
+      state.polling = false;
+      pendingDeviceCodes.delete(stateId);
+      stopPolling(stateId);
+      logger.info({ stateId }, 'Device Code Flow cancelled');
+    }
+  }
+
+  /**
+   * Get a pending Device Code state.
+   *
+   * @param stateId - State ID
+   * @returns Device Code state or undefined
+   */
+  getState(stateId: string): DeviceCodeState | undefined {
+    return pendingDeviceCodes.get(stateId);
+  }
+
+  /**
+   * Check if a state is currently polling.
+   *
+   * @param stateId - State ID
+   * @returns Whether polling is active
+   */
+  isPolling(stateId: string): boolean {
+    const state = pendingDeviceCodes.get(stateId);
+    return state?.polling ?? false;
+  }
+}
+
+/**
+ * Singleton Device Code Flow instance.
+ */
+let deviceCodeFlowInstance: DeviceCodeFlow | null = null;
+
+/**
+ * Get the global Device Code Flow instance.
+ */
+export function getDeviceCodeFlow(): DeviceCodeFlow {
+  if (!deviceCodeFlowInstance) {
+    deviceCodeFlowInstance = new DeviceCodeFlow();
+  }
+  return deviceCodeFlowInstance;
+}
+
+/**
+ * Create a Device Code authorization card for Feishu.
+ */
+export function createDeviceCodeCard(
+  userCode: string,
+  verificationUri: string,
+  provider: string
+): Record<string, unknown> {
+  return {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: 'plain_text', content: `🔐 ${provider} 授权` },
+      template: 'blue',
+    },
+    elements: [
+      {
+        tag: 'markdown',
+        content: `请在浏览器中完成授权：\n\n**1.** 访问: ${verificationUri}\n**2.** 输入设备码: \`${userCode}\`\n\n⏳ 等待授权中...`,
+      },
+      {
+        tag: 'action',
+        actions: [
+          {
+            tag: 'button',
+            text: { tag: 'plain_text', content: '打开授权页面' },
+            url: verificationUri,
+            type: 'primary',
+          },
+        ],
+      },
+      {
+        tag: 'markdown',
+        content: '_💡 授权信息将加密存储，AI 无法直接查看您的凭证_',
+      },
+    ],
+  };
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -3,6 +3,7 @@
  *
  * This module provides:
  * - OAuth 2.0 PKCE flow management
+ * - Device Code Flow (RFC 8628) for server/container deployments
  * - Encrypted token storage
  * - MCP tools for agent integration
  *
@@ -21,6 +22,12 @@ export type {
   ApiRequestConfig,
   ApiResponse,
   AuthConfig,
+  DeviceCodeResponse,
+  DeviceTokenResponse,
+  DeviceCodeState,
+  DeviceCodeProviderConfig,
+  DeviceCodeFlowResult,
+  DeviceCodePollResult,
 } from './types.js';
 
 // Crypto utilities
@@ -37,6 +44,9 @@ export { TokenStore, getTokenStore } from './token-store.js';
 
 // OAuth manager
 export { OAuthManager, getOAuthManager } from './oauth-manager.js';
+
+// Device Code Flow
+export { DeviceCodeFlow, getDeviceCodeFlow, createDeviceCodeCard } from './device-code-flow.js';
 
 // MCP tools
 export { authSdkTools, createAuthSdkMcpServer, createAuthCard } from './auth-mcp.js';

--- a/src/auth/oauth-manager.ts
+++ b/src/auth/oauth-manager.ts
@@ -23,7 +23,11 @@ import type {
   TokenCheckResult,
   ApiRequestConfig,
   ApiResponse,
+  DeviceCodeProviderConfig,
+  DeviceCodeFlowResult,
+  DeviceCodePollResult,
 } from './types.js';
+import { DeviceCodeFlow, getDeviceCodeFlow } from './device-code-flow.js';
 
 const logger = createLogger('OAuthManager');
 
@@ -54,9 +58,11 @@ function cleanupExpiredStates(): void {
 export class OAuthManager {
   private readonly tokenStore: TokenStore;
   private callbackServer: http.Server | null = null;
+  private readonly deviceCodeFlow: DeviceCodeFlow;
 
   constructor(tokenStore?: TokenStore) {
     this.tokenStore = tokenStore || getTokenStore();
+    this.deviceCodeFlow = getDeviceCodeFlow();
   }
 
   /**
@@ -432,6 +438,65 @@ export class OAuthManager {
       this.callbackServer = null;
       logger.info('OAuth callback server stopped');
     }
+  }
+
+  /**
+   * Initiate Device Code Flow for a provider.
+   * Alternative to PKCE flow for server/container deployments.
+   *
+   * @param provider - Provider configuration with device code endpoints
+   * @param chatId - Chat ID initiating the flow
+   * @returns Device Code Flow result with user code and verification URL
+   */
+  async initiateDeviceCodeFlow(
+    provider: DeviceCodeProviderConfig,
+    chatId: string
+  ): Promise<DeviceCodeFlowResult> {
+    logger.info({ chatId, provider: provider.name }, 'Initiating Device Code Flow');
+    return this.deviceCodeFlow.initiateDeviceCode(provider, chatId);
+  }
+
+  /**
+   * Poll for Device Code authorization.
+   *
+   * @param stateId - State ID from initiation
+   * @returns Poll result indicating authorization status
+   */
+  async pollDeviceCode(stateId: string): Promise<DeviceCodePollResult> {
+    return this.deviceCodeFlow.pollForToken(stateId);
+  }
+
+  /**
+   * Start automatic polling for Device Code authorization.
+   *
+   * @param stateId - State ID from initiation
+   * @param onProgress - Callback for progress updates (optional)
+   * @returns Final poll result
+   */
+  async startDeviceCodePolling(
+    stateId: string,
+    onProgress?: (result: DeviceCodePollResult) => void
+  ): Promise<DeviceCodePollResult> {
+    return this.deviceCodeFlow.startPolling(stateId, onProgress);
+  }
+
+  /**
+   * Cancel a pending Device Code Flow.
+   *
+   * @param stateId - State ID to cancel
+   */
+  cancelDeviceCodeFlow(stateId: string): void {
+    this.deviceCodeFlow.cancelDeviceCode(stateId);
+  }
+
+  /**
+   * Get Device Code state information.
+   *
+   * @param stateId - State ID
+   * @returns Device Code state or undefined
+   */
+  getDeviceCodeState(stateId: string) {
+    return this.deviceCodeFlow.getState(stateId);
   }
 }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -149,3 +149,112 @@ export interface AuthConfig {
   /** Callback URL base */
   callbackUrl?: string;
 }
+
+/**
+ * Device Code Flow response from OAuth provider.
+ * RFC 8628 Section 3.2
+ */
+export interface DeviceCodeResponse {
+  /** The device verification code */
+  device_code: string;
+  /** The end-user verification code */
+  user_code: string;
+  /** The end-user verification URI */
+  verification_uri: string;
+  /** The verification URI with user code included (optional) */
+  verification_uri_complete?: string;
+  /** Lifetime in seconds of the device_code */
+  expires_in: number;
+  /** The minimum amount of time in seconds between polling requests */
+  interval: number;
+}
+
+/**
+ * Device Token response from OAuth provider.
+ * RFC 8628 Section 3.5
+ */
+export interface DeviceTokenResponse {
+  /** Access token (on success) */
+  access_token?: string;
+  /** Token type (usually 'Bearer') */
+  token_type?: string;
+  /** Refresh token (optional) */
+  refresh_token?: string;
+  /** Lifetime in seconds of the access token */
+  expires_in?: number;
+  /** Granted scopes */
+  scope?: string;
+  /** Error code (on pending/failure) */
+  error?: 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied';
+  /** Human-readable error description */
+  error_description?: string;
+}
+
+/**
+ * Device Code Flow state for tracking pending authorizations.
+ */
+export interface DeviceCodeState {
+  /** Unique identifier for this flow */
+  id: string;
+  /** Chat ID that initiated the flow */
+  chatId: string;
+  /** Provider name */
+  provider: string;
+  /** The device code */
+  deviceCode: string;
+  /** The user code to display */
+  userCode: string;
+  /** The verification URL */
+  verificationUri: string;
+  /** When this state was created */
+  createdAt: number;
+  /** Expiration timestamp */
+  expiresAt: number;
+  /** Polling interval in seconds */
+  interval: number;
+  /** Provider configuration */
+  providerConfig: DeviceCodeProviderConfig;
+  /** Whether polling is active */
+  polling: boolean;
+}
+
+/**
+ * Device Code Flow provider configuration.
+ * Extends OAuthProviderConfig with Device Code specific endpoints.
+ */
+export interface DeviceCodeProviderConfig extends OAuthProviderConfig {
+  /** Device code endpoint URL */
+  deviceCodeUrl: string;
+  /** Whether this provider supports Device Code Flow */
+  supportsDeviceCode: boolean;
+}
+
+/**
+ * Result of initiating Device Code Flow.
+ */
+export interface DeviceCodeFlowResult {
+  /** Whether initiation was successful */
+  success: boolean;
+  /** User code to display */
+  userCode?: string;
+  /** Verification URL */
+  verificationUri?: string;
+  /** State ID for tracking */
+  stateId?: string;
+  /** Error message if failed */
+  error?: string;
+}
+
+/**
+ * Result of polling for Device Code token.
+ */
+export interface DeviceCodePollResult {
+  /** Whether authorization is complete */
+  complete: boolean;
+  /** Whether authorized successfully */
+  success?: boolean;
+  /** Error message if failed */
+  error?: string;
+  /** Error type for specific handling */
+  errorType?: 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied';
+}


### PR DESCRIPTION
## Summary

- 实现 Device Code Flow (RFC 8628) 认证方式，支持服务器/容器部署场景
- 新增 `DeviceCodeFlow` 类处理设备码授权流程
- 新增 MCP 工具 `auth_start_device_flow` 和 `auth_poll_device_flow`
- 支持 GitHub 和 Google 的 Device Code Flow 端点
- 添加飞书卡片 UI 用于用户授权
- 完整的单元测试覆盖 (14 个新测试用例)

## 关闭 Issue

Closes #1215

## 变更详情

### 新增文件
- `src/auth/device-code-flow.ts` - Device Code Flow 核心实现
- `src/auth/device-code-flow.test.ts` - 单元测试

### 修改文件
- `src/auth/types.ts` - 新增 Device Code 相关类型定义
- `src/auth/oauth-manager.ts` - 集成 Device Code Flow
- `src/auth/auth-mcp.ts` - 新增 MCP 工具
- `src/auth/index.ts` - 导出新模块

## 测试结果

```
✓ src/auth/device-code-flow.test.ts (14 tests) 40ms
✓ src/auth/oauth-manager.test.ts (16 tests)
✓ src/auth/token-store.test.ts (15 tests)
✓ src/auth/crypto.test.ts (13 tests)

Test Files  4 passed (4)
Tests  58 passed (58)
```

## 使用示例

```typescript
// 1. 启动 Device Code Flow
const result = await auth_start_device_flow({
  providerName: 'github',
  deviceCodeUrl: 'https://github.com/login/device/code',
  tokenUrl: 'https://github.com/login/oauth/access_token',
  clientId: 'YOUR_CLIENT_ID',
  clientSecret: 'YOUR_CLIENT_SECRET',
  scopes: 'repo user',
  chatId: 'chat-123'
});

// 2. 显示用户码和验证 URL
console.log(`请访问: ${result.verificationUri}`);
console.log(`输入设备码: ${result.userCode}`);

// 3. 轮询授权状态
const pollResult = await auth_poll_device_flow({
  stateId: result.stateId
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)