### PR TITLE
fix(test): add missing Config method mocks to fix CI failures

### DIFF
--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -41,6 +41,12 @@ vi.mock('../config/index.js', () => ({
       rotate: false,
       sdkDebug: true,
     })),
+    isAgentTeamsEnabled: vi.fn(() => false),
+    getSessionRestoreConfig: vi.fn(() => ({
+      historyDays: 7,
+      maxContextLength: 4000,
+      loadOnReset: false,
+    })),
   },
 }));
 

--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -38,6 +38,7 @@ vi.mock('../config/index.js', () => ({
       rotate: false,
       sdkDebug: false,
     })),
+    isAgentTeamsEnabled: vi.fn(() => false),
   },
 }));
 


### PR DESCRIPTION
## Summary

Fixes CI unit test failures caused by missing Config method mocks in test files.

The `pilot.test.ts` and `site-miner.test.ts` were missing mocks for newly added Config methods:
- `isAgentTeamsEnabled()` - added in Issue #1208
- `getSessionRestoreConfig()` - added in Issue #1213

This caused CI unit tests to fail with errors like:
```
TypeError: Config.isAgentTeamsEnabled is not a function
```

## Changes

- Add `isAgentTeamsEnabled` mock to `pilot.test.ts` and `site-miner.test.ts`
- Add `getSessionRestoreConfig` mock to `pilot.test.ts`

## Verification

- [x] All 1977 tests pass locally
- [x] Changes are minimal and focused on test mocks only

## Impact

Once merged, this should fix the main branch CI failures that are currently blocking all other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)