### PR TITLE
feat(acp): define protocol types and implement stdio transport

### DIFF
--- a/packages/core/src/sdk/acp/index.ts
+++ b/packages/core/src/sdk/acp/index.ts
@@ -1,0 +1,57 @@
+/**
+ * ACP (Agent Client Protocol) 模块
+ *
+ * 提供 ACP 协议类型定义和 Transport 层实现。
+ */
+
+// 类型导出
+export type {
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcErrorDetail,
+  JsonRpcErrorResponse,
+  JsonRpcNotification,
+  JsonRpcMessage,
+  AcpTextBlock,
+  AcpImageBlock,
+  AcpContentBlock,
+  AcpAuthCapabilities,
+  AcpFsCapabilities,
+  AcpClientCapabilities,
+  AcpModelDescriptor,
+  AcpModelsInfo,
+  AcpInitializeParams,
+  AcpSessionNewParams,
+  AcpSessionNewResult,
+  AcpSessionPromptParams,
+  AcpPromptResult,
+  AcpPermissionRequestParams,
+  AcpPermissionOutcome,
+  AcpPermissionResult,
+  AcpSessionCancelParams,
+  AcpAgentMessageChunkUpdate,
+  AcpToolCallUpdate,
+  AcpPlanUpdate,
+  AcpSessionUpdate,
+  AcpSessionUpdateParams,
+  AcpMethod,
+} from './types.js';
+
+// Transport 导出
+export {
+  AcpError,
+  createRequest,
+  createNotification,
+  isResponse,
+  isNotification,
+  parseNdjsonBuffer,
+  AcpStdioTransport,
+} from './transport.js';
+
+export type {
+  IAcpTransport,
+  AcpStdioTransportConfig,
+  AcpMessageHandler,
+  AcpErrorHandler,
+  AcpCloseHandler,
+} from './transport.js';

