### PR TITLE
fix(docker): copy tsconfig.json so tsc -b build works

### DIFF
--- a/Dockerfile.primary
+++ b/Dockerfile.primary
@@ -41,7 +41,8 @@ RUN apk add --no-cache python3 make g++ && \
     npm install -g bun
 
 # Copy package files
-COPY package.json package-lock.json ./
+# tsconfig.json is required by `tsc -b` (root project references) in the build step below.
+COPY package.json package-lock.json tsconfig.json ./
 COPY packages ./packages
 
 # Install dependencies using bun


### PR DESCRIPTION
## Summary

The builder stage of `Dockerfile.primary` runs `./node_modules/.bin/tsc -b`, which follows the root TypeScript **project references** (`core → mcp-server → primary-node`). That requires the **root `tsconfig.json`** to be present in the image — but it was missing from the `COPY` before `bun install`, so the Docker image build fails.

Add `tsconfig.json` to the package-file copy list.

## Change

```diff
 # Copy package files
-COPY package.json package-lock.json ./
+# tsconfig.json is required by `tsc -b` (root project references) in the build step below.
+COPY package.json package-lock.json tsconfig.json ./
 COPY packages ./packages
```

## Why

`tsc -b` is invoked here:
```dockerfile
RUN ./node_modules/.bin/tsc -b
```
Without the root `tsconfig.json`, project-reference resolution has no entry point and the build breaks.

## Checklist

- [x] 1 file, ~1 line — well under the 3-file / 200-line split threshold
- [x] No code logic changed; build config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)