### PR TITLE
fix(lint+types): resolve lint errors and TypeScript type issues

### DIFF
--- a/packages/primary-node/src/channels/rest-channel.test.ts
+++ b/packages/primary-node/src/channels/rest-channel.test.ts
@@ -270,10 +270,11 @@ describe('RestChannel', () => {
       channel = new RestChannel({ port: TEST_PORT });
       await channel.start();
 
-      expect(channel.checkHealth()).toBe(true);
+      // Access protected method for testing
+      expect((channel as any).checkHealth()).toBe(true);
 
       await channel.stop();
-      expect(channel.checkHealth()).toBe(false);
+      expect((channel as any).checkHealth()).toBe(false);
     });
   });
 });

--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -70,7 +70,7 @@ vi.mock('net', () => ({
             const lines = data.split('\n').filter((l: string) => l.trim());
             for (const line of lines) {
               try {
-                const request = JSON.parse(line);
+                JSON.parse(line);
                 // Simulate server response
                 serverSocket.emit('data', line);
               } catch {
@@ -398,9 +398,13 @@ describe('UnixSocketIpcClient', () => {
       unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
       generateInteractionPrompt: (messageId, actionValue, actionText) => {
         const context = mockContexts.get(messageId);
-        if (!context) return undefined;
+        if (!context) {
+          return undefined;
+        }
         const template = context.actionPrompts[actionValue];
-        if (!template) return undefined;
+        if (!template) {
+          return undefined;
+        }
         return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
       },
       cleanupExpiredContexts: () => 0,


### PR DESCRIPTION
## Summary

This PR fixes CI failures that were blocking all open PRs by resolving:
1. **Lint errors** in `src/ipc/ipc.test.ts`
2. **TypeScript type error** in `packages/primary-node/src/channels/rest-channel.test.ts`

## Problem

### Lint Errors (3 errors)
- Line 73: `'request' is assigned a value but never used` (@typescript-eslint/no-unused-vars)
- Lines 401, 403: `Expected { after 'if' condition` (curly)

### TypeScript Error
- Lines 273, 276: `Property 'checkHealth' is protected and only accessible within class 'RestChannel' and its subclasses`

## Changes

### src/ipc/ipc.test.ts
- Remove unused variable assignment (`const request = JSON.parse(line)` → `JSON.parse(line)`)
- Add curly braces to single-line `if` statements

### packages/primary-node/src/channels/rest-channel.test.ts
- Use type assertion `(channel as any).checkHealth()` to access protected method in tests

## Verification

- [x] `npm run lint`: 0 errors (111 warnings remain)
- [x] `npm run build`: success

## Impact

Once merged, all open PRs should be able to pass CI after rebasing/merging main.

Supersedes #1272 (which had the lint fixes but missed the TypeScript error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)