### PR TITLE
fix: install bash in Docker image for shell tool execution

### DIFF
--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -49,7 +49,8 @@ WORKDIR /app
 RUN apk add --no-cache \
     curl \
     ca-certificates \
-    procps
+    procps \
+    bash
 
 # Install GitHub CLI (gh)
 RUN apk add --no-cache github-cli


### PR DESCRIPTION
## Summary
- Install `bash` in the Alpine-based Docker production image (`Dockerfile.primary`)
- The Claude Agent SDK's Bash tool requires `/bin/bash`, but Alpine only ships `/bin/sh` (busybox), causing shell command execution to fail inside the container

## Test plan
- [x] Built and deployed new image to `disclaude-primary` container
- [x] Verified `/bin/bash` is available inside the running container
- [ ] Confirm shell tool execution works via Feishu bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)