### PR TITLE
feat(mcp): add spawn_subagents tool for master-workers pattern (Issue #897)

### DIFF
--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -36,6 +36,7 @@ import type { StreamingUserMessage, QueryHandle } from '../../sdk/index.js';
 import { Config } from '../../config/index.js';
 import { SESSION_RESTORE } from '../../config/constants.js';
 import { createFeishuSdkMcpServer } from '../../mcp/feishu-context-mcp.js';
+import { setSpawnSubagentsCallbacks } from '../../mcp/tools/spawn-subagents.js';
 import { messageLogger } from '../../feishu/message-logger.js';
 import { BaseAgent } from '../base-agent.js';
 import type { ChatAgent, UserInput } from '../types.js';
@@ -519,6 +520,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
   private startAgentLoop(): void {
     const chatId = this.boundChatId;
 
+    // Issue #897: Set callbacks for spawn_subagents tool
+    setSpawnSubagentsCallbacks(this.callbacks, chatId);
+
     // Issue #955: Trigger background loading of persisted history
     if (!this.historyLoaded) {
       this.loadPersistedHistory().catch((err) => {
@@ -763,6 +767,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
     // Clear persisted history context (Issue #955)
     this.persistedHistoryContext = undefined;
     this.historyLoaded = false;
+
+    // Issue #897: Clear spawn_subagents callbacks
+    setSpawnSubagentsCallbacks(null, null);
   }
 
   /**
@@ -817,6 +824,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
 
     // Clear restart states
     this.restartManager.clearAll();
+
+    // Issue #897: Clear spawn_subagents callbacks
+    setSpawnSubagentsCallbacks(null, null);
 
     this.logger.info({ chatId: this.boundChatId }, 'Pilot shutdown complete');
   }

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -11,6 +11,7 @@ import {
   send_file,
   send_interactive_message,
   setMessageSentCallback,
+  spawn_subagents,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 import { getGroupService } from '../platforms/feishu/group-service.js';
@@ -312,6 +313,104 @@ This tool initiates an async discussion. The conclusions will be returned when p
         return toolSuccess(`✅ 群聊讨论已启动\n- 群聊ID: ${chatId}\n- 话题: ${topic}\n- 成员数: ${members?.length || 0}\n- 超时: ${timeout || 30} 分钟\n\n请在群聊中进行讨论。讨论完成后，系统将收集结论并解散群聊。`);
       } catch (error) {
         return toolSuccess(`⚠️ Failed to start group discussion: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'spawn_subagents',
+    description: `Spawn multiple subagents to execute tasks in parallel (Master-Workers pattern).
+
+Issue #897: Master-Workers Multi-Agent Collaboration Pattern
+
+---
+
+## 🎯 Use Cases
+
+1. **Parallel File Processing**: Analyze multiple files simultaneously
+2. **Multi-Source Research**: Gather information from different sources in parallel
+3. **Task Decomposition**: Break complex tasks into smaller parallel subtasks
+4. **Batch Operations**: Execute multiple independent operations concurrently
+
+---
+
+## Parameters
+
+- **tasks**: Array of tasks to execute (required)
+  - Each task has: type, name, prompt, templateVars (optional)
+- **maxParallel**: Maximum concurrent executions (default: 3)
+- **timeout**: Total timeout in milliseconds (default: 300000 = 5 min)
+- **continueOnFailure**: Continue if some tasks fail (default: true)
+
+---
+
+## Example
+
+\`\`\`json
+{
+  "tasks": [
+    {"type": "task", "name": "analyze-auth", "prompt": "Analyze the auth module"},
+    {"type": "task", "name": "analyze-api", "prompt": "Analyze the API module"},
+    {"type": "task", "name": "analyze-db", "prompt": "Analyze the database module"}
+  ],
+  "maxParallel": 3
+}
+\`\`\`
+
+---
+
+## Task Types
+
+- **task**: General-purpose task agent
+- **skill**: Skill-based agent (requires skill name)
+- **schedule**: Scheduled task agent
+
+---
+
+## Returns
+
+- success: Whether all tasks completed successfully
+- message: Summary of execution
+- results: Array of individual task results
+- summary: Detailed summary with success/failure counts`,
+    parameters: z.object({
+      tasks: z.array(z.object({
+        type: z.enum(['task', 'skill', 'schedule']),
+        name: z.string(),
+        prompt: z.string(),
+        templateVars: z.record(z.string(), z.string()).optional(),
+      })).min(1),
+      maxParallel: z.number().min(1).max(10).optional(),
+      timeout: z.number().optional(),
+      continueOnFailure: z.boolean().optional(),
+    }),
+    handler: async ({ tasks, maxParallel, timeout, continueOnFailure }) => {
+      try {
+        const result = await spawn_subagents({
+          tasks,
+          maxParallel,
+          timeout,
+          continueOnFailure,
+        });
+
+        let responseText = result.message;
+        if (result.summary) {
+          responseText += `\n\n${result.summary}`;
+        }
+        if (result.results.length > 0) {
+          responseText += '\n\n### 任务详情\n';
+          for (const r of result.results) {
+            const statusEmoji = r.status === 'completed' ? '✅' : r.status === 'failed' ? '❌' : '⏹️';
+            responseText += `- ${statusEmoji} **${r.name}** (${(r.duration / 1000).toFixed(1)}s)`;
+            if (r.error) {
+              responseText += `: ${r.error}`;
+            }
+            responseText += '\n';
+          }
+        }
+
+        return toolSuccess(responseText);
+      } catch (error) {
+        return toolSuccess(`⚠️ spawn_subagents failed: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -65,3 +65,17 @@ export type {
   StudyGuideOptions,
   StudyGuideResult,
 } from './study-guide-generator.js';
+
+// Spawn Subagents (Issue #897: Master-Workers Multi-Agent Collaboration)
+export {
+  spawn_subagents,
+  setSpawnSubagentsCallbacks,
+  getSpawnSubagentsCallbacks,
+  disposeSpawnManager,
+} from './spawn-subagents.js';
+export type {
+  SpawnSubagentsResult,
+  SpawnSubagentsOptions,
+  SubagentResult,
+  SubagentTask,
+} from './spawn-subagents.js';

--- a/src/mcp/tools/spawn-subagents.test.ts
+++ b/src/mcp/tools/spawn-subagents.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for spawn_subagents tool.
+ *
+ * Issue #897: Master-Workers Multi-Agent Collaboration Pattern
+ */
+
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import {
+  spawn_subagents,
+  setSpawnSubagentsCallbacks,
+  getSpawnSubagentsCallbacks,
+  disposeSpawnManager,
+} from './spawn-subagents.js';
+import { SubagentManager } from '../../agents/subagent-manager.js';
+
+// Mock SubagentManager
+vi.mock('../../agents/subagent-manager.js', () => ({
+  SubagentManager: vi.fn().mockImplementation(() => ({
+    spawn: vi.fn(),
+    terminate: vi.fn(),
+    dispose: vi.fn(),
+    list: vi.fn().mockReturnValue([]),
+  })),
+}));
+
+const mockCallbacks = {
+  sendMessage: vi.fn(),
+  sendCard: vi.fn(),
+  sendFile: vi.fn(),
+};
+
+describe('spawn_subagents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Set up global callbacks
+    setSpawnSubagentsCallbacks(mockCallbacks, 'test-chat-123');
+  });
+
+  afterEach(() => {
+    disposeSpawnManager();
+    setSpawnSubagentsCallbacks(null, null);
+  });
+
+  describe('setSpawnSubagentsCallbacks', () => {
+    it('should set global callbacks', () => {
+      const callbacks = { sendMessage: vi.fn(), sendCard: vi.fn(), sendFile: vi.fn() };
+      setSpawnSubagentsCallbacks(callbacks, 'chat-456');
+
+      const result = getSpawnSubagentsCallbacks();
+      expect(result.callbacks).toBe(callbacks);
+      expect(result.chatId).toBe('chat-456');
+    });
+
+    it('should clear global callbacks when set to null', () => {
+      setSpawnSubagentsCallbacks(null, null);
+
+      const result = getSpawnSubagentsCallbacks();
+      expect(result.callbacks).toBeNull();
+      expect(result.chatId).toBeNull();
+    });
+  });
+
+  describe('spawn_subagents', () => {
+    it('should return error when tasks array is empty', async () => {
+      const result = await spawn_subagents({ tasks: [] });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('tasks array is empty');
+      expect(result.message).toContain('没有提供任务');
+    });
+
+    it('should return error when callbacks are not set', async () => {
+      setSpawnSubagentsCallbacks(null, null);
+
+      const result = await spawn_subagents({
+        tasks: [{ type: 'task', name: 'test', prompt: 'test prompt' }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('callbacks.sendMessage is required');
+    });
+
+    it('should return error when chatId is not set', async () => {
+      setSpawnSubagentsCallbacks(mockCallbacks, null);
+
+      const result = await spawn_subagents({
+        tasks: [{ type: 'task', name: 'test', prompt: 'test prompt' }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('chatId is required');
+    });
+
+    it('should spawn subagents and return results', async () => {
+      // Mock successful spawn
+      const mockHandle = {
+        id: 'task-test-123',
+        type: 'task',
+        name: 'test-task',
+        chatId: 'test-chat-123',
+        status: 'completed' as const,
+        startedAt: new Date(),
+        completedAt: new Date(),
+        output: 'Task completed successfully',
+        isolation: 'none' as const,
+      };
+
+      const mockManager = {
+        spawn: vi.fn().mockResolvedValue(mockHandle),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue([mockHandle]),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      const result = await spawn_subagents({
+        tasks: [{ type: 'task', name: 'test-task', prompt: 'Test prompt' }],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('任务完成');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].name).toBe('test-task');
+      expect(result.results[0].status).toBe('completed');
+    });
+
+    it('should handle partial failures', async () => {
+      const mockHandles = [
+        {
+          id: 'task-1',
+          type: 'task',
+          name: 'task-1',
+          chatId: 'test-chat-123',
+          status: 'completed' as const,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          output: 'Success',
+          isolation: 'none' as const,
+        },
+        {
+          id: 'task-2',
+          type: 'task',
+          name: 'task-2',
+          chatId: 'test-chat-123',
+          status: 'failed' as const,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          error: 'Task failed',
+          isolation: 'none' as const,
+        },
+      ];
+
+      const mockManager = {
+        spawn: vi.fn()
+          .mockResolvedValueOnce(mockHandles[0])
+          .mockResolvedValueOnce(mockHandles[1]),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue(mockHandles),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      const result = await spawn_subagents({
+        tasks: [
+          { type: 'task', name: 'task-1', prompt: 'Task 1' },
+          { type: 'task', name: 'task-2', prompt: 'Task 2' },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('部分任务失败');
+      expect(result.results).toHaveLength(2);
+      expect(result.summary).toContain('✅ 成功: 1');
+      expect(result.summary).toContain('❌ 失败: 1');
+    });
+
+    it('should respect maxParallel limit', async () => {
+      const mockHandle = {
+        id: 'task-1',
+        type: 'task',
+        name: 'task',
+        chatId: 'test-chat-123',
+        status: 'completed' as const,
+        startedAt: new Date(),
+        completedAt: new Date(),
+        isolation: 'none' as const,
+      };
+
+      const mockManager = {
+        spawn: vi.fn().mockResolvedValue(mockHandle),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue([mockHandle]),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      await spawn_subagents({
+        tasks: [
+          { type: 'task', name: 'task-1', prompt: 'Task 1' },
+          { type: 'task', name: 'task-2', prompt: 'Task 2' },
+          { type: 'task', name: 'task-3', prompt: 'Task 3' },
+          { type: 'task', name: 'task-4', prompt: 'Task 4' },
+        ],
+        maxParallel: 2,
+      });
+
+      // spawn should be called 4 times (once per task)
+      expect(mockManager.spawn).toHaveBeenCalledTimes(4);
+    });
+
+    it('should handle spawn failures gracefully', async () => {
+      const mockManager = {
+        spawn: vi.fn().mockRejectedValue(new Error('Spawn failed')),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue([]),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      const result = await spawn_subagents({
+        tasks: [{ type: 'task', name: 'test', prompt: 'test' }],
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].status).toBe('failed');
+      expect(result.results[0].error).toContain('Spawn failed');
+    });
+
+    it('should stop on first failure when continueOnFailure is false', async () => {
+      const mockHandles = [
+        {
+          id: 'task-1',
+          type: 'task',
+          name: 'task-1',
+          chatId: 'test-chat-123',
+          status: 'failed' as const,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          error: 'First task failed',
+          isolation: 'none' as const,
+        },
+      ];
+
+      const mockManager = {
+        spawn: vi.fn().mockResolvedValue(mockHandles[0]),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue(mockHandles),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      const result = await spawn_subagents({
+        tasks: [
+          { type: 'task', name: 'task-1', prompt: 'Task 1' },
+          { type: 'task', name: 'task-2', prompt: 'Task 2' },
+        ],
+        continueOnFailure: false,
+        maxParallel: 1, // Force sequential execution
+      });
+
+      // Only first task should be spawned
+      expect(mockManager.spawn).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('disposeSpawnManager', () => {
+    it('should dispose the manager and clear reference', () => {
+      const mockManager = {
+        spawn: vi.fn(),
+        terminate: vi.fn(),
+        dispose: vi.fn(),
+        list: vi.fn().mockReturnValue([]),
+      };
+
+      vi.mocked(SubagentManager).mockImplementation(() => mockManager as unknown as SubagentManager);
+
+      // Trigger manager creation
+      setSpawnSubagentsCallbacks(mockCallbacks, 'test-chat');
+
+      // Dispose
+      disposeSpawnManager();
+
+      // Should be able to call multiple times without error
+      disposeSpawnManager();
+    });
+  });
+});

--- a/src/mcp/tools/spawn-subagents.ts
+++ b/src/mcp/tools/spawn-subagents.ts
@@ -1,0 +1,360 @@
+/**
+ * Spawn Subagents tool implementation.
+ *
+ * This tool provides a master-workers pattern for parallel task execution.
+ * It uses SubagentManager to spawn multiple subagents and collect results.
+ *
+ * Issue #897: Master-Workers Multi-Agent Collaboration Pattern
+ *
+ * @module mcp/tools/spawn-subagents
+ */
+
+import { createLogger } from '../../utils/logger.js';
+import {
+  SubagentManager,
+  type SubagentOptions,
+  type SubagentHandle,
+  type SubagentStatus,
+} from '../../agents/subagent-manager.js';
+import type { PilotCallbacks } from '../../agents/pilot/index.js';
+
+const logger = createLogger('SpawnSubagents');
+
+/**
+ * Result from spawn_subagents tool.
+ */
+export interface SpawnSubagentsResult {
+  success: boolean;
+  message: string;
+  results: SubagentResult[];
+  summary?: string;
+  error?: string;
+}
+
+/**
+ * Result from a single subagent.
+ */
+export interface SubagentResult {
+  id: string;
+  name: string;
+  status: SubagentStatus;
+  output?: string;
+  error?: string;
+  duration: number;
+}
+
+/**
+ * Options for spawning multiple subagents.
+ */
+export interface SpawnSubagentsOptions {
+  /** Array of tasks to execute in parallel */
+  tasks: SubagentTask[];
+  /** Maximum number of parallel executions (default: 3) */
+  maxParallel?: number;
+  /** Timeout in milliseconds for all tasks (default: 300000 = 5 minutes) */
+  timeout?: number;
+  /** Continue on failure (default: true) */
+  continueOnFailure?: boolean;
+}
+
+/**
+ * A single task for a subagent.
+ */
+export interface SubagentTask {
+  /** Type of subagent to spawn */
+  type: SubagentOptions['type'];
+  /** Name/identifier for this task */
+  name: string;
+  /** Prompt/task for the subagent */
+  prompt: string;
+  /** Optional template variables for skill agents */
+  templateVars?: Record<string, string>;
+}
+
+// ============================================================================
+// Global Callback Registration
+// ============================================================================
+
+/**
+ * Global callbacks for spawn_subagents tool.
+ * Set by the Pilot agent when starting a session.
+ */
+let globalCallbacks: PilotCallbacks | null = null;
+let globalChatId: string | null = null;
+
+/**
+ * Set the global callbacks for spawn_subagents tool.
+ * Called by Pilot when starting an agent session.
+ */
+export function setSpawnSubagentsCallbacks(callbacks: PilotCallbacks | null, chatId: string | null): void {
+  globalCallbacks = callbacks;
+  globalChatId = chatId;
+  logger.debug({ hasCallbacks: !!callbacks, chatId }, 'Set spawn_subagents callbacks');
+}
+
+/**
+ * Get the current global callbacks.
+ */
+export function getSpawnSubagentsCallbacks(): { callbacks: PilotCallbacks | null; chatId: string | null } {
+  return { callbacks: globalCallbacks, chatId: globalChatId };
+}
+
+// ============================================================================
+// Global SubagentManager
+// ============================================================================
+
+/**
+ * Global SubagentManager instance for spawn_subagents tool.
+ * Lazily initialized on first use.
+ */
+let globalSpawnManager: SubagentManager | undefined;
+
+/**
+ * Get or create the global SubagentManager for spawn_subagents.
+ */
+function getSpawnManager(): SubagentManager {
+  if (!globalSpawnManager) {
+    globalSpawnManager = new SubagentManager();
+  }
+  return globalSpawnManager;
+}
+
+/**
+ * Wait for all subagents to complete with optional timeout.
+ */
+function waitForCompletion(
+  handles: SubagentHandle[],
+  manager: SubagentManager,
+  timeout?: number
+): Promise<void> {
+  const startTime = Date.now();
+  const timeoutMs = timeout || 300000; // 5 minutes default
+
+  return new Promise((resolve) => {
+    const checkInterval = setInterval(() => {
+      const allDone = handles.every(
+        (h) => h.status === 'completed' || h.status === 'failed' || h.status === 'stopped'
+      );
+
+      if (allDone) {
+        clearInterval(checkInterval);
+        resolve();
+        return;
+      }
+
+      // Check timeout
+      if (Date.now() - startTime > timeoutMs) {
+        logger.warn({ handleCount: handles.length }, 'Timeout reached, terminating running subagents');
+        for (const handle of handles) {
+          if (handle.status === 'running') {
+            manager.terminate(handle.id);
+          }
+        }
+        clearInterval(checkInterval);
+        resolve();
+      }
+    }, 500);
+  });
+}
+
+/**
+ * Collect results from completed subagents.
+ */
+function collectResults(handles: SubagentHandle[]): SubagentResult[] {
+  return handles.map((handle) => ({
+    id: handle.id,
+    name: handle.name,
+    status: handle.status,
+    output: handle.output,
+    error: handle.error,
+    duration: handle.completedAt
+      ? handle.completedAt.getTime() - handle.startedAt.getTime()
+      : Date.now() - handle.startedAt.getTime(),
+  }));
+}
+
+/**
+ * Generate a summary of results.
+ */
+function generateSummary(results: SubagentResult[]): string {
+  const completed = results.filter((r) => r.status === 'completed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const stopped = results.filter((r) => r.status === 'stopped').length;
+  const totalDuration = results.reduce((sum, r) => sum + r.duration, 0);
+
+  const lines = [
+    '## 执行结果汇总',
+    '',
+    `- ✅ 成功: ${completed}`,
+    `- ❌ 失败: ${failed}`,
+    `- ⏹️ 中止: ${stopped}`,
+    `- ⏱️ 总耗时: ${(totalDuration / 1000).toFixed(1)}s`,
+  ];
+
+  if (failed > 0) {
+    lines.push('', '### 失败的任务', '');
+    for (const result of results.filter((r) => r.status === 'failed')) {
+      lines.push(`- **${result.name}**: ${result.error || 'Unknown error'}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Spawn multiple subagents in parallel and collect results.
+ *
+ * This tool implements the master-workers pattern (Issue #897) using
+ * the existing SubagentManager infrastructure.
+ *
+ * @example
+ * ```typescript
+ * const result = await spawn_subagents({
+ *   tasks: [
+ *     { type: 'task', name: 'analyze-file-a', prompt: 'Analyze file A' },
+ *     { type: 'task', name: 'analyze-file-b', prompt: 'Analyze file B' },
+ *   ],
+ *   maxParallel: 2,
+ * });
+ * ```
+ */
+export async function spawn_subagents(
+  params: SpawnSubagentsOptions
+): Promise<SpawnSubagentsResult> {
+  const {
+    tasks,
+    maxParallel = 3,
+    timeout,
+    continueOnFailure = true,
+  } = params;
+
+  // Get callbacks and chatId from global context
+  const { callbacks, chatId } = getSpawnSubagentsCallbacks();
+
+  logger.info(
+    { taskCount: tasks.length, maxParallel, chatId },
+    'spawn_subagents called'
+  );
+
+  // Validate inputs
+  if (!tasks || tasks.length === 0) {
+    return {
+      success: false,
+      message: '❌ 没有提供任务',
+      results: [],
+      error: 'tasks array is empty',
+    };
+  }
+
+  if (!callbacks || !callbacks.sendMessage) {
+    return {
+      success: false,
+      message: '❌ 缺少必要的回调函数，请确保在会话上下文中调用此工具',
+      results: [],
+      error: 'callbacks.sendMessage is required (not in session context)',
+    };
+  }
+
+  if (!chatId) {
+    return {
+      success: false,
+      message: '❌ 缺少 chatId，请确保在会话上下文中调用此工具',
+      results: [],
+      error: 'chatId is required (not in session context)',
+    };
+  }
+
+  try {
+    const manager = getSpawnManager();
+    const handles: SubagentHandle[] = [];
+
+    // Spawn subagents in batches to respect maxParallel
+    for (let i = 0; i < tasks.length; i += maxParallel) {
+      const batch = tasks.slice(i, i + maxParallel);
+
+      // Spawn batch in parallel
+      const batchPromises = batch.map(async (task) => {
+        try {
+          const options: SubagentOptions = {
+            type: task.type,
+            name: task.name,
+            prompt: task.prompt,
+            chatId,
+            callbacks,
+            templateVars: task.templateVars,
+          };
+
+          const handle = await manager.spawn(options);
+          return handle;
+        } catch (error) {
+          logger.error({ err: error, task: task.name }, 'Failed to spawn subagent');
+          // Return a failed handle
+          return {
+            id: `failed-${task.name}`,
+            type: task.type,
+            name: task.name,
+            chatId,
+            status: 'failed' as SubagentStatus,
+            startedAt: new Date(),
+            completedAt: new Date(),
+            error: error instanceof Error ? error.message : String(error),
+            isolation: 'none' as const,
+          };
+        }
+      });
+
+      const batchHandles = await Promise.all(batchPromises);
+      handles.push(...batchHandles);
+
+      // If continueOnFailure is false, check for failures
+      if (!continueOnFailure) {
+        const hasFailure = batchHandles.some((h) => h.status === 'failed');
+        if (hasFailure) {
+          logger.warn('Stopping due to failure (continueOnFailure=false)');
+          break;
+        }
+      }
+    }
+
+    // Wait for all to complete
+    await waitForCompletion(handles, manager, timeout);
+
+    // Collect results
+    const results = collectResults(handles);
+    const summary = generateSummary(results);
+
+    // Determine overall success
+    const allCompleted = results.every((r) => r.status === 'completed');
+    const anyFailed = results.some((r) => r.status === 'failed');
+
+    return {
+      success: allCompleted,
+      message: allCompleted
+        ? `✅ 所有任务完成 (${results.length}/${tasks.length})`
+        : anyFailed
+          ? `⚠️ 部分任务失败 (${results.filter((r) => r.status === 'completed').length}/${tasks.length} 成功)`
+          : '⏹️ 任务被中止',
+      results,
+      summary,
+    };
+  } catch (error) {
+    logger.error({ err: error }, 'spawn_subagents failed');
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      success: false,
+      message: `❌ 执行失败: ${errorMessage}`,
+      results: [],
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Dispose of the global spawn manager.
+ */
+export function disposeSpawnManager(): void {
+  if (globalSpawnManager) {
+    globalSpawnManager.dispose();
+    globalSpawnManager = undefined;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `spawn_subagents` MCP tool that enables parallel task execution using the existing SubagentManager infrastructure, completing **Issue #897 Phase 2**.

## Changes

- Add `spawn_subagents` MCP tool in `src/mcp/tools/spawn-subagents.ts`
- Support parallel execution with configurable `maxParallel` limit
- Include result aggregation and summary generation
- Add comprehensive unit tests (11 tests, all passing)
- Integrate with Pilot via `setSpawnSubagentsCallbacks`

## Features

| Feature | Description |
|---------|-------------|
| **Parallel Execution** | Execute multiple subagents concurrently |
| **Batch Processing** | Respect maxParallel limit for resource control |
| **Error Handling** | Continue on failure option, graceful error handling |
| **Result Summary** | Generate comprehensive execution summary |

## Usage Example

```json
{
  "tasks": [
    {"type": "task", "name": "analyze-auth", "prompt": "Analyze the auth module"},
    {"type": "task", "name": "analyze-api", "prompt": "Analyze the API module"},
    {"type": "task", "name": "analyze-db", "prompt": "Analyze the database module"}
  ],
  "maxParallel": 3
}
```

## Use Cases

- **Parallel File Processing**: Analyze multiple files simultaneously
- **Multi-Source Research**: Gather information from different sources in parallel
- **Task Decomposition**: Break complex tasks into smaller parallel subtasks
- **Batch Operations**: Execute multiple independent operations concurrently

## Test Results

```
 ✓ spawn_subagents > setSpawnSubagentsCallbacks > should set global callbacks
 ✓ spawn_subagents > setSpawnSubagentsCallbacks > should clear global callbacks when set to null
 ✓ spawn_subagents > spawn_subagents > should return error when tasks array is empty
 ✓ spawn_subagents > spawn_subagents > should return error when callbacks are not set
 ✓ spawn_subagents > spawn_subagents > should return error when chatId is not set
 ✓ spawn_subagents > spawn_subagents > should spawn subagents and return results
 ✓ spawn_subagents > spawn_subagents > should handle partial failures
 ✓ spawn_subagents > spawn_subagents > should respect maxParallel limit
 ✓ spawn_subagents > spawn_subagents > should handle spawn failures gracefully
 ✓ spawn_subagents > spawn_subagents > should stop on first failure when continueOnFailure is false
 ✓ spawn_subagents > disposeSpawnManager > should dispose the manager and clear reference

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Related

- Closes #897 (Phase 2 - MCP Tool integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)