### PR TITLE
fix(filebeat): enable HTTP monitoring endpoint for container healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,11 +207,11 @@ services:
         max-file: "3"
 
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:5066"]
+      test: ["CMD", "curl", "-sf", "http://localhost:5066/"]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 20s
 
     profiles:
       - logging

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -69,6 +69,15 @@ setup.template.settings:
   # Set to 1 for multi-node ES clusters for data redundancy
   index.number_of_replicas: 0
 
+# HTTP monitoring endpoint — serves / and /stats with live metrics.
+# Required by the docker-compose healthcheck (curl http://localhost:5066).
+# Binds to localhost only; on the host network this stays on the host loopback
+# and is not exposed externally.
+http:
+  enabled: true
+  host: localhost
+  port: 5066
+
 # Filebeat's own logging
 logging.level: info
 logging.to_stderr: true

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -70,9 +70,10 @@ setup.template.settings:
   index.number_of_replicas: 0
 
 # HTTP monitoring endpoint — serves / and /stats with live metrics.
-# Required by the docker-compose healthcheck (curl http://localhost:5066).
-# Binds to localhost only; on the host network this stays on the host loopback
-# and is not exposed externally.
+# Required by the docker-compose healthcheck (curl http://localhost:5066/).
+# Binds to localhost only — not exposed externally.
+# NOTE: filebeat uses network_mode: host in docker-compose, so "localhost" here
+# maps directly to the host's 127.0.0.1 loopback interface.
 http:
   enabled: true
   host: localhost


### PR DESCRIPTION
## Problem
The `disclaude-filebeat` container reported `unhealthy` indefinitely. Root cause: the docker-compose healthcheck runs `curl -sf http://localhost:5066`, but filebeat's HTTP monitoring endpoint is **off by default**, so the probe always failed (curl exit 7) — even though filebeat was shipping logs normally. This was a false-positive health signal.

## Fix
Enable filebeat's HTTP monitoring endpoint in `filebeat.yml`:

```yaml
http:
  enabled: true
  host: localhost
  port: 5066
```

- Aligns the config with the existing `:5066` healthcheck.
- Binds to `localhost` only — on the host network this stays on the host loopback and is **not exposed externally**.
- Bonus: exposes `/` and `/stats` with live metrics for monitoring.

No credentials are involved; ES auth continues to come from `.env` via environment variables.

## Verification
- `curl http://localhost:5066/` returns **200** after restart.
- Container `State.Health.Status` → `healthy` (was `unhealthy` for days).
- All three services (`primary`, `playwright`, `filebeat`) now report healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
