### PR TITLE
fix(feishu): pass image/file attachments to agent for processing

### DIFF
--- a/packages/primary-node/src/cli.ts
+++ b/packages/primary-node/src/cli.ts
@@ -21,7 +21,9 @@ import {
   Config,
   type FeishuApiHandlers,
   type DisclaudeConfigWithChannels,
+  createInboundAttachment,
 } from '@disclaude/core';
+import type { FileRef } from '@disclaude/core';
 import type { PilotCallbacks } from '@disclaude/worker-node';
 import { PrimaryNode } from './primary-node.js';
 import { RestChannel, type RestChannelConfig } from './channels/rest-channel.js';
@@ -290,8 +292,8 @@ async function main(): Promise<void> {
 
     // Set up message handler for Feishu
     feishuChannel.onMessage(async (message: IncomingMessage) => {
-      const { chatId, content, messageId, userId, metadata } = message;
-      logger.info({ chatId, messageId, contentLength: content.length }, 'Processing message from Feishu channel');
+      const { chatId, content, messageId, userId, metadata, attachments } = message;
+      logger.info({ chatId, messageId, contentLength: content.length, hasAttachments: !!attachments }, 'Processing message from Feishu channel');
 
       const callbacks = createFeishuCallbacks();
       const agent = agentPool.getOrCreateChatAgent(chatId, callbacks);
@@ -300,9 +302,19 @@ async function main(): Promise<void> {
       const senderOpenId = userId;
       const chatHistoryContext = metadata?.chatHistoryContext as string | undefined;
 
+      // Convert MessageAttachment[] to FileRef[] for agent processing
+      const fileRefs: FileRef[] | undefined = attachments?.map((att) =>
+        createInboundAttachment(att.fileName, chatId, message.messageType as 'image' | 'file' | 'media', {
+          localPath: att.filePath,
+          mimeType: att.mimeType,
+          size: att.size,
+          messageId: message.messageId,
+        })
+      );
+
       try {
         // Use processMessage for streaming conversations
-        agent.processMessage(chatId, content, messageId, senderOpenId, undefined, chatHistoryContext);
+        agent.processMessage(chatId, content, messageId, senderOpenId, fileRefs, chatHistoryContext);
       } catch (error) {
         logger.error({ err: error, chatId, messageId }, 'Failed to process message');
         const errorMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- Fixed a bug where `agent.processMessage()` was called with hardcoded `undefined` for the attachments parameter, causing all user-uploaded images and files to be silently dropped
- The Feishu message handler correctly downloads images/files and creates `MessageAttachment[]` objects, but they were never passed to the agent
- Added type conversion from `MessageAttachment[]` to `FileRef[]` using `createInboundAttachment()` to ensure proper type compatibility
- Added `hasAttachments` to log output for better observability

## Test plan
- [ ] Send an image in a Feishu chat and verify the agent can see and analyze it
- [ ] Send a file attachment and verify the agent receives the file reference
- [ ] Send a text-only message and verify no regressions (attachments is `undefined`)
- [ ] Check logs for `hasAttachments` field appearing correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)