### PR TITLE
fix(docker): disable PID lockfile to prevent restart death loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,9 @@ services:
       - TZ=Asia/Shanghai
       - DISCLAUDE_MODE=primary
       - DISCLAUDE_WORKSPACE_DIR=/data/workspace
+      # Docker restart policy handles singleton enforcement; disable PID lockfile
+      # to prevent stale lockfile from blocking startup after container restart.
+      - LOCKFILE_PATH=
 
     volumes:
       - ./disclaude.config.yaml:/app/disclaude.config.yaml:ro

--- a/packages/primary-node/src/cli.test.ts
+++ b/packages/primary-node/src/cli.test.ts
@@ -380,3 +380,44 @@ describe('waitForPortAvailable', () => {
     expect(result).toBe(true);
   });
 });
+
+// ============================================================================
+// Lockfile path resolution (LOCKFILE_PATH empty string disables ProcessLock)
+// ============================================================================
+
+describe('lockfile path resolution', () => {
+  it('should resolve lockfilePath from LOCKFILE_PATH env when set', () => {
+    // When LOCKFILE_PATH is set to a non-empty value, it should be used as-is
+    process.env.LOCKFILE_PATH = '/tmp/test-lock.pid';
+    const lockfilePath = process.env.LOCKFILE_PATH
+      ?? '/default/path';
+    expect(lockfilePath).toBe('/tmp/test-lock.pid');
+    delete process.env.LOCKFILE_PATH;
+  });
+
+  it('should treat empty LOCKFILE_PATH as disabled (trim check)', () => {
+    // Empty string should be treated as disabled
+    process.env.LOCKFILE_PATH = '';
+    const lockfilePath = process.env.LOCKFILE_PATH ?? '/default/path';
+    expect(lockfilePath).toBe('');
+    expect(lockfilePath.trim()).toBe('');
+    expect(!!lockfilePath.trim()).toBe(false); // falsy → ProcessLock not created
+    delete process.env.LOCKFILE_PATH;
+  });
+
+  it('should treat whitespace-only LOCKFILE_PATH as disabled (trim check)', () => {
+    // Whitespace-only string should also be treated as disabled
+    process.env.LOCKFILE_PATH = '   ';
+    const lockfilePath = process.env.LOCKFILE_PATH ?? '/default/path';
+    expect(lockfilePath.trim()).toBe('');
+    expect(!!lockfilePath.trim()).toBe(false); // falsy → ProcessLock not created
+    delete process.env.LOCKFILE_PATH;
+  });
+
+  it('should fall back to default path when LOCKFILE_PATH is unset', () => {
+    // When env var is not set, nullish coalescing provides the default
+    delete process.env.LOCKFILE_PATH;
+    const lockfilePath = process.env.LOCKFILE_PATH ?? '/default/disclaude.pid';
+    expect(lockfilePath).toBe('/default/disclaude.pid');
+  });
+});

