### PR TITLE
feat(mcp): add get_current_task_status tool for Reporter Agent (Issue #857)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7844,7 +7844,7 @@
     },
     "packages/worker-node": {
       "name": "@disclaude/worker-node",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@disclaude/core": "*",
         "ws": "^8.18.0"

--- a/skills/reporter-agent/SKILL.md
+++ b/skills/reporter-agent/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: reporter-agent
+description: Intelligent progress reporter - monitors task status and provides smart progress updates to users (Issue #857)
+allowed-tools: [get_current_task_status, send_message, send_file]
+---
+
+# Reporter Agent
+
+You are an intelligent progress reporter that monitors task execution and provides smart updates to users.
+
+## Background
+
+**Issue #857**: This skill implements the independent Reporter Agent design pattern.
+
+Unlike fixed-rule progress reporting (e.g., 60-second intervals), you intelligently decide:
+- **When** to report progress
+- **What** to report
+- **How** to present it
+
+## Core Responsibility
+
+Monitor the current task status and provide timely, relevant updates to users.
+
+## Workflow
+
+### 1. Check Task Status
+
+First, use `get_current_task_status` to understand the current state:
+
+```json
+get_current_task_status({})
+```
+
+### 2. Analyze and Decide
+
+Based on the task status, decide:
+
+| Status | Action |
+|--------|--------|
+| `running` | Consider reporting if: progress changed significantly (>20%), new step started, or sufficient time elapsed (>2 min since last report) |
+| `paused` | Report pause status with current progress |
+| `completed` | Report completion with summary |
+| `error` | Report error and suggest actions |
+| `cancelled` | Acknowledge cancellation |
+| `no task` | Report no active task |
+
+### 3. Format and Send Report
+
+Use `send_message` to send a formatted progress card:
+
+```json
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {
+      "title": {"content": "🔄 任务进度更新", "tag": "plain_text"},
+      "template": "blue"
+    },
+    "elements": [
+      {"tag": "markdown", "content": "**任务**: <task description>"},
+      {"tag": "markdown", "content": "**进度**: ████░░░░░░ 40%"},
+      {"tag": "markdown", "content": "**当前步骤**: <current step>"},
+      {"tag": "markdown", "content": "**预计剩余**: ~5分钟"}
+    ]
+  },
+  "format": "card",
+  "chatId": "<chat-id-from-context>"
+}
+```
+
+## Smart Reporting Rules
+
+### When to Report
+
+1. **Significant Progress Change**: Report when progress increases by >20%
+2. **Step Changes**: Report when entering a new major step
+3. **Time-based**: Report if >3 minutes since last update (for long tasks)
+4. **State Changes**: Always report when status changes (completed, error, paused)
+5. **User-initiated**: Report when explicitly asked
+
+### What to Report
+
+- **Progress**: Current percentage and visual bar
+- **Current Step**: What's being done now
+- **Time Info**: Elapsed time and estimated remaining
+- **Key Milestones**: Notable completions or achievements
+- **Issues**: Any blockers or warnings
+
+### When NOT to Report
+
+- Progress change <10% (unless significant step completed)
+- Less than 1 minute since last report
+- Task just started (wait for meaningful progress)
+
+## Example Scenarios
+
+### Scenario 1: Task Running at 30%
+
+```json
+// Status: running, 30%, "Analyzing source files"
+// Decision: Report (progress milestone reached)
+
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {"title": {"content": "🔄 任务执行中", "tag": "plain_text"}, "template": "blue"},
+    "elements": [
+      {"tag": "markdown", "content": "**进度**: ██████░░░░░░ 30%"},
+      {"tag": "markdown", "content": "**当前步骤**: 正在分析源代码文件"},
+      {"tag": "markdown", "content": "**已用时**: 2分30秒"},
+      {"tag": "markdown", "content": "**预计剩余**: 约6分钟"}
+    ]
+  },
+  "format": "card",
+  "chatId": "oc_xxx"
+}
+```
+
+### Scenario 2: Task Completed
+
+```json
+// Status: completed, 100%
+// Decision: Report completion with summary
+
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {"title": {"content": "✅ 任务完成", "tag": "plain_text"}, "template": "green"},
+    "elements": [
+      {"tag": "markdown", "content": "**总耗时**: 8分45秒"},
+      {"tag": "markdown", "content": "**完成内容**: 代码分析报告已生成"},
+      {"tag": "markdown", "content": "报告文件将自动发送..."}
+    ]
+  },
+  "format": "card",
+  "chatId": "oc_xxx"
+}
+```
+
+### Scenario 3: Task Error
+
+```json
+// Status: error
+// Decision: Report error with actionable info
+
+{
+  "content": {
+    "config": {"wide_screen_mode": true},
+    "header": {"title": {"content": "❌ 任务出错", "tag": "plain_text"}, "template": "red"},
+    "elements": [
+      {"tag": "markdown", "content": "**错误**: 网络连接超时"},
+      {"tag": "markdown", "content": "**建议**: 请检查网络后重试"}
+    ]
+  },
+  "format": "card",
+  "chatId": "oc_xxx"
+}
+```
+
+## Important Notes
+
+1. **Chat ID**: Always use the Chat ID provided in the prompt context
+2. **Don't Over-report**: Avoid spamming users with too many updates
+3. **Be Helpful**: Include actionable information when possible
+4. **Handle Errors Gracefully**: If tool calls fail, provide informative feedback
+5. **Respect State**: Only report when there's meaningful new information
+
+## DO NOT
+
+- ❌ Report every tiny progress change (<10%)
+- ❌ Send multiple reports within 1 minute
+- ❌ Report without checking status first
+- ❌ Forget to include the Chat ID
+- ❌ Use fixed intervals - be intelligent about timing

--- a/src/mcp/feishu-context-mcp.ts
+++ b/src/mcp/feishu-context-mcp.ts
@@ -11,6 +11,8 @@ import {
   send_file,
   send_interactive_message,
   setMessageSentCallback,
+  get_current_task_status,
+  taskStatusToolDefinition,
 } from './tools/index.js';
 import { startIpcServer } from './tools/interactive-message.js';
 
@@ -30,6 +32,8 @@ export {
   unregisterFeishuHandlers,
 } from './tools/interactive-message.js';
 export { ask_user } from './tools/ask-user.js';
+export { get_current_task_status } from './tools/task-status.js';
+export type { TaskStatusResult } from './tools/task-status.js';
 
 // Start IPC server on module load for cross-process communication
 // This allows the main process to query interactive contexts
@@ -125,7 +129,8 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
   // ============================================================================
   // Issue #1155: Consolidated tools to reduce token overhead
   // Issue #1298: Removed start_group_discussion (business logic not MCP scope)
-  // Core tools: send_message, send_file
+  // Issue #857: Added get_current_task_status for Reporter Agent
+  // Core tools: send_message, send_file, get_current_task_status
   // ============================================================================
   {
     name: 'send_message',
@@ -213,6 +218,45 @@ export const feishuToolDefinitions: InlineToolDefinition[] = [
         return toolSuccess(result.success ? result.message : `⚠️ ${result.message}`);
       } catch (error) {
         return toolSuccess(`⚠️ File send failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  },
+  {
+    name: 'get_current_task_status',
+    description: `Get the current task status for progress reporting.
+
+Returns information about the currently running task:
+- Task ID and description (prompt)
+- Current status: running, paused, completed, cancelled, error
+- Progress percentage (0-100)
+- Current step description
+- Time elapsed (seconds)
+- Estimated time remaining (if available)
+
+Use this tool to:
+1. Check if a task is still running before reporting
+2. Get progress information for status updates
+3. Determine what to report to the user`,
+    parameters: z.object({}),
+    handler: async () => {
+      try {
+        const result = await get_current_task_status();
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: JSON.stringify({
+              success: false,
+              message: `Failed to get task status: ${error instanceof Error ? error.message : String(error)}`,
+            }, null, 2),
+          }],
+        };
       }
     },
   },

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -65,3 +65,11 @@ export type {
   StudyGuideOptions,
   StudyGuideResult,
 } from './study-guide-generator.js';
+
+// Task Status Tool (Issue #857: Reporter Agent)
+export {
+  get_current_task_status,
+  taskStatusSchema,
+  taskStatusToolDefinition,
+} from './task-status.js';
+export type { TaskStatusResult } from './task-status.js';

--- a/src/mcp/tools/task-status.test.ts
+++ b/src/mcp/tools/task-status.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for task-status tool.
+ *
+ * Issue #857: Reporter Agent - Task status reading tool
+ *
+ * @module mcp/tools/task-status.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { get_current_task_status } from './task-status.js';
+import * as taskStateManager from '../../utils/task-state-manager.js';
+import * as taskProgressService from '../../agents/task-progress-service.js';
+
+// Mock the task state manager
+vi.mock('../../utils/task-state-manager.js', () => ({
+  getTaskStateManager: vi.fn(),
+}));
+
+// Mock the task progress service
+vi.mock('../../agents/task-progress-service.js', () => ({
+  taskProgressService: {
+    getActiveTask: vi.fn(),
+  },
+}));
+
+const mockGetTaskStateManager = vi.mocked(taskStateManager.getTaskStateManager);
+const mockGetActiveTask = vi.mocked(taskProgressService.taskProgressService.getActiveTask);
+
+describe('get_current_task_status', () => {
+  let mockTaskStateManager: {
+    getCurrentTask: vi.Mock;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockTaskStateManager = {
+      getCurrentTask: vi.fn(),
+    };
+
+    mockGetTaskStateManager.mockReturnValue(mockTaskStateManager as unknown as taskStateManager.TaskStateManager);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('no active task', () => {
+    it('should return success with no task message when no task is running', async () => {
+      mockTaskStateManager.getCurrentTask.mockResolvedValue(null);
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('No active task found.');
+      expect(result.task).toBeUndefined();
+    });
+  });
+
+  describe('active task', () => {
+    it('should return task status for running task', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 300000); // 5 minutes ago
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_1234567890_abc12',
+        prompt: 'Analyze the codebase and generate a report',
+        status: 'running',
+        progress: 45,
+        chatId: 'oc_test_chat',
+        userId: 'user_123',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+        currentStep: 'Analyzing source files',
+      });
+
+      mockGetActiveTask.mockReturnValue(undefined);
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Current task: running (45%)');
+      expect(result.task).toBeDefined();
+      expect(result.task?.id).toBe('task_1234567890_abc12');
+      expect(result.task?.prompt).toBe('Analyze the codebase and generate a report');
+      expect(result.task?.status).toBe('running');
+      expect(result.task?.progress).toBe(45);
+      expect(result.task?.currentStep).toBe('Analyzing source files');
+      expect(result.task?.elapsedSeconds).toBeCloseTo(300, -1); // ~5 minutes
+    });
+
+    it('should return task status for paused task', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 60000); // 1 minute ago
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_paused',
+        prompt: 'Paused task',
+        status: 'paused',
+        progress: 30,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+        currentStep: 'Waiting for user input',
+      });
+
+      mockGetActiveTask.mockReturnValue({
+        taskId: 'task_paused',
+        percent: 30,
+        status: 'paused',
+      });
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.status).toBe('paused');
+      expect(result.task?.progress).toBe(30);
+    });
+
+    it('should return task status for completed task', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 600000); // 10 minutes ago
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_completed',
+        prompt: 'Completed task',
+        status: 'completed',
+        progress: 100,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+      });
+
+      mockGetActiveTask.mockReturnValue(undefined);
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.status).toBe('completed');
+      expect(result.task?.progress).toBe(100);
+    });
+
+    it('should return task status for error task', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 30000); // 30 seconds ago
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_error',
+        prompt: 'Failed task',
+        status: 'error',
+        progress: 50,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+        error: 'Network connection timeout',
+      });
+
+      mockGetActiveTask.mockReturnValue(undefined);
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.status).toBe('error');
+      expect(result.task?.error).toBe('Network connection timeout');
+    });
+
+    it('should calculate estimated remaining time based on progress', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 180000); // 3 minutes ago (180 seconds)
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_with_eta',
+        prompt: 'Task with ETA',
+        status: 'running',
+        progress: 45,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+        currentStep: 'Processing data',
+      });
+
+      mockGetActiveTask.mockReturnValue({
+        taskId: 'task_with_eta',
+        percent: 45,
+        status: 'running',
+      });
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.elapsedSeconds).toBeCloseTo(180, -1);
+      // ETA: 180 seconds / 45% * (100 - 45) = 4 * 55 = 220 seconds
+      expect(result.task?.estimatedSecondsRemaining).toBeCloseTo(220, -1);
+    });
+
+    it('should not calculate ETA when progress is 0', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 10000); // 10 seconds ago
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_no_progress',
+        prompt: 'Task with no progress yet',
+        status: 'running',
+        progress: 0,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+      });
+
+      mockGetActiveTask.mockReturnValue({
+        taskId: 'task_no_progress',
+        percent: 0,
+        status: 'running',
+      });
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.estimatedSecondsRemaining).toBeUndefined();
+    });
+
+    it('should not calculate ETA when progress service has no data', async () => {
+      const now = new Date();
+      const createdAt = new Date(now.getTime() - 60000);
+
+      mockTaskStateManager.getCurrentTask.mockResolvedValue({
+        id: 'task_no_service',
+        prompt: 'Task without progress service',
+        status: 'running',
+        progress: 50,
+        chatId: 'oc_test_chat',
+        createdAt: createdAt.toISOString(),
+        updatedAt: now.toISOString(),
+      });
+
+      mockGetActiveTask.mockReturnValue(undefined);
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(true);
+      expect(result.task?.estimatedSecondsRemaining).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle exceptions from task state manager', async () => {
+      mockTaskStateManager.getCurrentTask.mockRejectedValue(new Error('Storage error'));
+
+      const result = await get_current_task_status();
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Failed to get task status');
+      expect(result.message).toContain('Storage error');
+    });
+  });
+});

--- a/src/mcp/tools/task-status.ts
+++ b/src/mcp/tools/task-status.ts
@@ -1,0 +1,105 @@
+/**
+ * Task Status Tool - MCP tool for reading current task status.
+ *
+ * Issue #857: Reporter Agent needs to read task status for intelligent reporting.
+ *
+ * @module mcp/tools/task-status
+ */
+
+import { z } from 'zod';
+import { getTaskStateManager } from '../../utils/task-state-manager.js';
+import { taskProgressService } from '../../agents/task-progress-service.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('TaskStatusTool');
+
+/**
+ * Task status result for MCP tool response.
+ */
+export interface TaskStatusResult {
+  success: boolean;
+  message: string;
+  task?: {
+    id: string;
+    prompt: string;
+    status: string;
+    progress: number;
+    currentStep?: string;
+    createdAt: string;
+    updatedAt: string;
+    elapsedSeconds?: number;
+    estimatedSecondsRemaining?: number;
+    error?: string;
+  };
+}
+
+/**
+ * Get current task status.
+ *
+ * Returns information about the currently running task, including:
+ * - Task ID and description
+ * - Current status (running, paused, completed, cancelled, error)
+ * - Progress percentage
+ * - Current step description
+ * - Time elapsed
+ * - Estimated time remaining (if available)
+ *
+ * @returns Task status result
+ */
+export async function get_current_task_status(): Promise<TaskStatusResult> {
+  try {
+    const taskStateManager = getTaskStateManager();
+    const currentTask = await taskStateManager.getCurrentTask();
+
+    if (!currentTask) {
+      return {
+        success: true,
+        message: 'No active task found.',
+      };
+    }
+
+    // Calculate elapsed time
+    const startTime = new Date(currentTask.createdAt).getTime();
+    const elapsedSeconds = Math.floor((Date.now() - startTime) / 1000);
+
+    // Try to get progress info from TaskProgressService
+    let estimatedSecondsRemaining: number | undefined;
+    const activeProgress = taskProgressService.getActiveTask(currentTask.chatId);
+    if (activeProgress && currentTask.status === 'running') {
+      // If we have progress tracking, estimate remaining time based on progress
+      const remainingPercent = 100 - activeProgress.percent;
+      if (activeProgress.percent > 0 && elapsedSeconds > 0) {
+        const secondsPerPercent = elapsedSeconds / activeProgress.percent;
+        estimatedSecondsRemaining = Math.round(secondsPerPercent * remainingPercent);
+      }
+    }
+
+    const taskInfo: TaskStatusResult['task'] = {
+      id: currentTask.id,
+      prompt: currentTask.prompt,
+      status: currentTask.status,
+      progress: currentTask.progress,
+      currentStep: currentTask.currentStep,
+      createdAt: currentTask.createdAt,
+      updatedAt: currentTask.updatedAt,
+      elapsedSeconds,
+      estimatedSecondsRemaining,
+      error: currentTask.error,
+    };
+
+    logger.debug({ task: taskInfo }, 'Task status retrieved');
+
+    return {
+      success: true,
+      message: `Current task: ${currentTask.status} (${currentTask.progress}%)`,
+      task: taskInfo,
+    };
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to get task status');
+    return {
+      success: false,
+      message: `Failed to get task status: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `get_current_task_status` MCP tool for reading current task status
- Create Reporter Agent Skill (`skills/reporter-agent/SKILL.md`) for intelligent progress reporting
- Add unit tests for the tool

## Design
This implements the independent Reporter Agent design pattern from Issue #857:
- Reporter Agent is an independent agent that monitors task execution
- It intelligently decides when to report progress (vs fixed intervals)
- It uses the `get_current_task_status` tool to read task information

## Testing
- Unit tests cover various scenarios (no task, running task, paused, completed, error)
- Tests verify proper task status information is returned

## Related Issue
Closes #1262 (fixed-rule progress reporting)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>