### PR TITLE
feat(skill): add github-app Skill for GitHub App configuration (Issue #1318)

### DIFF
--- a/docs/github-app-guide.md
+++ b/docs/github-app-guide.md
@@ -1,0 +1,221 @@
+# GitHub App Configuration Guide
+
+This guide explains how to configure GitHub App authentication for use with Disclaude skills and schedules.
+
+## Overview
+
+Disclaude uses the `gh` CLI (GitHub CLI) for GitHub operations. The `gh` CLI supports GitHub App authentication, providing a secure way to interact with GitHub APIs without storing credentials in Disclaude configuration.
+
+## Prerequisites
+
+- GitHub CLI (`gh`) version 2.40 or higher
+- A GitHub account with permission to create GitHub Apps
+
+## Quick Start
+
+### 1. Create GitHub App
+
+1. Navigate to [GitHub App settings](https://github.com/settings/apps/new)
+2. Fill in the required fields:
+   - **GitHub App name**: A unique name for your app
+   - **Homepage URL**: Your app's homepage or repository URL
+   - **Webhook**: Uncheck if not needed (simpler setup)
+
+3. Configure permissions based on your use case:
+
+| Use Case | Required Permissions |
+|----------|---------------------|
+| Read PRs | `pull_requests: read`, `contents: read` |
+| Manage Issues | `issues: write`, `contents: read` |
+| Full Access | `contents: write`, `pull_requests: write`, `issues: write` |
+
+### 2. Generate Private Key
+
+1. After creating the app, go to **Private keys** section
+2. Click **Generate a private key**
+3. Download the `.pem` file
+4. Save securely:
+   ```bash
+   mv ~/Downloads/*.pem ~/.ssh/github-app-key.pem
+   chmod 600 ~/.ssh/github-app-key.pem
+   ```
+
+### 3. Install App to Repository
+
+1. Go to **Install App** in your GitHub App settings
+2. Select your account/organization
+3. Choose **Only select repositories**
+4. Select the repositories you want to access
+5. Note the **Installation ID** from the URL:
+   ```
+   https://github.com/settings/installations/{INSTALLATION_ID}
+   ```
+
+### 4. Authenticate with gh CLI
+
+```bash
+gh auth login --hostname github.com \
+  --app-id YOUR_APP_ID \
+  --app-key-path ~/.ssh/github-app-key.pem \
+  --app-installation-id INSTALLATION_ID
+```
+
+Replace:
+- `YOUR_APP_ID`: Found in GitHub App settings (top of the page)
+- `INSTALLATION_ID`: From the installation URL
+
+### 5. Verify Authentication
+
+```bash
+gh auth status
+```
+
+Expected output:
+```
+github.com
+  ✓ Logged in to github.com as your-app-name (GitHub App)
+  ✓ Git operations for github.com configured to use https protocol
+  ✓ Token: ghp_***********************************
+```
+
+## Configuration Details
+
+### Finding Your App ID
+
+1. Go to GitHub App settings
+2. Click on your app
+3. The **App ID** is displayed at the top of the page
+
+### Finding Your Installation ID
+
+1. Go to **Install App** in GitHub App settings
+2. Click the **Configure** button next to your installation
+3. The URL will contain the installation ID:
+   ```
+   https://github.com/settings/installations/12345678
+                                              ^^^^^^^^
+                                              Installation ID
+   ```
+
+### Permission Reference
+
+#### Repository Permissions
+
+| Permission | Description | API Access |
+|------------|-------------|------------|
+| `contents` | Repository contents | Read/write files |
+| `pull_requests` | Pull requests | Read/write PRs |
+| `issues` | Issues | Read/write issues |
+| `actions` | GitHub Actions | Read/write workflows |
+| `workflows` | Workflow files | Update workflow files |
+| `metadata` | Repository metadata | Required (always) |
+
+#### Organization Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `members` | Organization members |
+| `plan` | Organization plan |
+
+## Use Cases
+
+### PR Scanner Schedule
+
+```yaml
+---
+name: "PR Scanner"
+cron: "0 */30 * * * *"
+enabled: true
+chatId: "oc_your_chat_id"
+---
+
+# PR Scanner
+
+Scan open PRs and send notifications.
+
+gh pr list --repo OWNER/REPO --state open --json number,title,author,updatedAt
+```
+
+### Issue Creator Skill
+
+```markdown
+---
+name: issue-creator
+allowed-tools: [Bash]
+---
+
+gh issue create --repo OWNER/REPO \
+  --title "Auto-generated issue" \
+  --body "This issue was created automatically."
+```
+
+### PR Review Automation
+
+```bash
+# Get PR details
+gh pr view 123 --repo OWNER/REPO --json title,body,author,mergeable
+
+# Approve PR
+gh pr review 123 --repo OWNER/REPO --approve --body "Reviewed and approved!"
+
+# Merge PR
+gh pr merge 123 --repo OWNER/REPO --squash
+```
+
+## Troubleshooting
+
+### Authentication Failed
+
+```bash
+# Check authentication status
+gh auth status
+
+# Reset and re-authenticate
+gh auth logout
+gh auth login --hostname github.com \
+  --app-id YOUR_APP_ID \
+  --app-key-path ~/.ssh/github-app-key.pem \
+  --app-installation-id INSTALLATION_ID
+```
+
+### Permission Denied
+
+1. Check GitHub App permissions in settings
+2. Update permissions if needed
+3. Re-install the app to refresh permissions
+
+### Installation Not Found
+
+1. Verify the installation ID from the URL
+2. Ensure the app is installed to the correct repository
+3. Check if the installation is active
+
+### Token Expired
+
+GitHub App tokens are short-lived (1 hour). The `gh` CLI automatically refreshes them using the private key.
+
+## Security Best Practices
+
+1. **Private Key Storage**
+   - Store in `~/.ssh/` with restricted permissions
+   - Never commit to repositories
+   - Rotate keys periodically
+
+2. **Minimal Permissions**
+   - Request only necessary permissions
+   - Use repository-level installations
+   - Review permissions regularly
+
+3. **Environment Variables**
+   ```bash
+   # Optional: Use environment variables for CI/CD
+   export GH_APP_ID="your-app-id"
+   export GH_APP_INSTALLATION_ID="installation-id"
+   export GH_APP_KEY_PATH="/path/to/key.pem"
+   ```
+
+## Related Resources
+
+- [GitHub Apps Documentation](https://docs.github.com/en/apps)
+- [GitHub CLI Manual](https://cli.github.com/manual/)
+- [GitHub App Authentication](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app)

--- a/skills/github-app/SKILL.md
+++ b/skills/github-app/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: github-app
+description: GitHub App configuration and operation specialist - helps users configure GitHub App authentication and perform GitHub operations. Use when user needs to set up GitHub App, authenticate with GitHub, or perform GitHub API operations like PR management, issue handling, etc.
+allowed-tools: [Bash]
+---
+
+# GitHub App Skill
+
+You are a GitHub App configuration and operation specialist. Your job is to help users configure GitHub App authentication and perform GitHub operations using the `gh` CLI.
+
+## Core Principle
+
+**Use `gh` CLI for all GitHub operations** - The `gh` CLI tool supports GitHub App authentication and provides a secure, well-maintained interface for GitHub API operations. This is the recommended approach rather than configuring credentials in disclaude itself.
+
+## Capabilities
+
+### 1. GitHub App Setup Guide
+
+Help users through the complete GitHub App setup process:
+
+#### Step 1: Create GitHub App
+
+Guide users to https://github.com/settings/apps/new with these recommendations:
+
+| Setting | Recommended Value |
+|---------|-------------------|
+| **GitHub App name** | `your-app-name` (unique) |
+| **Homepage URL** | Your app's homepage or repository URL |
+| **Webhook** | Uncheck if not needed |
+| **Repository permissions** | Based on use case (see below) |
+
+**Common Permission Presets:**
+
+```yaml
+# PR Review & Management
+contents: read
+pull_requests: read
+issues: read
+metadata: read
+
+# Issue Management
+issues: write
+contents: read
+
+# Full Repository Access
+contents: write
+pull_requests: write
+issues: write
+actions: read
+```
+
+#### Step 2: Generate Private Key
+
+1. Go to App Settings → Private keys
+2. Click "Generate a private key"
+3. Download and save securely (e.g., `~/.ssh/github-app-key.pem`)
+
+#### Step 3: Install App to Repository
+
+1. Go to App Settings → Install App
+2. Select organization/account
+3. Choose "Only select repositories"
+4. Select target repositories
+5. Note the **Installation ID** from the URL: `/settings/installations/{INSTALLATION_ID}`
+
+### 2. Authentication with gh CLI
+
+Help users authenticate using GitHub App:
+
+```bash
+# Method 1: Using GitHub App (requires gh 2.40+)
+gh auth login --hostname github.com \
+  --app-id YOUR_APP_ID \
+  --app-key-path ~/.ssh/github-app-key.pem \
+  --app-installation-id INSTALLATION_ID
+
+# Method 2: Using GitHub CLI with existing token
+gh auth login
+# Then select: GitHub.com -> Paste an authentication token
+```
+
+**Verify authentication:**
+```bash
+gh auth status
+```
+
+### 3. Common Operations
+
+Provide ready-to-use commands for common scenarios:
+
+#### PR Management
+
+```bash
+# List open PRs
+gh pr list --repo OWNER/REPO --state open --json number,title,author,updatedAt
+
+# View PR details
+gh pr view {number} --repo OWNER/REPO --json title,body,author,mergeable,statusCheckRollup
+
+# Create PR review
+gh pr review {number} --repo OWNER/REPO --approve --body "LGTM!"
+
+# Merge PR
+gh pr merge {number} --repo OWNER/REPO --squash
+```
+
+#### Issue Management
+
+```bash
+# Create issue
+gh issue create --repo OWNER/REPO --title "Issue title" --body "Issue description"
+
+# List issues
+gh issue list --repo OWNER/REPO --state open --json number,title,labels
+
+# Close issue
+gh issue close {number} --repo OWNER/REPO
+```
+
+#### Repository Operations
+
+```bash
+# Get repository info
+gh repo view OWNER/REPO --json name,description,url
+
+# List workflows
+gh workflow list --repo OWNER/REPO
+
+# Trigger workflow
+gh workflow run {workflow-name} --repo OWNER/REPO
+```
+
+## Usage Scenarios
+
+### Scenario 1: User wants to set up PR scanning
+
+**User request:** "Help me set up GitHub App for PR scanning"
+
+**Response:**
+1. Guide through GitHub App creation with PR read permissions
+2. Help generate and save private key
+3. Help install app to target repository
+4. Provide `gh auth login` command with proper parameters
+5. Show sample PR scanning commands
+
+### Scenario 2: User wants to create issues automatically
+
+**User request:** "I want to automatically create GitHub issues"
+
+**Response:**
+1. Check if `gh auth status` shows valid authentication
+2. If not authenticated, guide through GitHub App setup
+3. Provide issue creation commands
+4. Help integrate into schedules or workflows
+
+### Scenario 3: User has authentication problems
+
+**User request:** "gh CLI authentication failed"
+
+**Response:**
+1. Run `gh auth status` to diagnose
+2. Check common issues:
+   - Expired token
+   - Missing permissions
+   - Wrong installation ID
+3. Provide fix commands
+
+## Workflow
+
+### When User Asks for GitHub App Setup
+
+1. **Check current authentication:**
+   ```bash
+   gh auth status
+   ```
+
+2. **If not authenticated:**
+   - Guide through GitHub App creation
+   - Help configure permissions
+   - Generate and save private key
+   - Install app to repository
+   - Run `gh auth login` with GitHub App
+
+3. **Verify setup:**
+   ```bash
+   gh repo list --limit 1
+   ```
+
+### When User Wants GitHub Operations
+
+1. **Verify authentication first**
+2. **Provide appropriate commands**
+3. **Help interpret results**
+4. **Handle errors gracefully**
+
+## Configuration Checklist
+
+Help users verify their setup:
+
+```bash
+# 1. Check gh CLI version (needs 2.40+ for GitHub App auth)
+gh --version
+
+# 2. Check authentication status
+gh auth status
+
+# 3. Test repository access
+gh repo view OWNER/REPO --json name
+
+# 4. List available scopes
+gh auth refresh -h github.com -s repo,workflow
+```
+
+## Error Handling
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `authentication required` | Not logged in | Run `gh auth login` |
+| `permission denied` | Insufficient app permissions | Update GitHub App permissions |
+| `installation not found` | Wrong installation ID | Re-check installation URL |
+| `private key invalid` | Key file corrupted | Regenerate private key |
+
+### Troubleshooting Steps
+
+```bash
+# Reset authentication
+gh auth logout
+
+# Re-login with GitHub App
+gh auth login --hostname github.com \
+  --app-id YOUR_APP_ID \
+  --app-key-path ~/.ssh/github-app-key.pem \
+  --app-installation-id INSTALLATION_ID
+
+# Verify
+gh auth status
+```
+
+## Security Best Practices
+
+1. **Private Key Storage:**
+   - Store in secure location (e.g., `~/.ssh/`)
+   - Set proper permissions: `chmod 600 ~/.ssh/github-app-key.pem`
+   - Never commit to repository
+
+2. **Environment Variables (Alternative):**
+   ```bash
+   export GH_APP_ID="your-app-id"
+   export GH_APP_INSTALLATION_ID="installation-id"
+   export GH_APP_KEY_PATH="~/.ssh/github-app-key.pem"
+   ```
+
+3. **Token Scope:**
+   - Request only necessary permissions
+   - Use repository-level installation
+   - Regularly review and rotate keys
+
+## Integration with Disclaude
+
+### Using in Schedules
+
+After GitHub App setup, users can create schedules like:
+
+```yaml
+---
+name: "PR Scanner"
+cron: "0 */30 * * * *"
+---
+
+# PR Scanner
+
+gh pr list --repo OWNER/REPO --state open --json number,title
+```
+
+### Using in Skills
+
+Skills can leverage `gh` CLI directly:
+
+```markdown
+---
+allowed-tools: [Bash]
+---
+
+gh issue create --repo OWNER/REPO --title "Auto-generated issue"
+```
+
+## DO NOT
+
+- Do NOT ask users to configure GitHub App in disclaude.config.yaml
+- Do NOT store private keys in the repository
+- Do NOT expose authentication tokens in logs
+- Do NOT perform operations without verifying authentication first


### PR DESCRIPTION
## Summary

Add a new skill that helps users configure GitHub App authentication and perform GitHub operations using the `gh` CLI.

This addresses the feedback from PR #1323: instead of configuring GitHub App in disclaude's config file, we provide a skill that guides users to use `gh` CLI for GitHub App authentication and operations.

## Changes

| File | Change |
|------|--------|
| `skills/github-app/SKILL.md` | New skill for GitHub App configuration |
| `docs/github-app-guide.md` | Detailed configuration guide |

## Features

### 1. GitHub App Setup Guide
- Step-by-step GitHub App creation
- Permission configuration recommendations
- Private key generation and storage

### 2. gh CLI Authentication
- GitHub App authentication commands
- Installation ID retrieval
- Verification steps

### 3. Common Operations
- PR management (list, view, review, merge)
- Issue management (create, list, close)
- Repository operations

### 4. Integration Examples
- Schedule integration (PR Scanner)
- Skill integration (Issue Creator)

## Key Design Decisions

1. **Use `gh` CLI** - Recommended approach rather than configuring credentials in disclaude itself
2. **Skill-based guidance** - Users interact with the skill to get help, not configure disclaude
3. **Comprehensive documentation** - Both skill and docs folder have guides

## Test Results

- New Markdown files only (no code changes)
- TypeScript check passes for new files (they are Markdown)

## Related Issues

Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)