### PR TITLE
fix(filebeat): add ignore_older so clean_inactive doesn't crash startup

### DIFF
--- a/filebeat.yml
+++ b/filebeat.yml
@@ -33,6 +33,8 @@ filebeat.inputs:
     # Remove registry state for deleted/rotated files
     clean_removed: true
     # Clean up file state for files older than 72h (after rotation)
+    # ignore_older is required when clean_inactive is set, and must be less than it
+    ignore_older: 71h
     clean_inactive: 72h
 
 processors:


### PR DESCRIPTION
## Problem
`filebeat.yml` configures the log input with `clean_inactive: 72h` but never sets `ignore_older`. filebeat 8.x enforces this constraint at input initialization — **filebeat fails to start**:

```
Exiting: Failed to start crawler: starting input failed: error while initializing input: ignore_older must be enabled when clean_inactive is used accessing 'filebeat.inputs.0'
```

`filebeat test config` does **not** catch this — it only validates syntax/types, not the cross-field rule, which is enforced only at `filebeat run` input init. So with the current upstream config the `filebeat` container crash-loops.

## Fix
Add `ignore_older: 71h` alongside `clean_inactive: 72h` (filebeat requires `ignore_older < clean_inactive`).

## Verification
Reproduced against `elastic/filebeat:8.18.0`:
- Without `ignore_older` → fatal `Exiting: ... ignore_older must be enabled when clean_inactive is used`.
- With `ignore_older: 71h` → starts cleanly, registrar active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
