### PR TITLE
fix: call setupSkillsInWorkspace() at agent SDK initialization

### DIFF
--- a/packages/core/src/sdk/factory.ts
+++ b/packages/core/src/sdk/factory.ts
@@ -8,6 +8,13 @@
 import type { IAgentSDKProvider, ProviderFactory, ProviderConstructor } from './interface.js';
 import type { ProviderInfo } from './types.js';
 import { ClaudeSDKProvider } from './providers/index.js';
+import { setupSkillsInWorkspace } from '../utils/skills-setup.js';
+import { createLogger } from '../utils/logger.js';
+
+/**
+ * 模块级标志位，保证 skills setup 幂等（只执行一次）
+ */
+let skillsSetupDone = false;
 
 /**
  * 已注册的 Provider 类型
@@ -42,6 +49,17 @@ const providerCache = new Map<ProviderType, IAgentSDKProvider>();
  */
 export function getProvider(type?: ProviderType): IAgentSDKProvider {
   const providerType = type ?? defaultProviderType;
+
+  // Copy built-in skills to workspace .claude/skills/ for SDK discovery
+  // Fire-and-forget: failure only logs warning, doesn't block agent creation
+  if (!skillsSetupDone) {
+    skillsSetupDone = true;
+    setupSkillsInWorkspace().then((result) => {
+      if (!result.success) {
+        createLogger('SkillsSetup').warn({ error: result.error }, 'Failed to setup skills');
+      }
+    }).catch(() => {});
+  }
 
   // 检查缓存
   const cached = providerCache.get(providerType);


### PR DESCRIPTION
## Summary
- `setupSkillsInWorkspace()` was implemented but never called — built-in skills (`github-jwt-auth`, `github-app`, etc.) were never copied to `workspace/.claude/skills/`, so the SDK could not discover them
- Fire-and-forget call added in `getProvider()` (the universal entry point for all agent creation), with a module-level flag for idempotency
- Failure only logs a warning and does not block agent creation

## Test plan
- [ ] Build: `npm run build`
- [ ] Verify: `disclaude --prompt "list available skills"` should include built-in skills
- [ ] Docker: `docker compose build primary && docker compose up -d primary && docker exec disclaude-primary ls /app/workspace/.claude/skills/github-jwt-auth/` — expect `SKILL.md` present
- [ ] Logs: `docker compose logs --tail 10 primary | grep -i skill` — expect "Skills copied to workspace" log

🤖 Generated with [Claude Code](https://claude.com/claude-code)