### PR TITLE
fix(filebeat): disable auto-template so logs use plain indices, not data streams

### DIFF
--- a/docs/log-forwarding.md
+++ b/docs/log-forwarding.md
@@ -134,9 +134,14 @@ See `filebeat.yml` in the project root for the full configuration.
 
 - **Registry persistence**: Filebeat tracks read positions in a Docker named volume
   (`filebeat_data`). This prevents re-reading all logs after container restarts.
-- **Template updates**: If you modify `setup.template.settings` after initial setup,
-  you must delete the existing template from ES (`DELETE _template/disclaude-logs`)
-  or temporarily set `setup.template.overwrite: true` in `filebeat.yml`.
+- **Index templates**: Filebeat's auto-managed index template is disabled
+  (`setup.template.enabled: false`). Filebeat 8.x generates a template with a
+  top-level `data_stream: {}`, which — together with the `disclaude-logs-YYYY.MM.dd`
+  index name matching ES's data-stream naming convention — would make ES auto-create
+  data streams instead of plain indices. With the template disabled, ES creates plain
+  indices (dynamic mappings) and no data streams. To use explicit field mappings,
+  create your own plain index template in ES, e.g.
+  `PUT _index_template/disclaude-logs` (no `data_stream` key).
 - **Network mode**: Filebeat uses `network_mode: host` for maximum compatibility
   (same as primary and playwright services). If you need stricter network isolation,
   replace it with a custom bridge network and expose only the ES port.
@@ -161,8 +166,8 @@ output.elasticsearch:
   index: "disclaude-logs-%{+yyyy.MM.dd}"
 
 setup.ilm.enabled: false
-setup.template.name: disclaude-logs
-setup.template.pattern: disclaude-logs-*
+# Disable Filebeat's auto-template to avoid data streams (see Configuration Details)
+setup.template.enabled: false
 ```
 
 ### Step 2: Start Filebeat

--- a/docs/log-forwarding.md
+++ b/docs/log-forwarding.md
@@ -139,9 +139,31 @@ See `filebeat.yml` in the project root for the full configuration.
   top-level `data_stream: {}`, which — together with the `disclaude-logs-YYYY.MM.dd`
   index name matching ES's data-stream naming convention — would make ES auto-create
   data streams instead of plain indices. With the template disabled, ES creates plain
-  indices (dynamic mappings) and no data streams. To use explicit field mappings,
-  create your own plain index template in ES, e.g.
-  `PUT _index_template/disclaude-logs` (no `data_stream` key).
+  indices (dynamic mappings) and no data streams. For single-node ES deployments,
+  create a plain index template to set shard/replica counts (the ES default of 1
+  replica causes yellow status on a single node):
+
+  ```bash
+  PUT _index_template/disclaude-logs
+  {
+    "index_patterns": ["disclaude-logs-*"],
+    "template": {
+      "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0
+      }
+    }
+  }
+  ```
+
+- **Upgrading from auto-template**: If you previously used Filebeat's auto-managed
+  template, delete the old template before starting Filebeat to avoid residual
+  data-stream settings:
+
+  ```bash
+  curl -X DELETE "http://localhost:9200/_index_template/disclaude-logs"
+  curl -X DELETE "http://localhost:9200/_template/disclaude-logs"
+  ```
 - **Network mode**: Filebeat uses `network_mode: host` for maximum compatibility
   (same as primary and playwright services). If you need stricter network isolation,
   replace it with a custom bridge network and expose only the ES port.
@@ -166,7 +188,8 @@ output.elasticsearch:
   index: "disclaude-logs-%{+yyyy.MM.dd}"
 
 setup.ilm.enabled: false
-# Disable Filebeat's auto-template to avoid data streams (see Configuration Details)
+# Disable Filebeat's auto-template to avoid data streams — see Index templates
+# in the Configuration Details section for context and a custom template example.
 setup.template.enabled: false
 ```
 

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -66,9 +66,21 @@ setup.ilm.enabled: false
 # `disclaude-logs-YYYY.MM.dd` matches ES's data-stream naming convention
 # (type-dataset-namespace), so ES would auto-create data streams instead of
 # plain indices. With template management disabled, no data-stream template is
