### PR TITLE
perf(docker): use USTC apk mirror and remove unused GITHUB_TOKEN

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -62,8 +62,8 @@ logs/
 # Task records
 tasks/
 
-# Workspace (mounted as volume)
-workspace/*
+# Workspace (mounted as volume - never needed in build)
+workspace/
 
 # Build output (will be generated in container)
 dist/

--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -18,7 +18,7 @@
 FROM docker.m.daocloud.io/library/node:22-alpine AS builder
 WORKDIR /app
 
-# Use Aliyun mirror for faster apk downloads
+# Use USTC mirror for faster apk downloads
 RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install build dependencies
@@ -33,7 +33,6 @@ RUN npm config set registry https://registry.npmmirror.com && \
     npm install
 
 # Copy source code (explicitly list needed dirs to avoid traversing excluded directories like workspace)
-COPY packages ./packages
 COPY skills ./skills
 COPY ecosystem.primary.config.json ./ecosystem.primary.config.json
 
@@ -50,7 +49,7 @@ RUN npm prune --production && \
 FROM docker.m.daocloud.io/library/node:22-alpine AS production
 WORKDIR /app
 
-# Use Aliyun mirror for faster apk downloads
+# Use USTC mirror for faster apk downloads
 RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install runtime dependencies

--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -18,6 +18,9 @@
 FROM docker.m.daocloud.io/library/node:22-alpine AS builder
 WORKDIR /app
 
+# Use Aliyun mirror for faster apk downloads
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
+
 # Install build dependencies
 RUN apk add --no-cache python3 make g++
 
@@ -29,8 +32,10 @@ COPY packages ./packages
 RUN npm config set registry https://registry.npmmirror.com && \
     npm install
 
-# Copy source code
-COPY . .
+# Copy source code (explicitly list needed dirs to avoid traversing excluded directories like workspace)
+COPY packages ./packages
+COPY skills ./skills
+COPY ecosystem.primary.config.json ./ecosystem.primary.config.json
 
 # Build the project
 RUN npm run build
@@ -44,6 +49,9 @@ RUN npm prune --production && \
 # -----------------------------------------------------------------------------
 FROM docker.m.daocloud.io/library/node:22-alpine AS production
 WORKDIR /app
+
+# Use Aliyun mirror for faster apk downloads
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install runtime dependencies
 RUN apk add --no-cache \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -21,6 +21,9 @@
 FROM docker.m.daocloud.io/library/node:22-alpine AS builder
 WORKDIR /app
 
+# Use Aliyun mirror for faster apk downloads
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
+
 # Install build dependencies
 RUN apk add --no-cache python3 make g++
 
@@ -32,8 +35,10 @@ COPY packages ./packages
 RUN npm config set registry https://registry.npmmirror.com && \
     npm install
 
-# Copy source code
-COPY . .
+# Copy source code (explicitly list needed dirs to avoid traversing excluded directories like workspace)
+COPY packages ./packages
+COPY skills ./skills
+COPY ecosystem.worker.config.json ./ecosystem.worker.config.json
 
 # Build the project
 RUN npm run build
@@ -48,6 +53,9 @@ RUN npm prune --production && \
 # -----------------------------------------------------------------------------
 FROM docker.m.daocloud.io/library/node:22-alpine AS production
 WORKDIR /app
+
+# Use Aliyun mirror for faster apk downloads
+RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install Python and runtime dependencies via apk
 # Note: Alpine uses musl libc instead of glibc

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -21,7 +21,7 @@
 FROM docker.m.daocloud.io/library/node:22-alpine AS builder
 WORKDIR /app
 
-# Use Aliyun mirror for faster apk downloads
+# Use USTC mirror for faster apk downloads
 RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install build dependencies
@@ -36,7 +36,6 @@ RUN npm config set registry https://registry.npmmirror.com && \
     npm install
 
 # Copy source code (explicitly list needed dirs to avoid traversing excluded directories like workspace)
-COPY packages ./packages
 COPY skills ./skills
 COPY ecosystem.worker.config.json ./ecosystem.worker.config.json
 
@@ -54,7 +53,7 @@ RUN npm prune --production && \
 FROM docker.m.daocloud.io/library/node:22-alpine AS production
 WORKDIR /app
 
-# Use Aliyun mirror for faster apk downloads
+# Use USTC mirror for faster apk downloads
 RUN sed -i 's|dl-cdn.alpinelinux.org|mirrors.ustc.edu.cn|g' /etc/apk/repositories
 
 # Install Python and runtime dependencies via apk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,6 @@ services:
     environment:
       - NODE_ENV=production
       - TZ=Asia/Shanghai
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
       - DISCLAUDE_MODE=primary
 
     volumes:
@@ -100,7 +99,6 @@ services:
     environment:
       - NODE_ENV=production
       - TZ=Asia/Shanghai
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
       - DISCLAUDE_MODE=worker
       - COMM_URL=${COMM_URL:-ws://localhost:3001}
 
@@ -157,7 +155,6 @@ services:
     environment:
       - NODE_ENV=test
       - TZ=Asia/Shanghai
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
       - DISCLAUDE_MODE=primary
       - PORT=3011                    # WebSocket port (different from primary's 3001)
       - HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- Replace default Alpine apk mirror with USTC (`mirrors.ustc.edu.cn`) for faster package downloads in China (~3s vs 50s+ for build deps)
- Remove `GITHUB_TOKEN` env var from `docker-compose.yml` (now using GitHub App auth via `disclaude.config.yaml`)
- Use explicit `COPY` instead of `COPY . .` in Dockerfiles for better caching
- Update `.dockerignore` workspace pattern

## Test plan
- [x] `docker compose up -d --build` builds successfully with USTC mirror
- [x] Primary container starts and passes health check
- [ ] Verify GitHub App auth works without `GITHUB_TOKEN` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)