### PR TITLE
fix(feishu): add enhanced fallback mechanism for image downloads (Issue #1205)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -120,13 +120,21 @@ export class MessageHandler {
     // Initialize FileHandler
     this.fileHandler = new FeishuFileHandler({
       attachmentManager,
-      downloadFile: async (fileKey: string, messageType: string, fileName?: string, messageId?: string, parentId?: string) => {
+      downloadFile: async (
+        fileKey: string,
+        messageType: string,
+        fileName?: string,
+        messageId?: string,
+        parentId?: string,
+        rootId?: string,
+        upperMessageId?: string
+      ) => {
         if (!this.client) {
           logger.error({ fileKey }, 'Client not initialized for file download');
           return { success: false };
         }
         try {
-          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId, parentId);
+          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId, parentId, rootId, upperMessageId);
           return { success: true, filePath };
         } catch (error) {
           logger.error({ err: error, fileKey, messageType }, 'File download failed');
@@ -528,7 +536,7 @@ export class MessageHandler {
       return;
     }
 
-    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id } = message;
+    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id, root_id, upper_message_id } = message;
 
     // Bot replies to user message by setting parent_id = message_id
     // Feishu automatically handles thread affiliation
@@ -568,18 +576,30 @@ export class MessageHandler {
       // Issue #1205: Log complete message structure for debugging message_id + file_key pairing
       // This helps identify if the message_id being used matches the file_key in the content
       // Issue #1290: Also log parent_id which may help with quoted/forwarded images
+      // Issue #1205: Also log root_id and upper_message_id for additional fallback scenarios
       logger.info(
         {
           chatId: chat_id,
           messageType: message_type,
           messageId: message_id,
           parentId: parent_id,
+          rootId: root_id,
+          upperMessageId: upper_message_id,
           contentPreview: content.substring(0, 200),
         },
         'Processing file/image message'
       );
       // Issue #1290: Pass parent_id to handle quoted/forwarded images where image_key may belong to original message
-      const result = await this.fileHandler.handleFileMessage(chat_id, message_type, content, message_id, parent_id);
+      // Issue #1205: Pass root_id and upper_message_id as additional fallback IDs
+      const result = await this.fileHandler.handleFileMessage(
+        chat_id,
+        message_type,
+        content,
+        message_id,
+        parent_id,
+        root_id,
+        upper_message_id
+      );
       if (!result.success) {
         // Issue #1205: Include message_id in error logging for debugging pairing issues
         logger.error(

--- a/src/file-transfer/inbound/feishu-downloader.test.ts
+++ b/src/file-transfer/inbound/feishu-downloader.test.ts
@@ -294,7 +294,8 @@ describe('downloadFile', () => {
   });
 
   // Issue #1290: Tests for parentId fallback for quoted/forwarded images
-  describe('parentId fallback (Issue #1290)', () => {
+  // Issue #1205: Extended to test multiple fallback IDs
+  describe('fallback mechanism (Issue #1290, #1205)', () => {
     it('should fallback to parentId when primary message_id fails', async () => {
       const mockClient = createMockClient();
       const mockWriteFile = vi.fn().mockResolvedValue(undefined);
@@ -345,10 +346,94 @@ describe('downloadFile', () => {
       expect(result).toContain('quoted.png');
     });
 
-    it('should throw error when both message_id and parentId fail', async () => {
+    it('should fallback to rootId when parentId fails (Issue #1205)', async () => {
+      const mockClient = createMockClient();
+      const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+      // First call with message_id fails
+      // Second call with parentId fails
+      // Third call with rootId succeeds
+      (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('message_id mismatch'))
+        .mockRejectedValueOnce(new Error('parentId mismatch'))
+        .mockResolvedValueOnce({
+          writeFile: mockWriteFile,
+        });
+
+      const result = await downloadFile(
+        mockClient as unknown as Parameters<typeof downloadFile>[0],
+        'img_key_thread',
+        'image',
+        'thread.png',
+        'msg_reply_123',     // Reply message ID
+        'msg_parent_456',    // Parent ID (direct parent in thread)
+        'msg_root_789'       // Root ID (root of the thread)
+      );
+
+      // Should have called API three times
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(3);
+
+      // Third call should use rootId as fallback
+      expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(3, {
+        path: {
+          message_id: 'msg_root_789',
+          file_key: 'img_key_thread',
+        },
+        params: {
+          type: 'image',
+        },
+      });
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      expect(result).toContain('thread.png');
+    });
+
+    it('should fallback to upperMessageId when other fallbacks fail (Issue #1205)', async () => {
+      const mockClient = createMockClient();
+      const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+      // All previous calls fail, upperMessageId succeeds
+      (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('message_id mismatch'))
+        .mockRejectedValueOnce(new Error('parentId mismatch'))
+        .mockRejectedValueOnce(new Error('rootId mismatch'))
+        .mockResolvedValueOnce({
+          writeFile: mockWriteFile,
+        });
+
+      const result = await downloadFile(
+        mockClient as unknown as Parameters<typeof downloadFile>[0],
+        'img_key_packed',
+        'image',
+        'packed.png',
+        'msg_forwarded_123',
+        'msg_parent_456',
+        'msg_root_789',
+        'msg_upper_abc'      // Upper message ID (from packed history)
+      );
+
+      // Should have called API four times
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(4);
+
+      // Fourth call should use upperMessageId as fallback
+      expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(4, {
+        path: {
+          message_id: 'msg_upper_abc',
+          file_key: 'img_key_packed',
+        },
+        params: {
+          type: 'image',
+        },
+      });
+
+      expect(mockWriteFile).toHaveBeenCalled();
+      expect(result).toContain('packed.png');
+    });
+
+    it('should throw error when all fallback IDs fail', async () => {
       const mockClient = createMockClient();
 
-      // Both calls fail
+      // All calls fail
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
         .mockRejectedValue(new Error('API Error'));
 
@@ -359,15 +444,16 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_new_123',
-          'msg_original_456'
+          'msg_parent_456',
+          'msg_root_789'
         )
       ).rejects.toThrow('API Error');
 
-      // Should have tried both message_id and parentId
-      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
+      // Should have tried all fallback IDs
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(3);
     });
 
-    it('should not try parentId fallback when parentId equals message_id', async () => {
+    it('should not try fallback when fallback ID equals message_id', async () => {
       const mockClient = createMockClient();
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('API Error')
@@ -380,15 +466,16 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_123',
-          'msg_123' // Same as message_id
+          'msg_123', // Same as message_id
+          'msg_123'  // Same as message_id
         )
       ).rejects.toThrow('API Error');
 
-      // Should only try once since parentId equals message_id
+      // Should only try once since all fallback IDs equal message_id
       expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
     });
 
-    it('should not try parentId fallback when parentId is undefined', async () => {
+    it('should not try fallback when no fallback IDs provided', async () => {
       const mockClient = createMockClient();
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('API Error')
@@ -401,11 +488,11 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_123'
-          // No parentId
+          // No fallback IDs
         )
       ).rejects.toThrow('API Error');
 
-      // Should only try once since no parentId
+      // Should only try once since no fallback IDs
       expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
     });
 
@@ -424,7 +511,9 @@ describe('downloadFile', () => {
         'image',
         'test.png',
         'msg_123',
-        'msg_parent_456' // parentId available but not needed
+        'msg_parent_456',
+        'msg_root_789',
+        'msg_upper_abc'
       );
 
       // Should only call API once since first try succeeded

--- a/src/file-transfer/inbound/feishu-downloader.ts
+++ b/src/file-transfer/inbound/feishu-downloader.ts
@@ -173,12 +173,20 @@ function mapToFileType(fileType: string, fileName?: string): string {
  * Issue #1290: For quoted/forwarded images, the message_id may not match the image_key.
  * We try the primary message_id first, then fallback to parentId if provided.
  *
+ * Issue #1205: Extended fallback mechanism to try multiple message IDs:
+ * - Primary message_id (first try)
+ * - parentId (for quoted/reply messages)
+ * - rootId (for thread messages)
+ * - upperMessageId (for packed chat history)
+ *
  * @param client - Lark API client
  * @param fileKey - Feishu file key (image_key or file_key)
  * @param fileType - File type (image, file, media, etc.)
  * @param fileName - Optional original filename
  * @param messageId - The message ID containing the file (REQUIRED for user uploads)
  * @param parentId - Optional parent message ID (for quoted/forwarded messages)
+ * @param rootId - Optional root message ID (for thread messages)
+ * @param upperMessageId - Optional upper message ID (for packed chat history)
  * @returns Local file path
  */
 export async function downloadFile(
@@ -187,7 +195,9 @@ export async function downloadFile(
   fileType: string,
   fileName?: string,
   messageId?: string,
-  parentId?: string
+  parentId?: string,
+  rootId?: string,
+  upperMessageId?: string
 ): Promise<string> {
   await ensureAttachmentsDir();
 
@@ -208,7 +218,7 @@ export async function downloadFile(
   const localFileName = `${timestamp}_${baseFileName}${extension}`;
   const localPath = path.join(getAttachmentsDir(), localFileName);
 
-  logger.info({ fileKey, fileType, fileName, messageId, parentId, localPath }, 'Downloading file from Feishu');
+  logger.info({ fileKey, fileType, fileName, messageId, parentId, rootId, upperMessageId, localPath }, 'Downloading file from Feishu');
 
   try {
     let fileResource: FileResourceResponse | undefined;
@@ -226,6 +236,7 @@ export async function downloadFile(
       logger.debug({ messageId, fileKey, fileType, fileName, apiFileType }, 'Using file type for API call');
 
       // Issue #1290: Try primary message_id first
+      // Issue #1205: Extended to try multiple fallback IDs in sequence
       try {
         // SDK type doesn't include params.type, so we need to cast
         fileResource = await client.im.messageResource.get({
@@ -238,33 +249,57 @@ export async function downloadFile(
           },
         }) as unknown as FileResourceResponse;
       } catch (primaryError) {
-        // Issue #1290: If primary message_id fails and we have a parentId, try fallback
-        if (parentId && parentId !== messageId) {
+        // Issue #1205: Build list of fallback IDs to try
+        // Order: parentId (quoted/reply), rootId (thread), upperMessageId (packed history)
+        const fallbackIds = [
+          { id: parentId, name: 'parentId', reason: 'quoted/forwarded image' },
+          { id: rootId, name: 'rootId', reason: 'thread message' },
+          { id: upperMessageId, name: 'upperMessageId', reason: 'packed chat history' },
+        ].filter(item => item.id && item.id !== messageId);
+
+        if (fallbackIds.length > 0) {
           logger.info(
-            { messageId, parentId, fileKey, error: (primaryError as Error).message },
-            'Primary message_id download failed, trying parentId fallback for quoted/forwarded image'
+            { messageId, fileKey, error: (primaryError as Error).message, fallbackIds: fallbackIds.map(f => f.name) },
+            'Primary message_id download failed, trying fallback IDs'
           );
-          try {
-            fileResource = await client.im.messageResource.get({
-              path: {
-                message_id: parentId,
-                file_key: fileKey,
-              },
-              params: {
-                type: apiFileType,
-              },
-            }) as unknown as FileResourceResponse;
-            logger.info({ parentId, fileKey }, 'parentId fallback succeeded');
-          } catch (fallbackError) {
-            // Fallback also failed, throw the original error
+
+          let lastError = primaryError;
+          for (const fallback of fallbackIds) {
+            try {
+              logger.debug(
+                { fallbackId: fallback.id, fallbackName: fallback.name, fileKey },
+                `Trying ${fallback.name} fallback for ${fallback.reason}`
+              );
+              fileResource = await client.im.messageResource.get({
+                path: {
+                  message_id: fallback.id!,
+                  file_key: fileKey,
+                },
+                params: {
+                  type: apiFileType,
+                },
+              }) as unknown as FileResourceResponse;
+              logger.info({ fallbackId: fallback.id, fallbackName: fallback.name, fileKey }, `${fallback.name} fallback succeeded`);
+              break; // Success, exit the fallback loop
+            } catch (fallbackError) {
+              logger.debug(
+                { fallbackId: fallback.id, fallbackName: fallback.name, fileKey, error: (fallbackError as Error).message },
+                `${fallback.name} fallback failed, trying next`
+              );
+              lastError = fallbackError as Error;
+            }
+          }
+
+          // If all fallbacks failed, throw the original error
+          if (!fileResource) {
             logger.warn(
-              { parentId, fileKey, error: (fallbackError as Error).message },
-              'parentId fallback also failed'
+              { messageId, fileKey, triedFallbacks: fallbackIds.map(f => f.name) },
+              'All fallback IDs failed'
             );
-            throw primaryError;
+            throw lastError;
           }
         } else {
-          // No parentId available or same as messageId, throw original error
+          // No fallback IDs available, throw original error
           throw primaryError;
         }
       }

--- a/src/platforms/feishu/feishu-file-handler.test.ts
+++ b/src/platforms/feishu/feishu-file-handler.test.ts
@@ -69,6 +69,8 @@ describe('FeishuFileHandler', () => {
         'image',
         'image_img_key_123',
         'msg-456',
+        undefined,
+        undefined,
         undefined
       );
     });
@@ -95,6 +97,8 @@ describe('FeishuFileHandler', () => {
         'file',
         'document.pdf',
         'msg-456',
+        undefined,
+        undefined,
         undefined
       );
     });
@@ -204,7 +208,9 @@ describe('FeishuFileHandler', () => {
         'image',
         'image_img_key_quoted',
         'msg-new-789',
-        'msg-original-456'
+        'msg-original-456',
+        undefined,
+        undefined
       );
     });
 
@@ -229,7 +235,39 @@ describe('FeishuFileHandler', () => {
         'file',
         'quoted_doc.pdf',
         'msg-new-123',
-        'msg-original-456'
+        'msg-original-456',
+        undefined,
+        undefined
+      );
+    });
+
+    // Issue #1205: Tests for rootId and upperMessageId parameters
+    it('should pass rootId and upperMessageId to downloadFile (Issue #1205)', async () => {
+      const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
+      mockDownload.mockResolvedValue({
+        success: true,
+        filePath: '/tmp/thread_image.png',
+      });
+
+      const result = await handler.handleFileMessage(
+        'chat-123',
+        'image',
+        JSON.stringify({ image_key: 'img_key_thread' }),
+        'msg-reply-789',
+        'msg-parent-456',
+        'msg-root-123',      // rootId for thread messages
+        'msg-upper-abc'      // upperMessageId for packed history
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockDownload).toHaveBeenCalledWith(
+        'img_key_thread',
+        'image',
+        'image_img_key_thread',
+        'msg-reply-789',
+        'msg-parent-456',
+        'msg-root-123',
+        'msg-upper-abc'
       );
     });
   });

--- a/src/platforms/feishu/feishu-file-handler.ts
+++ b/src/platforms/feishu/feishu-file-handler.ts
@@ -17,13 +17,16 @@ const logger = createLogger('FeishuFileHandler');
 
 /**
  * File download function type.
+ * Issue #1205: Added rootId and upperMessageId for additional fallback scenarios
  */
 export type FileDownloadFunction = (
   fileKey: string,
   messageType: string,
   fileName?: string,
   messageId?: string,
-  parentId?: string
+  parentId?: string,
+  rootId?: string,
+  upperMessageId?: string
 ) => Promise<{ success: boolean; filePath?: string }>;
 
 /**
@@ -55,7 +58,9 @@ export class FeishuFileHandler implements IFileHandler {
     messageType: 'image' | 'file' | 'media',
     content: string,
     messageId: string,
-    parentId?: string
+    parentId?: string,
+    rootId?: string,
+    upperMessageId?: string
   ): Promise<FileHandlerResult> {
     try {
       logger.info({ chatId, messageType, messageId }, 'File/image message received');
@@ -85,12 +90,15 @@ export class FeishuFileHandler implements IFileHandler {
       // This helps identify mismatch issues between the message containing the file
       // and the file_key being downloaded
       // Issue #1290: Also log parentId for quoted/forwarded images
+      // Issue #1205: Also log rootId and upperMessageId for additional fallback scenarios
       logger.info(
         {
           chatId,
           messageType,
           messageId,
           parentId,
+          rootId,
+          upperMessageId,
           fileKey,
           fileName,
           pairing: `message_id=${messageId} + file_key=${fileKey}`,
@@ -100,7 +108,16 @@ export class FeishuFileHandler implements IFileHandler {
 
       // Download file to local storage
       // Issue #1290: Pass parentId for quoted/forwarded image fallback
-      const downloadResult = await this.downloadFile(fileKey, messageType, fileName, messageId, parentId);
+      // Issue #1205: Pass rootId and upperMessageId for additional fallback scenarios
+      const downloadResult = await this.downloadFile(
+        fileKey,
+        messageType,
+        fileName,
+        messageId,
+        parentId,
+        rootId,
+        upperMessageId
+      );
       if (!downloadResult.success || !downloadResult.filePath) {
         const errorDetail = downloadResult.filePath ? 'Download returned success but no path' : 'Download failed';
         logger.error(


### PR DESCRIPTION
## Summary
Extended the fallback mechanism for Feishu image/file downloads to try multiple message IDs when the primary `message_id` doesn't match the `file_key`.

## Problem
When users forward or interact with images in Feishu, the `message_id` and `image_key` may not match because:
- Forwarded images get new `message_id` but keep original `image_key`
- Thread messages have different `root_id`
- Packed chat history has `upper_message_id`

## Solution
Added support for multiple fallback IDs in the download chain:
| Fallback ID | Purpose | Source |
|-------------|---------|--------|
| `parentId` | Quoted/reply messages | Already supported |
| `rootId` | Thread messages | **New** |
| `upperMessageId` | Packed chat history | **New** |

The download function now tries each fallback ID in sequence until one succeeds or all fail.

## Changes
| File | Change |
|------|--------|
| `feishu-downloader.ts` | Accept and try multiple fallback IDs in sequence |
| `feishu-file-handler.ts` | Pass additional parameters (`rootId`, `upperMessageId`) |
| `message-handler.ts` | Extract `root_id` and `upper_message_id` from message |
| `feishu-downloader.test.ts` | Add tests for multi-fallback scenarios |
| `feishu-file-handler.test.ts` | Add tests for new parameters |

## Test Results
```
✓ src/file-transfer/inbound/feishu-downloader.test.ts (24 tests)
✓ src/platforms/feishu/feishu-file-handler.test.ts (15 tests)

Test Files  2 passed (2)
     Tests  39 passed (39)

# Full test suite
Test Files  113 passed (113)
     Tests  2029 passed | 1 skipped (2030)
```

## Technical Details

The enhanced fallback logic:
1. First try downloading with the primary `message_id`
2. If that fails and fallback IDs are available:
   - Try `parentId` (for quoted/forwarded images)
   - Try `rootId` (for thread messages)
   - Try `upperMessageId` (for packed chat history)
3. If any fallback succeeds, log success and continue
4. If all fail, throw the last error

Fixes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)