### PR TITLE
feat(docker): add PIP_INDEX_URL build arg and env_file support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,11 @@ services:
       args:
         APK_MIRROR: ${APK_MIRROR:-dl-cdn.alpinelinux.org}
         NPM_REGISTRY: ${NPM_REGISTRY:-https://registry.npmjs.org}
+        PIP_INDEX_URL: ${PIP_INDEX_URL:-}
         DOCKER_IMAGE_PREFIX: ${DOCKER_IMAGE_PREFIX:-}
+    env_file:
+      - path: docker-source.env
+        required: false
     image: disclaude:primary
     container_name: disclaude-primary
     restart: unless-stopped

--- a/docker-source.env.example
+++ b/docker-source.env.example
@@ -27,10 +27,10 @@
 
 # pip index URL
 # Default: https://pypi.org/simple
-# China mirrors: https://pypi.tuna.tsinghua.edu.cn/simple, https://mirrors.aliyun.com/pypi/simple
-# PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+# China mirrors: https://mirrors.ustc.edu.cn/pypi/web/simple/, https://pypi.tuna.tsinghua.edu.cn/simple, https://mirrors.aliyun.com/pypi/simple
+# PIP_INDEX_URL=https://mirrors.ustc.edu.cn/pypi/web/simple/
 
 # Docker base image prefix
 # Default: (empty = docker.io)
 # China mirrors: docker.m.daocloud.io
-# DOCKER_IMAGE_PREFIX=docker.m.daocloud.io
+# DOCKER_IMAGE_PREFIX=docker.m.daocloud.io/


### PR DESCRIPTION
## Summary
- Pass `PIP_INDEX_URL` as a Docker build arg so pip mirrors work during image build
- Add `env_file: docker-source.env` (optional) for runtime env overrides
- Update pip mirror recommendations to prefer USTC mirror

## Test plan
- [ ] `docker compose build` succeeds with default settings
- [ ] `docker compose build` succeeds with `PIP_INDEX_URL` set
- [ ] Container starts correctly with/without `docker-source.env` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)