### PR TITLE
fix(ci): resolve lint and TypeScript errors blocking all PRs

### DIFF
--- a/packages/primary-node/src/channels/rest-channel.test.ts
+++ b/packages/primary-node/src/channels/rest-channel.test.ts
@@ -270,10 +270,10 @@ describe('RestChannel', () => {
       channel = new RestChannel({ port: TEST_PORT });
       await channel.start();
 
-      expect(channel.checkHealth()).toBe(true);
+      expect((channel as any).checkHealth()).toBe(true);
 
       await channel.stop();
-      expect(channel.checkHealth()).toBe(false);
+      expect((channel as any).checkHealth()).toBe(false);
     });
   });
 });

--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -41,6 +41,7 @@ vi.mock('../config/index.js', () => ({
       rotate: false,
       sdkDebug: true,
     })),
+    isAgentTeamsEnabled: vi.fn(() => false),
   },
 }));
 

--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -38,6 +38,7 @@ vi.mock('../config/index.js', () => ({
       rotate: false,
       sdkDebug: false,
     })),
+    isAgentTeamsEnabled: vi.fn(() => false),
   },
 }));
 

--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -70,7 +70,7 @@ vi.mock('net', () => ({
             const lines = data.split('\n').filter((l: string) => l.trim());
             for (const line of lines) {
               try {
-                const request = JSON.parse(line);
+                JSON.parse(line);
                 // Simulate server response
                 serverSocket.emit('data', line);
               } catch {
@@ -398,9 +398,13 @@ describe('UnixSocketIpcClient', () => {
       unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
       generateInteractionPrompt: (messageId, actionValue, actionText) => {
         const context = mockContexts.get(messageId);
-        if (!context) return undefined;
+        if (!context) {
+          return undefined;
+        }
         const template = context.actionPrompts[actionValue];
-        if (!template) return undefined;
+        if (!template) {
+          return undefined;
+        }
         return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
       },
       cleanupExpiredContexts: () => 0,


### PR DESCRIPTION
## Summary

This PR fixes CI failures on the main branch that are blocking all open PRs from being merged.

### Root Cause Analysis

The main branch has accumulated several CI issues:

1. **Lint errors** (3 errors in `src/ipc/ipc.test.ts`):
   - Line 73: `'request' is assigned a value but never used`
   - Lines 401, 403: `Expected { after 'if' condition`

2. **TypeScript errors** (2 errors in `packages/primary-node/src/channels/rest-channel.test.ts`):
   - Lines 273, 276: `Property 'checkHealth' is protected and only accessible within class 'RestChannel' and its subclasses`

3. **Test failures** (8 tests in `pilot.test.ts` and `site-miner.test.ts`):
   - `TypeError: Config.isAgentTeamsEnabled is not a function`

## Changes

| File | Change |
|------|--------|
| `src/ipc/ipc.test.ts` | Remove unused variable, add curly braces to if statements |
| `packages/primary-node/src/channels/rest-channel.test.ts` | Use type assertion `(channel as any)` for protected method access |
| `src/agents/pilot.test.ts` | Add `isAgentTeamsEnabled: vi.fn(() => false)` to Config mock |
| `src/agents/site-miner.test.ts` | Add `isAgentTeamsEnabled: vi.fn(() => false)` to Config mock |

## Verification

- ✅ **Lint**: 0 errors, 111 warnings (warnings are acceptable)
- ✅ **TypeScript build**: All packages build successfully
- ✅ **Tests**: 1970 tests pass, 1 skipped

## Impact

Once this PR is merged:
- All currently blocked PRs will be able to pass CI
- New PRs will not be blocked by these base issues

## Test Plan

- [x] Run `npm run lint` locally - 0 errors
- [x] Run `npm run build:packages` locally - success
- [x] Run `npm test` locally - 1970 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)