### PR TITLE
feat(feishu): support reading forwarded chat history via upper_message_id (Issue #846)

### DIFF
--- a/src/channels/feishu/__tests__/message-handler-chat-record.test.ts
+++ b/src/channels/feishu/__tests__/message-handler-chat-record.test.ts
@@ -5,8 +5,10 @@ import type { PassiveModeManager } from '../passive-mode.js';
 import type { MentionDetector } from '../mention-detector.js';
 import type { InteractionManager } from '../../../platforms/feishu/interaction-manager.js';
 
+const mockGetMessage = vi.fn();
+
 vi.mock('../../../services/index.js', () => ({
-  getLarkClientService: vi.fn(() => ({ getClient: vi.fn(() => ({})), getMessage: vi.fn() })),
+  getLarkClientService: vi.fn(() => ({ getClient: vi.fn(() => ({})), getMessage: mockGetMessage })),
   isLarkClientServiceInitialized: vi.fn(() => true),
 }));
 vi.mock('../../../file-transfer/inbound/index.js', () => ({
@@ -66,5 +68,44 @@ describe('MessageHandler - chat_record metadata', () => {
     expect(callArgs.messageType).toBe('chat_record');
     expect(callArgs.metadata?.isChatRecord).toBe(true);
     expect(callArgs.metadata?.messageCount).toBe(2);
+  });
+
+  it('should fetch forwarded chat history via upper_message_id', async () => {
+    // Mock the getMessage to return a chat_record message
+    mockGetMessage.mockResolvedValueOnce({
+      content: JSON.stringify({
+        messages: [
+          { message_id: 'fwd-msg-1', message_type: 'text', content: JSON.stringify({ text: 'Forwarded message 1' }), create_time: 1704067200000, sender: { sender_id: { open_id: 'user_a' } } },
+          { message_id: 'fwd-msg-2', message_type: 'text', content: JSON.stringify({ text: 'Forwarded message 2' }), create_time: 1704067260000, sender: { sender_id: { open_id: 'user_b' } } },
+        ],
+      }),
+      messageType: 'chat_record',
+    });
+
+    const textContent = JSON.stringify({ text: '我给你发了一个会话记录' });
+    const eventData: FeishuEventData = {
+      event: {
+        message: {
+          message_id: 'test-msg-id',
+          chat_id: 'test-chat-id',
+          chat_type: 'p2p',
+          content: textContent,
+          message_type: 'text',
+          create_time: Date.now(),
+          upper_message_id: 'upper-msg-id',
+        },
+        sender: { sender_type: 'user', sender_id: { open_id: 'sender-open-id' } },
+      },
+    };
+
+    await handler.handleMessageReceive(eventData);
+
+    expect(emitMessageMock).toHaveBeenCalledTimes(1);
+    const [[callArgs]] = emitMessageMock.mock.calls;
+
+    // The content should include the forwarded chat history
+    expect(callArgs.content).toContain('Forwarded message 1');
+    expect(callArgs.content).toContain('Forwarded message 2');
+    expect(callArgs.content).toContain('用户消息: 我给你发了一个会话记录');
   });
 });

--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -344,6 +344,96 @@ export class MessageHandler {
   }
 
   /**
+   * Get forwarded/packed chat history content using upper_message_id.
+   * Issue #846: Support reading forwarded chat history via upper_message_id
+   *
+   * When a user forwards a conversation in Feishu, the message may contain
+   * an upper_message_id field pointing to the original packed message.
+   * This method fetches that message and extracts its content.
+   *
+   * @param upperMessageId - The upper message ID (original forwarded message)
+   * @returns Formatted forwarded chat history or undefined if not available
+   */
+  private async getForwardedChatHistory(upperMessageId: string): Promise<string | undefined> {
+    if (!this.client) {
+      return undefined;
+    }
+
+    try {
+      const { getLarkClientService } = await import('../../services/index.js');
+      const larkService = getLarkClientService();
+      const message = await larkService.getMessage(upperMessageId);
+
+      if (!message) {
+        logger.debug({ upperMessageId }, 'Forwarded message not found or no permission');
+        return undefined;
+      }
+
+      logger.info(
+        { upperMessageId, messageType: message.messageType },
+        'Fetching forwarded message content via upper_message_id'
+      );
+
+      // Handle chat_record type messages (packed conversation history)
+      if (message.messageType === 'chat_record') {
+        const formattedContent = this.parseChatRecordContent(message.content);
+        if (formattedContent) {
+          return formattedContent;
+        }
+      }
+
+      // Handle text messages that might contain forwarded content
+      if (message.messageType === 'text') {
+        try {
+          const parsed = JSON.parse(message.content);
+          const text = parsed.text || message.content;
+          if (text.trim()) {
+            return `📋 **转发的消息**:\n\n${text}`;
+          }
+        } catch {
+          if (message.content.trim()) {
+            return `📋 **转发的消息**:\n\n${message.content}`;
+          }
+        }
+      }
+
+      // Handle post messages
+      if (message.messageType === 'post') {
+        try {
+          const parsed = JSON.parse(message.content);
+          if (parsed.content && Array.isArray(parsed.content)) {
+            let text = '';
+            for (const row of parsed.content) {
+              if (Array.isArray(row)) {
+                for (const segment of row) {
+                  if (segment?.tag === 'text' && segment.text) {
+                    text += segment.text;
+                  }
+                }
+              }
+            }
+            if (text.trim()) {
+              return `📋 **转发的消息**:\n\n${text}`;
+            }
+          }
+        } catch {
+          // Fall through
+        }
+      }
+
+      // For other message types, indicate the type
+      logger.debug(
+        { upperMessageId, messageType: message.messageType },
+        'Forwarded message has unsupported type'
+      );
+      return undefined;
+    } catch (error) {
+      logger.debug({ err: error, upperMessageId }, 'Failed to get forwarded message content');
+      return undefined;
+    }
+  }
+
+  /**
    * Format timestamp to readable date string.
    * Issue #1123: Enhanced chat_record formatting
    *
@@ -528,7 +618,7 @@ export class MessageHandler {
       return;
     }
 
-    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id } = message;
+    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id, upper_message_id } = message;
 
     // Bot replies to user message by setting parent_id = message_id
     // Feishu automatically handles thread affiliation
@@ -849,6 +939,20 @@ export class MessageHandler {
           { messageId: message_id, parent_id, quotedLength: quotedMessageContext.length },
           'Including quoted message context for reply'
         );
+      }
+    }
+
+    // Issue #846: Get forwarded chat history if upper_message_id is present
+    let forwardedChatHistory: string | undefined;
+    if (upper_message_id) {
+      forwardedChatHistory = await this.getForwardedChatHistory(upper_message_id);
+      if (forwardedChatHistory) {
+        logger.info(
+          { messageId: message_id, upper_message_id, historyLength: forwardedChatHistory.length },
+          'Including forwarded chat history via upper_message_id'
+        );
+        // Prepend forwarded history to the enhanced text
+        enhancedText = `${forwardedChatHistory}\n\n---\n\n用户消息: ${text}`;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes #846

When users forward a conversation in Feishu, the message may contain an `upper_message_id` field pointing to the original packed message. This PR adds support for fetching and displaying that forwarded content.

## Problem

When a user forwards a conversation record in Feishu, the bot only receives a text message like "我给你发了一个 XXX的会话记录" without the actual content of the forwarded conversation.

## Solution

- Add `getForwardedChatHistory()` method to fetch message content via `upper_message_id`
- Extract `upper_message_id` from incoming messages
- Prepend forwarded chat history to enhanced text when available
- Handle multiple message types: `chat_record`, `text`, `post`

## Changes

| File | Change |
|------|--------|
| `src/channels/feishu/message-handler.ts` | Add `getForwardedChatHistory()` method and use `upper_message_id` |
| `src/channels/feishu/__tests__/message-handler-chat-record.test.ts` | Add test for `upper_message_id` functionality |

## Test Plan

- [x] All 17 existing message-handler tests pass
- [x] New test for `upper_message_id` functionality passes
- [ ] Manual testing with actual Feishu forwarded messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)