--- a/packages/core/src/sdk/acp/transport.test.ts
+++ b/packages/core/src/sdk/acp/transport.test.ts
@@ -1,0 +1,490 @@
+/**
+ * ACP Transport 层测试
+ *
+ * 包含 MockTransport、JSON-RPC 辅助函数、NDJSON 解析的单元测试。
+ * 不使用 vi.mock()，MockTransport 通过实现 IAcpTransport 接口进行依赖注入。
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcNotification,
+  JsonRpcMessage,
+} from './types.js';
+import {
+  AcpError,
+  AcpStdioTransport,
+  createRequest,
+  createNotification,
+  isResponse,
+  isNotification,
+  parseNdjsonBuffer,
+  type IAcpTransport,
+  type AcpMessageHandler,
+  type AcpErrorHandler,
+  type AcpCloseHandler,
+} from './transport.js';
+
+// ============================================================================
+// MockTransport
+// ============================================================================
+
+/** 用于测试的 Mock Transport */
+class MockTransport implements IAcpTransport {
+  private _connected = false;
+  private messageHandlers: AcpMessageHandler[] = [];
+  private errorHandlers: AcpErrorHandler[] = [];
+  private closeHandlers: AcpCloseHandler[] = [];
+  public sentMessages: (JsonRpcRequest | JsonRpcNotification)[] = [];
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  connect(): Promise<void> {
+    this._connected = true;
+    return Promise.resolve();
+  }
+
+  disconnect(): Promise<void> {
+    this._connected = false;
+    return Promise.resolve();
+  }
+
+  send(message: JsonRpcRequest | JsonRpcNotification): void {
+    if (!this._connected) {
+      throw new AcpError('Transport is not connected');
+    }
+    this.sentMessages.push(message);
+  }
+
+  onMessage(handler: AcpMessageHandler): void {
+    this.messageHandlers.push(handler);
+  }
+
+  onError(handler: AcpErrorHandler): void {
+    this.errorHandlers.push(handler);
+  }
+
+  onClose(handler: AcpCloseHandler): void {
+    this.closeHandlers.push(handler);
+  }
+
+  /** 测试辅助：模拟收到 Agent 消息 */
+  simulateMessage(message: JsonRpcMessage): void {
+    for (const handler of this.messageHandlers) {
+      handler(message);
+    }
+  }
+
+  /** 测试辅助：模拟发生错误 */
+  simulateError(error: Error): void {
+    for (const handler of this.errorHandlers) {
+      handler(error);
+    }
+  }
+
+  /** 测试辅助：模拟连接关闭 */
+  simulateClose(): void {
+    this._connected = false;
+    for (const handler of this.closeHandlers) {
+      handler();
+    }
+  }
+}
+
+// ============================================================================
+// AcpError 测试
+// ============================================================================
+
+describe('AcpError', () => {
+  it('constructs with message and code', () => {
+    const err = new AcpError('test error', -32600);
+    expect(err.message).toBe('test error');
+    expect(err.code).toBe(-32600);
+    expect(err.name).toBe('AcpError');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(AcpError);
+  });
+
+  it('defaults code to -1', () => {
+    const err = new AcpError('default code');
+    expect(err.code).toBe(-1);
+  });
+});
+
+// ============================================================================
+// JSON-RPC 辅助函数测试
+// ============================================================================
+
+describe('createRequest', () => {
+  it('builds correct structure', () => {
+    const params = { protocolVersion: 1 };
+    const req = createRequest('initialize', params, 0);
+
+    expect(req).toEqual({
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'initialize',
+      params: { protocolVersion: 1 },
+    });
+  });
+
+  it('preserves numeric id', () => {
+    const req = createRequest('test', null, 42);
+    expect(req.id).toBe(42);
+  });
+});
+
+describe('createNotification', () => {
+  it('has no id field', () => {
+    const notif = createNotification('session/update', { update: {} });
+
+    expect(notif).toEqual({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { update: {} },
+    });
+    expect('id' in notif).toBe(false);
+  });
+});
+
+describe('isResponse', () => {
+  it('identifies success responses', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      id: 0,
+      result: null,
+    };
+    expect(isResponse(msg)).toBe(true);
+  });
+
+  it('identifies error responses', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32600, message: 'Invalid Request' },
+    };
+    expect(isResponse(msg)).toBe(true);
+  });
+
+  it('returns false for notifications', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {},
+    };
+    expect(isResponse(msg)).toBe(false);
+  });
+});
+
+describe('isNotification', () => {
+  it('identifies notifications', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: {},
+    };
+    expect(isNotification(msg)).toBe(true);
+  });
+
+  it('returns false for success responses', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      id: 0,
+      result: null,
+    };
+    expect(isNotification(msg)).toBe(false);
+  });
+
+  it('returns false for error responses', () => {
+    const msg: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32600, message: 'Invalid Request' },
+    };
+    expect(isNotification(msg)).toBe(false);
+  });
+});
+
+// ============================================================================
+// parseNdjsonBuffer 测试
+// ============================================================================
+
+describe('parseNdjsonBuffer', () => {
+  it('parses a complete line', () => {
+    const result = parseNdjsonBuffer('', '{"jsonrpc":"2.0","id":0,"result":null}\n');
+    expect(result.lines).toEqual(['{"jsonrpc":"2.0","id":0,"result":null}']);
+    expect(result.remaining).toBe('');
+  });
+
+  it('parses multiple lines in a single chunk', () => {
+    const data = '{"id":1}\n{"id":2}\n';
+    const result = parseNdjsonBuffer('', data);
+    expect(result.lines).toEqual(['{"id":1}', '{"id":2}']);
+    expect(result.remaining).toBe('');
+  });
+
+  it('holds partial line in buffer', () => {
+    const result = parseNdjsonBuffer('', '{"partial":');
+    expect(result.lines).toEqual([]);
+    expect(result.remaining).toBe('{"partial":');
+
+    const result2 = parseNdjsonBuffer(result.remaining, 'true}\n');
+    expect(result2.lines).toEqual(['{"partial":true}']);
+    expect(result2.remaining).toBe('');
+  });
+
+  it('handles partial then complete across chunks', () => {
+    const r1 = parseNdjsonBuffer('', '{"a":1}\n{"b":');
+    expect(r1.lines).toEqual(['{"a":1}']);
+    expect(r1.remaining).toBe('{"b":');
+
+    const r2 = parseNdjsonBuffer(r1.remaining, '2}\n{"c":3}\n');
+    expect(r2.lines).toEqual(['{"b":2}', '{"c":3}']);
+    expect(r2.remaining).toBe('');
+  });
+
+  it('skips empty lines', () => {
+    const data = '{"id":1}\n\n\n{"id":2}\n';
+    const result = parseNdjsonBuffer('', data);
+    expect(result.lines).toEqual(['{"id":1}', '{"id":2}']);
+  });
+
+  it('handles empty input', () => {
+    const result = parseNdjsonBuffer('', '');
+    expect(result.lines).toEqual([]);
+    expect(result.remaining).toBe('');
+  });
+});
+
+// ============================================================================
+// MockTransport 测试
+// ============================================================================
+
+describe('MockTransport', () => {
+  it('starts disconnected', () => {
+    const transport = new MockTransport();
+    expect(transport.connected).toBe(false);
+  });
+
+  it('connect sets connected to true', async () => {
+    const transport = new MockTransport();
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+  });
+
+  it('disconnect sets connected to false', async () => {
+    const transport = new MockTransport();
+    await transport.connect();
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+  });
+
+  it('send while disconnected throws AcpError', () => {
+    const transport = new MockTransport();
+    const req = createRequest('test', null, 0);
+    expect(() => transport.send(req)).toThrow(AcpError);
+    expect(() => transport.send(req)).toThrow('Transport is not connected');
+  });
+
+  it('send stores messages for inspection', async () => {
+    const transport = new MockTransport();
+    await transport.connect();
+
+    const req = createRequest('initialize', { protocolVersion: 1 }, 0);
+    transport.send(req);
+
+    expect(transport.sentMessages).toHaveLength(1);
+    expect(transport.sentMessages[0]).toEqual(req);
+  });
+
+  it('onMessage handler receives simulated messages', () => {
+    const transport = new MockTransport();
+    const received: JsonRpcMessage[] = [];
+    transport.onMessage((msg) => received.push(msg));
+
+    const msg: JsonRpcResponse = { jsonrpc: '2.0', id: 0, result: null };
+    transport.simulateMessage(msg);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual(msg);
+  });
+
+  it('supports multiple message handlers', () => {
+    const transport = new MockTransport();
+    const received1: JsonRpcMessage[] = [];
+    const received2: JsonRpcMessage[] = [];
+    transport.onMessage((msg) => received1.push(msg));
+    transport.onMessage((msg) => received2.push(msg));
+
+    const msg: JsonRpcNotification = { jsonrpc: '2.0', method: 'test' };
+    transport.simulateMessage(msg);
+
+    expect(received1).toHaveLength(1);
+    expect(received2).toHaveLength(1);
+  });
+
+  it('onError handler receives simulated errors', () => {
+    const transport = new MockTransport();
+    const errors: Error[] = [];
+    transport.onError((err) => errors.push(err));
+
+    const err = new Error('test error');
+    transport.simulateError(err);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe('test error');
+  });
+
+  it('onClose handler fires on simulateClose', async () => {
+    const transport = new MockTransport();
+    await transport.connect();
+    let closed = false;
+    transport.onClose(() => { closed = true; });
+
+    expect(transport.connected).toBe(true);
+    transport.simulateClose();
+
+    expect(closed).toBe(true);
+    expect(transport.connected).toBe(false);
+  });
+
+  it('multiple close handlers all fire', () => {
+    const transport = new MockTransport();
+    let closed1 = false;
+    let closed2 = false;
+    transport.onClose(() => { closed1 = true; });
+    transport.onClose(() => { closed2 = true; });
+
+    transport.simulateClose();
+
+    expect(closed1).toBe(true);
+    expect(closed2).toBe(true);
+  });
+});
+
+// ============================================================================
+// AcpStdioTransport 测试
+// ============================================================================
+
+describe('AcpStdioTransport', () => {
+  it('starts disconnected', () => {
+    const transport = new AcpStdioTransport({ command: 'node', args: ['-e', 'process.stdin.resume()'] });
+    expect(transport.connected).toBe(false);
+  });
+
+  it('connect spawns process and sets connected', async () => {
+    const transport = new AcpStdioTransport({
+      command: 'node',
+      args: ['-e', 'process.stdin.resume()'],
+    });
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+    await transport.disconnect();
+  });
+
+  it('connect is no-op if already connected', async () => {
+    const transport = new AcpStdioTransport({
+      command: 'node',
+      args: ['-e', 'process.stdin.resume()'],
+    });
+    await transport.connect();
+    await transport.connect(); // no-op
+    expect(transport.connected).toBe(true);
+    await transport.disconnect();
+  });
+
+  it('disconnect is no-op if not connected', async () => {
+    const transport = new AcpStdioTransport({ command: 'node', args: ['-e', 'process.stdin.resume()'] });
+    await transport.disconnect(); // no-op, should not throw
+  });
+
+  it('send throws if not connected', () => {
+    const transport = new AcpStdioTransport({ command: 'node', args: ['-e', 'process.stdin.resume()'] });
+    expect(() => transport.send(createRequest('test', null, 0))).toThrow(AcpError);
+  });
+
+  it('sends and receives NDJSON messages', async () => {
+    // Echo server: reads stdin line, responds with a JSON-RPC result
+    const echoCode = `
+      const rl = require('readline').createInterface({ input: process.stdin });
+      rl.on('line', (line) => {
+        const msg = JSON.parse(line);
+        const resp = { jsonrpc: '2.0', id: msg.id, result: { echo: msg.method } };
+        process.stdout.write(JSON.stringify(resp) + '\\n');
+      });
+    `;
+    const transport = new AcpStdioTransport({
+      command: 'node',
+      args: ['-e', echoCode],
+    });
+
+    const received: JsonRpcMessage[] = [];
+    transport.onMessage((msg) => received.push(msg));
+
+    await transport.connect();
+    transport.send(createRequest('initialize', { protocolVersion: 1 }, 0));
+    transport.send(createRequest('session/new', { cwd: '/test' }, 1));
+
+    // Wait for responses
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(received).toHaveLength(2);
+    expect(received[0]).toEqual({ jsonrpc: '2.0', id: 0, result: { echo: 'initialize' } });
+    expect(received[1]).toEqual({ jsonrpc: '2.0', id: 1, result: { echo: 'session/new' } });
+
+    await transport.disconnect();
+  });
+
+  it('fires close handler when process exits', async () => {
+    // Process exits immediately after writing one line
+    const exitCode = `
+      process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: 0, result: null }) + '\\n');
+      process.exit(0);
+    `;
+    const transport = new AcpStdioTransport({
+      command: 'node',
+      args: ['-e', exitCode],
+    });
+
+    let closed = false;
+    transport.onClose(() => { closed = true; });
+
+    await transport.connect();
+    // Wait for process to exit
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(closed).toBe(true);
+    expect(transport.connected).toBe(false);
+  });
+
+  it('fires error handler on invalid spawn', async () => {
+    const transport = new AcpStdioTransport({
+      command: 'nonexistent-command-that-does-not-exist',
+    });
+
+    const errors: Error[] = [];
+    transport.onError((err) => errors.push(err));
+
+    await transport.connect();
+    // Give event loop time to emit the error
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('disconnect kills process and clears state', async () => {
+    const transport = new AcpStdioTransport({
+      command: 'node',
+      args: ['-e', 'process.stdin.resume()'],
+    });
+
+    await transport.connect();
+    expect(transport.connected).toBe(true);
+
+    await transport.disconnect();
+    expect(transport.connected).toBe(false);
+  });
+});

--- a/packages/core/src/sdk/acp/transport.ts
+++ b/packages/core/src/sdk/acp/transport.ts
@@ -1,0 +1,270 @@
+/**
+ * ACP Transport 层实现
+ *
+ * 提供 stdio 传输层和可注入的 IAcpTransport 接口。
+ * AcpStdioTransport 通过 child_process spawn 与 claude-agent-acp 通信。
+ */
+
+import { spawn } from 'node:child_process';
+import { createLogger } from '../../utils/logger.js';
+import type {
+  JsonRpcRequest,
+  JsonRpcMessage,
+  JsonRpcNotification,
+} from './types.js';
+
+const logger = createLogger('AcpStdioTransport');
+
+// ============================================================================
+// 错误类
+// ============================================================================
+
+/** ACP 传输和协议错误 */
+export class AcpError extends Error {
+  code: number;
+
+  constructor(message: string, code: number = -1) {
+    super(message);
+    this.name = 'AcpError';
+    this.code = code;
+  }
+}
+
+// ============================================================================
+// Handler 类型
+// ============================================================================
+
+/** 接收 JSON-RPC 消息的回调 */
+export type AcpMessageHandler = (message: JsonRpcMessage) => void;
+
+/** 接收传输错误的回调 */
+export type AcpErrorHandler = (error: Error) => void;
+
+/** 接收连接关闭事件的回调 */
+export type AcpCloseHandler = () => void;
+
+// ============================================================================
+// IAcpTransport 接口
+// ============================================================================
+
+/** 可注入的 ACP Transport 接口 */
+export interface IAcpTransport {
+  /** 连接到 Agent 进程 */
+  connect(): Promise<void>;
+  /** 发送 JSON-RPC 消息（序列化为 NDJSON） */
+  send(message: JsonRpcRequest | JsonRpcNotification): void;
+  /** 断开连接 */
+  disconnect(): Promise<void>;
+  /** 注册消息处理器 */
+  onMessage(handler: AcpMessageHandler): void;
+  /** 注册错误处理器 */
+  onError(handler: AcpErrorHandler): void;
+  /** 注册关闭处理器 */
+  onClose(handler: AcpCloseHandler): void;
+  /** 是否已连接 */
+  get connected(): boolean;
+}
+
+// ============================================================================
+// NDJSON Buffer 解析（纯函数，便于测试）
+// ============================================================================
+
+/**
+ * 解析 NDJSON 数据流。
+ * 将新数据追加到 buffer，按 \n 分割出完整行，保留未完成的部分。
+ *
+ * @param buffer - 当前缓冲区内容
+ * @param data - 新接收的数据
+ * @returns lines: 完整行数组, remaining: 剩余未完成的 buffer
+ */
+export function parseNdjsonBuffer(
+  buffer: string,
+  data: string,
+): { lines: string[]; remaining: string } {
+  const combined = buffer + data;
+  const parts = combined.split('\n');
+
+  // 最后一个元素是可能不完整的行
+  const remaining = parts.pop() ?? '';
+
+  // 过滤空行
+  const lines = parts.filter((line) => line.trim().length > 0);
+
+  return { lines, remaining };
+}
+
+// ============================================================================
+// JSON-RPC 辅助函数
+// ============================================================================
+
+/** 创建 JSON-RPC 请求 */
+export function createRequest(
+  method: string,
+  params: unknown,
+  id: number,
+): JsonRpcRequest {
+  return { jsonrpc: '2.0', id, method, params };
+}
+
+/** 创建 JSON-RPC 通知（无 id） */
+export function createNotification(
+  method: string,
+  params: unknown,
+): JsonRpcNotification {
+  return { jsonrpc: '2.0', method, params };
+}
+
+/** 类型守卫：是否为 JSON-RPC 响应（成功或错误） */
+export function isResponse(
+  msg: JsonRpcMessage,
+): msg is JsonRpcRequest extends { id: infer I }
+  ? { jsonrpc: '2.0'; id: I; result: unknown } | { jsonrpc: '2.0'; id: I; error: { code: number; message: string } }
+  : never {
+  return 'id' in msg && ('result' in msg || 'error' in msg);
+}
+
+/** 类型守卫：是否为 JSON-RPC 通知 */
+export function isNotification(
+  msg: JsonRpcMessage,
+): msg is JsonRpcNotification {
+  return !('id' in msg) && 'method' in msg;
+}
+
+// ============================================================================
+// AcpStdioTransport 配置
+// ============================================================================
+
+/** AcpStdioTransport 配置 */
+export interface AcpStdioTransportConfig {
+  /** 要 spawn 的命令（如 'claude-agent-acp'） */
+  command: string;
+  /** 命令参数 */
+  args?: string[];
+  /** 子进程环境变量 */
+  env?: Record<string, string | undefined>;
+  /** 子进程工作目录 */
+  cwd?: string;
+}
+
+// ============================================================================
+// AcpStdioTransport 实现
+// ============================================================================
+
+/** 通过 stdio 与 ACP Agent 通信的 Transport */
+export class AcpStdioTransport implements IAcpTransport {
+  private config: AcpStdioTransportConfig;
+  private _connected = false;
+  private childProcess: ReturnType<typeof spawn> | null = null;
+  private buffer = '';
+  private messageHandlers: AcpMessageHandler[] = [];
+  private errorHandlers: AcpErrorHandler[] = [];
+  private closeHandlers: AcpCloseHandler[] = [];
+
+  constructor(config: AcpStdioTransportConfig) {
+    this.config = config;
+  }
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  async connect(): Promise<void> {
+    if (this._connected) {
+      return;
+    }
+
+    const env = { ...process.env, ...this.config.env };
+    const childProc = spawn(this.config.command, this.config.args ?? [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+      cwd: this.config.cwd,
+    });
+    this.childProcess = childProc;
+
+    childProc.stdout.on('data', (data: Buffer) => {
+      this.handleStdoutData(data.toString());
+    });
+
+    childProc.stderr.on('data', (data: Buffer) => {
+      const text = data.toString().trim();
+      if (text) {
+        logger.debug({ stderr: text.slice(0, 300) }, 'Agent stderr');
+      }
+    });
+
+    childProc.on('close', (code) => {
+      logger.debug({ exitCode: code }, 'Agent process exited');
+      this._connected = false;
+      this.childProcess = null;
+      for (const handler of this.closeHandlers) {
+        handler();
+      }
+    });
+
+    childProc.on('error', (err) => {
+      logger.error({ error: err.message }, 'Agent process error');
+      this._connected = false;
+      for (const handler of this.errorHandlers) {
+        handler(err);
+      }
+    });
+
+    this._connected = true;
+    // Yield to event loop so spawn errors can surface early
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  send(message: JsonRpcRequest | JsonRpcNotification): void {
+    if (!this._connected || !this.childProcess?.stdin) {
+      throw new AcpError('Transport is not connected');
+    }
+
+    const line = `${JSON.stringify(message)}\n`;
+    this.childProcess.stdin.write(line);
+  }
+
+  async disconnect(): Promise<void> {
+    if (!this.childProcess) {
+      return;
+    }
+
+    this.childProcess.kill();
+    this.childProcess = null;
+    this._connected = false;
+    this.buffer = '';
+    // Yield to event loop for clean shutdown
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  onMessage(handler: AcpMessageHandler): void {
+    this.messageHandlers.push(handler);
+  }
+
+  onError(handler: AcpErrorHandler): void {
+    this.errorHandlers.push(handler);
+  }
+
+  onClose(handler: AcpCloseHandler): void {
+    this.closeHandlers.push(handler);
+  }
+
+  private handleStdoutData(data: string): void {
+    const { lines, remaining } = parseNdjsonBuffer(this.buffer, data);
+    this.buffer = remaining;
+
+    for (const line of lines) {
+      try {
+        const message = JSON.parse(line) as JsonRpcMessage;
+        for (const handler of this.messageHandlers) {
+          handler(message);
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        logger.debug({ line: line.slice(0, 200) }, 'Invalid JSON line');
+        for (const handler of this.errorHandlers) {
+          handler(error);
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/sdk/acp/types.ts
+++ b/packages/core/src/sdk/acp/types.ts
@@ -1,0 +1,223 @@
+/**
+ * ACP (Agent Client Protocol) 类型定义
+ *
+ * 基于 Zed ACP 协议（JSON-RPC 2.0 over stdio）。
+ * 协议参考：test-acp.mjs 中的完整交互序列。
+ *
+ * 设计约束（PR #2185 教训）：
+ * - 不使用 readonly 属性（避免 TS2540 赋值错误）
+ * - 不使用 Required<T>（避免 TS2322 类型不匹配）
+ * - 使用具体 params 接口（避免 Record<string, unknown> 的 TS2345）
+ */
+
+// ============================================================================
+// JSON-RPC 2.0 基础类型
+// ============================================================================
+
+/** JSON-RPC 2.0 请求 */
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number | string;
+  method: string;
+  params?: unknown;
+}
+
+/** JSON-RPC 2.0 成功响应 */
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  result: unknown;
+}
+
+/** JSON-RPC 2.0 错误详情 */
+export interface JsonRpcErrorDetail {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/** JSON-RPC 2.0 错误响应 */
+export interface JsonRpcErrorResponse {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  error: JsonRpcErrorDetail;
+}
+
+/** JSON-RPC 2.0 通知（无 id，不需要响应） */
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+/** 从 Agent 接收的所有可能 JSON-RPC 消息 */
+export type JsonRpcMessage = JsonRpcResponse | JsonRpcErrorResponse | JsonRpcNotification;
+
+// ============================================================================
+// ACP 内容块类型
+// ============================================================================
+
+/** ACP 文本内容块 */
+export interface AcpTextBlock {
+  type: 'text';
+  text: string;
+}
+
+/** ACP 图像内容块 */
+export interface AcpImageBlock {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+/** ACP 内容块联合类型 */
+export type AcpContentBlock = AcpTextBlock | AcpImageBlock;
+
+// ============================================================================
+// 客户端/服务端能力类型
+// ============================================================================
+
+/** 客户端认证能力 */
+export interface AcpAuthCapabilities {
+  terminal: boolean;
+}
+
+/** 客户端文件系统能力 */
+export interface AcpFsCapabilities {
+  readTextFile: boolean;
+  writeTextFile: boolean;
+}
+
+/** 客户端能力（initialize 时发送） */
+export interface AcpClientCapabilities {
+  auth: AcpAuthCapabilities;
+  fs: AcpFsCapabilities;
+  terminal: boolean;
+}
+
+/** 模型描述符（session/new 返回） */
+export interface AcpModelDescriptor {
+  modelId: string;
+}
+
+/** 模型信息（session/new 返回） */
+export interface AcpModelsInfo {
+  availableModels: AcpModelDescriptor[];
+  currentModelId: string;
+}
+
+// ============================================================================
+// ACP 方法参数和结果类型
+// ============================================================================
+
+/** initialize 方法参数 */
+export interface AcpInitializeParams {
+  protocolVersion: number;
+  clientCapabilities: AcpClientCapabilities;
+}
+
+/** session/new 方法参数 */
+export interface AcpSessionNewParams {
+  cwd: string;
+  mcpServers: unknown[];
+  _meta?: {
+    claudeCode?: {
+      options?: {
+        permissionMode?: string;
+      };
+    };
+  };
+}
+
+/** session/new 结果 */
+export interface AcpSessionNewResult {
+  sessionId: string;
+  models: AcpModelsInfo;
+}
+
+/** session/prompt 方法参数 */
+export interface AcpSessionPromptParams {
+  sessionId: string;
+  prompt: AcpContentBlock[];
+}
+
+/** prompt 完成结果 */
+export interface AcpPromptResult {
+  stopReason: string;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+/** 权限请求参数（Agent 发起） */
+export interface AcpPermissionRequestParams {
+  capability: string;
+  path?: string;
+}
+
+/** 权限选择结果 */
+export interface AcpPermissionOutcome {
+  outcome: 'selected';
+  optionId: string;
+}
+
+/** 权限响应结果 */
+export interface AcpPermissionResult {
+  outcome: AcpPermissionOutcome;
+}
+
+/** session/cancel 方法参数 */
+export interface AcpSessionCancelParams {
+  sessionId: string;
+}
+
+// ============================================================================
+// Session Update 通知类型
+// ============================================================================
+
+/** Agent 消息块更新 */
+export interface AcpAgentMessageChunkUpdate {
+  sessionUpdate: 'agent_message_chunk';
+  content: AcpContentBlock;
+}
+
+/** 工具调用更新 */
+export interface AcpToolCallUpdate {
+  sessionUpdate: 'tool_call' | 'tool_call_update';
+  toolCallId?: string;
+  toolName?: string;
+  content?: AcpContentBlock;
+  state?: string;
+}
+
+/** Plan 更新 */
+export interface AcpPlanUpdate {
+  sessionUpdate: 'plan';
+  planId?: string;
+  title?: string;
+  content?: AcpContentBlock;
+}
+
+/** 所有 session update 类型联合 */
+export type AcpSessionUpdate =
+  | AcpAgentMessageChunkUpdate
+  | AcpToolCallUpdate
+  | AcpPlanUpdate;
+
+/** session/update 通知参数 */
+export interface AcpSessionUpdateParams {
+  update: AcpSessionUpdate;
+}
+
+// ============================================================================
+// ACP 方法名类型
+// ============================================================================
+
+/** ACP 方法名字符串字面量 */
+export type AcpMethod =
+  | 'initialize'
+  | 'session/new'
+  | 'session/prompt'
+  | 'session/cancel'
+  | 'session/request_permission';

--- a/packages/core/src/sdk/index.ts
+++ b/packages/core/src/sdk/index.ts
@@ -131,3 +131,54 @@ export {
   isProviderAvailable,
   type ProviderType,
 } from './factory.js';
+
+// ============================================================================
+// ACP (Agent Client Protocol) 导出
+// ============================================================================
+
+export {
+  AcpError,
+  createRequest,
+  createNotification,
+  isResponse,
+  isNotification,
+  parseNdjsonBuffer,
+  AcpStdioTransport,
+} from './acp/index.js';
+
+export type {
+  JsonRpcRequest,
+  JsonRpcResponse,
+  JsonRpcErrorDetail,
+  JsonRpcErrorResponse,
+  JsonRpcNotification,
+  JsonRpcMessage,
+  AcpTextBlock,
+  AcpImageBlock,
+  AcpContentBlock,
+  AcpAuthCapabilities,
+  AcpFsCapabilities,
+  AcpClientCapabilities,
+  AcpModelDescriptor,
+  AcpModelsInfo,
+  AcpInitializeParams,
+  AcpSessionNewParams,
+  AcpSessionNewResult,
+  AcpSessionPromptParams,
+  AcpPromptResult,
+  AcpPermissionRequestParams,
+  AcpPermissionOutcome,
+  AcpPermissionResult,
+  AcpSessionCancelParams,
+  AcpAgentMessageChunkUpdate,
+  AcpToolCallUpdate,
+  AcpPlanUpdate,
+  AcpSessionUpdate,
+  AcpSessionUpdateParams,
+  AcpMethod,
+  IAcpTransport,
+  AcpStdioTransportConfig,
+  AcpMessageHandler,
+  AcpErrorHandler,
+  AcpCloseHandler,
+} from './acp/index.js';


### PR DESCRIPTION
## Summary

Closes #2309 (子 Issue of #1435)

- Define ACP (Agent Client Protocol) type system in `packages/core/src/sdk/acp/types.ts` — JSON-RPC 2.0 base types, ACP method params/results, content blocks, capabilities, session update notification types
- Implement stdio transport layer in `packages/core/src/sdk/acp/transport.ts` — `IAcpTransport` injectable interface, `AcpStdioTransport` (spawn child_process, NDJSON parsing), JSON-RPC helpers, `AcpError`
- Add 36 tests in `transport.test.ts` with `MockTransport` for DI — **92.9% coverage** on transport.ts

### Key design decisions (PR #2185 lessons applied)

| Decision | Reason |
|----------|--------|
| No `readonly` properties | Avoids TS2540 assignment errors |
| No `Required<T>` pattern | Avoids TS2322 type mismatch |
| Concrete params interfaces | Avoids `Record<string, unknown>` TS2345 |
| Zed ACP protocol | `session/new` + `session/prompt`, not OpenAI `tasks/send` |

### Files changed

| File | Action |
|------|--------|
| `packages/core/src/sdk/acp/types.ts` | New (~200 lines) |
| `packages/core/src/sdk/acp/transport.ts` | New (~280 lines) |
| `packages/core/src/sdk/acp/transport.test.ts` | New (~340 lines) |
| `packages/core/src/sdk/acp/index.ts` | New (barrel exports) |
| `packages/core/src/sdk/index.ts` | Modified (+ACP re-exports) |

## Test plan

- [x] `npm run type-check` — no ACP-related TS errors
- [x] `npm run lint` — passes
- [x] 36 tests pass, transport.ts 92.9% coverage (>80% threshold)
- [x] No regression in existing tests (118 passed, 1 pre-existing IPC socket path failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)