-# installed, and ES creates plain indices with dynamic mappings. To use explicit
-# field mappings, create your own plain template in ES, e.g.
-# `PUT _index_template/disclaude-logs` (without a `data_stream` key).
+# installed, and ES creates plain indices with dynamic mappings.
+#
+# For single-node ES deployments, create a plain index template to control
+# shard/replica settings (the default 1 replica causes yellow status on a
+# single node). For example:
+#   PUT _index_template/disclaude-logs
+#   {
+#     "index_patterns": ["disclaude-logs-*"],
+#     "template": {
+#       "settings": {
+#         "number_of_shards": 1,
+#         "number_of_replicas": 0
+#       }
+#     }
+#   }
 setup.template.enabled: false
 
 # HTTP monitoring endpoint — serves / and /stats with live metrics.

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -60,16 +60,16 @@ output.elasticsearch:
 
 # Disable ILM and data streams — use simple daily indices
 setup.ilm.enabled: false
-setup.template.name: disclaude-logs
-setup.template.pattern: disclaude-logs-*
-setup.template.type: index
-# NOTE: If you modify template settings after initial setup, you must either
-# delete the existing template from ES or set overwrite: true temporarily.
-setup.template.overwrite: false
-setup.template.settings:
-  index.number_of_shards: 1
-  # Set to 1 for multi-node ES clusters for data redundancy
-  index.number_of_replicas: 0
+# Disable Filebeat's auto-managed index template.
+# Filebeat 8.x generates a template containing a top-level `data_stream: {}`,
+# which marks it as a data-stream template. The daily index name
+# `disclaude-logs-YYYY.MM.dd` matches ES's data-stream naming convention
+# (type-dataset-namespace), so ES would auto-create data streams instead of
+# plain indices. With template management disabled, no data-stream template is
+# installed, and ES creates plain indices with dynamic mappings. To use explicit
+# field mappings, create your own plain template in ES, e.g.
+# `PUT _index_template/disclaude-logs` (without a `data_stream` key).
+setup.template.enabled: false
 
 # HTTP monitoring endpoint — serves / and /stats with live metrics.
 # Required by the docker-compose healthcheck (curl http://localhost:5066/).


### PR DESCRIPTION
## Problem
Filebeat 8.x generates an index template containing a top-level `data_stream: {}` (confirmed via `filebeat export template`). The configured daily index name `disclaude-logs-YYYY.MM.dd` matches Elasticsearch's **data-stream naming convention** (`<type>-<dataset>-<namespace>` = `disclaude` / `logs` / `2026.06.12`). The combination makes ES **auto-create data streams** instead of plain indices — logs land in data-stream backing indices rather than the expected `disclaude-logs-YYYY.MM.dd` plain indices.

This occurs even with `setup.ilm.enabled: false` — disabling ILM does not strip the template's `data_stream: {}`.

## Fix
Disable Filebeat's auto-managed index template (`setup.template.enabled: false`). With no data-stream template installed, ES creates **plain indices** (dynamic mappings) and no data streams. (`setup.template.settings`/`name` cannot remove the `data_stream` flag, so disabling template management is the clean fix.)

`docs/log-forwarding.md` is updated to match (template note + macOS example) so code and docs stay consistent. To use explicit field mappings, users can `PUT _index_template/disclaude-logs` with their own plain template (no `data_stream` key) — documented inline.

## Verification
Against `elastic/filebeat:8.18` + ES `8.17.4`:
- `filebeat export template` (upstream config) → the generated template has top-level `data_stream: {}` (a data-stream trigger).
- Live `disclaude-logs` indices were plain only because a manually-managed plain template (no `data_stream`) was already present in ES; with the auto-template they would become data streams.
- After `setup.template.enabled: false`: no data-stream template is installed → ES creates plain indices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
