### PR TITLE
fix: ensure timestamp is converted to number before Date constructor

### DIFF
--- a/packages/primary-node/src/utils/channel-handlers.ts
+++ b/packages/primary-node/src/utils/channel-handlers.ts
@@ -200,7 +200,7 @@ export function createDefaultMessageHandler(
         chatHistoryContext,
         chatType,
         threadContext,
-        createdAt: message.timestamp ? new Date(message.timestamp).toISOString() : new Date().toISOString(),
+        createdAt: message.timestamp ? new Date(Number(message.timestamp)).toISOString() : new Date().toISOString(),
       };
 
       try {


### PR DESCRIPTION
## Summary
- Wrap `message.timestamp` with `Number()` in `channel-handlers.ts` to ensure correct epoch conversion
- Without this fix, `new Date(stringTimestamp)` may produce incorrect dates when the timestamp is a numeric string

## Test plan
- [ ] Verify messages with numeric string timestamps produce correct `createdAt` values
- [ ] Verify messages with number timestamps still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)