--- a/packages/primary-node/src/cli.ts
+++ b/packages/primary-node/src/cli.ts
@@ -149,7 +149,7 @@ async function main(): Promise<void> {
   // can block startup after container restart due to PID reuse).
   const lockfilePath = process.env.LOCKFILE_PATH
     ?? path.resolve(process.env.LOG_DIR ?? path.join(homedir(), 'Library/Logs/disclaude'), 'disclaude.pid');
-  const processLock = lockfilePath
+  const processLock = lockfilePath.trim()
     ? new ProcessLock({ lockfilePath, logger })
     : null;
   if (processLock && !processLock.acquire()) {

--- a/packages/primary-node/src/cli.ts
+++ b/packages/primary-node/src/cli.ts
@@ -143,12 +143,21 @@ async function main(): Promise<void> {
   // Issue #3417: Acquire process lock to prevent multiple concurrent instances.
   // When launchd restarts after a crash, the old process may still be exiting.
   // The PID file lock ensures only one instance runs at a time.
+  //
+  // Set LOCKFILE_PATH to empty string to disable (e.g., Docker where
+  // restart policy handles singleton enforcement and stale lockfiles
+  // can block startup after container restart due to PID reuse).
   const lockfilePath = process.env.LOCKFILE_PATH
     ?? path.resolve(process.env.LOG_DIR ?? path.join(homedir(), 'Library/Logs/disclaude'), 'disclaude.pid');
-  const processLock = new ProcessLock({ lockfilePath, logger });
-  if (!processLock.acquire()) {
+  const processLock = lockfilePath
+    ? new ProcessLock({ lockfilePath, logger })
+    : null;
+  if (processLock && !processLock.acquire()) {
     console.error('Error: Another instance is already running. Exiting.');
     process.exit(1);
+  }
+  if (!processLock) {
+    logger.info('PID lockfile disabled (LOCKFILE_PATH is empty)');
   }
 
   // Load configuration if provided
@@ -158,7 +167,7 @@ async function main(): Promise<void> {
     if (!config._fromFile) {
       logger.error({ path: options.configPath }, 'Failed to load configuration file');
       console.error(`Error: Could not load configuration file: ${options.configPath}`);
-      processLock.release();
+      processLock?.release();
       process.exit(1);
     }
     setLoadedConfig(config);
@@ -183,7 +192,7 @@ async function main(): Promise<void> {
     console.error('Error: At least one channel must be configured.');
     console.error('  - For Feishu: set feishu.appId and feishu.appSecret');
     console.error('  - For REST: set channels.rest.port, host, and fileStorageDir');
-    processLock.release();
+    processLock?.release();
     process.exit(1);
   }
 
@@ -206,7 +215,7 @@ async function main(): Promise<void> {
         'Port is still in use after waiting. Another instance may be running.'
       );
       console.error(`Error: Port ${restConf.port} is still in use after waiting. Exiting.`);
-      processLock.release();
+      processLock?.release();
       process.exit(1);
     }
   }
@@ -235,7 +244,7 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.error({ err: error }, 'Failed to get agent configuration');
     console.error('Error: No API key configured. Please set up disclaude.config.yaml with glm or anthropic settings.');
-    processLock.release();
+    processLock?.release();
     process.exit(1);
   }
 
@@ -355,7 +364,7 @@ async function main(): Promise<void> {
       await lifecycleManager.stopAll();
       await primaryNode.stop();
       // Issue #3417: Release process lock on shutdown so next instance can start immediately.
-      processLock.release();
+      processLock?.release();
       logger.info('Primary Node stopped');
 
       // Flush all buffered log entries to disk before exiting.
@@ -368,7 +377,7 @@ async function main(): Promise<void> {
       logger.error({ err: error }, 'Error during shutdown');
       // Best-effort flush even on error
       await flushLogger().catch(() => {});
-      processLock.release();
+      processLock?.release();
       process.exit(1);
     }
   };
@@ -384,7 +393,7 @@ async function main(): Promise<void> {
   // the PID file behind, blocking subsequent starts if the PID gets recycled.
   process.on('uncaughtException', async (error) => {
     logger.error({ err: error }, 'Uncaught exception');
-    processLock.release();
+    processLock?.release();
     await flushLogger().catch(() => {});
     process.exit(1);
   });
@@ -421,7 +430,7 @@ async function main(): Promise<void> {
       const apiPortReady = await isPortAvailable(options.apiPort, 'localhost');
       if (!apiPortReady) {
         console.error(`Error: API port ${options.apiPort} is already in use. Exiting.`);
-        processLock.release();
+        processLock?.release();
         process.exit(1);
       }
       httpApiServer = new HttpApiServer({ port: options.apiPort, apiToken: options.apiToken });
@@ -449,7 +458,7 @@ async function main(): Promise<void> {
   } catch (error) {
     logger.error({ err: error }, 'Failed to start Primary Node');
     console.error('Failed to start Primary Node:', error instanceof Error ? error.message : String(error));
-    processLock.release();
+    processLock?.release();
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Problem

Docker containers reuse PIDs on restart. When a container crashes and restarts via `restart: unless-stopped`, the stale PID lockfile (`disclaude.pid`) contains the same PID as the new process. `ProcessLock.acquire()` detects its own PID as "another instance" and exits, causing an **infinite restart loop**:

```
lockfile has PID 7 → new process gets PID 7 → "Another instance is already running" → exit → Docker restarts → repeat
```

## Fix

- **`docker-compose.yml`**: Set `LOCKFILE_PATH=` (empty string) to disable the PID lockfile in Docker
- **`cli.ts`**: When `LOCKFILE_PATH` is empty, skip `ProcessLock` entirely (previously would pass empty path to `writeFileSync` causing `ENOENT`)

Docker's `restart: unless-stopped` policy already ensures only one instance runs, making the lockfile redundant in Docker.

Related: #3903