### PR TITLE
fix(context): optimize context attachment logic for session startup and passive mode

### DIFF
--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -195,6 +195,14 @@ export interface ChatAgent extends Disposable {
    * @param chatId - Optional chat ID to reset specific session
    */
   reset(chatId?: string): void;
+
+  /**
+   * Check if the agent has an active session.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   *
+   * @returns true if there's an active session, false if it's a new session
+   */
+  hasActiveSession(): boolean;
 }
 
 // ============================================================================

--- a/src/channels/feishu-channel.ts
+++ b/src/channels/feishu-channel.ts
@@ -78,6 +78,12 @@ export interface FeishuChannelConfig extends ChannelConfig {
       trigger?: string;
     };
   }) => Promise<boolean>;
+  /**
+   * Check if an agent session is currently active for a chat.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   * Returns true if there's an active session, false if it's a new session.
+   */
+  isSessionActive?: (chatId: string) => boolean;
 }
 
 /**
@@ -132,6 +138,8 @@ export class FeishuChannel extends BaseChannel<FeishuChannelConfig> {
       },
       // Issue #935: Route card action to Worker Node if applicable
       routeCardAction: config.routeCardAction,
+      // Issue #1230: Check if agent session is active for context attachment
+      isSessionActive: config.isSessionActive,
     };
 
     this.feishuMessageHandler = new FeishuMessageHandler({

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -70,6 +70,12 @@ export interface MessageCallbacks {
       trigger?: string;
     };
   }) => Promise<boolean>;
+  /**
+   * Check if an agent session is currently active for a chat.
+   * Issue #1230: Used to determine if chat history context should be attached.
+   * Returns true if there's an active session, false if it's a new session.
+   */
+  isSessionActive?: (chatId: string) => boolean;
 }
 
 /**
@@ -852,15 +858,21 @@ export class MessageHandler {
       }
     }
 
-    // Get chat history context for passive mode
+    // Get chat history context for passive mode or new session
+    // Issue #1230: Attach context only when:
+    // 1. New agent session (session not active yet)
+    // 2. Group chat passive mode (bot mentioned in group chat)
+    // NOT for already-active 1:1 conversations where agent already knows the context
     const isPassiveModeTrigger = this.isGroupChat(chat_type) && botMentioned;
+    const isNewSession = !this.callbacks.isSessionActive?.(chat_id);
+    const shouldAttachContext = isNewSession || isPassiveModeTrigger;
     let chatHistoryContext: string | undefined;
 
-    if (isPassiveModeTrigger) {
+    if (shouldAttachContext) {
       chatHistoryContext = await this.getChatHistoryContext(chat_id);
       logger.debug(
-        { messageId: message_id, chatId: chat_id, historyLength: chatHistoryContext?.length },
-        'Including chat history context for passive mode trigger'
+        { messageId: message_id, chatId: chat_id, historyLength: chatHistoryContext?.length, isNewSession, isPassiveModeTrigger },
+        'Including chat history context'
       );
     }
 

--- a/src/nodes/primary-node.ts
+++ b/src/nodes/primary-node.ts
@@ -233,6 +233,14 @@ export class PrimaryNode extends EventEmitter {
             action: message.action,
           });
         },
+        // Issue #1230: Check if agent session is active for context attachment
+        isSessionActive: (chatId: string) => {
+          if (!this.agentPool) {
+            return false;
+          }
+          const agent = this.agentPool.get(chatId);
+          return agent?.hasActiveSession() ?? false;
+        },
       });
 
       // Initialize TaskFlowOrchestrator for Feishu channel


### PR DESCRIPTION
## Summary
- Optimizes context attachment logic to only attach chat history when needed
- Adds `hasActiveSession()` method to `ChatAgent` interface
- Attaches context for new sessions and group chat passive mode, but not for active 1:1 conversations

Fixes #1230

## Problem
Context (chat history) was only attached during group chat passive mode (bot mentioned). However, new agent sessions also need context to understand the conversation, while active 1:1 conversations don't need repeated context attachment.

## Solution
Modified context attachment logic to attach chat history context only when:
1. **New agent session** (session not active yet) - needs context to understand conversation
2. **Group chat passive mode** (bot mentioned in group chat) - needs context to catch up

NOT for already-active 1:1 conversations where agent already knows the context.

## Changes
- Added `hasActiveSession()` method to `ChatAgent` interface
- Added `isSessionActive` callback to `MessageCallbacks` and `FeishuChannelConfig` interfaces
- Modified `shouldAttachContext` logic in `message-handler.ts`
- Implemented `isSessionActive` callback in `PrimaryNode` using `AgentPool`

## Test plan
- [ ] Manual testing: Start a new 1:1 conversation and verify context is attached
- [ ] Manual testing: Continue an active 1:1 conversation and verify context is NOT attached
- [ ] Manual testing: @mention bot in group chat and verify context is attached
- [ ] Manual testing: Continue group chat after @mention and verify context is attached (session is now active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)