### PR TITLE
fix(feishu): add multi-level fallback for forwarded/quoted images (Issue #1205)

### DIFF
--- a/src/channels/feishu/message-handler.ts
+++ b/src/channels/feishu/message-handler.ts
@@ -120,13 +120,13 @@ export class MessageHandler {
     // Initialize FileHandler
     this.fileHandler = new FeishuFileHandler({
       attachmentManager,
-      downloadFile: async (fileKey: string, messageType: string, fileName?: string, messageId?: string, parentId?: string) => {
+      downloadFile: async (fileKey: string, messageType: string, fileName?: string, messageId?: string, fallbackIds?: string[]) => {
         if (!this.client) {
           logger.error({ fileKey }, 'Client not initialized for file download');
           return { success: false };
         }
         try {
-          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId, parentId);
+          const filePath = await downloadFile(this.client, fileKey, messageType, fileName, messageId, fallbackIds);
           return { success: true, filePath };
         } catch (error) {
           logger.error({ err: error, fileKey, messageType }, 'File download failed');
@@ -528,7 +528,7 @@ export class MessageHandler {
       return;
     }
 
-    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id } = message;
+    const { message_id, chat_id, chat_type, content, message_type, create_time, mentions, parent_id, root_id, upper_message_id } = message;
 
     // Bot replies to user message by setting parent_id = message_id
     // Feishu automatically handles thread affiliation
@@ -568,18 +568,28 @@ export class MessageHandler {
       // Issue #1205: Log complete message structure for debugging message_id + file_key pairing
       // This helps identify if the message_id being used matches the file_key in the content
       // Issue #1290: Also log parent_id which may help with quoted/forwarded images
+      // Issue #1205: Also log root_id and upper_message_id for more fallback options
       logger.info(
         {
           chatId: chat_id,
           messageType: message_type,
           messageId: message_id,
           parentId: parent_id,
+          rootId: root_id,
+          upperMessageId: upper_message_id,
           contentPreview: content.substring(0, 200),
         },
         'Processing file/image message'
       );
-      // Issue #1290: Pass parent_id to handle quoted/forwarded images where image_key may belong to original message
-      const result = await this.fileHandler.handleFileMessage(chat_id, message_type, content, message_id, parent_id);
+      // Issue #1205: Pass multiple fallback IDs to handle forwarded/quoted images
+      // Priority: parent_id (reply) -> root_id (thread) -> upper_message_id (forwarded history)
+      const result = await this.fileHandler.handleFileMessage(
+        chat_id,
+        message_type,
+        content,
+        message_id,
+        [parent_id, root_id, upper_message_id].filter(Boolean) as string[]
+      );
       if (!result.success) {
         // Issue #1205: Include message_id in error logging for debugging pairing issues
         logger.error(

--- a/src/file-transfer/inbound/feishu-downloader.test.ts
+++ b/src/file-transfer/inbound/feishu-downloader.test.ts
@@ -293,48 +293,59 @@ describe('downloadFile', () => {
     expect(result).toContain('image_file_key_1234');
   });
 
-  // Issue #1290: Tests for parentId fallback for quoted/forwarded images
-  describe('parentId fallback (Issue #1290)', () => {
-    it('should fallback to parentId when primary message_id fails', async () => {
+  // Issue #1205: Tests for multi-level fallback (parent_id, root_id, upper_message_id)
+  describe('multi-level fallback (Issue #1205)', () => {
+    it('should try all fallback IDs when primary message_id fails', async () => {
       const mockClient = createMockClient();
       const mockWriteFile = vi.fn().mockResolvedValue(undefined);
 
-      // First call with message_id fails
-      // Second call with parentId succeeds
+      // First two calls fail, third succeeds
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
         .mockRejectedValueOnce(new Error('message_id and file_key mismatch'))
+        .mockRejectedValueOnce(new Error('root_id and file_key mismatch'))
         .mockResolvedValueOnce({
           writeFile: mockWriteFile,
         });
 
       const result = await downloadFile(
         mockClient as unknown as Parameters<typeof downloadFile>[0],
-        'img_key_quoted',
+        'img_key_forwarded',
         'image',
-        'quoted.png',
-        'msg_new_123',      // New message ID (for quoted message)
-        'msg_original_456'  // Parent ID (original message containing the image)
+        'forwarded.png',
+        'msg_new_123',                      // New message ID (for forwarded message)
+        ['msg_parent_456', 'msg_root_789']  // Fallback IDs (parent_id, root_id)
       );
 
-      // Should have called API twice: once with message_id, once with parentId
-      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
+      // Should have called API three times
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(3);
 
       // First call should use primary message_id
       expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(1, {
         path: {
           message_id: 'msg_new_123',
-          file_key: 'img_key_quoted',
+          file_key: 'img_key_forwarded',
         },
         params: {
           type: 'image',
         },
       });
 
-      // Second call should use parentId as fallback
+      // Second call should use first fallback ID
       expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(2, {
         path: {
-          message_id: 'msg_original_456',
-          file_key: 'img_key_quoted',
+          message_id: 'msg_parent_456',
+          file_key: 'img_key_forwarded',
+        },
+        params: {
+          type: 'image',
+        },
+      });
+
+      // Third call should use second fallback ID
+      expect(mockClient.im.messageResource.get).toHaveBeenNthCalledWith(3, {
+        path: {
+          message_id: 'msg_root_789',
+          file_key: 'img_key_forwarded',
         },
         params: {
           type: 'image',
@@ -342,13 +353,13 @@ describe('downloadFile', () => {
       });
 
       expect(mockWriteFile).toHaveBeenCalled();
-      expect(result).toContain('quoted.png');
+      expect(result).toContain('forwarded.png');
     });
 
-    it('should throw error when both message_id and parentId fail', async () => {
+    it('should throw error when all IDs fail', async () => {
       const mockClient = createMockClient();
 
-      // Both calls fail
+      // All calls fail
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>)
         .mockRejectedValue(new Error('API Error'));
 
@@ -359,15 +370,15 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_new_123',
-          'msg_original_456'
+          ['msg_parent_456', 'msg_root_789']
         )
       ).rejects.toThrow('API Error');
 
-      // Should have tried both message_id and parentId
-      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
+      // Should have tried all IDs
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(3);
     });
 
-    it('should not try parentId fallback when parentId equals message_id', async () => {
+    it('should not try duplicate IDs', async () => {
       const mockClient = createMockClient();
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('API Error')
@@ -380,15 +391,15 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_123',
-          'msg_123' // Same as message_id
+          ['msg_123', 'msg_456', 'msg_123'] // Duplicates should be removed
         )
       ).rejects.toThrow('API Error');
 
-      // Should only try once since parentId equals message_id
-      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
+      // Should only try unique IDs (msg_123, msg_456)
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(2);
     });
 
-    it('should not try parentId fallback when parentId is undefined', async () => {
+    it('should not try fallback when no fallback IDs provided', async () => {
       const mockClient = createMockClient();
       (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
         new Error('API Error')
@@ -401,11 +412,11 @@ describe('downloadFile', () => {
           'image',
           'test.png',
           'msg_123'
-          // No parentId
+          // No fallbackIds
         )
       ).rejects.toThrow('API Error');
 
-      // Should only try once since no parentId
+      // Should only try once since no fallback IDs
       expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
     });
 
@@ -424,12 +435,33 @@ describe('downloadFile', () => {
         'image',
         'test.png',
         'msg_123',
-        'msg_parent_456' // parentId available but not needed
+        ['msg_parent_456'] // Fallback available but not needed
       );
 
       // Should only call API once since first try succeeded
       expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
       expect(result).toContain('test.png');
+    });
+
+    it('should handle empty fallbackIds array', async () => {
+      const mockClient = createMockClient();
+      (mockClient.im.messageResource.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('API Error')
+      );
+
+      await expect(
+        downloadFile(
+          mockClient as unknown as Parameters<typeof downloadFile>[0],
+          'img_key_123',
+          'image',
+          'test.png',
+          'msg_123',
+          [] // Empty array
+        )
+      ).rejects.toThrow('API Error');
+
+      // Should only try once since no fallback IDs
+      expect(mockClient.im.messageResource.get).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/file-transfer/inbound/feishu-downloader.ts
+++ b/src/file-transfer/inbound/feishu-downloader.ts
@@ -170,15 +170,15 @@ function mapToFileType(fileType: string, fileName?: string): string {
  * IMPORTANT: For user-uploaded files in messages, we MUST use the message-resource API,
  * NOT the direct image.get or file.download APIs. Those only work for files uploaded by the bot.
  *
- * Issue #1290: For quoted/forwarded images, the message_id may not match the image_key.
- * We try the primary message_id first, then fallback to parentId if provided.
+ * Issue #1205: For quoted/forwarded images, the message_id may not match the image_key.
+ * We try the primary message_id first, then fallback to any provided fallback IDs.
  *
  * @param client - Lark API client
  * @param fileKey - Feishu file key (image_key or file_key)
  * @param fileType - File type (image, file, media, etc.)
  * @param fileName - Optional original filename
  * @param messageId - The message ID containing the file (REQUIRED for user uploads)
- * @param parentId - Optional parent message ID (for quoted/forwarded messages)
+ * @param fallbackIds - Optional array of fallback message IDs to try (for forwarded/quoted images)
  * @returns Local file path
  */
 export async function downloadFile(
@@ -187,7 +187,7 @@ export async function downloadFile(
   fileType: string,
   fileName?: string,
   messageId?: string,
-  parentId?: string
+  fallbackIds?: string[]
 ): Promise<string> {
   await ensureAttachmentsDir();
 
@@ -208,7 +208,7 @@ export async function downloadFile(
   const localFileName = `${timestamp}_${baseFileName}${extension}`;
   const localPath = path.join(getAttachmentsDir(), localFileName);
 
-  logger.info({ fileKey, fileType, fileName, messageId, parentId, localPath }, 'Downloading file from Feishu');
+  logger.info({ fileKey, fileType, fileName, messageId, fallbackIds, localPath }, 'Downloading file from Feishu');
 
   try {
     let fileResource: FileResourceResponse | undefined;
@@ -225,48 +225,57 @@ export async function downloadFile(
 
       logger.debug({ messageId, fileKey, fileType, fileName, apiFileType }, 'Using file type for API call');
 
-      // Issue #1290: Try primary message_id first
-      try {
-        // SDK type doesn't include params.type, so we need to cast
-        fileResource = await client.im.messageResource.get({
-          path: {
-            message_id: messageId,
-            file_key: fileKey,
-          },
-          params: {
-            type: apiFileType,
-          },
-        }) as unknown as FileResourceResponse;
-      } catch (primaryError) {
-        // Issue #1290: If primary message_id fails and we have a parentId, try fallback
-        if (parentId && parentId !== messageId) {
-          logger.info(
-            { messageId, parentId, fileKey, error: (primaryError as Error).message },
-            'Primary message_id download failed, trying parentId fallback for quoted/forwarded image'
-          );
-          try {
-            fileResource = await client.im.messageResource.get({
-              path: {
-                message_id: parentId,
-                file_key: fileKey,
-              },
-              params: {
-                type: apiFileType,
-              },
-            }) as unknown as FileResourceResponse;
-            logger.info({ parentId, fileKey }, 'parentId fallback succeeded');
-          } catch (fallbackError) {
-            // Fallback also failed, throw the original error
-            logger.warn(
-              { parentId, fileKey, error: (fallbackError as Error).message },
-              'parentId fallback also failed'
-            );
-            throw primaryError;
+      // Issue #1205: Try primary message_id first, then fallback IDs
+      // Build list of IDs to try: primary message_id first, then all fallback IDs
+      const idsToTry = [messageId, ...(fallbackIds || [])].filter(
+        (id): id is string => typeof id === 'string' && id.length > 0
+      );
+
+      // Remove duplicates while preserving order
+      const uniqueIdsToTry = [...new Set(idsToTry)];
+
+      let lastError: Error | undefined;
+
+      for (const currentId of uniqueIdsToTry) {
+        try {
+          // SDK type doesn't include params.type, so we need to cast
+          fileResource = await client.im.messageResource.get({
+            path: {
+              message_id: currentId,
+              file_key: fileKey,
+            },
+            params: {
+              type: apiFileType,
+            },
+          }) as unknown as FileResourceResponse;
+
+          // If successful, break out of the loop
+          if (fileResource) {
+            if (currentId !== messageId) {
+              logger.info(
+                { originalMessageId: messageId, successfulId: currentId, fileKey },
+                'Download succeeded using fallback message_id'
+              );
+            }
+            break;
           }
-        } else {
-          // No parentId available or same as messageId, throw original error
-          throw primaryError;
+        } catch (error) {
+          lastError = error as Error;
+          logger.debug(
+            { messageId: currentId, fileKey, error: (error as Error).message },
+            'Download attempt failed for this message_id'
+          );
+          // Continue to try next ID
         }
+      }
+
+      // If all IDs failed and we have a lastError, throw it
+      if (!fileResource && lastError) {
+        logger.warn(
+          { messageId, fallbackIds, fileKey, error: lastError.message },
+          'All message_id attempts failed for file download'
+        );
+        throw lastError;
       }
     } else if (fileType === 'image') {
       // Fallback: Try direct image API (only works for bot-uploaded images)

--- a/src/platforms/feishu/feishu-file-handler.test.ts
+++ b/src/platforms/feishu/feishu-file-handler.test.ts
@@ -69,7 +69,7 @@ describe('FeishuFileHandler', () => {
         'image',
         'image_img_key_123',
         'msg-456',
-        undefined
+        []
       );
     });
 
@@ -95,7 +95,7 @@ describe('FeishuFileHandler', () => {
         'file',
         'document.pdf',
         'msg-456',
-        undefined
+        []
       );
     });
 
@@ -182,8 +182,8 @@ describe('FeishuFileHandler', () => {
       expect(attachment.messageId).toBe('msg-456');
     });
 
-    // Issue #1290: Tests for parentId parameter
-    it('should pass parentId to downloadFile for quoted images', async () => {
+    // Issue #1205: Tests for fallbackIds parameter (enhanced from Issue #1290)
+    it('should pass fallbackIds to downloadFile for quoted/forwarded images', async () => {
       const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
       mockDownload.mockResolvedValue({
         success: true,
@@ -195,7 +195,7 @@ describe('FeishuFileHandler', () => {
         'image',
         JSON.stringify({ image_key: 'img_key_quoted' }),
         'msg-new-789',
-        'msg-original-456' // parentId for quoted image
+        ['msg-parent-456', 'msg-root-789'] // fallbackIds for quoted/forwarded image
       );
 
       expect(result.success).toBe(true);
@@ -204,11 +204,11 @@ describe('FeishuFileHandler', () => {
         'image',
         'image_img_key_quoted',
         'msg-new-789',
-        'msg-original-456'
+        ['msg-parent-456', 'msg-root-789']
       );
     });
 
-    it('should handle quoted file message with parentId', async () => {
+    it('should handle quoted file message with fallbackIds', async () => {
       const mockDownload = mockDownloadFile as ReturnType<typeof vi.fn>;
       mockDownload.mockResolvedValue({
         success: true,
@@ -220,7 +220,7 @@ describe('FeishuFileHandler', () => {
         'file',
         JSON.stringify({ file_key: 'file_key_quoted', file_name: 'quoted_doc.pdf' }),
         'msg-new-123',
-        'msg-original-456'
+        ['msg-original-456']
       );
 
       expect(result.success).toBe(true);
@@ -229,7 +229,7 @@ describe('FeishuFileHandler', () => {
         'file',
         'quoted_doc.pdf',
         'msg-new-123',
-        'msg-original-456'
+        ['msg-original-456']
       );
     });
   });

--- a/src/platforms/feishu/feishu-file-handler.ts
+++ b/src/platforms/feishu/feishu-file-handler.ts
@@ -17,13 +17,14 @@ const logger = createLogger('FeishuFileHandler');
 
 /**
  * File download function type.
+ * Issue #1205: Updated to accept array of fallback IDs for forwarded/quoted images.
  */
 export type FileDownloadFunction = (
   fileKey: string,
   messageType: string,
   fileName?: string,
   messageId?: string,
-  parentId?: string
+  fallbackIds?: string[]
 ) => Promise<{ success: boolean; filePath?: string }>;
 
 /**
@@ -55,7 +56,7 @@ export class FeishuFileHandler implements IFileHandler {
     messageType: 'image' | 'file' | 'media',
     content: string,
     messageId: string,
-    parentId?: string
+    fallbackIds: string[] = []
   ): Promise<FileHandlerResult> {
     try {
       logger.info({ chatId, messageType, messageId }, 'File/image message received');
@@ -84,13 +85,13 @@ export class FeishuFileHandler implements IFileHandler {
       // Issue #1205: Log the complete message_id + file_key pairing for debugging
       // This helps identify mismatch issues between the message containing the file
       // and the file_key being downloaded
-      // Issue #1290: Also log parentId for quoted/forwarded images
+      // Issue #1290: Also log fallbackIds for quoted/forwarded images
       logger.info(
         {
           chatId,
           messageType,
           messageId,
-          parentId,
+          fallbackIds,
           fileKey,
           fileName,
           pairing: `message_id=${messageId} + file_key=${fileKey}`,
@@ -99,8 +100,8 @@ export class FeishuFileHandler implements IFileHandler {
       );
 
       // Download file to local storage
-      // Issue #1290: Pass parentId for quoted/forwarded image fallback
-      const downloadResult = await this.downloadFile(fileKey, messageType, fileName, messageId, parentId);
+      // Issue #1205: Pass fallbackIds for quoted/forwarded image fallback
+      const downloadResult = await this.downloadFile(fileKey, messageType, fileName, messageId, fallbackIds);
       if (!downloadResult.success || !downloadResult.filePath) {
         const errorDetail = downloadResult.filePath ? 'Download returned success but no path' : 'Download failed';
         logger.error(


### PR DESCRIPTION
## Summary

Add multi-level fallback mechanism for downloading forwarded/quoted images in Feishu. When the primary `message_id` doesn't match the `image_key`, the system now tries multiple fallback IDs in order:

1. Primary `message_id` (first attempt)
2. `parent_id` (for reply messages)
3. `root_id` (for thread messages)
4. `upper_message_id` (for forwarded chat history)

## Problem

When users forward images in Feishu, a new `message_id` is generated but the `image_key` remains the same. The `messageResource.get` API requires the `message_id` that originally contained the `image_key`, causing downloads to fail for forwarded images.

## Solution

Enhanced the fallback mechanism to try all available message IDs:
- Extract `parent_id`, `root_id`, and `upper_message_id` from message events
- Pass them as an array of fallback IDs to the download function
- Try each ID in order until one succeeds or all fail
- Remove duplicate IDs to avoid redundant API calls

## Changes

| File | Change |
|------|--------|
| `src/channels/feishu/message-handler.ts` | Extract all available IDs and pass as fallback array |
| `src/platforms/feishu/feishu-file-handler.ts` | Update signature to accept fallback IDs array |
| `src/file-transfer/inbound/feishu-downloader.ts` | Implement multi-level fallback loop |
| Test files | Update tests for new signature and add new test cases |

## Test Results

```
✓ src/file-transfer/inbound/feishu-downloader.test.ts (23 tests)
✓ src/platforms/feishu/feishu-file-handler.test.ts (14 tests)
✓ src/channels/feishu/message-handler.test.ts (15 tests)
```

Fixes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)