### PR TITLE
fix(docker): re-add Playwright container with CDP port flexibility

### DIFF
--- a/disclaude.config.example.yaml
+++ b/disclaude.config.example.yaml
@@ -227,8 +227,9 @@ tools:
   # MCP server configurations
   mcpServers:
     # Playwright browser automation via CDP (Chrome DevTools Protocol)
-    # For Docker: Start Chrome CDP on host first: ./scripts/start-playwright-cdp.sh
-    # Then configure the CDP endpoint here (http://localhost:9222 for network_mode: host)
+    # Option 1 (Docker): Run `docker compose --profile playwright up -d` to start CDP container
+    # Option 2 (Host):   Run `./scripts/start-playwright-cdp.sh` to start Chrome CDP on host
+    # Both expose CDP at http://localhost:9222 (default, configurable via CDP_PORT)
     playwright:
       type: "stdio"
       command: "npx"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       resources:
         limits:
           cpus: '1'
-          memory: 1G
+          memory: 2G
         reservations:
           cpus: '0.25'
           memory: 256M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,3 +130,77 @@ services:
 
     profiles:
       - test
+
+  # ===========================================================================
+  # Playwright Browser (optional)
+  # ===========================================================================
+  # Headless Chromium with CDP for browser automation.
+  # Start with: docker compose --profile playwright up -d
+  #
+  # The CDP endpoint is available at http://localhost:9222
+  # Configure in disclaude.config.yaml:
+  #   tools:
+  #     mcpServers:
+  #       playwright:
+  #         command: npx
+  #         args: ["@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]
+  playwright:
+    image: mcr.microsoft.com/playwright:${PLAYWRIGHT_IMAGE_TAG:-v1.52.2-noble}
+    container_name: disclaude-playwright
+    restart: unless-stopped
+
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        exec $$(node -e "process.stdout.write(require('playwright').chromium.executablePath())") \
+          --headless=new \
+          --no-sandbox \
+          --disable-setuid-sandbox \
+          --disable-dev-shm-usage \
+          --disable-gpu \
+          --disable-software-rasterizer \
+          --disable-background-networking \
+          --disable-default-apps \
+          --disable-extensions \
+          --disable-sync \
+          --disable-translate \
+          --hide-scrollbars \
+          --metrics-recording-only \
+          --mute-audio \
+          --no-first-run \
+          --safebrowsing-disable-auto-update \
+          --disable-features=site-per-process \
+          --remote-debugging-port=$${CDP_PORT:-9222} \
+          --remote-debugging-address=0.0.0.0 \
+          --user-data-dir=/tmp/chrome-cdp \
+          about:blank
+
+    network_mode: host
+
+    environment:
+      - CDP_PORT=${CDP_PORT:-9222}
+
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:$${CDP_PORT:-9222}/json/version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    profiles:
+      - playwright


### PR DESCRIPTION
## Summary
- Re-introduce Playwright service in `docker-compose.yml` (was removed during prior merge)
- Add `--disable-features=site-per-process` for CDP compatibility
- Use `$CDP_PORT` variable in healthcheck to match configurable debug port

## Test plan
- [ ] `docker compose --profile playwright up -d` starts successfully
- [ ] `curl http://localhost:9222/json/version` returns CDP info
- [ ] Verify healthcheck passes with default and custom `CDP_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)