### PR TITLE
fix(lint): resolve lint errors blocking all PR CI

### DIFF
--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -70,7 +70,7 @@ vi.mock('net', () => ({
             const lines = data.split('\n').filter((l: string) => l.trim());
             for (const line of lines) {
               try {
-                const request = JSON.parse(line);
+                JSON.parse(line);
                 // Simulate server response
                 serverSocket.emit('data', line);
               } catch {
@@ -398,9 +398,13 @@ describe('UnixSocketIpcClient', () => {
       unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
       generateInteractionPrompt: (messageId, actionValue, actionText) => {
         const context = mockContexts.get(messageId);
-        if (!context) return undefined;
+        if (!context) {
+          return undefined;
+        }
         const template = context.actionPrompts[actionValue];
-        if (!template) return undefined;
+        if (!template) {
+          return undefined;
+        }
         return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
       },
       cleanupExpiredContexts: () => 0,


### PR DESCRIPTION
## Summary

Fix 3 lint errors in `src/ipc/ipc.test.ts` that were causing CI failures for all open PRs.

## Problem

The main branch had 3 lint errors:
- Line 73: `'request' is assigned a value but never used` (@typescript-eslint/no-unused-vars)
- Line 401: `Expected { after 'if' condition` (curly)
- Line 403: `Expected { after 'if' condition` (curly)

These errors were causing **all 18 open PRs** to fail CI with "Lint & Type Check" failures.

## Changes

- Line 73: Removed unused variable assignment (`const request = JSON.parse(line)` → `JSON.parse(line)`)
- Lines 401, 403: Added curly braces to single-line `if` statements

## Verification

- [x] `npm run lint` passes with 0 errors (only warnings remain)
- [x] Changes are minimal and focused

## Impact

Once merged, all open PRs should be able to pass CI after rebasing/merging main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)