### PR TITLE
fix(ci): resolve lint and TypeScript errors blocking all PRs

### DIFF
--- a/packages/primary-node/src/channels/rest-channel.test.ts
+++ b/packages/primary-node/src/channels/rest-channel.test.ts
@@ -270,10 +270,10 @@ describe('RestChannel', () => {
       channel = new RestChannel({ port: TEST_PORT });
       await channel.start();
 
-      expect(channel.checkHealth()).toBe(true);
+      expect(channel.isHealthy()).toBe(true);
 
       await channel.stop();
-      expect(channel.checkHealth()).toBe(false);
+      expect(channel.isHealthy()).toBe(false);
     });
   });
 });

--- a/src/ipc/ipc.test.ts
+++ b/src/ipc/ipc.test.ts
@@ -70,7 +70,7 @@ vi.mock('net', () => ({
             const lines = data.split('\n').filter((l: string) => l.trim());
             for (const line of lines) {
               try {
-                const request = JSON.parse(line);
+                JSON.parse(line);
                 // Simulate server response
                 serverSocket.emit('data', line);
               } catch {
@@ -398,9 +398,13 @@ describe('UnixSocketIpcClient', () => {
       unregisterActionPrompts: (messageId) => mockContexts.delete(messageId),
       generateInteractionPrompt: (messageId, actionValue, actionText) => {
         const context = mockContexts.get(messageId);
-        if (!context) return undefined;
+        if (!context) {
+          return undefined;
+        }
         const template = context.actionPrompts[actionValue];
-        if (!template) return undefined;
+        if (!template) {
+          return undefined;
+        }
         return template.replace(/\{\{actionText\}\}/g, actionText ?? '');
       },
       cleanupExpiredContexts: () => 0,


### PR DESCRIPTION
## Summary

- Remove unused variable `request` in `src/ipc/ipc.test.ts`
- Add missing curly braces for if statements in `src/ipc/ipc.test.ts` (curly rule)
- Use public `isHealthy()` method instead of protected `checkHealth()` in `packages/primary-node/src/channels/rest-channel.test.ts`

## Problem

The main branch CI was failing with 3 lint errors and 2 TypeScript errors, blocking all PRs from being merged:

**Lint errors:**
1. `src/ipc/ipc.test.ts:73:23` - 'request' is assigned a value but never used
2. `src/ipc/ipc.test.ts:401:23` - Expected { after 'if' condition
3. `src/ipc/ipc.test.ts:403:24` - Expected { after 'if' condition

**TypeScript errors:**
1. `rest-channel.test.ts:273,22` - Property 'checkHealth' is protected
2. `rest-channel.test.ts:276,22` - Property 'checkHealth' is protected

## Solution

1. Removed the unused `request` variable (just parse JSON without storing)
2. Added curly braces to single-line if statements
3. Changed `checkHealth()` to `isHealthy()` (the public method)

## Test Plan

- [x] `npm run lint` - 0 errors (111 warnings remain, but are non-blocking)
- [x] `npm run type-check` - All TypeScript builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)