### PR TITLE
fix(core): use process-specific IPC socket path in tests

### DIFF
--- a/packages/core/src/ipc/protocol.ts
+++ b/packages/core/src/ipc/protocol.ts
@@ -121,10 +121,22 @@ export interface IpcConfig {
 }
 
 /**
+ * Get the default IPC socket path.
+ * Uses unique path per process to avoid conflicts in parallel tests.
+ */
+function getDefaultSocketPath(): string {
+  // In test environment, use process-specific socket path to avoid conflicts
+  if (process.env.NODE_ENV === 'test' || process.env.VITEST === 'true') {
+    return `/tmp/disclaude-interactive-${process.pid}.ipc`;
+  }
+  return '/tmp/disclaude-interactive.ipc';
+}
+
+/**
  * Default IPC configuration.
  */
 export const DEFAULT_IPC_CONFIG: IpcConfig = {
-  socketPath: '/tmp/disclaude-interactive.ipc',
+  get socketPath() { return getDefaultSocketPath(); },
   timeout: 5000,
   maxRetries: 3,
 };


### PR DESCRIPTION
## Summary
- Added `getDefaultSocketPath()` function to check for test environment
- Modified `DEFAULT_IPC_CONFIG.socketPath` to use a getter that returns process-specific path in tests

## Problem
When running tests in parallel (e.g., CI environment), or during module initialization, `feishu-context-mcp.ts` automatically starts an IPC server using a fixed socket path (`/tmp/disclaude-interactive.ipc`). This causes `EADDRINUSE` errors when multiple test processes try to bind to the same socket.

## Solution
- Added `getDefaultSocketPath()` function that detects test environment via `NODE_ENV=test` or `VITEST=true` environment variables
- Modified `DEFAULT_IPC_CONFIG.socketPath` to use a getter that calls `getDefaultSocketPath()`
- In test environment, returns `/tmp/disclaude-interactive-${process.pid}.ipc`
- In production, returns the original `/tmp/disclaude-interactive.ipc`

## Test Results
```
✓ All 112 test files passed (112)
✓ All 2011 tests passed (1 skipped)
```

This fix resolves the IPC socket conflict issue observed in PR #1288, where the Unit Tests job was due to parallel test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)