### PR TITLE
refactor: remove PM2, use direct Node.js start in Docker

### DIFF
--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -142,5 +142,6 @@ USER disclaude
 # Issue #3987: auto-configure lark-cli auth from disclaude.config.yaml
 ENTRYPOINT ["docker-entrypoint.sh"]
 
+
 # Default command: run Primary Node directly
 CMD ["node", "packages/primary-node/dist/cli.js", "start"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "bin": {
         "disclaude": "packages/primary-node/dist/cli.js",
         "disclaude-mcp": "packages/mcp-server/dist/cli.js",
-        "disclaude-primary": "packages/primary-node/dist/cli.js"
+        "disclaude-primary": "packages/primary-node/dist/cli.js",
+        "disclaude-push": "packages/primary-node/dist/push-cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "qrcode": "1.5.4"
       },
       "bin": {
-        "disclaude": "packages/primary-node/dist/cli.js",
+        "disclaude": "bin/disclaude.js",
         "disclaude-mcp": "packages/mcp-server/dist/cli.js",
         "disclaude-primary": "packages/primary-node/dist/cli.js",
         "disclaude-push": "packages/primary-node/dist/push-cli.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "bin": {
     "disclaude": "./bin/disclaude.js",
     "disclaude-primary": "./packages/primary-node/dist/cli.js",
-    "disclaude-mcp": "./packages/mcp-server/dist/cli.js"
+    "disclaude-mcp": "./packages/mcp-server/dist/cli.js",
+    "disclaude-push": "./packages/primary-node/dist/push-cli.js"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
## Summary

Remove PM2 process manager from Docker setup — Docker itself already provides process restart (`restart: unless-stopped`), log capture (`json-file` driver), and resource limits.

## Changes

- **Dockerfile**: Remove PM2 install and ecosystem config copy; use direct `node` CMD
- **docker-compose**: Replace `pm2-runtime` with direct Node.js start, add Filebeat log forwarding profile
- **package.json**: Remove `pm2:*` scripts and `pm2` devDependency
- **CLAUDE.md**: Update commands to use `npx`/`docker`, remove PM2 sections
- Delete PM2-only ecosystem config files
- Cleanup `.dockerignore` and `.gitignore`
- Fix TS2367 type error in `provider.ts` where `tool_use` was compared against a type union that doesn't include it

## Remaining diff (after rebase onto latest main)

Only 2 files differ from `main` after rebasing:

| File | Change |
|------|--------|
| `Dockerfile.primary` | +1 line (whitespace) |
| `package-lock.json` | +2/-1 (adds `disclaude-push` bin entry) |

The bulk of the PM2 removal was already merged into `main` via other PRs. This branch now mainly carries the rebased commit with minor residual changes.

Related: #3903

🤖 Generated with [Claude Code](https://claude.com/claude-code)