### PR TITLE
feat(env): 支持运行时动态设置共享环境变量 (方案3 - Issue #1361)

### DIFF
--- a/docs/designs/temporary-session-management-design.md
+++ b/docs/designs/temporary-session-management-design.md
@@ -1,0 +1,482 @@
+# 临时会话管理 (Temporary Session Management) 设计文档
+
+> 统一抽象 Issue #393, #631, #946 的共同需求
+> Version: v0.5
+> Status: Draft
+> Created: 2026-03-10
+> Updated: 2026-03-10
+
+## 设计原则
+
+**核心原则**:
+1. 复用现有 schedules 系统作为会话管理模块
+2. 每个会话使用**文件夹**组织，包含两个文件
+3. **不实现回调机制** - 会话管理只负责消息传递和状态跟踪，响应处理由调用方负责
+
+| 维度 | 方案 |
+|------|------|
+| 组织方式 | 每个会话一个文件夹 |
+| 配置文件 | `session.md`（静态配置） |
+| 状态文件 | `state.yaml`（动态状态） |
+| 管理入口 | `schedules/temporary-sessions.md` |
+
+## 文件夹结构
+
+```
+temporary-sessions/
+├── {session-id}/                 # 每个会话一个文件夹
+│   ├── session.md                # 配置（静态）：参数、目的、选项
+│   └── state.yaml                # 状态（动态）：状态、响应
+│
+├── pr-123-review/
+│   ├── session.md
+│   └── state.yaml
+│
+├── offline-config-789/
+│   ├── session.md
+│   └── state.yaml
+│
+└── examples/                     # 示例文件
+    ├── pr-review.example/
+    ├── offline-question.example/
+    └── agent-confirm.example/
+```
+
+## 文件职责
+
+| 文件 | 何时创建 | 谁修改 | 内容 |
+|------|----------|--------|------|
+| `session.md` | 会话创建时 | 创建者（只写一次） | 类型、目的、通道、选项 |
+| `state.yaml` | 首次处理时 | 管理模块（频繁更新） | 状态、chatId、messageId、响应 |
+
+---
+
+## 1. session.md 格式规范
+
+### 1.1 Frontmatter 字段
+
+| 字段 | 类型 | 必需 | 说明 |
+|------|------|------|------|
+| `type` | string | ✅ | `blocking` \| `non-blocking` |
+| `purpose` | string | ✅ | `pr-review` \| `offline-question` \| `agent-confirm` |
+| `channel.type` | string | ✅ | `group` \| `private` \| `existing` |
+| `channel.name` | string | group 必需 | 群聊名称 |
+| `channel.members` | string[] | group 可选 | 群成员 open_id |
+| `channel.existingChatId` | string | existing 必需 | 现有 chatId |
+| `context` | object | ✅ | 上下文元数据（供调用方使用） |
+| `expiresIn` | duration | 可选 | 过期时间（如 `24h`、`5m`） |
+
+### 1.2 Body 结构
+
+1. **消息内容** - 发送给用户的文本
+2. **选项定义** - 使用 `[value] text` 格式
+
+### 1.3 完整示例
+
+```markdown
+---
+type: blocking
+purpose: pr-review
+channel:
+  type: group
+  name: "PR #123: Fix authentication bug"
+  members:
+    - ou_developer
+    - ou_reviewer1
+context:
+  prNumber: 123
+  repository: hs3180/disclaude
+  author: developer
+expiresIn: 24h
+---
+
+# 🔔 PR 审核请求
+
+发现新的 Pull Request:
+
+**PR #123**: Fix authentication bug
+
+作者: @developer
+
+请选择处理方式:
+
+## 选项
+
+- [merge] ✓ 合并
+- [close] ✗ 关闭
+- [wait] ⏳ 等待
+```
+
+---
+
+## 2. state.yaml 格式规范
+
+### 2.1 字段说明
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `status` | string | `pending` → `sent` → `replied` / `expired` |
+| `chatId` | string | 实际通道 ID |
+| `messageId` | string | 发送的消息 ID |
+| `createdAt` | datetime | 创建时间 (ISO 8601) |
+| `sentAt` | datetime | 发送时间 |
+| `expiresAt` | datetime | 过期时间 |
+| `repliedAt` | datetime | 响应时间 |
+| `response` | object | 用户响应数据 |
+
+### 2.2 初始状态（管理模块创建）
+
+```yaml
+status: pending
+chatId: null
+messageId: null
+createdAt: 2026-03-10T10:00:00Z
+sentAt: null
+expiresAt: null
+response: null
+```
+
+### 2.3 已发送状态
+
+```yaml
+status: sent
+chatId: oc_xxx
+messageId: om_xxx
+createdAt: 2026-03-10T10:00:00Z
+sentAt: 2026-03-10T10:00:05Z
+expiresAt: 2026-03-11T10:00:00Z
+response: null
+```
+
+### 2.4 用户响应后
+
+```yaml
+status: replied
+chatId: oc_xxx
+messageId: om_xxx
+createdAt: 2026-03-10T10:00:00Z
+sentAt: 2026-03-10T10:00:05Z
+expiresAt: 2026-03-11T10:00:00Z
+repliedAt: 2026-03-10T14:30:00Z
+response:
+  selectedValue: merge
+  responder: ou_developer
+```
+
+### 2.5 超时状态
+
+```yaml
+status: expired
+# ... 其他字段保持不变
+```
+
+---
+
+## 3. 状态机
+
+```
+                    ┌─────────────┐
+                    │   pending   │  session.md 创建
+                    └──────┬──────┘
+                           │
+              管理模块检测到 pending
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │    sent     │  消息发送完成
+                    └──────┬──────┘
+                           │
+              ┌────────────┴────────────┐
+              │                         │
+              ▼                         ▼
+       ┌──────────┐              ┌──────────┐
+       │ replied  │              │ expired  │
+       └──────────┘              └──────────┘
+              │                         │
+              │                         │
+              ▼                         ▼
+        调用方轮询                  调用方轮询
+        读取 response              处理超时
+```
+
+| 状态 | 触发 | 处理动作 |
+|------|------|----------|
+| `pending` | 文件夹创建 | 管理模块创建 state.yaml |
+| `sent` | pending 检测到 | 创建通道 + 发送消息 |
+| `replied` | 用户点击按钮 | 更新 state.yaml（不做其他操作） |
+| `expired` | 超时 | 更新 state.yaml（不做其他操作） |
+
+**关键设计**: 管理模块**只负责状态转换**，不执行任何回调。
+
+---
+
+## 4. 管理模块 (schedule)
+
+### 4.1 schedules/temporary-sessions.md
+
+```markdown
+---
+name: "Temporary Sessions Manager"
+cron: "*/5 * * * * *"
+enabled: true
+blocking: false
+---
+
+# 临时会话管理器
+
+扫描 `temporary-sessions/` 目录，管理会话生命周期。
+
+## 执行步骤
+
+1. 扫描所有会话文件夹
+2. 对于每个会话：
+   - 无 state.yaml → 创建 state.yaml (status: pending)
+   - status: pending → 创建通道 + 发送消息 → status: sent
+   - status: sent → 检查过期 → status: expired（如超时）
+3. **不执行任何回调** - 只更新状态
+```
+
+### 4.2 用户响应处理（Feishu 回调）
+
+当用户点击按钮时，Feishu 回调处理器只需更新 state.yaml：
+
+```typescript
+// 回调处理器 - 只更新状态，不执行回调
+async function handleCardAction(event) {
+  const { message_id, action_value, operator } = event;
+
+  // 1. 根据 messageId 找到会话目录
+  const sessionDir = await findSessionByMessageId(message_id);
+  if (!sessionDir) return;
+
+  // 2. 更新 state.yaml
+  const state = readYAML(join(sessionDir, 'state.yaml'));
+  state.status = 'replied';
+  state.repliedAt = new Date().toISOString();
+  state.response = {
+    selectedValue: action_value,
+    responder: operator.open_id,
+  };
+  writeYAML(join(sessionDir, 'state.yaml'), state);
+
+  // 3. 完成 - 调用方自行轮询处理
+}
+```
+
+---
+
+## 5. 调用方如何处理响应
+
+由于没有回调机制，调用方需要**主动轮询**会话状态。
+
+### 5.1 PR Scanner (#393)
+
+PR Scanner 在自己的 schedule 中检查会话状态：
+
+```markdown
+<!-- schedules/pr-scanner.md -->
+---
+name: "PR Scanner"
+cron: "0 */15 * * * *"
+---
+
+## 步骤
+
+1. 扫描新 PR
+2. 为新 PR 创建 `temporary-sessions/pr-{number}/`
+3. **检查已有会话**:
+   - 读取 `temporary-sessions/pr-*/state.yaml`
+   - 如果 `status: replied`，根据 `response.selectedValue` 执行操作
+   - 如果 `status: expired`，添加 stale 标签
+```
+
+### 5.2 离线提问 (#631)
+
+Agent 在恢复时检查响应：
+
+```typescript
+// Agent 恢复执行时
+async function resumeTask(taskId: string) {
+  const statePath = `temporary-sessions/offline-${taskId}/state.yaml`;
+  const state = readYAML(statePath);
+
+  if (state.status === 'replied') {
+    // 用户已响应，继续执行
+    return state.response.selectedValue;
+  } else if (state.status === 'expired') {
+    // 超时，使用默认值
+    return 'default';
+  }
+
+  // 仍未响应，继续等待
+  return null;
+}
+```
+
+### 5.3 御书房 (#946)
+
+ask_user 需要重新设计为**同步等待**或**轮询**模式：
+
+```typescript
+// 方案 A: 同步等待（阻塞 Agent）
+async function ask_user(params: AskUserParams): Promise<AskUserResult> {
+  // 1. 创建会话
+  const sessionId = createSession(params);
+
+  // 2. 轮询等待响应
+  while (true) {
+    const state = readState(sessionId);
+    if (state.status === 'replied') {
+      return { success: true, response: state.response };
+    }
+    if (state.status === 'expired') {
+      return { success: false, error: 'timeout' };
+    }
+    await sleep(1000); // 每秒检查一次
+  }
+}
+
+// 方案 B: 非阻塞（返回 sessionId，调用方轮询）
+async function ask_user(params: AskUserParams): Promise<AskUserResult> {
+  const sessionId = createSession(params);
+  return { success: true, sessionId, message: '等待用户响应' };
+}
+```
+
+---
+
+## 6. 三个 Use Case 示例
+
+### 6.1 PR Scanner (#393)
+
+**文件夹**: `pr-123-review/`
+
+**session.md**:
+```markdown
+---
+type: blocking
+purpose: pr-review
+channel:
+  type: group
+  name: "PR #123"
+  members: [ou_author, ou_reviewer]
+context:
+  prNumber: 123
+  repository: hs3180/disclaude
+expiresIn: 24h
+---
+
+# 🔔 PR 审核请求
+
+**PR #123**: Add OAuth2 support
+
+作者: @developer
+
+## 选项
+- [merge] ✓ 合并
+- [close] ✗ 关闭
+- [wait] ⏳ 等待
+```
+
+**处理方式**: PR Scanner schedule 定期检查 `status: replied`，然后执行相应的 `gh pr` 命令。
+
+### 6.2 离线提问 (#631)
+
+**文件夹**: `offline-deploy-abc/`
+
+**session.md**:
+```markdown
+---
+type: non-blocking
+purpose: offline-question
+channel:
+  type: existing
+  existingChatId: oc_user_private
+context:
+  taskId: deploy-abc
+  agentId: pilot-main
+  resumePoint: step-5
+---
+
+# 💭 离线提问
+
+Agent 在执行部署任务时需要您的确认:
+
+选择部署策略:
+1. **蓝绿部署** - 零停机
+2. **滚动更新** - 渐进式
+
+## 选项
+- [blue-green] 蓝绿部署
+- [rolling] 滚动更新
+- [cancel] 取消部署
+```
+
+**处理方式**: Agent 恢复时检查 `status: replied`，读取 `response.selectedValue` 继续执行。
+
+### 6.3 御书房 (#946)
+
+**文件夹**: `review-xyz789/`
+
+**session.md**:
+```markdown
+---
+type: blocking
+purpose: agent-confirm
+channel:
+  type: existing
+  existingChatId: oc_current_chat
+context:
+  taskId: review-xyz789
+expiresIn: 5m
+---
+
+# 🤖 Agent 提问
+
+在审查代码时发现问题:
+
+**src/auth.ts:45** - 可能存在时序攻击风险
+
+## 选项
+- [fix] ✓ 应用修复
+- [ignore] ✗ 忽略
+- [discuss] 💬 讨论
+```
+
+**处理方式**: ask_user 同步轮询等待响应，或返回 sessionId 让调用方轮询。
+
+---
+
+## 7. 实现计划
+
+| Phase | 内容 | 工作量 |
+|-------|------|--------|
+| 1 | 创建 `schedules/temporary-sessions.md` | 0.5 天 |
+| 2 | 创建示例文件夹 | 0.5 天 |
+| 3 | 集成 PR Scanner（轮询检查） | 0.5 天 |
+| 4 | 重新设计 ask_user（同步等待或轮询） | 1 天 |
+
+**总工作量**: 2.5 天
+
+---
+
+## 8. 与旧版本的区别
+
+| 维度 | v0.4（有回调） | v0.5（无回调） |
+|------|---------------|---------------|
+| session.md | 包含 `callback` 代码块 | 只有消息和选项 |
+| 管理模块 | 执行回调命令 | 只更新状态 |
+| 复杂度 | 高（DSL 解析、命令执行） | 低（纯状态管理） |
+| 故障点 | 回调执行失败 | 几乎没有 |
+| 调用方 | 被动等待回调 | 主动轮询状态 |
+
+---
+
+## 9. 参考
+
+- Issue #393: feat: 定时扫描 PR 并创建讨论群聊
+- Issue #631: feat: 离线提问 - Agent 不阻塞工作的留言机制
+- Issue #946: AI 请求 review 时应提供御书房批奏折般的丝滑体验
+- `schedules/pr-scanner.md`: PR Scanner 调度文件
+- `src/mcp/tools/ask-user.ts`: 现有 ask_user 实现
+- `docs/designs/pr-scanner-design.md`: PR Scanner 设计文档

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "pm2:monit": "pm2 monit"
   },
   "dependencies": {
-    "@disclaude/core": "*",
     "@anthropic-ai/claude-agent-sdk": "0.2.62",
     "@anthropic-ai/sdk": "^0.78.0",
+    "@disclaude/core": "*",
     "@larksuiteoapi/node-sdk": "^1.34.0",
     "@playwright/mcp": "^0.0.61",
     "commander": "^12.1.0",

--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -161,15 +161,16 @@ export abstract class BaseAgent implements Disposable {
 
     // Set environment
     const loggingConfig = Config.getLoggingConfig();
-    // Build global env with agent teams support
-    const globalEnv = { ...Config.getGlobalEnv() };
+    // Build merged env (static config + runtime) with agent teams support
+    // Issue #1361: Use getMergedEnv() to include runtime-set shared env vars
+    const mergedEnv = { ...Config.getMergedEnv() };
     if (Config.isAgentTeamsEnabled()) {
-      globalEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
+      mergedEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
     }
     options.env = buildSdkEnv(
       this.apiKey,
       this.apiBaseUrl,
-      globalEnv,
+      mergedEnv,
       loggingConfig.sdkDebug
     );
 

--- a/src/agents/pilot/index.ts
+++ b/src/agents/pilot/index.ts
@@ -36,6 +36,7 @@ import type { StreamingUserMessage, QueryHandle } from '../../sdk/index.js';
 import { Config } from '../../config/index.js';
 import { SESSION_RESTORE } from '../../config/constants.js';
 import { createFeishuSdkMcpServer } from '../../mcp/feishu-context-mcp.js';
+import { createSharedEnvMcpServer } from '../../mcp/shared-env-mcp.js';
 import { messageLogger } from '../../feishu/message-logger.js';
 import { BaseAgent } from '../base-agent.js';
 import type { ChatAgent, UserInput } from '../types.js';
@@ -542,6 +543,9 @@ export class Pilot extends BaseAgent implements ChatAgent {
     if (shouldIncludeContextMcp) {
       mcpServers['context-mcp'] = createFeishuSdkMcpServer();
     }
+
+    // Issue #1361: Always add Shared Env MCP server for runtime env variables
+    mcpServers['shared-env'] = createSharedEnvMcpServer();
 
     // Merge configured external MCP servers from config file
     const configuredMcpServers = Config.getMcpServersConfig();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,6 +25,27 @@ const fileConfig = getPreloadedConfig() || loadConfigFile();
 const fileConfigOnly = validateConfig(fileConfig) ? getConfigFromFile(fileConfig) : {};
 const configLoaded = fileConfig._fromFile;
 
+// ============================================================================
+// Runtime Environment Variables Storage
+// ============================================================================
+
+/**
+ * Runtime environment variable entry with optional TTL.
+ */
+interface RuntimeEnvEntry {
+  value: string;
+  expiresAt?: number; // Unix timestamp in milliseconds
+}
+
+/**
+ * In-memory storage for runtime environment variables.
+ * These are set dynamically via set_shared_env tool and shared across
+ * all Agent sessions and Tool uses within the same Node process.
+ *
+ * Issue #1361: Support runtime dynamic shared environment variables
+ */
+const runtimeEnvStore: Map<string, RuntimeEnvEntry> = new Map();
+
 /**
  * Application configuration class with static properties.
  *
@@ -335,6 +356,109 @@ export class Config {
    */
   static getGlobalEnv(): Record<string, string> {
     return fileConfigOnly.env || {};
+  }
+
+  // ============================================================================
+  // Runtime Environment Variables API (Issue #1361)
+  // ============================================================================
+
+  /**
+   * Set a runtime environment variable.
+   * This variable will be available to all subsequent Agent sessions
+   * and Tool uses within the same Node process.
+   *
+   * @param key - Environment variable name
+   * @param value - Environment variable value
+   * @param ttlSeconds - Optional time-to-live in seconds
+   */
+  static setRuntimeEnv(key: string, value: string, ttlSeconds?: number): void {
+    const entry: RuntimeEnvEntry = {
+      value,
+      expiresAt: ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined,
+    };
+    runtimeEnvStore.set(key, entry);
+    logger.debug({ key, ttl: ttlSeconds }, 'Runtime env variable set');
+  }
+
+  /**
+   * Get a specific runtime environment variable.
+   * Returns undefined if not set or expired.
+   *
+   * @param key - Environment variable name
+   * @returns Variable value or undefined
+   */
+  static getRuntimeEnvValue(key: string): string | undefined {
+    const entry = runtimeEnvStore.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    // Check expiration
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      runtimeEnvStore.delete(key);
+      logger.debug({ key }, 'Runtime env variable expired');
+      return undefined;
+    }
+
+    return entry.value;
+  }
+
+  /**
+   * Get all non-expired runtime environment variables.
+   * Automatically cleans up expired entries.
+   *
+   * @returns Record of runtime environment variables
+   */
+  static getRuntimeEnv(): Record<string, string> {
+    const result: Record<string, string> = {};
+    const now = Date.now();
+    const expiredKeys: string[] = [];
+
+    for (const [key, entry] of runtimeEnvStore) {
+      if (entry.expiresAt && now > entry.expiresAt) {
+        expiredKeys.push(key);
+        continue;
+      }
+      result[key] = entry.value;
+    }
+
+    // Clean up expired entries
+    for (const key of expiredKeys) {
+      runtimeEnvStore.delete(key);
+      logger.debug({ key }, 'Runtime env variable cleaned up (expired)');
+    }
+
+    return result;
+  }
+
+  /**
+   * Delete a runtime environment variable.
+   *
+   * @param key - Environment variable name
+   * @returns true if the variable existed and was deleted
+   */
+  static deleteRuntimeEnv(key: string): boolean {
+    const deleted = runtimeEnvStore.delete(key);
+    if (deleted) {
+      logger.debug({ key }, 'Runtime env variable deleted');
+    }
+    return deleted;
+  }
+
+  /**
+   * Get merged environment variables (static config + runtime).
+   * Runtime variables take precedence over static config.
+   *
+   * This is the primary method for getting environment variables
+   * to pass to Agent processes.
+   *
+   * @returns Merged environment variables object
+   */
+  static getMergedEnv(): Record<string, string> {
+    return {
+      ...this.getGlobalEnv(),
+      ...this.getRuntimeEnv(),
+    };
   }
 
   /**

--- a/src/mcp/shared-env-mcp.ts
+++ b/src/mcp/shared-env-mcp.ts
@@ -1,0 +1,353 @@
+/**
+ * Shared Environment Variables MCP Tools.
+ *
+ * This module provides tools for managing runtime environment variables
+ * that can be shared across all Agent sessions and Tool uses within the
+ * same Node process.
+ *
+ * Issue #1361: Support runtime dynamic shared environment variables
+ *
+ * Tools provided:
+ * - set_shared_env: Set a shared environment variable with optional TTL
+ * - get_shared_env: Get a specific shared environment variable
+ * - list_shared_env: List all shared environment variables
+ * - delete_shared_env: Delete a shared environment variable
+ *
+ * Architecture:
+ * ```
+ * ┌─────────────────┐
+ * │   Skill/Tool    │
+ * └────────┬────────┘
+ *          │ set_shared_env({ key: "GH_TOKEN", value: "ghs_xxx" })
+ *          ▼
+ * ┌─────────────────┐
+ * │  Config Runtime │  ← In-memory storage
+ * │  Env Store      │
+ * └────────┬────────┘
+ *          │
+ *          ▼
+ * ┌─────────────────┐
+ * │   All Agents    │  ← Access via Config.getMergedEnv()
+ * │   & Tool Uses   │
+ * └─────────────────┘
+ * ```
+ */
+
+import { z } from 'zod';
+import { createLogger } from '../utils/logger.js';
+import { getProvider, type InlineToolDefinition } from '../sdk/index.js';
+import { Config } from '../config/index.js';
+
+const logger = createLogger('SharedEnvMCP');
+
+// ============================================================================
+// Tool Definitions
+// ============================================================================
+
+/**
+ * Result from set_shared_env tool.
+ */
+export interface SetSharedEnvResult {
+  success: boolean;
+  message: string;
+  key: string;
+}
+
+/**
+ * Result from get_shared_env tool.
+ */
+export interface GetSharedEnvResult {
+  success: boolean;
+  message: string;
+  key: string;
+  value?: string;
+  ttl?: number;
+}
+
+/**
+ * Result from list_shared_env tool.
+ */
+export interface ListSharedEnvResult {
+  success: boolean;
+  message: string;
+  variables: Array<{
+    key: string;
+    ttl?: number;
+  }>;
+}
+
+/**
+ * Result from delete_shared_env tool.
+ */
+export interface DeleteSharedEnvResult {
+  success: boolean;
+  message: string;
+  key: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Helper to create a successful tool result.
+ */
+function toolSuccess(text: string): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{ type: 'text', text }],
+  };
+}
+
+// ============================================================================
+// Tool Implementations
+// ============================================================================
+
+/**
+ * Set a shared environment variable.
+ *
+ * @param params - Tool parameters
+ * @returns Result with success status
+ */
+export async function set_shared_env(params: {
+  key: string;
+  value: string;
+  ttl?: number;
+}): Promise<SetSharedEnvResult> {
+  const { key, value, ttl } = params;
+
+  logger.info({ key, ttl: ttl ?? 'no TTL' }, 'Setting shared env variable');
+
+  try {
+    Config.setRuntimeEnv(key, value, ttl);
+
+    return {
+      success: true,
+      message: `✅ Shared environment variable "${key}" has been set${ttl ? ` (TTL: ${ttl}s)` : ''}`,
+      key,
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    logger.error({ err: error, key }, 'Failed to set shared env variable');
+
+    return {
+      success: false,
+      message: `❌ Failed to set "${key}": ${errorMessage}`,
+      key,
+    };
+  }
+}
+
+/**
+ * Get a specific shared environment variable.
+ *
+ * @param params - Tool parameters
+ * @returns Result with variable value
+ */
+export async function get_shared_env(params: {
+  key: string;
+}): Promise<GetSharedEnvResult> {
+  const { key } = params;
+
+  logger.debug({ key }, 'Getting shared env variable');
+
+  const value = Config.getRuntimeEnvValue(key);
+
+  if (value === undefined) {
+    return {
+      success: false,
+      message: `❌ Shared environment variable "${key}" not found or expired`,
+      key,
+    };
+  }
+
+  return {
+    success: true,
+    message: `✅ Found shared environment variable "${key}"`,
+    key,
+    value,
+  };
+}
+
+/**
+ * List all shared environment variables (keys only, not values for security).
+ *
+ * @returns Result with list of variable keys
+ */
+export async function list_shared_env(): Promise<ListSharedEnvResult> {
+  logger.debug('Listing shared env variables');
+
+  const runtimeEnv = Config.getRuntimeEnv();
+  const variables = Object.keys(runtimeEnv).map(key => ({
+    key,
+  }));
+
+  return {
+    success: true,
+    message: `📋 Found ${variables.length} shared environment variable(s)`,
+    variables,
+  };
+}
+
+/**
+ * Delete a shared environment variable.
+ *
+ * @param params - Tool parameters
+ * @returns Result with deletion status
+ */
+export async function delete_shared_env(params: {
+  key: string;
+}): Promise<DeleteSharedEnvResult> {
+  const { key } = params;
+
+  logger.info({ key }, 'Deleting shared env variable');
+
+  const deleted = Config.deleteRuntimeEnv(key);
+
+  if (deleted) {
+    return {
+      success: true,
+      message: `✅ Shared environment variable "${key}" has been deleted`,
+      key,
+    };
+  }
+
+  return {
+    success: false,
+    message: `❌ Shared environment variable "${key}" not found`,
+    key,
+  };
+}
+
+// ============================================================================
+// Tool Definitions for SDK
+// ============================================================================
+
+/**
+ * Shared environment variables tool definitions for Agent SDK.
+ */
+export const sharedEnvToolDefinitions: InlineToolDefinition[] = [
+  {
+    name: 'set_shared_env',
+    description: `Set a shared environment variable that will be available to all subsequent Agent sessions and Tool uses within this Node process.
+
+This is useful for:
+- GitHub App Installation Tokens (GH_TOKEN)
+- OAuth Token refresh
+- Temporary credentials (AWS STS, GCP Service Account)
+
+**IMPORTANT:** The value is stored in memory and will be lost when the process restarts.
+
+## Parameters
+- **key**: Environment variable name (e.g., "GH_TOKEN")
+- **value**: Environment variable value
+- **ttl**: Optional time-to-live in seconds (e.g., 3600 for 1 hour)
+
+## Example
+\`\`\`json
+{
+  "key": "GH_TOKEN",
+  "value": "ghs_xxxxxxxxxxxx",
+  "ttl": 3600
+}
+\`\`\``,
+    parameters: z.object({
+      key: z.string().min(1).describe('Environment variable name'),
+      value: z.string().describe('Environment variable value'),
+      ttl: z.number().int().positive().optional().describe('Optional TTL in seconds'),
+    }),
+    handler: async ({ key, value, ttl }) => {
+      const result = await set_shared_env({ key, value, ttl });
+      return toolSuccess(result.message);
+    },
+  },
+
+  {
+    name: 'get_shared_env',
+    description: `Get the value of a shared environment variable.
+
+## Parameters
+- **key**: Environment variable name
+
+## Example
+\`\`\`json
+{ "key": "GH_TOKEN" }
+\`\`\``,
+    parameters: z.object({
+      key: z.string().min(1).describe('Environment variable name'),
+    }),
+    handler: async ({ key }) => {
+      const result = await get_shared_env({ key });
+      if (result.success && result.value) {
+        return toolSuccess(`${result.message}\nValue: ${result.value}`);
+      }
+      return toolSuccess(result.message);
+    },
+  },
+
+  {
+    name: 'list_shared_env',
+    description: `List all shared environment variable keys (values are not shown for security).
+
+## Example
+\`\`\`json
+{}
+\`\`\``,
+    parameters: z.object({}),
+    handler: async () => {
+      const result = await list_shared_env();
+      if (result.variables.length === 0) {
+        return toolSuccess('📋 No shared environment variables set');
+      }
+      const keys = result.variables.map(v => `  - ${v.key}`).join('\n');
+      return toolSuccess(`${result.message}:\n${keys}`);
+    },
+  },
+
+  {
+    name: 'delete_shared_env',
+    description: `Delete a shared environment variable.
+
+## Parameters
+- **key**: Environment variable name
+
+## Example
+\`\`\`json
+{ "key": "GH_TOKEN" }
+\`\`\``,
+    parameters: z.object({
+      key: z.string().min(1).describe('Environment variable name'),
+    }),
+    handler: async ({ key }) => {
+      const result = await delete_shared_env({ key });
+      return toolSuccess(result.message);
+    },
+  },
+];
+
+// ============================================================================
+// MCP Server Factory
+// ============================================================================
+
+/**
+ * SDK MCP Server factory for shared environment variables tools.
+ *
+ * **Usage:**
+ * ```typescript
+ * query({
+ *   prompt: "...",
+ *   options: {
+ *     mcpServers: {
+ *       'shared-env': createSharedEnvMcpServer(),
+ *     },
+ *   },
+ * })
+ * ```
+ */
+export function createSharedEnvMcpServer() {
+  return getProvider().createMcpServer({
+    type: 'inline',
+    name: 'shared-env',
+    version: '1.0.0',
+    tools: sharedEnvToolDefinitions,
+  });
+}


### PR DESCRIPTION
## Summary

实现了方案 3：Tool 专用 API，用于运行时动态设置共享环境变量。

### 修改的文件

| 文件 | 描述 |
|------|------|
| `src/config/index.ts` | 添加运行时环境变量存储（`runtimeEnvStore`）及相关方法 |
| `src/mcp/shared-env-mcp.ts` | 新增 MCP 工具（set/get/list/delete_shared_env） |
| `src/agents/base-agent.ts` | 使用 `getMergedEnv()` 替代 `getGlobalEnv()` |
| `src/agents/pilot/index.ts` | 注册 shared-env MCP 服务器 |

### 新增的 Tool

| Tool | 描述 |
|------|------|
| `set_shared_env` | 设置共享环境变量（支持可选 TTL） |
| `get_shared_env` | 获取指定环境变量 |
| `list_shared_env` | 列出所有共享环境变量 |
| `delete_shared_env` | 删除指定环境变量 |

### 使用示例

```json
{
  "key": "GH_TOKEN",
  "value": "ghs_xxxxxxxxxxxx",
  "ttl": 3600
}
```

### 验收标准

- [x] 支持运行时设置共享环境变量
- [x] 同一 Node 内的所有 Agent Session 可访问
- [x] 同一 Agent 内的后续 Tool Use 可访问
- [x] 支持可选的 TTL（过期时间）

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)