### PR TITLE
fix(docker): upgrade Playwright image and use hardcoded Chrome path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,14 +145,14 @@ services:
   #         command: npx
   #         args: ["@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]
   playwright:
-    image: mcr.microsoft.com/playwright:${PLAYWRIGHT_IMAGE_TAG:-v1.52.2-noble}
+    image: mcr.microsoft.com/playwright:${PLAYWRIGHT_IMAGE_TAG:-v1.60.0-noble}
     container_name: disclaude-playwright
     restart: unless-stopped
 
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        exec $$(node -e "process.stdout.write(require('playwright').chromium.executablePath())") \
+        exec /ms-playwright/chromium-*/chrome-linux64/chrome \
           --headless=new \
           --no-sandbox \
           --disable-setuid-sandbox \


### PR DESCRIPTION
## Summary
- Upgrade Playwright Docker image from v1.52.2 to v1.60.0
- Replace dynamic `node -e "require('playwright').chromium.executablePath()"` with hardcoded glob path `/ms-playwright/chromium-*/chrome-linux64/chrome`

## Test plan
- [ ] Verify `docker compose --profile playwright up -d` starts successfully
- [ ] Verify CDP endpoint at `http://localhost:9222/json/version` returns browser info
- [ ] Verify Playwright MCP server connects to the CDP endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)