### PR TITLE
chore: increase memory limit to 16G and remove CPU constraints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,10 +63,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
-          memory: 4G
+          memory: 16G
         reservations:
-          cpus: '0.5'
           memory: 512M
 
     logging:


### PR DESCRIPTION
## Summary
- Increase Docker container memory limit from 4G to 16G
- Remove CPU limits (`cpus: '2'` and `cpus: '0.5'`) to avoid unnecessary throttling

## Test plan
- [ ] Verify docker-compose.yml syntax is valid
- [ ] Confirm container starts with updated resource limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)