### PR TITLE
feat(env): file-based runtime env vars using workspace .runtime-env (Issue #1361)

### DIFF
--- a/packages/core/src/agents/base-agent.ts
+++ b/packages/core/src/agents/base-agent.ts
@@ -26,6 +26,7 @@ import { AppError, ErrorCategory, formatError } from '../utils/error-handler.js'
 import type { AgentMessage } from '../types/index.js';
 import { getRuntimeContext, hasRuntimeContext, type Disposable, type BaseAgentConfig, type AgentProvider } from './types.js';
 import { Config } from '../config/index.js';
+import { loadRuntimeEnv } from '../config/runtime-env.js';
 
 // Re-export BaseAgentConfig for backward compatibility
 export type { BaseAgentConfig } from './types.js';
@@ -170,10 +171,12 @@ export abstract class BaseAgent implements Disposable {
       options.mcpServers = extra.mcpServers as Record<string, import('../sdk/index.js').SdkMcpServerConfig>;
     }
 
-    // Set environment
+    // Set environment: config env + runtime env file (Issue #1361)
     const loggingConfig = this.getLoggingConfig();
-    // Build global env with agent teams support
-    const globalEnv = { ...this.getGlobalEnv() };
+    const globalEnv = {
+      ...this.getGlobalEnv(),
+      ...loadRuntimeEnv(this.getWorkspaceDir()),
+    };
     if (this.isAgentTeamsEnabled()) {
       globalEnv.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = '1';
     }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -27,6 +27,7 @@ import type {
 export * from './types.js';
 export * from './loader.js';
 export * from './tool-configuration.js';
+export { loadRuntimeEnv, setRuntimeEnv, deleteRuntimeEnv } from './runtime-env.js';
 
 const logger = createLogger('Config');
 

--- a/packages/core/src/config/runtime-env.test.ts
+++ b/packages/core/src/config/runtime-env.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, beforeEach, afterEach, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { loadRuntimeEnv, setRuntimeEnv, deleteRuntimeEnv } from './runtime-env.js';
+
+describe('runtime-env', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'runtime-env-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('loadRuntimeEnv', () => {
+    it('returns empty object when file does not exist', () => {
+      expect(loadRuntimeEnv(tmpDir)).toEqual({});
+    });
+
+    it('reads KEY=VALUE pairs', () => {
+      fs.writeFileSync(path.join(tmpDir, '.runtime-env'), 'GH_TOKEN=ghs_abc\nAWS_KEY=AKIAxyz\n');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({
+        GH_TOKEN: 'ghs_abc',
+        AWS_KEY: 'AKIAxyz',
+      });
+    });
+
+    it('ignores comments and blank lines', () => {
+      fs.writeFileSync(path.join(tmpDir, '.runtime-env'), '# comment\n\nGH_TOKEN=ghs_abc\n# another\nAWS_KEY=AKIAxyz\n');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({
+        GH_TOKEN: 'ghs_abc',
+        AWS_KEY: 'AKIAxyz',
+      });
+    });
+
+    it('trims whitespace', () => {
+      fs.writeFileSync(path.join(tmpDir, '.runtime-env'), '  GH_TOKEN  =  ghs_abc  \n');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ GH_TOKEN: 'ghs_abc' });
+    });
+
+    it('handles values with = sign', () => {
+      fs.writeFileSync(path.join(tmpDir, '.runtime-env'), 'EQUATION=a=b=c\n');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ EQUATION: 'a=b=c' });
+    });
+  });
+
+  describe('setRuntimeEnv', () => {
+    it('creates file and writes key', () => {
+      setRuntimeEnv(tmpDir, 'GH_TOKEN', 'ghs_abc');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ GH_TOKEN: 'ghs_abc' });
+    });
+
+    it('appends to existing file', () => {
+      setRuntimeEnv(tmpDir, 'KEY1', 'val1');
+      setRuntimeEnv(tmpDir, 'KEY2', 'val2');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ KEY1: 'val1', KEY2: 'val2' });
+    });
+
+    it('overwrites existing key', () => {
+      setRuntimeEnv(tmpDir, 'KEY', 'old');
+      setRuntimeEnv(tmpDir, 'KEY', 'new');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ KEY: 'new' });
+    });
+  });
+
+  describe('deleteRuntimeEnv', () => {
+    it('removes a key', () => {
+      setRuntimeEnv(tmpDir, 'KEY1', 'val1');
+      setRuntimeEnv(tmpDir, 'KEY2', 'val2');
+      deleteRuntimeEnv(tmpDir, 'KEY1');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ KEY2: 'val2' });
+    });
+
+    it('removes file when last key deleted', () => {
+      setRuntimeEnv(tmpDir, 'KEY', 'val');
+      deleteRuntimeEnv(tmpDir, 'KEY');
+      expect(fs.existsSync(path.join(tmpDir, '.runtime-env'))).toBe(false);
+    });
+
+    it('does nothing for non-existent key', () => {
+      setRuntimeEnv(tmpDir, 'KEY', 'val');
+      deleteRuntimeEnv(tmpDir, 'MISSING');
+      expect(loadRuntimeEnv(tmpDir)).toEqual({ KEY: 'val' });
+    });
+  });
+});

