### PR TITLE
fix(feishu): add parentId fallback for forwarded images (Issue #1205)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -120,13 +120,13 @@ export class MessageHandler {
     // Initialize FileHandler
     this.fileHandler = new FeishuFileHandler({
       attachmentManager,
-      downloadFile: async (fileKey: string, messageType: string, fileName?: string, messageId?: string) => {
+      downloadFile: async (fileKey: string, messageType: string, fileName?: string, messageId?: string, parentId?: string) => {
         if (!this.client) {
           logger.error({ fileKey }, 'Client not initialized for file download');
           return { success: false };
         }
         try {
-          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId);
+          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId, parentId);
           return { success: true, filePath };
         } catch (error) {
           logger.error({ err: error, fileKey, messageType }, 'File download failed');
@@ -567,6 +567,7 @@ export class MessageHandler {
     if (message_type === 'image' || message_type === 'file' || message_type === 'media') {
       // Issue #1205: Log complete message structure for debugging message_id + file_key pairing
       // This helps identify if the message_id being used matches the file_key in the content
+      // Also log parent_id which may help with forwarded images
       logger.info(
         {
           chatId: chat_id,
@@ -577,7 +578,8 @@ export class MessageHandler {
         },
         'Processing file/image message'
       );
-      const result = await this.fileHandler.handleFileMessage(chat_id, message_type, content, message_id);
+      // Issue #1205: Pass parent_id to handle forwarded images where image_key may belong to original message
+      const result = await this.fileHandler.handleFileMessage(chat_id, message_type, content, message_id, parent_id);
       if (!result.success) {
         // Issue #1205: Include message_id in error logging for debugging pairing issues
         logger.error(

--- a/src/file-transfer/inbound/feishu-downloader.test.ts
+++ b/src/file-transfer/inbound/feishu-downloader.test.ts
@@ -257,6 +257,99 @@ describe('downloadFile', () => {
     ).rejects.toThrow('Empty response from Feishu API');
   });
 
+  it('should fallback to parentId when primary message_id fails (Issue #1205)', async () => {
+    const mockClient = createMockClient();
+    const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+    // First call with message_id fails
+    // Second call with parentId succeeds
+    (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('message_id and file_key mismatch'))
+      .mockResolvedValueOnce({
+        writeFile: mockWriteFile,
+      });
+
+    const result = await downloadFile(
+      mockClient as unknown as Parameters<typeof downloadFile>[0],
+      'img_key_forwarded',
+      'image',
+      'forwarded.png',
+      'msg_new_123',      // New message ID (for forwarded message)
+      'msg_original_456'  // Parent ID (original message containing the image)
+    );
+
+    // Should have called API twice: once with message_id, once with parentId
+    expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
+
+    // First call should use primary message_id
+    expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(1, {
+      path: {
+        message_id: 'msg_new_123',
+        file_key: 'img_key_forwarded',
+      },
+      params: {
+        type: 'image',
+      },
+    });
+
+    // Second call should use parentId as fallback
+    expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(2, {
+      path: {
+        message_id: 'msg_original_456',
+        file_key: 'img_key_forwarded',
+      },
+      params: {
+        type: 'image',
+      },
+    });
+
+    expect(mockWriteFile).toHaveBeenCalled();
+    expect(result).toContain('forwarded.png');
+  });
+
+  it('should throw error when both message_id and parentId fail (Issue #1205)', async () => {
+    const mockClient = createMockClient();
+
+    // Both calls fail
+    (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
+      .mockRejectedValue(new Error('API Error'));
+
+    await expect(
+      downloadFile(
+        mockClient as unknown as Parameters<typeof downloadFile>[0],
+        'img_key_123',
+        'image',
+        'test.png',
+        'msg_new_123',
+        'msg_original_456'
+      )
+    ).rejects.toThrow('API Error');
+
+    // Should have tried both message_id and parentId
+    expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not try parentId fallback when parentId equals message_id', async () => {
+    const mockClient = createMockClient();
+    (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('API Error')
+    );
+
+    await expect(
+      downloadFile(
+        mockClient as unknown as Parameters<typeof downloadFile>[0],
+        'img_key_123',
+        'image',
+        'test.png',
+        'msg_123',
+        'msg_123' // Same as message_id
+      )
+    ).rejects.toThrow('API Error');
+
+    // Should only try once since parentId equals message_id
+    expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
+  });
+
   it('should handle API errors', async () => {
     const mockClient = createMockClient();
     const apiError = new Error('API Error') as Error & { response?: { status: number } };

--- a/src/file-transfer/inbound/feishu-downloader.ts
+++ b/src/file-transfer/inbound/feishu-downloader.ts
@@ -170,11 +170,15 @@ function mapToFileType(fileType: string, fileName?: string): string {
  * IMPORTANT: For user-uploaded files in messages, we MUST use the message-resource API,
  * NOT the direct image.get or file.download APIs. Those only work for files uploaded by the bot.
  *
+ * Issue #1205: For forwarded images, the message_id may not match the image_key.
+ * We try the primary message_id first, then fallback to parentId if provided.
+ *
  * @param client - Lark API client
  * @param fileKey - Feishu file key (image_key or file_key)
  * @param fileType - File type (image, file, media, etc.)
  * @param fileName - Optional original filename
  * @param messageId - The message ID containing the file (REQUIRED for user uploads)
+ * @param parentId - Optional parent message ID (for forwarded/replied messages)
  * @returns Local file path
  */
 export async function downloadFile(
@@ -182,7 +186,8 @@ export async function downloadFile(
   fileKey: string,
   fileType: string,
   fileName?: string,
-  messageId?: string
+  messageId?: string,
+  parentId?: string
 ): Promise<string> {
   await ensureAttachmentsDir();
 
@@ -203,10 +208,10 @@ export async function downloadFile(
   const localFileName = `${timestamp}_${baseFileName}${extension}`;
   const localPath = path.join(getAttachmentsDir(), localFileName);
 
-  logger.info({ fileKey, fileType, fileName, messageId, localPath }, 'Downloading file from Feishu');
+  logger.info({ fileKey, fileType, fileName, messageId, parentId, localPath }, 'Downloading file from Feishu');
 
   try {
-    let fileResource: FileResourceResponse;
+    let fileResource: FileResourceResponse | undefined;
 
     // For user-uploaded files in messages, we MUST use messageResource.get API
     // This API retrieves files from messages regardless of who uploaded them
@@ -220,16 +225,52 @@ export async function downloadFile(
 
       logger.debug({ messageId, fileKey, fileType, fileName, apiFileType }, 'Using file type for API call');
 
+      // Issue #1205: Try primary message_id first
       // SDK type doesn't include params.type, so we need to cast
-      fileResource = await client.im.messageResource.get({
-        path: {
-          message_id: messageId,
-          file_key: fileKey,
-        },
-        params: {
-          type: apiFileType,
-        },
-      }) as unknown as FileResourceResponse;
+      try {
+        fileResource = await client.im.messageResource.get({
+          path: {
+            message_id: messageId,
+            file_key: fileKey,
+          },
+          params: {
+            type: apiFileType,
+          },
+        }) as unknown as FileResourceResponse;
+      } catch (primaryError) {
+        // Issue #1205: If primary message_id fails and we have a parentId, try that
+        // This handles forwarded images where the image_key belongs to the original message
+        if (parentId && parentId !== messageId) {
+          logger.warn(
+            { messageId, parentId, fileKey, error: primaryError },
+            'Primary message_id download failed, trying parentId as fallback (may be forwarded image)'
+          );
+          try {
+            fileResource = await client.im.messageResource.get({
+              path: {
+                message_id: parentId,
+                file_key: fileKey,
+              },
+              params: {
+                type: apiFileType,
+              },
+            }) as unknown as FileResourceResponse;
+            logger.info(
+              { parentId, fileKey },
+              'Successfully downloaded using parentId fallback'
+            );
+          } catch {
+            // parentId also failed, keep the original error
+            logger.error(
+              { parentId, fileKey, error: primaryError },
+              'parentId fallback also failed'
+            );
+            throw primaryError;
+          }
+        } else {
+          throw primaryError;
+        }
+      }
     } else if (fileType === 'image') {
       // Fallback: Try direct image API (only works for bot-uploaded images)
       // Reference: https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/image/get
@@ -257,7 +298,7 @@ export async function downloadFile(
     if (!fileResource) {
       // Log the pairing that caused the failure for debugging
       logger.error(
-        { messageId, fileKey, fileType, apiCall: 'messageResource.get' },
+        { messageId, parentId, fileKey, fileType, apiCall: 'messageResource.get' },
         'Feishu API returned null/undefined - possible message_id and file_key mismatch'
       );
       throw new Error(`Empty response from Feishu API. This may indicate message_id (${messageId}) and file_key (${fileKey}) do not match.`);
@@ -296,6 +337,7 @@ export async function downloadFile(
       fileKey,
       fileType,
       messageId,
+      parentId,
       errorMessage: apiError.message,
       errorCode: apiError.code,
     };

--- a/src/platforms/feishu/feishu-file-handler.test.ts
+++ b/src/platforms/feishu/feishu-file-handler.test.ts
@@ -68,7 +68,8 @@ describe('FeishuFileHandler', () => {
         'img_key_123',
         'image',
         'image_img_key_123',
-        'msg-456'
+        'msg-456',
+        undefined
       );
     });
 
@@ -93,7 +94,8 @@ describe('FeishuFileHandler', () => {
         'file_key_789',
         'file',
         'document.pdf',
-        'msg-456'
+        'msg-456',
+        undefined
       );
     });
 
@@ -113,6 +115,33 @@ describe('FeishuFileHandler', () => {
 
       expect(result.success).toBe(true);
       expect(result.filePath).toBe('/tmp/video.mp4');
+    });
+
+    it('should pass parentId to downloadFile for forwarded images (Issue #1205)', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/forwarded_image.png',
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        JSON.stringify({ image_key: 'img_key_forwarded' }),
+        'msg-new-789',
+        'msg-original-456' // parentId - the original message containing the image
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe('/tmp/forwarded_image.png');
+      // Verify parentId is passed to downloadFile
+      expect(mockDownload).toHaveBeenCalledWith(
+        'img_key_forwarded',
+        'image',
+        'image_img_key_forwarded',
+        'msg-new-789',
+        'msg-original-456'
+      );
     });
 
     it('should return error when no file_key found', async () => {

--- a/src/platforms/feishu/feishu-file-handler.ts
+++ b/src/platforms/feishu/feishu-file-handler.ts
@@ -22,7 +22,8 @@ export type FileDownloadFunction = (
   fileKey: string,
   messageType: string,
   fileName?: string,
-  messageId?: string
+  messageId?: string,
+  parentId?: string
 ) => Promise<{ success: boolean; filePath?: string }>;
 
 /**
@@ -53,10 +54,11 @@ export class FeishuFileHandler implements IFileHandler {
     chatId: string,
     messageType: 'image' | 'file' | 'media',
     content: string,
-    messageId: string
+    messageId: string,
+    parentId?: string
   ): Promise<FileHandlerResult> {
     try {
-      logger.info({ chatId, messageType, messageId }, 'File/image message received');
+      logger.info({ chatId, messageType, messageId, parentId }, 'File/image message received');
 
       // Extract file_key from content based on message type
       let fileKey: string | undefined;
@@ -82,20 +84,23 @@ export class FeishuFileHandler implements IFileHandler {
       // Issue #1205: Log the complete message_id + file_key pairing for debugging
       // This helps identify mismatch issues between the message containing the file
       // and the file_key being downloaded
+      // Also include parentId which may help with forwarded images
       logger.info(
         {
           chatId,
           messageType,
           messageId,
+          parentId,
           fileKey,
           fileName,
           pairing: `message_id=${messageId} + file_key=${fileKey}`,
+          fallback: parentId ? `fallback_message_id=${parentId}` : 'none',
         },
         'Starting file download with message_id + file_key pairing'
       );
 
       // Download file to local storage
-      const downloadResult = await this.downloadFile(fileKey, messageType, fileName, messageId);
+      const downloadResult = await this.downloadFile(fileKey, messageType, fileName, messageId, parentId);
       if (!downloadResult.success || !downloadResult.filePath) {
         const errorDetail = downloadResult.filePath ? 'Download returned success but no path' : 'Download failed';
         logger.error(


### PR DESCRIPTION
## Summary
Add a fallback mechanism for Feishu image downloads to handle forwarded/quoted images where `message_id` and `image_key` don't match.

## Problem
When users forward or quote images in Feishu, the platform may generate a new `message_id` while keeping the original `image_key`. This causes `messageResource.get` API to fail because the `message_id` and `image_key` don't match.

## Solution
- Add `parentId` parameter to the file download chain
- When primary `message_id` download fails, try using `parentId` as fallback
- This handles forwarded/quoted images where `parentId` may point to the original message containing the image

## Changes

| File | Change |
|------|--------|
| `src/file-transfer/inbound/feishu-downloader.ts` | Add `parentId` param and fallback logic |
| `src/platforms/feishu/feishu-file-handler.ts` | Add `parentId` param to `handleFileMessage` |
| `src/channels/feishu/message-handler.ts` | Pass `parent_id` to file handler |
| `src/file-transfer/inbound/feishu-downloader.test.ts` | Add tests for fallback behavior |
| `src/platforms/feishu/feishu-file-handler.test.ts` | Add tests for parentId parameter |

## Test Results

```
✓ src/file-transfer/inbound/feishu-downloader.test.ts (20 tests)
✓ src/platforms/feishu/feishu-file-handler.test.ts (13 tests)
✓ src/channels/feishu/message-handler.test.ts (15 tests)

Test Files  3 passed (3)
     Tests  48 passed (48)
```

## Technical Details

The fallback logic:
1. First try downloading with the primary `message_id`
2. If that fails and we have a `parentId` different from `message_id`:
   - Try downloading with `parentId` instead
3. If fallback succeeds, log success and continue
4. If both fail, throw the original error

Fixes #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)