### PR TITLE
fix(docker): make playwright healthcheck expand CDP_PORT at runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,8 +159,11 @@ services:
         max-size: "10m"
         max-file: "3"
 
+    # CMD-SHELL so the container shell expands ${CDP_PORT} at runtime (matching
+    # the --remote-debugging-port flag above). The exec-form "CMD" does not run a
+    # shell, so $${CDP_PORT:-9222} would be passed to curl literally and never expand.
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:$${CDP_PORT:-9222}/json/version"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${CDP_PORT:-9222}/json/version"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

The playwright container's healthcheck was using **exec form** (`["CMD", "curl", ...]`), which does not invoke a shell. As a result `$${CDP_PORT:-9222}` was passed to `curl` **literally** and never expanded — so the check could not actually follow a custom `CDP_PORT`.

```diff
-      test: ["CMD", "curl", "-sf", "http://localhost:$${CDP_PORT:-9222}/json/version"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${CDP_PORT:-9222}/json/version"]
```

## Why

`CDP_PORT` is already a first-class knob in this service:
- L136 `--remote-debugging-port=$${CDP_PORT:-9222}` — Chromium listens on this port (shell-expanded via the `entrypoint: ["/bin/sh","-c"]`)
- L145 `CDP_PORT=${CDP_PORT:-9200}` … actually `:-9222` — exported into the container env

Switching the healthcheck to **`CMD-SHELL`** runs the URL through `/bin/sh -c`, which expands `${CDP_PORT:-9222}` from the container env at runtime — the same mechanism L136 already relies on.

## What this avoids

Hardcoding `9222` (the alternative) would "work" only because `.env` doesn't set `CDP_PORT` today. It would also diverge from L136/L145: override `CDP_PORT` and Chromium would listen on the new port while the healthcheck still probed 9222 → a silently `unhealthy` container. This preserves the flexibility explicitly added in #3761.

## Validation

- `docker compose --profile playwright config -q` → valid (YAML + CMD-SHELL form accepted)

## Scope

1 file, 4 insertions / 1 deletion — well under the split threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)