### PR TITLE
feat(config): add SOUL.md - Agent personality/behavior definition system (Issue #1315)

### DIFF
--- a/examples/soul/SOUL.example.md
+++ b/examples/soul/SOUL.example.md
@@ -1,0 +1,47 @@
+# Disclaude Agent SOUL
+
+This is an example SOUL.md file that defines the Agent's personality and behavior guidelines.
+
+## Core Truths
+
+- Be helpful and responsive to user needs
+- Provide accurate and well-reasoned responses
+- Maintain a professional yet friendly tone
+- Proactively suggest relevant next steps
+- Learn from conversation context to provide better assistance
+
+## Boundaries
+
+- Do not make up information or guess when uncertain
+- Do not be overly verbose when a concise answer suffices
+- Do not ignore user preferences stated in conversation
+- Do not suggest actions that could harm systems or data
+
+## Lifecycle
+
+- Stop Condition: User explicitly ends the conversation or task is fully completed
+- Trigger Phrase: [SESSION_END]
+
+---
+
+## Usage
+
+Copy this file to one of the following locations:
+
+1. `config/SOUL.md` - System default personality (lowest priority)
+2. `skills/{skill-name}/SOUL.md` - Skill-specific personality (medium priority)
+3. `~/.disclaude/SOUL.md` - User-defined personality (highest priority)
+
+Higher priority files override lower priority ones for each section.
+
+## Customization
+
+Edit the sections above to customize your Agent's personality:
+
+- **Core Truths**: What the Agent should always do
+- **Boundaries**: What the Agent should never do
+- **Lifecycle**: When and how to end sessions (optional)
+
+---
+
+*Reference: Issue #1315 - SOUL.md - Agent 人格/行为定义系统*

--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -34,6 +34,7 @@
 
 import type { StreamingUserMessage, QueryHandle } from '../../sdk/index.js';
 import { Config } from '../../config/index.js';
+import { soulLoader, formatSoulForPrompt } from '../../config/soul-loader.js';
 import { createFeishuSdkMcpServer } from '../../mcp/feishu-context-mcp.js';
 import { messageLogger } from '../../feishu/message-logger.js';
 import { BaseAgent } from '../base-agent.js';
@@ -112,6 +113,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
     // Initialize message builder (Issue #697)
     this.messageBuilder = new MessageBuilder();
 
+    // Load SOUL.md content (Issue #1315)
+    this.loadSoulContent();
+
     // Initialize task complexity agent (Issue #857)
     this.complexityAgent = new TaskComplexityAgent({
       ...config,
@@ -130,6 +134,32 @@ export class Pilot extends BaseAgent implements ChatAgent {
    */
   getChatId(): string {
     return this.boundChatId;
+  }
+
+  /**
+   * Load SOUL.md content and set it to MessageBuilder (Issue #1315).
+   *
+   * This method loads the merged SOUL.md content from multiple sources:
+   * 1. config/SOUL.md - System default personality (lowest priority)
+   * 2. skills/{skill}/SOUL.md - Skill-specific personality (medium priority)
+   * 3. ~/.disclaude/SOUL.md - User-defined personality (highest priority)
+   *
+   * Higher priority files override lower priority ones for each section.
+   */
+  private async loadSoulContent(): Promise<void> {
+    try {
+      const soul = await soulLoader.getSoul();
+      if (soul) {
+        const formattedSoul = formatSoulForPrompt(soul);
+        this.messageBuilder.setSoulSection(formattedSoul);
+        this.logger.info({ source: soul.source }, 'SOUL.md loaded and applied');
+      } else {
+        this.logger.debug('No SOUL.md files found, using default behavior');
+      }
+    } catch (error) {
+      // Non-fatal: continue without SOUL if loading fails
+      this.logger.warn({ error }, 'Failed to load SOUL.md, continuing without personality');
+    }
   }
 
   /**

--- a/src/agents/pilot/message-builder.ts
+++ b/src/agents/pilot/message-builder.ts
@@ -7,9 +7,11 @@
  * Issue #893: Added in-prompt next-step guidance.
  * Issue #962: Added output format guidance to prevent raw JSON in responses.
  * Issue #1198: Added location awareness guidance - agent should not infer user location.
+ * Issue #1315: Added SOUL.md support for Agent personality/behavior definition.
  */
 
 import { Config } from '../../config/index.js';
+import { soulLoader, formatSoulForPrompt } from '../../config/soul-loader.js';
 import type { ChannelCapabilities } from '../../channels/types.js';
 import type { MessageData } from './types.js';
 
@@ -25,8 +27,30 @@ import type { MessageData } from './types.js';
  * - Next-step guidance (Issue #893)
  * - Output format guidance (Issue #962)
  * - Location awareness guidance (Issue #1198)
+ * - Agent personality (SOUL.md) (Issue #1315)
  */
 export class MessageBuilder {
+  /** Cached SOUL section content (Issue #1315) */
+  private soulSection: string | null = null;
+
+  /**
+   * Set the SOUL section content.
+   * Called by Pilot agent after loading SOUL.md files.
+   *
+   * @param soulContent - Formatted SOUL content or null to disable
+   */
+  setSoulSection(soulContent: string | null): void {
+    this.soulSection = soulContent;
+  }
+
+  /**
+   * Get the current SOUL section content.
+   *
+   * @returns Cached SOUL section or null
+   */
+  getSoulSection(): string | null {
+    return this.soulSection;
+  }
   /**
    * Build enhanced content with Feishu context.
    *
@@ -104,6 +128,9 @@ ${msg.persistedHistoryContext}
     // Build location awareness guidance section (Issue #1198)
     const locationAwarenessGuidance = this.buildLocationAwarenessGuidance();
 
+    // Build SOUL section (Issue #1315)
+    const soulSection = this.soulSection || '';
+
     // For regular messages: context FIRST, then user message
     if (msg.senderOpenId) {
       const mentionSection = capabilities?.supportsMention !== false
@@ -121,7 +148,7 @@ To notify the user in your FINAL response, use:
 - This triggers a Feishu notification to the user`
         : '';
 
-      return `You are responding in a Feishu chat.
+      return `${soulSection}You are responding in a Feishu chat.
 
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}
@@ -140,7 +167,7 @@ ${locationAwarenessGuidance}
 ${msg.text}${this.buildAttachmentsInfo(msg.attachments)}`;
     }
 
-    return `You are responding in a Feishu chat.
+    return `${soulSection}You are responding in a Feishu chat.
 
 **Chat ID:** ${chatId}
 **Message ID:** ${msg.messageId}

--- a/src/config/soul-loader.test.ts
+++ b/src/config/soul-loader.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for SOUL.md Loader (Issue #1315).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  parseSoulContent,
+  getSoulLocations,
+  loadMergedSoul,
+  formatSoulForPrompt,
+  SoulLoader,
+} from './soul-loader.js';
+
+// Mock Config module
+vi.mock('./index.js', () => ({
+  Config: {
+    getWorkspaceDir: () => '/test/workspace',
+    getSkillsDir: () => '/test/skills',
+  },
+}));
+
+describe('SoulLoader', () => {
+  describe('parseSoulContent', () => {
+    it('should parse basic SOUL.md content', () => {
+      const content = `# Test SOUL
+
+## Core Truths
+- Always be helpful
+- Be concise in responses
+
+## Boundaries
+- Do not make up information
+- Do not be rude
+`;
+
+      const result = parseSoulContent(content, '/test/SOUL.md', 1);
+
+      expect(result.coreTruths).toContain('Always be helpful');
+      expect(result.coreTruths).toContain('Be concise in responses');
+      expect(result.boundaries).toContain('Do not make up information');
+      expect(result.boundaries).toContain('Do not be rude');
+      expect(result.lifecycle).toBeUndefined();
+    });
+
+    it('should parse SOUL.md with lifecycle section', () => {
+      const content = `# Discussion SOUL
+
+## Core Truths
+Stay focused on the topic.
+
+## Boundaries
+Do not chase tangents.
+
+## Lifecycle
+- Stop Condition: User confirms the discussion is complete
+- Trigger Phrase: [DISCUSSION_END]
+`;
+
+      const result = parseSoulContent(content, '/test/SOUL.md', 2);
+
+      expect(result.coreTruths).toBe('Stay focused on the topic.');
+      expect(result.boundaries).toBe('Do not chase tangents.');
+      expect(result.lifecycle).toBeDefined();
+      expect(result.lifecycle?.stopCondition).toBe('User confirms the discussion is complete');
+      expect(result.lifecycle?.triggerPhrase).toBe('[DISCUSSION_END]');
+    });
+
+    it('should handle missing sections gracefully', () => {
+      // Test with no sections at all
+      const content = `# Empty SOUL
+
+Just some content without proper sections.
+`;
+
+      const result = parseSoulContent(content, '/test/SOUL.md', 1);
+
+      // All sections should be empty
+      expect(result.coreTruths).toBe('');
+      expect(result.boundaries).toBe('');
+      expect(result.lifecycle).toBeUndefined();
+    });
+
+    it('should handle case-insensitive section headers', () => {
+      const content = `# Test SOUL
+
+## core truths
+Lower case header
+
+## BOUNDARIES
+Upper case header
+`;
+
+      const result = parseSoulContent(content, '/test/SOUL.md', 1);
+
+      expect(result.coreTruths).toBe('Lower case header');
+      expect(result.boundaries).toBe('Upper case header');
+    });
+  });
+
+  describe('getSoulLocations', () => {
+    it('should return default locations without skill name', () => {
+      const locations = getSoulLocations();
+
+      // Should include config/SOUL.md (priority 1)
+      expect(locations.some(l => l.priority === 1 && l.path.includes('config'))).toBe(true);
+
+      // Should include user home (priority 3)
+      expect(locations.some(l => l.priority === 3 && l.path.includes('.disclaude'))).toBe(true);
+    });
+
+    it('should include skill-specific locations when skill name is provided', () => {
+      const locations = getSoulLocations('my-skill');
+
+      // Should include skill SOUL (priority 2)
+      const skillLocations = locations.filter(l => l.priority === 2);
+      expect(skillLocations.length).toBeGreaterThan(0);
+      expect(skillLocations.every(l => l.path.includes('my-skill'))).toBe(true);
+    });
+
+    it('should return locations sorted by priority', () => {
+      const locations = getSoulLocations('test-skill');
+
+      for (let i = 1; i < locations.length; i++) {
+        expect(locations[i].priority).toBeGreaterThanOrEqual(locations[i - 1].priority);
+      }
+    });
+  });
+
+  describe('formatSoulForPrompt', () => {
+    it('should format soul content for system prompt', () => {
+      const soul = {
+        raw: '',
+        coreTruths: 'Be helpful and concise.',
+        boundaries: 'Do not be rude.',
+        source: '/test/SOUL.md',
+        priority: 1,
+      };
+
+      const formatted = formatSoulForPrompt(soul);
+
+      expect(formatted).toContain('Agent Personality (SOUL)');
+      expect(formatted).toContain('Core Truths');
+      expect(formatted).toContain('Be helpful and concise.');
+      expect(formatted).toContain('Boundaries');
+      expect(formatted).toContain('Do not be rude.');
+    });
+
+    it('should include lifecycle info when present', () => {
+      const soul = {
+        raw: '',
+        coreTruths: 'Stay focused.',
+        boundaries: 'No tangents.',
+        lifecycle: {
+          stopCondition: 'Task is complete',
+          triggerPhrase: '[END]',
+        },
+        source: '/test/SOUL.md',
+        priority: 2,
+      };
+
+      const formatted = formatSoulForPrompt(soul);
+
+      expect(formatted).toContain('Lifecycle');
+      expect(formatted).toContain('Task is complete');
+      expect(formatted).toContain('[END]');
+    });
+
+    it('should handle empty core truths and boundaries', () => {
+      const soul = {
+        raw: '',
+        coreTruths: '',
+        boundaries: '',
+        source: '/test/SOUL.md',
+        priority: 1,
+      };
+
+      const formatted = formatSoulForPrompt(soul);
+
+      // Should still include the header
+      expect(formatted).toContain('Agent Personality (SOUL)');
+    });
+  });
+
+  describe('SoulLoader class', () => {
+    let loader: SoulLoader;
+
+    beforeEach(() => {
+      loader = new SoulLoader(1000); // 1 second TTL for testing
+    });
+
+    afterEach(() => {
+      loader.clearCache();
+    });
+
+    it('should cache loaded soul content', async () => {
+      // First call
+      const soul1 = await loader.getSoul();
+      // Second call should return cached version
+      const soul2 = await loader.getSoul();
+
+      // Both should be the same object (or both null)
+      expect(soul1).toBe(soul2);
+    });
+
+    it('should respect force reload flag', async () => {
+      // First call
+      await loader.getSoul();
+      // Force reload
+      const soul = await loader.getSoul(undefined, true);
+
+      // Should work without error
+      expect(soul).toBeDefined();
+    });
+
+    it('should clear cache', () => {
+      loader.clearCache();
+      // Cache should be empty
+      expect(loader.getSoul(undefined, false)).resolves.toBeDefined();
+    });
+  });
+});
+
+describe('loadMergedSoul integration', () => {
+  it('should return null when no SOUL files exist', async () => {
+    // This test uses the mocked Config which points to non-existent directories
+    const result = await loadMergedSoul();
+    expect(result).toBeNull();
+  });
+});

--- a/src/config/soul-loader.ts
+++ b/src/config/soul-loader.ts
@@ -1,0 +1,395 @@
+/**
+ * SOUL.md Loader - Agent personality/behavior definition system.
+ *
+ * SOUL.md is a "personality definition" design pattern that defines AI's core
+ * behavior guidelines through Markdown files, allowing Agents to drive behavior
+ * through "self-awareness" rather than "rule constraints".
+ *
+ * @see Issue #1315
+ * @see https://www.verysmallwoods.com/blog/20260205-openclaw-soul-md-design
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
+import { Config } from './index.js';
+
+const logger = createLogger('SoulLoader');
+
+/**
+ * Parsed SOUL.md content structure.
+ */
+export interface SoulContent {
+  /** Raw content of the SOUL.md file */
+  raw: string;
+
+  /** Core truths - Agent's core values and behavior guidelines */
+  coreTruths: string;
+
+  /** Boundaries - What the Agent should NOT do */
+  boundaries: string;
+
+  /** Lifecycle configuration (optional) */
+  lifecycle?: {
+    /** When to end the session */
+    stopCondition?: string;
+    /** Trigger phrase for ending */
+    triggerPhrase?: string;
+  };
+
+  /** Source file path */
+  source: string;
+
+  /** Priority level (higher = more important) */
+  priority: number;
+}
+
+/**
+ * SOUL.md file location configuration.
+ */
+export interface SoulLocation {
+  /** File path */
+  path: string;
+
+  /** Priority level */
+  priority: number;
+
+  /** Description for logging */
+  description: string;
+}
+
+/**
+ * Get all potential SOUL.md file locations in priority order.
+ *
+ * Priority (low to high):
+ * 1. config/SOUL.md - System default personality (lowest)
+ * 2. skills/{skill}/SOUL.md - Skill-specific personality (medium)
+ * 3. ~/.disclaude/SOUL.md - User-defined personality (highest)
+ *
+ * @param skillName - Optional skill name for skill-specific SOUL
+ * @returns Array of potential locations sorted by priority
+ */
+export function getSoulLocations(skillName?: string): SoulLocation[] {
+  const locations: SoulLocation[] = [];
+  const workspaceDir = Config.getWorkspaceDir();
+
+  // 1. System default: config/SOUL.md (lowest priority = 1)
+  locations.push({
+    path: path.join(workspaceDir, 'config', 'SOUL.md'),
+    priority: 1,
+    description: 'System default personality',
+  });
+
+  // 2. Skill-specific: skills/{skill}/SOUL.md (medium priority = 2)
+  if (skillName) {
+    locations.push({
+      path: path.join(workspaceDir, 'skills', skillName, 'SOUL.md'),
+      priority: 2,
+      description: `Skill-specific personality (${skillName})`,
+    });
+
+    // Also check built-in skills directory
+    const builtinSkillsDir = Config.getSkillsDir();
+    locations.push({
+      path: path.join(builtinSkillsDir, skillName, 'SOUL.md'),
+      priority: 2,
+      description: `Built-in skill personality (${skillName})`,
+    });
+  }
+
+  // 3. User-defined: ~/.disclaude/SOUL.md (highest priority = 3)
+  const homeDir = process.env.HOME || process.env.USERPROFILE;
+  if (homeDir) {
+    locations.push({
+      path: path.join(homeDir, '.disclaude', 'SOUL.md'),
+      priority: 3,
+      description: 'User-defined personality',
+    });
+  }
+
+  return locations;
+}
+
+/**
+ * Parse SOUL.md content into structured format.
+ *
+ * Expected format:
+ * ```markdown
+ * # {Name} SOUL
+ *
+ * ## Core Truths
+ * {content}
+ *
+ * ## Boundaries
+ * {content}
+ *
+ * ## Lifecycle (optional)
+ * - Stop Condition: {condition}
+ * - Trigger Phrase: {phrase}
+ * ```
+ *
+ * @param content - Raw markdown content
+ * @param source - Source file path
+ * @param priority - Priority level
+ * @returns Parsed SoulContent
+ */
+export function parseSoulContent(
+  content: string,
+  source: string,
+  priority: number
+): SoulContent {
+  const result: SoulContent = {
+    raw: content,
+    coreTruths: '',
+    boundaries: '',
+    source,
+    priority,
+  };
+
+  // Extract Core Truths section
+  // Use (?=\n## |$) to match end of section (next ## header or end of string)
+  const coreTruthsMatch = content.match(/##\s*Core Truths\s*\n([\s\S]*?)(?=\n## |$)/i);
+  if (coreTruthsMatch) {
+    result.coreTruths = coreTruthsMatch[1].trim();
+  }
+
+  // Extract Boundaries section
+  const boundariesMatch = content.match(/##\s*Boundaries\s*\n([\s\S]*?)(?=\n## |$)/i);
+  if (boundariesMatch) {
+    result.boundaries = boundariesMatch[1].trim();
+  }
+
+  // Extract Lifecycle section
+  const lifecycleMatch = content.match(/##\s*Lifecycle\s*\n([\s\S]*?)(?=\n## |$)/i);
+  if (lifecycleMatch) {
+    const lifecycleContent = lifecycleMatch[1];
+
+    // Parse Stop Condition
+    const stopConditionMatch = lifecycleContent.match(/[-*]\s*Stop Condition:\s*(.+)/i);
+    // Parse Trigger Phrase
+    const triggerPhraseMatch = lifecycleContent.match(/[-*]\s*Trigger Phrase:\s*(.+)/i);
+
+    if (stopConditionMatch || triggerPhraseMatch) {
+      result.lifecycle = {
+        stopCondition: stopConditionMatch?.[1]?.trim(),
+        triggerPhrase: triggerPhraseMatch?.[1]?.trim(),
+      };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Load a single SOUL.md file.
+ *
+ * @param location - File location configuration
+ * @returns Parsed SoulContent or null if file doesn't exist
+ */
+export async function loadSoulFile(location: SoulLocation): Promise<SoulContent | null> {
+  try {
+    const content = await fs.readFile(location.path, 'utf-8');
+    logger.debug({ path: location.path, description: location.description }, 'Loaded SOUL.md');
+    return parseSoulContent(content, location.path, location.priority);
+  } catch (error) {
+    // File doesn't exist is expected, not an error
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    logger.warn({ error, path: location.path }, 'Failed to load SOUL.md');
+    return null;
+  }
+}
+
+/**
+ * Load and merge all SOUL.md files based on priority.
+ *
+ * Higher priority files override lower priority ones for each section.
+ * If a higher priority file has an empty section, it still overrides.
+ *
+ * @param skillName - Optional skill name for skill-specific SOUL
+ * @returns Merged SoulContent or null if no files exist
+ */
+export async function loadMergedSoul(skillName?: string): Promise<SoulContent | null> {
+  const locations = getSoulLocations(skillName);
+  const loadedSouls: SoulContent[] = [];
+
+  // Load all existing SOUL files
+  for (const location of locations) {
+    const soul = await loadSoulFile(location);
+    if (soul) {
+      loadedSouls.push(soul);
+    }
+  }
+
+  if (loadedSouls.length === 0) {
+    logger.debug('No SOUL.md files found');
+    return null;
+  }
+
+  // Sort by priority (ascending) so higher priority overrides lower
+  loadedSouls.sort((a, b) => a.priority - b.priority);
+
+  // Merge: start with lowest priority, override with higher
+  const merged: SoulContent = {
+    raw: '',
+    coreTruths: '',
+    boundaries: '',
+    source: loadedSouls.map(s => s.source).join(', '),
+    priority: Math.max(...loadedSouls.map(s => s.priority)),
+  };
+
+  for (const soul of loadedSouls) {
+    if (soul.coreTruths) {
+      merged.coreTruths = soul.coreTruths;
+    }
+    if (soul.boundaries) {
+      merged.boundaries = soul.boundaries;
+    }
+    if (soul.lifecycle) {
+      merged.lifecycle = { ...merged.lifecycle, ...soul.lifecycle };
+    }
+  }
+
+  // Reconstruct raw content from merged sections
+  merged.raw = buildRawContent(merged);
+
+  logger.info(
+    {
+      sources: loadedSouls.map(s => ({ path: s.source, priority: s.priority })),
+      hasLifecycle: !!merged.lifecycle,
+    },
+    'Merged SOUL.md files'
+  );
+
+  return merged;
+}
+
+/**
+ * Build raw markdown content from SoulContent.
+ *
+ * @param soul - Parsed soul content
+ * @returns Raw markdown string
+ */
+function buildRawContent(soul: SoulContent): string {
+  const parts: string[] = [];
+
+  parts.push('# Agent SOUL\n');
+
+  if (soul.coreTruths) {
+    parts.push('## Core Truths\n');
+    parts.push(soul.coreTruths);
+    parts.push('\n');
+  }
+
+  if (soul.boundaries) {
+    parts.push('## Boundaries\n');
+    parts.push(soul.boundaries);
+    parts.push('\n');
+  }
+
+  if (soul.lifecycle) {
+    parts.push('## Lifecycle\n');
+    if (soul.lifecycle.stopCondition) {
+      parts.push(`- Stop Condition: ${soul.lifecycle.stopCondition}\n`);
+    }
+    if (soul.lifecycle.triggerPhrase) {
+      parts.push(`- Trigger Phrase: ${soul.lifecycle.triggerPhrase}\n`);
+    }
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Format SoulContent for injection into Agent system prompt.
+ *
+ * @param soul - Parsed soul content
+ * @returns Formatted string for system prompt
+ */
+export function formatSoulForPrompt(soul: SoulContent): string {
+  const parts: string[] = [];
+
+  parts.push('---\n');
+  parts.push('## Agent Personality (SOUL)\n\n');
+  parts.push('> Your behavior is guided by the following personality definition.\n');
+  parts.push('> This shapes how you respond, not what you can do.\n\n');
+
+  if (soul.coreTruths) {
+    parts.push('### Core Truths\n\n');
+    parts.push(soul.coreTruths);
+    parts.push('\n\n');
+  }
+
+  if (soul.boundaries) {
+    parts.push('### Boundaries\n\n');
+    parts.push(soul.boundaries);
+    parts.push('\n\n');
+  }
+
+  if (soul.lifecycle) {
+    parts.push('### Lifecycle\n\n');
+    if (soul.lifecycle.stopCondition) {
+      parts.push(`**Stop Condition:** ${soul.lifecycle.stopCondition}\n\n`);
+    }
+    if (soul.lifecycle.triggerPhrase) {
+      parts.push(`**Trigger Phrase:** When the stop condition is met, include \`${soul.lifecycle.triggerPhrase}\` in your response to signal session end.\n\n`);
+    }
+  }
+
+  parts.push('---\n');
+
+  return parts.join('');
+}
+
+/**
+ * SoulLoader class for caching and managing SOUL.md loading.
+ */
+export class SoulLoader {
+  private cache: Map<string, SoulContent> = new Map();
+  private lastLoadTime: Map<string, number> = new Map();
+  private readonly cacheTtlMs: number;
+
+  constructor(cacheTtlMs: number = 60000) { // Default 1 minute TTL
+    this.cacheTtlMs = cacheTtlMs;
+  }
+
+  /**
+   * Get merged SOUL content with caching.
+   *
+   * @param skillName - Optional skill name
+   * @param forceReload - Force reload from disk
+   * @returns Merged SoulContent or null
+   */
+  async getSoul(skillName?: string, forceReload = false): Promise<SoulContent | null> {
+    const cacheKey = skillName || '__default__';
+    const now = Date.now();
+    const lastLoad = this.lastLoadTime.get(cacheKey) || 0;
+
+    // Return cached if valid and not forcing reload
+    if (!forceReload && this.cache.has(cacheKey) && (now - lastLoad) < this.cacheTtlMs) {
+      return this.cache.get(cacheKey) || null;
+    }
+
+    // Load from disk
+    const soul = await loadMergedSoul(skillName);
+
+    if (soul) {
+      this.cache.set(cacheKey, soul);
+      this.lastLoadTime.set(cacheKey, now);
+    }
+
+    return soul;
+  }
+
+  /**
+   * Clear the cache.
+   */
+  clearCache(): void {
+    this.cache.clear();
+    this.lastLoadTime.clear();
+  }
+}
+
+// Export singleton instance for convenience
+export const soulLoader = new SoulLoader();


### PR DESCRIPTION
## Summary

Implements Issue #1315: SOUL.md - Agent personality/behavior definition system.

SOUL.md is a "personality definition" design pattern that defines AI's core behavior guidelines through Markdown files, allowing Agents to drive behavior through "self-awareness" rather than "rule constraints".

## Key Components

| File | Description |
|------|-------------|
| \`src/config/soul-loader.ts\` | Core SOUL.md loading and parsing module |
| \`src/config/soul-loader.test.ts\` | Unit tests (14 tests) |
| \`src/agents/pilot/message-builder.ts\` | Integration with MessageBuilder |
| \`src/agents/pilot/index.ts\` | SOUL loading in Pilot initialization |
| \`examples/soul/SOUL.example.md\` | Example SOUL.md file |

## Features

### 1. Multi-level Priority Loading
SOUL.md files are loaded from multiple locations with priority:
- \`config/SOUL.md\` - System default (priority 1, lowest)
- \`skills/{skill}/SOUL.md\` - Skill-specific (priority 2)
- \`~/.disclaude/SOUL.md\` - User-defined (priority 3, highest)

Higher priority files override lower priority ones for each section.

### 2. Section Parsing
- **Core Truths**: Agent's core values and behavior guidelines
- **Boundaries**: What the Agent should NOT do
- **Lifecycle** (optional): Stop conditions and trigger phrases

### 3. Caching
- SoulLoader class with configurable TTL
- Cache can be force-refreshed when needed

### 4. Prompt Integration
- SOUL content is formatted and injected into Agent system prompt
- Non-intrusive: Falls back gracefully if no SOUL.md files exist

## Test Results

\`\`\`
✓ src/config/soul-loader.test.ts (14 tests)
  ✓ parseSoulContent (4 tests)
  ✓ getSoulLocations (3 tests)
  ✓ formatSoulForPrompt (3 tests)
  ✓ SoulLoader class (3 tests)
  ✓ loadMergedSoul integration (1 test)
\`\`\`

## Acceptance Criteria

- [x] SOUL.md file format specification
- [x] Multi-level SOUL.md loading and merging
- [x] Agent system prompt correctly includes SOUL.md content
- [x] Compatible with existing SKILL.md mechanism

## Related Issues

- Prerequisite for: #1228 (讨论焦点保持)
- Prerequisite for: #1229 (智能会话结束)

Fixes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)