### PR TITLE
fix(docker): use /data for runtime data in primary container (Issue #3903)

### DIFF
--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -98,9 +98,9 @@ RUN addgroup -g 1001 disclaude && \
     adduser -D -u 1001 -G disclaude -h /app -s /sbin/nologin disclaude
 
 # Create directories for runtime with proper permissions
-RUN mkdir -p /app/workspace /app/logs /app/.claude /app/.claude/backups /app/.claude/debug /app/.pm2 && \
+RUN mkdir -p /data/workspace /data/logs /app/.claude /app/.claude/backups /app/.claude/debug /app/.pm2 && \
     echo '{}' > /app/.claude.json && \
-    chown -R disclaude:disclaude /app
+    chown -R disclaude:disclaude /app /data
 
 # Copy built artifacts and production dependencies from builder
 COPY --from=builder --chown=disclaude:disclaude /app/packages ./packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,12 +53,12 @@ services:
       - NODE_ENV=production
       - TZ=Asia/Shanghai
       - DISCLAUDE_MODE=primary
-      - DISCLAUDE_WORKSPACE_DIR=/app/workspace
+      - DISCLAUDE_WORKSPACE_DIR=/data/workspace
 
     volumes:
       - ./disclaude.config.yaml:/app/disclaude.config.yaml:ro
-      - ./workspace:/app/workspace
-      - ./logs:/app/logs
+      - ./workspace:/data/workspace
+      - ./logs:/data/logs
 
     deploy:
       resources:

--- a/ecosystem.primary.config.json
+++ b/ecosystem.primary.config.json
@@ -8,8 +8,8 @@
     "watch": false,
     "max_memory_restart": "2G",
     "log_date_format": "YYYY-MM-DD HH:mm:ss Z",
-    "error_file": "/app/logs/pm2-error.log",
-    "out_file": "/app/logs/pm2-out.log",
+    "error_file": "/data/logs/pm2-error.log",
+    "out_file": "/data/logs/pm2-out.log",
     "merge_logs": true,
     "env": {
       "NODE_ENV": "production"


### PR DESCRIPTION
## Summary
- Primary container: `/app/workspace` → `/data/workspace`, `/app/logs` → `/data/logs`
- Dockerfile.primary: create `/data/workspace` and `/data/logs` with proper ownership
- PM2 ecosystem config: log paths updated to `/data/logs`

## Context
PR #3908 intended to separate `/app` (source) from `/data` (runtime) per Issue #3903, but the primary container was still using `/app/` paths. Only test-primary had the correct `/data/` paths.

## Test plan
- [ ] Verify `docker compose up -d --build` starts successfully
- [ ] Confirm workspace files appear in `/data/workspace` inside container
- [ ] Confirm PM2 logs written to `/data/logs/`

Closes #3903

🤖 Generated with [Claude Code](https://claude.com/claude-code)