### PR TITLE
feat(config): add sessionRestore configuration and improve reset command (Issue #1213)

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -241,6 +241,25 @@ tools:
     #     CUSTOM_VAR: "value"
 
 # -----------------------------------------------------------------------------
+# Session Restoration Configuration (Issue #1213)
+# -----------------------------------------------------------------------------
+# Controls how chat history is loaded when agent starts or resets.
+sessionRestore:
+  # Number of days to look back for chat history
+  # Default: 7
+  historyDays: 7
+
+  # Maximum characters for restored session context
+  # Default: 4000
+  maxContextLength: 4000
+
+  # Whether to load history on reset (default: false)
+  # When false: /reset gives a clean session without history
+  # When true: /reset reloads history context
+  # Users can override with /reset --keep-context
+  loadOnReset: false
+
+# -----------------------------------------------------------------------------
 # Global Environment Variables
 # -----------------------------------------------------------------------------
 # Environment variables defined here will be passed to all agent processes.

--- a/packages/core/src/types/websocket-messages.ts
+++ b/packages/core/src/types/websocket-messages.ts
@@ -34,6 +34,8 @@ export interface CommandMessage {
   chatId: string;
   /** Target exec node ID for switch-node command */
   targetNodeId?: string;
+  /** Whether to keep context when resetting (Issue #1213) */
+  keepContext?: boolean;
 }
 
 /**

--- a/src/agents/agent-pool.ts
+++ b/src/agents/agent-pool.ts
@@ -128,12 +128,13 @@ export class AgentPool {
    * If the ChatAgent exists, calls its reset method.
    *
    * @param chatId - The chat identifier
+   * @param keepContext - If true, reloads history context after reset (default: false)
    */
-  reset(chatId: string): void {
+  reset(chatId: string, keepContext?: boolean): void {
     const agent = this.chatAgents.get(chatId);
     if (agent) {
-      this.log.debug({ chatId }, 'Resetting ChatAgent for chatId');
-      agent.reset(chatId);
+      this.log.debug({ chatId, keepContext }, 'Resetting ChatAgent for chatId');
+      agent.reset(chatId, keepContext);
     }
   }
 

--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -34,7 +34,6 @@
 
 import type { StreamingUserMessage, QueryHandle } from '../../sdk/index.js';
 import { Config } from '../../config/index.js';
-import { SESSION_RESTORE } from '../../config/constants.js';
 import { createFeishuSdkMcpServer } from '../../mcp/feishu-context-mcp.js';
 import { messageLogger } from '../../feishu/message-logger.js';
 import { BaseAgent } from '../base-agent.js';
@@ -160,23 +159,26 @@ export class Pilot extends BaseAgent implements ChatAgent {
 
   /**
    * Internal method to perform the actual history loading.
+   * Uses configurable parameters from Config.getSessionRestoreConfig().
    */
   private async doLoadPersistedHistory(): Promise<void> {
     try {
+      const sessionConfig = Config.getSessionRestoreConfig();
+
       this.logger.info(
-        { chatId: this.boundChatId, days: SESSION_RESTORE.HISTORY_DAYS },
+        { chatId: this.boundChatId, days: sessionConfig.historyDays },
         'Loading persisted chat history for session restoration'
       );
 
       const history = await messageLogger.getChatHistory(
         this.boundChatId,
-        SESSION_RESTORE.HISTORY_DAYS
+        sessionConfig.historyDays
       );
 
       if (history && history.trim()) {
         // Truncate if too long
-        this.persistedHistoryContext = history.length > SESSION_RESTORE.MAX_CONTEXT_LENGTH
-          ? history.slice(-SESSION_RESTORE.MAX_CONTEXT_LENGTH)
+        this.persistedHistoryContext = history.length > sessionConfig.maxContextLength
+          ? history.slice(-sessionConfig.maxContextLength)
           : history;
 
         this.logger.info(
@@ -726,10 +728,12 @@ export class Pilot extends BaseAgent implements ChatAgent {
    * Reset the agent session (ChatAgent interface).
    *
    * Clears conversation history and state for this Pilot's bound chatId.
+   * By default, does NOT reload history context after reset, giving a clean session.
    *
    * @param chatId - Optional chat ID (must match bound chatId if provided)
+   * @param keepContext - If true, reloads history context after reset (default: false, uses config)
    */
-  reset(chatId?: string): void {
+  reset(chatId?: string, keepContext?: boolean): void {
     // Issue #644: If chatId is provided, it must match bound chatId
     if (chatId && chatId !== this.boundChatId) {
       this.logger.warn(
@@ -739,7 +743,7 @@ export class Pilot extends BaseAgent implements ChatAgent {
       return;
     }
 
-    this.logger.info({ chatId: this.boundChatId }, 'Resetting Pilot session');
+    this.logger.info({ chatId: this.boundChatId, keepContext }, 'Resetting Pilot session');
 
     // Mark session as inactive BEFORE closing to signal explicit close
     this.isSessionActive = false;
@@ -763,6 +767,15 @@ export class Pilot extends BaseAgent implements ChatAgent {
     // Clear persisted history context (Issue #955)
     this.persistedHistoryContext = undefined;
     this.historyLoaded = false;
+
+    // Issue #1213: Reload history only if explicitly requested or config says so
+    const shouldLoadContext = keepContext ?? Config.getSessionRestoreConfig().loadOnReset;
+    if (shouldLoadContext) {
+      this.logger.info({ chatId: this.boundChatId }, 'Reloading history context after reset');
+      this.loadPersistedHistory().catch((err) => {
+        this.logger.error({ err, chatId: this.boundChatId }, 'Failed to reload history after reset');
+      });
+    }
   }
 
   /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -193,8 +193,9 @@ export interface ChatAgent extends Disposable {
    * Clears conversation history and state.
    *
    * @param chatId - Optional chat ID to reset specific session
+   * @param keepContext - If true, reloads history context after reset (default: false)
    */
-  reset(chatId?: string): void;
+  reset(chatId?: string, keepContext?: boolean): void;
 }
 
 // ============================================================================

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -367,4 +367,24 @@ export class Config {
   static isAgentTeamsEnabled(): boolean {
     return fileConfigOnly.agent?.enableAgentTeams ?? false;
   }
+
+  /**
+   * Get session restoration configuration.
+   * Controls how chat history is loaded when agent starts or resets.
+   * @see Issue #1213
+   *
+   * @returns Session restoration configuration with defaults
+   */
+  static getSessionRestoreConfig(): {
+    historyDays: number;
+    maxContextLength: number;
+    loadOnReset: boolean;
+  } {
+    const config = fileConfigOnly.sessionRestore || {};
+    return {
+      historyDays: config.historyDays ?? 7,
+      maxContextLength: config.maxContextLength ?? 4000,
+      loadOnReset: config.loadOnReset ?? false,
+    };
+  }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -310,6 +310,19 @@ export interface MessagingConfig {
 }
 
 /**
+ * Session restoration configuration (Issue #1213).
+ * Controls how chat history is loaded when agent starts or resets.
+ */
+export interface SessionRestoreConfig {
+  /** Number of days to look back for chat history (default: 7) */
+  historyDays?: number;
+  /** Maximum characters for restored session context (default: 4000) */
+  maxContextLength?: number;
+  /** Whether to load history on reset (default: false) */
+  loadOnReset?: boolean;
+}
+
+/**
  * Run mode for the application.
  * - comm: Communication Node (Feishu WebSocket handler)
  * - exec: Execution Node (Pilot/Agent handler)
@@ -343,6 +356,8 @@ export interface DisclaudeConfig {
   channels?: ChannelsConfig;
   /** Message routing configuration */
   messaging?: MessagingConfig;
+  /** Session restoration configuration (Issue #1213) */
+  sessionRestore?: SessionRestoreConfig;
   /** Global environment variables applied to all agent processes */
   env?: Record<string, string>;
 }

--- a/src/nodes/command-services.ts
+++ b/src/nodes/command-services.ts
@@ -36,7 +36,7 @@ export interface CommandServicesDeps {
   /** Execution node registry */
   execNodeRegistry: ExecNodeRegistry;
   /** Send command to execution node */
-  sendCommand: (command: 'reset' | 'restart', chatId: string) => Promise<void>;
+  sendCommand: (command: 'reset' | 'restart', chatId: string, options?: { keepContext?: boolean }) => Promise<void>;
   /** Get Feishu client */
   getFeishuClient: () => lark.Client;
   /** Group service */

--- a/src/nodes/commands/commands/session-commands.ts
+++ b/src/nodes/commands/commands/session-commands.ts
@@ -12,17 +12,31 @@ import type { Command, CommandContext, CommandResult } from '../types.js';
 
 /**
  * Reset Command - Reset the conversation session.
+ *
+ * Issue #1213: Supports optional `--keep-context` flag to preserve history.
  */
 export class ResetCommand implements Command {
   readonly name = 'reset';
   readonly category = 'session' as const;
   readonly description = '重置对话';
+  readonly usage = '/reset [--keep-context]  # 使用 --keep-context 保留历史上下文';
 
   async execute(context: CommandContext): Promise<CommandResult> {
-    await context.services.sendCommand('reset', context.chatId);
+    // Check for --keep-context flag (Issue #1213)
+    const keepContext = context.args.includes('--keep-context');
+
+    await context.services.sendCommand('reset', context.chatId, { keepContext });
+
+    if (keepContext) {
+      return {
+        success: true,
+        message: '✅ **对话已重置**\n\n新的会话已启动，历史上下文已保留。',
+      };
+    }
+
     return {
       success: true,
-      message: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。',
+      message: '✅ **对话已重置**\n\n新的会话已启动，之前的上下文已清除。\n\n💡 使用 `/reset --keep-context` 可保留历史上下文。',
     };
   }
 }

--- a/src/nodes/commands/types.ts
+++ b/src/nodes/commands/types.ts
@@ -159,7 +159,7 @@ export interface CommandServices {
   getNode: (nodeId: string) => { name: string } | undefined;
 
   /** Send a command to execution node */
-  sendCommand: (command: 'reset' | 'restart', chatId: string) => Promise<void>;
+  sendCommand: (command: 'reset' | 'restart', chatId: string, options?: { keepContext?: boolean }) => Promise<void>;
 
   /** Get Feishu client for group operations */
   getFeishuClient: () => lark.Client;

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -676,8 +676,8 @@ export class PrimaryNode extends EventEmitter {
       isRunning: () => this.running,
       getLocalNodeId: () => this.localNodeId,
       execNodeRegistry: this.execNodeRegistry,
-      sendCommand: async (cmd: 'reset' | 'restart', chatId: string) => {
-        await this.sendCommand({ type: 'command', command: cmd, chatId });
+      sendCommand: async (cmd: 'reset' | 'restart', chatId: string, options?: { keepContext?: boolean }) => {
+        await this.sendCommand({ type: 'command', command: cmd, chatId, keepContext: options?.keepContext });
       },
       getFeishuClient: () => this.getFeishuClient(),
       groupService: this.groupService,
@@ -745,14 +745,15 @@ export class PrimaryNode extends EventEmitter {
 
     // Handle locally
     if (execNode.isLocal && this.agentPool) {
-      const { command, chatId } = message;
-      logger.info({ command, chatId }, 'Executing command locally');
+      const { command, chatId, keepContext } = message;
+      logger.info({ command, chatId, keepContext }, 'Executing command locally');
 
       try {
         if (command === 'reset' || command === 'restart') {
           // Issue #644: Reset the Pilot for this chatId via AgentPool
-          this.agentPool.reset(chatId);
-          logger.info({ chatId }, `Pilot ${command} executed for chatId`);
+          // Issue #1213: Pass keepContext option
+          this.agentPool.reset(chatId, keepContext);
+          logger.info({ chatId, keepContext }, `Pilot ${command} executed for chatId`);
         }
       } catch (error) {
         const err = error as Error;


### PR DESCRIPTION
## Summary

This PR implements the feedback from Issue #1213, making session restoration configurable and improving the reset command behavior.

## Changes

### Configuration
- Add `sessionRestore` config section with `historyDays`, `maxContextLength`, and `loadOnReset` options
- Add `Config.getSessionRestoreConfig()` method with sensible defaults
- Update example config file with documentation

### Reset Command Improvements
- `/reset` now gives a completely clean session (no history loaded by default)
- `/reset --keep-context` preserves history context after reset
- Add usage hint in reset response message

### Type Updates
- Add `SessionRestoreConfig` interface to config types
- Add `keepContext` field to `CommandMessage` for WebSocket communication
- Update `ChatAgent.reset()` signature to accept `keepContext` parameter

## Migration

No breaking changes. Default behavior:
- `historyDays`: 7 (unchanged)
- `maxContextLength`: 4000 (unchanged)
- `loadOnReset`: false (new default - reset gives clean session)

Users who want the old behavior can set `loadOnReset: true` in config.

## Test Plan

- [x] TypeScript compilation passes
- [x] Configuration changes are backward compatible
- [x] Reset command supports `--keep-context` flag
- [x] Default reset behavior gives clean session

🤖 Generated with [Claude Code](https://claude.com/claude-code)