--- a/packages/core/src/config/runtime-env.ts
+++ b/packages/core/src/config/runtime-env.ts
@@ -1,0 +1,89 @@
+/**
+ * File-based Runtime Environment Variables (Issue #1361)
+ *
+ * Reads runtime env vars from `{workspace}/.runtime-env` file.
+ * Format: simple KEY=VALUE per line, # comments, blank lines ignored.
+ *
+ * Why file-based? Agent runs in an SDK subprocess — in-memory singletons
+ * in the main process are not accessible. A workspace file is readable
+ * by both main process (MCP servers) and agent subprocess.
+ *
+ * Usage:
+ *   // Main process: agent env auto-merged in createSdkOptions()
+ *   // Agent: write via existing Write tool to {workspace}/.runtime-env
+ *   //   GH_TOKEN=ghs_xxx
+ *   //   AWS_KEY=AKIAxxx
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('RuntimeEnv');
+
+const FILENAME = '.runtime-env';
+
+/**
+ * Load runtime env vars from workspace directory.
+ * Returns empty object if file doesn't exist or is unreadable.
+ */
+export function loadRuntimeEnv(workspaceDir: string): Record<string, string> {
+  const filePath = path.join(workspaceDir, FILENAME);
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const env: Record<string, string> = {};
+
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) { continue; }
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex > 0) {
+        env[trimmed.slice(0, eqIndex).trim()] = trimmed.slice(eqIndex + 1).trim();
+      }
+    }
+
+    if (Object.keys(env).length > 0) {
+      logger.debug({ keys: Object.keys(env) }, 'Loaded runtime env vars');
+    }
+    return env;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Write a runtime env var to the workspace file.
+ * Creates or appends to `.runtime-env` in the workspace directory.
+ * Thread-safe for single-writer scenarios.
+ */
+export function setRuntimeEnv(workspaceDir: string, key: string, value: string): void {
+  const filePath = path.join(workspaceDir, FILENAME);
+  const existing = loadRuntimeEnv(workspaceDir);
+  existing[key] = value;
+
+  const lines = Object.entries(existing).map(([k, v]) => `${k}=${v}`);
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf-8');
+
+  logger.debug({ key }, 'Set runtime env var');
+}
+
+/**
+ * Delete a runtime env var from the workspace file.
+ */
+export function deleteRuntimeEnv(workspaceDir: string, key: string): void {
+  const existing = loadRuntimeEnv(workspaceDir);
+  if (!(key in existing)) { return; }
+
+  delete existing[key];
+  const filePath = path.join(workspaceDir, FILENAME);
+
+  if (Object.keys(existing).length === 0) {
+    fs.rmSync(filePath, { force: true });
+  } else {
+    const lines = Object.entries(existing).map(([k, v]) => `${k}=${v}`);
+    fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf-8');
+  }
+
+  logger.debug({ key }, 'Deleted runtime env var');
+}


### PR DESCRIPTION
## Summary

使用工作目录下的 `.runtime-env` 文件实现运行时环境变量共享（替代已关闭的 #1364）。

## 为什么不用内存单例

Agent 运行在 SDK 子进程中，与主进程内存隔离，无法访问 `RuntimeEnv` 单例。
文件放在工作目录下，主进程和 Agent subprocess 都可读写。

## 实现

| 模块 | 说明 |
|------|------|
| 文件位置 | `{workspace}/.runtime-env` |
| 格式 | KEY=VALUE，# 注释，空行 |
| 读取 | `loadRuntimeEnv(workspaceDir)` 在 `createSdkOptions()` 中自动调用 |
| 写入 | Agent 通过 Write 工具写入；主进程用 `setRuntimeEnv()` |
| 删除 | `deleteRuntimeEnv(workspaceDir, key)` |

## 改动文件

- `packages/core/src/config/runtime-env.ts` — 新增，load/set/delete 三个函数
- `packages/core/src/config/runtime-env.test.ts` — 新增，11 个单元测试
- `packages/core/src/agents/base-agent.ts` — createSdkOptions() 合并 runtime env
- `packages/core/src/config/index.ts` — 导出函数

Closes #1361

🤖 Generated with [Claude Code](https://claude.com/claude-code)