### PR TITLE
feat(schedules): add temporary session management system (Issue #1317)

### DIFF
--- a/examples/temporary-sessions/README.md
+++ b/examples/temporary-sessions/README.md
@@ -1,0 +1,78 @@
+# 临时会话管理系统
+
+基于文件系统的临时会话管理，支持 PR 审核、离线提问、御书房审核等场景。
+
+## 目录结构
+
+```
+temporary-sessions/
+├── {session-id}/              # 每个会话一个文件夹
+│   ├── session.md             # 静态配置
+│   └── state.yaml             # 动态状态
+│
+└── examples/                  # 示例模板
+    ├── template/              # 通用模板
+    ├── pr-review-example/     # PR 审核示例
+    ├── offline-question-example/  # 离线提问示例
+    └── agent-confirm-example/ # 御书房审核示例
+```
+
+## 使用方法
+
+### 1. 创建新会话
+
+复制模板到新目录：
+
+```bash
+cp -r examples/template my-session-123
+```
+
+### 2. 编辑 session.md
+
+填写会话配置和内容：
+
+- 设置 `type`、`purpose`、`channel` 等元数据
+- 填写会话内容（消息正文、选项等）
+- 设置 `expiresIn` 过期时间
+
+### 3. 初始化 state.yaml
+
+```yaml
+status: pending
+createdAt: 2026-03-10T10:00:00Z
+```
+
+### 4. 等待处理
+
+临时会话管理 schedule 会自动：
+- 检测 pending 状态的会话
+- 创建通道并发送消息
+- 更新状态为 sent
+
+### 5. 轮询结果
+
+调用方主动轮询 `state.yaml` 检查状态：
+- `replied`: 用户已响应，查看 `response` 字段
+- `expired`: 会话已过期
+
+## 会话类型
+
+| 类型 | 用途 | 阻塞 | 通道 |
+|------|------|------|------|
+| `pr-review` | PR 审核 | ✅ | 新建群聊 |
+| `offline-question` | 离线提问 | ❌ | 复用现有 |
+| `agent-confirm` | 御书房审核 | ✅ | 复用现有 |
+
+## 状态说明
+
+| 状态 | 含义 |
+|------|------|
+| `pending` | 等待发送 |
+| `sent` | 已发送，等待响应 |
+| `replied` | 用户已响应 |
+| `expired` | 会话已过期 |
+
+## 相关文档
+
+- [Issue #1317](https://github.com/hs3180/disclaude/issues/1317) - 临时会话管理系统设计
+- [schedules/temporary-sessions.md](../../schedules/temporary-sessions.md) - 会话管理 schedule

--- a/examples/temporary-sessions/agent-confirm-example/session.md
+++ b/examples/temporary-sessions/agent-confirm-example/session.md
@@ -1,0 +1,43 @@
+---
+type: blocking
+purpose: agent-confirm
+channel:
+  type: existing
+  chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+  members: []
+context:
+  workSummary: "完成了 Issue #999 的修复"
+  changes:
+    - "修复了登录页面的样式问题"
+    - "添加了表单验证"
+    - "更新了相关测试"
+  prCreated: true
+  prNumber: 1000
+expiresIn: 24h
+---
+
+# 📋 工作完成确认
+
+Agent 已完成指定任务，请确认后续操作。
+
+## 工作摘要
+
+✅ 完成了 Issue #999 的修复
+
+### 变更内容
+
+1. 修复了登录页面的样式问题
+2. 添加了表单验证
+3. 更新了相关测试
+
+### 已创建 PR
+
+PR #1000 已创建并提交审核。
+
+---
+
+## 请确认
+
+- [approve] ✅ 确认完成 - 任务已成功完成
+- [modify] 🔄 需要修改 - 还有需要调整的地方
+- [reject] ❌ 不满意 - 需要重新处理

--- a/examples/temporary-sessions/agent-confirm-example/state.yaml
+++ b/examples/temporary-sessions/agent-confirm-example/state.yaml
@@ -1,0 +1,8 @@
+status: pending
+chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+messageId: null
+createdAt: 2026-03-10T12:00:00Z
+sentAt: null
+expiresAt: null
+repliedAt: null
+response: null

--- a/examples/temporary-sessions/offline-question-example/session.md
+++ b/examples/temporary-sessions/offline-question-example/session.md
@@ -1,0 +1,37 @@
+---
+type: non-blocking
+purpose: offline-question
+channel:
+  type: existing
+  chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+  members: []
+context:
+  taskId: "task-789"
+  taskType: "finance-parsing"
+  originalPrompt: "请分析这份财务报表..."
+  agentState: "waiting_for_input"
+expiresIn: 72h
+---
+
+# 💬 离线提问
+
+Agent 在执行任务过程中需要您的输入。
+
+## 任务信息
+
+- **任务ID**: task-789
+- **任务类型**: 财务数据解析
+- **当前状态**: 等待用户输入
+
+## 问题
+
+[Agent 提出的具体问题...]
+
+## 背景
+
+原始请求：
+> 请分析这份财务报表...
+
+---
+
+请在方便时回复此消息，Agent 将继续执行任务。

--- a/examples/temporary-sessions/offline-question-example/state.yaml
+++ b/examples/temporary-sessions/offline-question-example/state.yaml
@@ -1,0 +1,8 @@
+status: pending
+chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+messageId: null
+createdAt: 2026-03-10T11:00:00Z
+sentAt: null
+expiresAt: null
+repliedAt: null
+response: null

--- a/examples/temporary-sessions/pr-review-example/session.md
+++ b/examples/temporary-sessions/pr-review-example/session.md
@@ -1,0 +1,52 @@
+---
+type: blocking
+purpose: pr-review
+channel:
+  type: group
+  name: "PR #123 审核"
+  members: []
+context:
+  prNumber: 123
+  repository: hs3180/disclaude
+  title: "feat: 添加新功能"
+  author: developer
+  headRef: feature-branch
+  baseRef: main
+  additions: 150
+  deletions: 30
+  changedFiles: 5
+  mergeable: true
+  ciStatus: "success"
+expiresIn: 24h
+---
+
+# 🔔 PR 审核请求
+
+检测到新的 PR 需要审核。
+
+## PR 信息
+
+| 属性 | 值 |
+|------|-----|
+| 📌 编号 | #123 |
+| 📝 标题 | feat: 添加新功能 |
+| 👤 作者 | @developer |
+| 🌿 分支 | feature-branch → main |
+| 📊 合并状态 | ✅ 可合并 |
+| 🔍 CI 检查 | ✅ 通过 |
+| 📈 变更 | +150 -30 (5 files) |
+
+### 描述摘要
+
+[PR 描述内容...]
+
+---
+
+🔗 [查看 PR](https://github.com/hs3180/disclaude/pull/123)
+
+## 请选择处理方式
+
+- [merge] ✅ 合并 - 执行 PR 合并
+- [request_changes] 🔄 请求修改 - 添加评论请求修改
+- [close] ❌ 关闭 - 关闭此 PR
+- [later] ⏳ 稍后处理 - 下次再处理

--- a/examples/temporary-sessions/pr-review-example/state.yaml
+++ b/examples/temporary-sessions/pr-review-example/state.yaml
@@ -1,0 +1,8 @@
+status: pending
+chatId: null
+messageId: null
+createdAt: 2026-03-10T10:00:00Z
+sentAt: null
+expiresAt: null
+repliedAt: null
+response: null

--- a/examples/temporary-sessions/template/session.md
+++ b/examples/temporary-sessions/template/session.md
@@ -1,0 +1,25 @@
+---
+type: blocking           # blocking | non-blocking
+purpose: pr-review       # pr-review | offline-question | agent-confirm
+channel:
+  type: group            # group | private | existing
+  name: "示例会话"        # 群名（type=group 时）
+  chatId: null           # 现有chatId（type=existing 时）
+  members: []            # 成员列表
+context: {}              # 自定义上下文数据
+expiresIn: 24h
+---
+
+# 🔔 示例会话标题
+
+这里是会话的主要内容...
+
+## 选项
+
+- [option1] 选项1描述
+- [option2] 选项2描述
+- [option3] 选项3描述
+
+---
+
+*此会话由临时会话管理系统创建*

--- a/examples/temporary-sessions/template/state.yaml
+++ b/examples/temporary-sessions/template/state.yaml
@@ -1,0 +1,17 @@
+# 临时会话状态文件
+# 此文件由临时会话管理系统自动更新
+
+status: pending          # pending | sent | replied | expired
+
+# 通道信息（发送后填充）
+chatId: null
+messageId: null
+
+# 时间戳
+createdAt: null          # ISO 8601 格式，创建时填充
+sentAt: null             # 发送时间
+expiresAt: null          # 过期时间
+repliedAt: null          # 用户响应时间
+
+# 用户响应
+response: null           # 用户选择的选项值

--- a/schedules/temporary-sessions.md
+++ b/schedules/temporary-sessions.md
@@ -1,0 +1,205 @@
+---
+name: "临时会话管理"
+cron: "*/5 * * * *"
+enabled: true
+blocking: true
+chatId: "oc_71e5f41a029f3a120988b7ecb76df314"
+createdAt: "2026-03-10T00:00:00.000Z"
+---
+
+# 临时会话管理
+
+基于文件系统的临时会话管理模块，统一管理 PR 讨论、离线提问、御书房审核等场景。
+
+## 设计原则
+
+| 维度 | 方案 |
+|------|------|
+| 组织方式 | 每个会话一个文件夹 |
+| 配置文件 | `session.md`（静态配置） |
+| 状态文件 | `state.yaml`（动态状态） |
+| 回调机制 | **不实现** - 调用方主动轮询 |
+
+## 文件夹结构
+
+```
+workspace/temporary-sessions/
+├── {session-id}/
+│   ├── session.md    # 配置（静态）：参数、目的、选项
+│   └── state.yaml    # 状态（动态）：状态、响应
+│
+├── pr-123-review/
+├── offline-config-789/
+└── examples/
+    └── template/
+        ├── session.md
+        └── state.yaml
+```
+
+## 执行步骤
+
+### 1. 扫描 pending 状态的会话
+
+```bash
+# 查找所有 state.yaml 中 status 为 pending 的会话
+find workspace/temporary-sessions -name "state.yaml" -exec grep -l "status: pending" {} \;
+```
+
+### 2. 处理 pending 会话
+
+对于每个 pending 会话：
+
+#### 2.1 读取会话配置
+
+```bash
+cat workspace/temporary-sessions/{session-id}/session.md
+```
+
+#### 2.2 创建通道并发送消息
+
+根据 `channel.type` 决定创建方式：
+
+| channel.type | 操作 |
+|--------------|------|
+| `group` | 创建新群聊，邀请成员 |
+| `private` | 创建私聊 |
+| `existing` | 使用现有 chatId |
+
+使用 `send_message` 发送会话内容：
+
+```
+send_message({
+  chatId: "{创建或现有的chatId}",
+  parentMessageId: null,
+  content: "{session.md 内容格式化后}",
+  format: "card" | "text"
+})
+```
+
+#### 2.3 更新状态为 sent
+
+```yaml
+# 更新 state.yaml
+status: sent
+chatId: "{创建的chatId}"
+messageId: "{消息ID}"
+sentAt: "{当前时间ISO}"
+expiresAt: "{createdAt + expiresIn}"
+```
+
+### 3. 检查已过期会话
+
+```bash
+# 查找所有 sent 状态且已过期的会话
+find workspace/temporary-sessions -name "state.yaml" -exec grep -l "status: sent" {} \;
+```
+
+对于每个已过期的会话，更新状态：
+
+```yaml
+status: expired
+expiredAt: "{当前时间ISO}"
+```
+
+### 4. 处理用户响应（通过轮询）
+
+用户点击按钮后，外部系统会更新 `state.yaml`：
+
+```yaml
+status: replied
+repliedAt: "{响应时间ISO}"
+response: "{用户选择的选项}"
+```
+
+**注意**：管理模块**只负责状态转换**，不执行任何回调或业务逻辑。
+
+## 状态机
+
+```
+pending → sent → replied → 调用方轮询处理
+              ↘ expired → 调用方轮询处理
+```
+
+| 状态 | 触发 | 处理动作 |
+|------|------|----------|
+| `pending` | 文件夹创建 | 等待下次扫描 |
+| `sent` | pending 检测到 | 创建通道 + 发送消息 + 更新状态 |
+| `replied` | 用户点击按钮 | 外部更新 state.yaml |
+| `expired` | 超时 | 更新 state.yaml |
+
+## 会话配置格式
+
+### session.md 模板
+
+```markdown
+---
+type: blocking           # blocking | non-blocking
+purpose: pr-review       # pr-review | offline-question | agent-confirm
+channel:
+  type: group            # group | private | existing
+  name: "PR #123"        # 群名（type=group 时）
+  chatId: null           # 现有chatId（type=existing 时）
+  members: [ou_xxx]      # 成员列表
+context:
+  prNumber: 123
+  repository: owner/repo
+expiresIn: 24h
+---
+
+# 🔔 PR 审核请求
+
+消息内容...
+
+## 选项
+- [merge] ✓ 合并
+- [close] ✗ 关闭
+- [wait] ⏳ 等待
+```
+
+### state.yaml 模板
+
+```yaml
+status: pending          # pending | sent | replied | expired
+chatId: null
+messageId: null
+createdAt: 2026-03-10T10:00:00Z
+sentAt: null
+expiresAt: null
+repliedAt: null
+response: null           # 用户响应后填充
+```
+
+## 三个 Use Case
+
+### PR Scanner (#393)
+- `type: blocking`
+- `channel.type: group` (创建新群)
+- PR Scanner schedule 轮询检查 `status: replied`，执行 `gh pr` 命令
+
+### 离线提问 (#631)
+- `type: non-blocking`
+- `channel.type: existing` (复用通道)
+- Agent 恢复时检查状态，继续执行
+
+### 御书房 (#946)
+- `type: blocking`
+- `channel.type: existing` (复用通道)
+- ask_user 同步轮询等待响应，或返回 sessionId
+
+## 错误处理
+
+1. 如果读取 session.md 失败，记录错误日志，跳过该会话
+2. 如果创建群聊失败，更新 state.yaml 记录错误信息
+3. 如果发送消息失败，保留 pending 状态，下次重试
+
+## 配置说明
+
+- **cron**: 每 5 分钟扫描一次
+- **enabled**: 默认启用
+- **chatId**: 默认聊天 ID（用于错误通知）
+
+## 依赖
+
+- `send_message` MCP Tool
+- `workspace/temporary-sessions/` 目录
+- 会话调用方负责轮询和处理响应


### PR DESCRIPTION
## Summary

- 实现 Issue #1317 Phase 1：临时会话管理系统
- 创建基于文件系统的会话管理 schedule
- 提供三种场景的示例模板（PR审核、离线提问、御书房确认）

## Changes

- `schedules/temporary-sessions.md`: 临时会话管理主调度文件
- `examples/temporary-sessions/`: 示例模板和使用说明

## Design

### 核心原则
- 每个会话使用文件夹组织：`session.md`（静态配置）+ `state.yaml`（动态状态）
- 管理模块只负责消息传递和状态跟踪，**不执行回调**
- 调用方主动轮询 `state.yaml` 检查状态

### 状态机
```
pending → sent → replied → 调用方轮询处理
              ↘ expired → 调用方轮询处理
```

### 三个 Use Case
| 类型 | 用途 | Issue |
|------|------|-------|
| PR Review | PR 审核 | #393 |
| Offline Question | 离线提问 | #631 |
| Agent Confirm | 御书房审核 | #946 |

## Test plan

- [ ] 验证 schedule 文件格式正确
- [ ] 验证示例模板结构完整
- [ ] 手动创建测试会话验证流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)