### PR TITLE
refactor(config): remove loadOnReset from sessionRestore config

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -253,12 +253,6 @@ sessionRestore:
   # Default: 4000
   maxContextLength: 4000
 
-  # Whether to load history on reset (default: false)
-  # When false: /reset gives a clean session without history
-  # When true: /reset reloads history context
-  # Users can override with /reset --keep-context
-  loadOnReset: false
-
 # -----------------------------------------------------------------------------
 # Global Environment Variables
 # -----------------------------------------------------------------------------

--- a/src/agents/pilot.test.ts
+++ b/src/agents/pilot.test.ts
@@ -45,7 +45,6 @@ vi.mock('../config/index.js', () => ({
     getSessionRestoreConfig: vi.fn(() => ({
       historyDays: 7,
       maxContextLength: 4000,
-      loadOnReset: false,
     })),
   },
 }));

--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -839,9 +839,8 @@ export class Pilot extends BaseAgent implements ChatAgent {
     this.firstMessageHistoryContext = undefined;
     this.firstMessageHistoryLoaded = false;
 
-    // Issue #1213: Reload history only if explicitly requested or config says so
-    const shouldLoadContext = keepContext ?? Config.getSessionRestoreConfig().loadOnReset;
-    if (shouldLoadContext) {
+    // Issue #1213: Reload history only if explicitly requested via keepContext
+    if (keepContext) {
       this.logger.info({ chatId: this.boundChatId }, 'Reloading history context after reset');
       this.loadPersistedHistory().catch((err) => {
         this.logger.error({ err, chatId: this.boundChatId }, 'Failed to reload history after reset');

--- a/src/agents/site-miner.test.ts
+++ b/src/agents/site-miner.test.ts
@@ -42,7 +42,6 @@ vi.mock('../config/index.js', () => ({
     getSessionRestoreConfig: vi.fn(() => ({
       historyDays: 7,
       maxContextLength: 4000,
-      loadOnReset: false,
     })),
   },
 }));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -378,13 +378,11 @@ export class Config {
   static getSessionRestoreConfig(): {
     historyDays: number;
     maxContextLength: number;
-    loadOnReset: boolean;
   } {
     const config = fileConfigOnly.sessionRestore || {};
     return {
       historyDays: config.historyDays ?? 7,
       maxContextLength: config.maxContextLength ?? 4000,
-      loadOnReset: config.loadOnReset ?? false,
     };
   }
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -318,8 +318,6 @@ export interface SessionRestoreConfig {
   historyDays?: number;
   /** Maximum characters for restored session context (default: 4000) */
   maxContextLength?: number;
-  /** Whether to load history on reset (default: false) */
-  loadOnReset?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Remove the `loadOnReset` configuration option from `SessionRestoreConfig` to simplify the session restoration configuration.

### Changes
- Remove `loadOnReset` property from `SessionRestoreConfig` interface
- Remove `loadOnReset` from `Config.getSessionRestoreConfig()` return type
- Update `Pilot.reset()` to only use explicit `keepContext` parameter
- Update example config file to remove `loadOnReset` option
- Update test files to remove `loadOnReset` mock data

### Behavior Change
- **Before**: Users could set `sessionRestore.loadOnReset: true` in config to automatically reload history after `/reset`
- **After**: `/reset` always gives a clean session; users must use `/reset --keep-context` to preserve context

### Rationale
The config option adds complexity without significant benefit. Users who want to keep context can explicitly use the command-line flag.

## Test plan

- [x] All existing tests pass (135 tests)
- [x] Verified `SessionRestoreConfig` type is correctly updated
- [x] Verified `Config.getSessionRestoreConfig()` returns correct type
- [x] Verified `Pilot.reset()` logic works correctly with explicit `keepContext` parameter

Fixes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)